### PR TITLE
fix: prevent Kafka topic deletion based on RBAC

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,8 @@
       {
         "command": "confluent.topics.delete",
         "title": "Delete Topic",
-        "category": "Confluent: Topics"
+        "category": "Confluent: Topics",
+        "enablement": "viewItem =~ /.*-delete.*/"
       },
       {
         "command": "confluent.topics.refresh",
@@ -243,6 +244,11 @@
           "type": "boolean",
           "default": false,
           "description": "Alert on sidecar process exceptions"
+        },
+        "confluent.ccloud.kafkaTopics.permissions.showWarnings": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show warnings when attempting to perform actions that require additional permissions"
         }
       }
     },

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,0 +1,10 @@
+import { workspace, WorkspaceConfiguration } from "vscode";
+import { Logger } from "./logging";
+
+const logger = new Logger("configs");
+
+export function getConfigs(): WorkspaceConfiguration {
+  const configs = workspace.getConfiguration("confluent");
+  logger.debug("configs", configs);
+  return configs;
+}

--- a/src/rbac/topics.ts
+++ b/src/rbac/topics.ts
@@ -1,0 +1,59 @@
+import { TopicV3Api } from "../clients/kafkaRest";
+import { Logger } from "../logging";
+import { KafkaTopic, KafkaTopicAuthorizedOperation } from "../models/topic";
+import { getSidecar } from "../sidecar";
+
+const logger = new Logger("rbac.topics");
+
+export async function addPermissionsToTopic(topic: KafkaTopic): Promise<KafkaTopic> {
+  if (topic.isLocalTopic()) {
+    return topic;
+  }
+
+  let updatedTopic: KafkaTopic = topic;
+  const sidecar = await getSidecar();
+  const client: TopicV3Api = sidecar.getTopicV3Api(topic.clusterId, topic.connectionId);
+  try {
+    const topicResp = await client.getKafkaTopic({
+      cluster_id: topic.clusterId,
+      topic_name: topic.name,
+      include_authorized_operations: true,
+    });
+    const permissions: KafkaTopicAuthorizedOperation[] = validatePermissions(
+      topicResp.authorized_operations ?? [],
+    );
+    updatedTopic = KafkaTopic.create({
+      ...topic,
+      authorizedOperations: permissions,
+    });
+  } catch (error) {
+    logger.error("Error checking topic permissions", error);
+  }
+  return updatedTopic;
+}
+
+/**
+ * Filter permissions to only include valid {@link KafkaTopicAuthorizedOperation} values.
+ */
+export function validatePermissions(permissions: string[]): KafkaTopicAuthorizedOperation[] {
+  if (permissions.length === 0) {
+    return [];
+  }
+  const validPermissions: KafkaTopicAuthorizedOperation[] = [];
+  const invalidPermissions: string[] = [];
+  for (const permission of permissions) {
+    if (
+      Object.values(KafkaTopicAuthorizedOperation).includes(
+        permission as KafkaTopicAuthorizedOperation,
+      )
+    ) {
+      validPermissions.push(permission as KafkaTopicAuthorizedOperation);
+    } else {
+      invalidPermissions.push(permission);
+    }
+  }
+  if (invalidPermissions.length > 0) {
+    logger.warn(`Invalid permissions found: ${invalidPermissions.join(", ")}`);
+  }
+  return validPermissions;
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

When loading the topics to populate the Topics view, we'll also try to fetch the `authorized_operations` string array to add to the `KafkaTopic` items before the tree data provider gets them.

RBAC-impacted commands/actions will then have one of two easy options (design/UX input pending):
- We can update the `contextValue` by appending RBAC-related action suffixes (e.g. `-delete`, `-alter_configs`, etc) and then set the command `enablement` value to match that suffix, which will gray out things the user can't do:
  <img width="454" alt="image" src="https://github.com/user-attachments/assets/b82e3199-fea1-4f05-8f13-2bd6d9379007">
   - Downside: we can't update the command/action tooltip (`title`) since it's hard-coded in package.json

- We can look up the property during any command logic and float an error notification with some sort of help to the user:
  <img width="947" alt="image" src="https://github.com/user-attachments/assets/0a893924-d18d-4ad2-989f-00c232a9650f">
    - Downside: we don't show the user whether there are access issues before they click the action

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
