### PR TITLE
[v0.14.x] fix: clear out stored session bool when no connection exists

### DIFF
--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -126,6 +126,10 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       // react to the actual change in secret state).
       logger.debug("getSessions() session secret exists but no connection found, removing secret");
       await storageManager.deleteSecret(this.sessionKey);
+    } else if (!sessionSecretExists && connectionExists) {
+      // NOTE: this should never happen, because in order for the connection to be made with the
+      // sidecar, we should have also stored the secret, so we mainly just want to log this
+      logger.error("getSessions() no session secret found but connection exists");
     }
 
     // NOTE: if either of these two are true, it's due to a change in the auth state outside of the


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

If a user was logged in and closed VS Code, and the sidecar process exits (for any reason), we may still be showing a `"true"` value in secret storage indicating an authentication flow previously completed. When the extension activates the next time, a single workspace will be able to sign in correctly, but it will _**not**_ be able to broadcast that change in the form of a `secrets.onDidChange` event (because the value will be "changing" from `"true"` to `"true"`), which means other workspace windows will not correctly reflect the signed-in state.

Ways to click-test:
- sign in through the normal Accounts menu in one or more windows/workspaces
- exit VS Code and optionally kill the sidecar process (or wait long enough for it to exit on its own)
- (re)open multiple VS Code windows/workspaces
- sign in again and see all windows/workspaces should react to signing in

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
