### PR TITLE
MINOR: include `gulp check` in default VS Code task [ci skip]

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
     {
       "label": "gulp build",
       "type": "shell",
-      "command": "npx gulp build",
+      "command": "npx gulp --series check build",
       "group": {
         "kind": "build",
         "isDefault": true


### PR DESCRIPTION
Will help to catch issues that may not be raised by `gulp build` by default.

Examples with same underlying `src/` code:

`gulp build`
![image](https://github.com/user-attachments/assets/7695ba0c-7bf0-44c7-aa59-ef463e0391d3)

`gulp --series check build`
![image](https://github.com/user-attachments/assets/4f7042f4-ca74-4c93-8a56-4ebadedca8a3)
