### PR TITLE
Implement a cache of open webview panels, starting with for scaffold

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -7,7 +7,7 @@ import { Template, TemplateList, TemplatesApi } from "./clients/sidecar";
 import { Logger } from "./logging";
 import { getSidecar } from "./sidecar";
 
-import { ExtensionContext, Uri, ViewColumn, window } from "vscode";
+import { ExtensionContext, Uri, ViewColumn } from "vscode";
 import { registerCommandWithLogging } from "./commands";
 import { getTelemetryLogger } from "./telemetry";
 import { WebviewPanelCache } from "./webview-cache";
@@ -52,13 +52,8 @@ export const scaffoldProjectRequest = async (context: ExtensionContext) => {
     return;
   }
 
-  if (scaffoldWebviewCache.getWebviewPanel(pickedTemplate.spec.name)) {
-    // If preexisting webview is found, it will have been revealed().
-    // No need to open a new one.
-    return;
-  }
-
-  const optionsForm = window.createWebviewPanel(
+  const [optionsForm, wasExisting] = scaffoldWebviewCache.findOrCreate(
+    pickedTemplate.spec.name,
     "template-options-form",
     `Generate ${pickedTemplate.spec.display_name} Template`,
     ViewColumn.One,
@@ -67,7 +62,10 @@ export const scaffoldProjectRequest = async (context: ExtensionContext) => {
     },
   );
 
-  scaffoldWebviewCache.addWebviewPanel(pickedTemplate.spec.name, optionsForm);
+  if (wasExisting) {
+    optionsForm.reveal();
+    return;
+  }
 
   const staticRoot = Uri.joinPath(context.extensionUri, "webview");
 

--- a/src/webview-cache.ts
+++ b/src/webview-cache.ts
@@ -13,25 +13,38 @@ export class WebviewPanelCache {
   }
 
   /**
-   * Get a webview panel instance by its unique id. Returns undefined if the webview is not open.
-   * If is exists already, will reveal the webview prior to returning it, so it is brought to the
-   * users's attention in a pleasant manner.
+   * Find or create a webview panel with the given id. If a webview with this id exists, return it, else create a new one.
+   *
+   * @param id Unique identifier for the webview. If a webview with this id is already open, it will be returned.
+   * @param viewType createWebviewPanel() viewType parameter, if needing to create a new webview.
+   * @param title  createWebviewPanel() title parameter, if needing to create a new webview.
+   * @param viewColumn createWebviewPanel() viewColumn parameter, if needing to create a new webview.
+   * @param options createWebviewPanel() options parameter, if needing to create a new webview.
+   * @returns [vscode.WebviewPanel, boolean] The webview panel and a boolean indicating if it was already open.
    */
-  getWebviewPanel(id: string): vscode.WebviewPanel | undefined {
-    const webview = this.openWebviews.get(id);
-    if (webview) {
-      webview.reveal();
+  public findOrCreate(
+    id: string,
+    viewType: string,
+    title: string,
+    viewColumn: vscode.ViewColumn,
+    options: vscode.WebviewOptions,
+  ): [vscode.WebviewPanel, boolean] {
+    // If one cached already by this id, return it.
+    const existing = this.openWebviews.get(id);
+    if (existing) {
+      // existing.reveal();
+      return [existing, true];
     }
-    return webview;
-  }
 
-  /** Add a webview panel instance to the cache. */
-  addWebviewPanel(id: string, webview: vscode.WebviewPanel) {
+    // Create a new webview and add it to the cache.
+    const webview = vscode.window.createWebviewPanel(viewType, title, viewColumn, options);
     this.openWebviews.set(id, webview);
 
     // Remove the webview from this cache when it is disposed.
     webview.onDidDispose(() => {
       this.openWebviews.delete(id);
     });
+
+    return [webview, false];
   }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Implement a cache of webview panels, so that if user gestures to open same one again, we can find + reveal it instead of opening a redundant clone. Intent is to have one cache instance per each major kind of webview panel.

- Not wrapping message browser consumption with the cache at this time, in that now with filters it can be argued that having two separate message browsers over the same topic but with different filters and / or pagination state is meaningful, whereas two concurrent forms to instantiate a code template isn't.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Extracted subset from my long overdue configure topic feature work.

![webview-cache](https://github.com/user-attachments/assets/fb9b58de-21b8-45a6-8dca-84aec672c796)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
