### PR TITLE
uniqueId property on Topic + test

### DIFF
--- a/src/models/topic.test.ts
+++ b/src/models/topic.test.ts
@@ -13,6 +13,15 @@ describe("Test KafkaTopic methods", () => {
   it("CCLoud topics should not smell local", () => {
     assert.strictEqual(false, TEST_CCLOUD_KAFKA_TOPIC.isLocalTopic());
   });
+});
+
+describe("Test KafkaTopic properties", () => {
+  it("uniqueId should return a unique identifier for the topic", () => {
+    assert.strictEqual(
+      `${TEST_LOCAL_KAFKA_TOPIC.clusterId}-${TEST_LOCAL_KAFKA_TOPIC.name}`,
+      TEST_LOCAL_KAFKA_TOPIC.uniqueId,
+    );
+  });
 
   it("ccloudUrl should return the correct URL for ccloud-resident topics", () => {
     assert.strictEqual(

--- a/src/models/topic.ts
+++ b/src/models/topic.ts
@@ -5,23 +5,33 @@ import { CCLOUD_CONNECTION_ID, IconNames, LOCAL_CONNECTION_ID } from "../constan
 /** Main class representing Kafka topic */
 export class KafkaTopic extends Data {
   name!: Enforced<string>;
-  is_internal!: Enforced<boolean>;
   replication_factor!: Enforced<number>;
   partition_count!: Enforced<number>;
   partitions!: Enforced<object>;
   configs!: Enforced<object>;
+  /** Is this a topic internal to the cluster's operation
+   * ("__consumer_offsets", "__transaction_state", etc.)
+   * Most likely false.
+   */
+  is_internal!: Enforced<boolean>;
 
   clusterId!: Enforced<string>;
   /** CCloud env id. If null, implies a "local cluster" topic. */
   environmentId: string | null = null;
   hasSchema: boolean = false;
 
+  /** Property producing a URL for the topic in the Confluent Cloud UI */
   get ccloudUrl(): string {
     // Only ccloud topics have a ccloud URL.
     if (this.isLocalTopic()) {
       return "";
     }
     return `https://confluent.cloud/environments/${this.environmentId}/clusters/${this.clusterId}/topics/${this.name}/overview`;
+  }
+
+  /** Property producing a unique identifier for a topic based on both the cluster id and the topic name */
+  get uniqueId(): string {
+    return `${this.clusterId}-${this.name}`;
   }
 
   /** Is this a local cluster topic (if not, then is ccloud)? */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- New property `uniqueId` on dataclass Topic, to be used within the configure topic feature branch. Am pulling the extractable bits of out that branch so as to reduce ongoing conflict fodder in long-running branch.
- Document meaning of the `is_internal` data member.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
