### PR TITLE
Update known limitations

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -62,6 +62,7 @@ Confluent Cloud.
 - Windows OS is not yet supported. None of the VSIX files can be installed into VS Code on Windows.
 - Uncaught Errors and Exceptions are anonymously reported to Sentry ignoring VSCode's telemetry settings. The setting will be respected in the near future.
 - Message Viewer is not able to correctly show messages with schemas in a Confluent Local Kafka cluster. This works when the topics are in Confluent Cloud.
+- Preview links for non-default organizations work only after switching to the non-default organization in the Confluent Cloud UI in your browser.
 
 ## Features
 


### PR DESCRIPTION
## Summary of Changes

This PR updates the [Known Limitations](https://github.com/confluentinc/vscode/blob/main/public/README.md#known-limitations) section of the public readme:

- Remove the known limitation regarding Safari because @alexeyraspopov has fixed the underlying bug.
- State that we are aware of preview links not working for non-default CCloud organizations.
