### PR TITLE
[v0.14.x] clear Topics & Schemas parent resources on org switch

### DIFF
--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -36,6 +36,8 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
     currentSchemaRegistryChanged.event(async (schemaRegistry: SchemaRegistryCluster | null) => {
       if (!schemaRegistry) {
         vscode.commands.executeCommand("setContext", "confluent.schemaRegistrySelected", false);
+        this.schemaRegistry = null;
+        this.ccloudEnvironment = null;
         this.treeView.description = "";
       } else {
         vscode.commands.executeCommand("setContext", "confluentSchemaRegistrySelected", true);

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -43,6 +43,8 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
     currentKafkaClusterChanged.event(async (cluster: KafkaCluster | null) => {
       if (!cluster) {
         vscode.commands.executeCommand("setContext", "confluent.kafkaClusterSelected", false);
+        this.kafkaCluster = null;
+        this.ccloudEnvironment = null;
         this.treeView.description = "";
       } else {
         vscode.commands.executeCommand("setContext", "confluent.kafkaClusterSelected", true);


### PR DESCRIPTION
Previously we were holding references to the parent CCloud environment and (Kafka/SR) cluster, which meant during the `refresh()` call ([Topics](https://github.com/confluentinc/vscode/blob/9dd546712d9d51ba9f3a09a1862e38bebaeec191/src/viewProviders/topics.ts#L65), [Schemas](https://github.com/confluentinc/vscode/blob/9dd546712d9d51ba9f3a09a1862e38bebaeec191/src/viewProviders/schemas.ts#L50)), the view provider would attempt making a request based on the old-organization's (or old connection's) resource.

Now, we clear those out when the `current*Changed` event fires with `null` so we effectively lose reference to the resources the old organization (or connection) used.