### PR TITLE
[v0.14.x] fix(DTX-675): context value setup on extension activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,15 +82,16 @@ async function _activateExtension(
 ): Promise<vscode.ExtensionContext> {
   getTelemetryLogger().logUsage("Extension Activated");
 
+  // must be done first to allow any other downstream callers to call `getExtensionContext()`
+  // (e.g. StorageManager for secrets/states, webviews for extension root path, etc)
   setExtensionContext(context);
 
   context = await setupDebugHelpers(context);
+  await setupContextValues();
 
-  // these three need to be in order because they depend on each other
+  // these two need to be in order because they depend on each other
   context = await setupStorage(context);
   context = await setupAuthProvider(context);
-
-  await setupContextValues();
 
   context = setupViewProviders(context);
   context = setupCommands(context);
@@ -123,19 +124,17 @@ async function setupDebugHelpers(
 
 /** Configure any starting contextValues to use for view/menu controls during activation. */
 async function setupContextValues() {
-  // starting states before resources/connections populate, because these won't clear out between
-  // reloading the extension/window
-  const initialcontextKeys = [
-    "confluent.ccloudConnectionAvailable",
-    "confluent.localKafkaClusterAvailable",
+  // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
+  const kafkaClusterSelected = vscode.commands.executeCommand(
+    "setContext",
     "confluent.kafkaClusterSelected",
-    "confluent.schemaRegistrySelected",
-  ];
-  const initialContextPromises = initialcontextKeys.map((key) =>
-    vscode.commands.executeCommand("setContext", key, false),
+    false,
   );
-  await Promise.all(initialContextPromises);
-
+  const schemaRegistrySelected = vscode.commands.executeCommand(
+    "setContext",
+    "confluent.schemaRegistrySelected",
+    false,
+  );
   // enables the "Select for Compare" / "Compare with Selected" commands
   const diffResources = vscode.commands.executeCommand(
     "setContext",
@@ -188,6 +187,8 @@ async function setupContextValues() {
     ],
   );
   await Promise.all([
+    kafkaClusterSelected,
+    schemaRegistrySelected,
     diffResources,
     openInCCloudResources,
     viewsWithResources,
@@ -211,6 +212,16 @@ async function setupAuthProvider(
 ): Promise<vscode.ExtensionContext> {
   logger.debug("setupAuthProvider()");
   const provider = new ConfluentCloudAuthProvider(context);
+
+  // set the initial connection states of our main views; these will be adjusted by the following:
+  // - ccloudConnectionAvailable: `true/false` if the auth provider has a valid CCloud connection
+  // - localKafkaClusterAvailable: `true/false` if the Resources view loads/refreshes and can find a
+  //   local Kafka cluster (and CCloud connection changes will refresh the Resources view via the
+  //   `ccloudConnected` event emitter)
+  await Promise.all([
+    vscode.commands.executeCommand("setContext", "confluent.ccloudConnectionAvailable", false),
+    vscode.commands.executeCommand("setContext", "confluent.localKafkaClusterAvailable", false),
+  ]);
 
   // attempt to get a session to trigger the initial auth badge for signing in
   await getAuthSession();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Problem: when a user authenticates to CCloud and restarts the extension (but doesn't reload their VS Code workspace/window), the auth provider notices an existing CCloud connection and sets `ccloudConnectionAvailable` to `true`, but then `setupContextValues()` comes in and reverts it to `false` so we mistakenly show a mixed-state between the Resources view and the Topics/Schemas views.

This fixes our ordering of `setupContextValues()` and `setupAuthProvider()` and more tightly couples the CCloud/local context values during extension activation.

To clicktest this against the `v0.14.x` branch:
- install the extension from a .vsix
- sign in to CCloud via the Accounts menu
- go to the Extensions tab to find the Confluent extension, click "Disable" and then "Restart Extensions", followed by "Enable"
- open the Confluent sidebar again: the Resources view should still show a connected state, and the Topics view will now correctly show the "Select Kafka Cluster" button instead of the "Connect to Confluent Cloud" button

| v0.14.x ❌ | this branch ✅ |
|--------|--------|
| <img width="328" alt="image" src="https://github.com/user-attachments/assets/6bad0d88-1118-4981-8e52-47f87ae292af"> | <img width="328" alt="image" src="https://github.com/user-attachments/assets/15a75d1c-7b02-4080-b8a4-662ca5e76d6e"> | 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp bundle && code --install-extension ./out/*.vsix
  ```
