### PR TITLE
hotfix: remove `.only` from test suite

### DIFF
--- a/src/authz/topics.test.ts
+++ b/src/authz/topics.test.ts
@@ -36,7 +36,7 @@ function createTestTopicData(
   };
 }
 
-describe.only("authz.topics", function () {
+describe("authz.topics", function () {
   let sandbox: sinon.SinonSandbox;
   let mockClient: sinon.SinonStubbedInstance<TopicV3Api>;
 


### PR DESCRIPTION
This slipped in during yesterday's https://github.com/confluentinc/vscode/pull/79 merge, need to remove it and run all the tests.