### PR TITLE
chore: Remove internally accessible badges from README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Confluent Extension for VSCode
 
-[![Build Status](https://semaphore.ci.confluent.io/badges/vscode/branches/main.svg?style=shields&key=333d39fa-5f9e-4c87-aca5-dc8618ff3864)](https://semaphore.ci.confluent.io/projects/vscode)
 ![Release](release.svg)
-[![Lines of Code](https://sonarqube.dp.confluent.io/api/project_badges/measure?project=vscode&metric=ncloc&token=sqb_9831824953870c5267d6f56b32dd2d339f2b1e78)](https://sonarqube.dp.confluent.io/dashboard?id=vscode)
 
 Our goal for the [Confluent extension for VS Code](https://github.com/confluentinc/vscode) is to
 help make it very easy for developers to build stream processing applications using Confluent by


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Remove semaphore and sonarqube badges from README, since they're only accessible from within Confluent VPN.