### PR TITLE
add `launch.json`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/out"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "${defaultBuildTask}",
+      "env": {
+        "LOGGING_MODE": "development",
+        "ENABLE_REQUEST_RESPONSE_LOGGING": "false"
+      },
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}


### PR DESCRIPTION
Re-enables us to run with the extension dev host window
<img width="776" alt="image" src="https://github.com/user-attachments/assets/8a57846d-f6da-4887-9db2-8effedc1ff34">
