### PR TITLE
[v0.14.x] fix Schema Registry cluster select

### DIFF
--- a/package.json
+++ b/package.json
@@ -423,7 +423,7 @@
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",
-          "when": "view == confluent-schemas && confluent.SchemaRegistrySelected",
+          "when": "view == confluent-schemas && confluent.schemaRegistrySelected",
           "group": "2_copy@1"
         },
         {

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -38,7 +38,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
         vscode.commands.executeCommand("setContext", "confluent.schemaRegistrySelected", false);
         this.treeView.description = "";
       } else {
-        vscode.commands.executeCommand("setContext", "confluent.SchemaRegistrySelected", true);
+        vscode.commands.executeCommand("setContext", "confluent.schemaRegistrySelected", true);
         this.schemaRegistry = schemaRegistry;
         const environment: CCloudEnvironment | null =
           await getResourceManager().getCCloudEnvironment(this.schemaRegistry.environmentId);


### PR DESCRIPTION
We had some old `contextValue` references to `confluentSchemaRegistrySelected` that weren't updated to use `confluent.schemaRegistrySelected`, so some of the cluster selection was not being updating properly and causing some misbehaving in the UI.

No more mentions of `confluentSchemaRegistrySelected` after this change. ✅ 