### PR TITLE
Message Viewer: avoid cyclic updates of histogram selection

### DIFF
--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -77,7 +77,8 @@ class MessageViewerViewModel extends ViewModel {
     return post("GetHistogram", { timestamp: this.timestamp() });
   }, null);
   selection = this.resolve(() => {
-    return post("GetSelection", { timestamp: this.timestamp() });
+    // get selection from the host when webview gets restored, otherwise use local state
+    return post("GetSelection", {});
   }, null);
   async updateHistogramFilter(timestamps: [number, number] | null) {
     await post("TimestampFilterChange", { timestamps });


### PR DESCRIPTION
The jitter behavior we've seen recently in click testing coming from the unidirectional data flow: user updates selection, selection propagated to the host, host updates filter and triggers ui update which then tries to pull selection state from the host again. This final part didn't play out well with throttling and user trying to keep moving the selection on certain pace.

In this PR I drop the dependency on host state updates. Meaning, the selection state is going to be local to the webview. It is still going to be saved in the host state, obviously for filtering purpose and whenever we need to restore webview state, the webview going to pull initial selection state from the host.
