### PR TITLE
remove unnecessary request for CCloud connection in `watchCCloudConnectionStatus()`

### DIFF
--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { getSidecar } from ".";
-import { getAuthSession } from "../authProvider";
 import { AuthErrors, Connection, ConnectionsResourceApi, ResponseError } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../constants";
 import {
@@ -78,12 +77,6 @@ export async function createCCloudConnection(): Promise<Connection> {
 }
 
 export async function watchCCloudConnectionStatus(): Promise<void> {
-  const session: vscode.AuthenticationSession | undefined = await getAuthSession();
-  if (!session) {
-    // not logged in according to auth provider
-    return;
-  }
-
   const connection: Connection | null = await getCCloudConnection();
   if (!connection) {
     logger.warn("no connection found for current auth session");


### PR DESCRIPTION
Auth provider controls whether or not the polling is even happening, so we don't need to check before getting the sidecar connection response.

No more duplicate logs:
<img width="1930" alt="image" src="https://github.com/user-attachments/assets/5893707f-8c9f-4116-9856-942b75449500">
