### PR TITLE
[main] Fix Semaphore trigger conditions for updating notices (#37)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -114,7 +114,7 @@ blocks:
   - name: "Update third party notices PR"
     dependencies: ["Bump microversion"]
     run:
-      when: "branch =~ '.*' and change_in(['/package.json', '/NOTICE.txt', '/scripts/notices/NOTICE-vsix_PREAMBLE.txt'], {default_branch: 'main'})"
+      when: "branch =~ '.*' and change_in(['/package.json', '/NOTICE.txt', '/scripts/notices/NOTICE-vsix_PREAMBLE.txt'], {default_branch: 'main', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', pipeline_file: 'ignore'})"
     task:
       jobs:
         - name: "Update Third Party Notices PR"


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- `branch_range` which configures the range of commits that Semaphore looks for on non-default branches, the default behavior is to diff against `main`. Setting `branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE'` limits it to only the commit on which the pipeline was triggered.
- Set `pipeline_file: 'ignore'` to not trigger this block when the Semaphore pipeline file is updated. See [here](https://docs.semaphoreci.com/reference/conditions-reference/) for more context on the behavior of the `pipeline_file` parameter.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Cherry picked from v0.14.x branch
