### PR TITLE
MINOR: only log auth status, not the whole session

### DIFF
--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -294,7 +294,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
 
 /** Converts a {@link Connection} to a {@link vscode.AuthenticationSession}. */
 function convertToAuthSession(connection: Connection): vscode.AuthenticationSession {
-  logger.debug("convertToAuthSession()", connection);
+  logger.debug("convertToAuthSession()", connection.status.authentication.status);
   const session: vscode.AuthenticationSession = {
     id: CCLOUD_CONNECTION_ID,
     accessToken: connection.status.authentication.status,


### PR DESCRIPTION
We just care about `NO_TOKEN`/`INVALID_TOKEN`/`VALID_TOKEN`