### PR TITLE
fix: contextValues for copying Kafka Cluster properties from Topics view

### DIFF
--- a/package.json
+++ b/package.json
@@ -443,17 +443,17 @@
         },
         {
           "command": "confluent.topics.copyKafkaClusterId",
-          "when": "view == confluent-topics && confluentKafkaClusterSelected",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "2_copy@1"
         },
         {
           "command": "confluent.topics.copyKafkaClusterName",
-          "when": "view == confluent-topics && confluentKafkaClusterSelected",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "2_copy@2"
         },
         {
           "command": "confluent.topics.copyKafkaClusterBootstrapServers",
-          "when": "view == confluent-topics && confluentKafkaClusterSelected",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "2_copy@3"
         }
       ],


### PR DESCRIPTION
The previous contextValues were incorrect, and now the `Copy Kafka Cluster ___` commands appear as expected:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/0d81dfbd-848b-4240-83bf-82dc78fb7282">