### PR TITLE
Make text search case-insensitive and resilient to whitespaces

### DIFF
--- a/src/stream/stream.ts
+++ b/src/stream/stream.ts
@@ -339,20 +339,20 @@ export class SkipList<Value> {
   }
 }
 
-export function includesSubstring(value: PartitionConsumeRecord, query: string): boolean {
+export function includesSubstring(value: PartitionConsumeRecord, query: RegExp): boolean {
   let key = value.key;
 
   if (typeof key === "string") {
-    if ((key as string).indexOf(query) >= 0) return true;
+    if (query.test(key as string)) return true;
   } else {
-    if (JSON.stringify(key, null, " ").indexOf(query) >= 0) return true;
+    if (query.test(JSON.stringify(key, null, " "))) return true;
   }
   let val = value.value;
 
   if (typeof val === "string") {
-    if ((val as string).indexOf(query) >= 0) return true;
+    if (query.test(val as string)) return true;
   } else {
-    if (JSON.stringify(val, null, " ").indexOf(query) >= 0) return true;
+    if (query.test(JSON.stringify(val, null, " "))) return true;
   }
 
   return false;

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -307,13 +307,13 @@
                   <td
                     class="grid-cell cell-text-overflow"
                     tabindex="-1"
-                    data-children="this.formatMessageValue(this.message().key, this.search())"
+                    data-children="this.formatMessageValue(this.message().key, this.searchRegexp())"
                     data-prop-title="this.message().key"
                   ></td>
                   <td
                     class="grid-cell cell-text-overflow"
                     tabindex="-1"
-                    data-children="this.formatMessageValue(this.message().value, this.search())"
+                    data-children="this.formatMessageValue(this.message().value, this.searchRegexp())"
                     data-prop-title="this.formatMessageValueFull(this.message())"
                   ></td>
                 </tr>


### PR DESCRIPTION
Initially I skipped the idea of using regular expressions for basic text search due to worries of regexes affecting the search performance significantly. Some testing I've done over the weekend showing that 1) we gonna spend a lot more time serializing objects back to string in order to perform search in the first place 2) regular expressions outperform `string.indexOf()` in many occasions, especially for large strings. Enabling case insensitive search while using `indexOf()` method also adds overhead of setting serialized key/value of a message to a uniform case.

In this PR I convert a search input into a regex, preliminary escaping the characters that have extra functionality when being inside regular expressions. The regex is marked with `i` flag to perform case insensitive search (so we don't need to lowercase serialized values). And now that we're in the regex land, I figured we can make the search a bit more flexible by making it disregard whitespaces either in message key/value or in the search query itself.

I will be adding automated tests later this week, after other features are complete and ready for click testing.

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/d3e8d5d7-c946-4a58-9816-59c345bba383">
