### PR TITLE
Bump max_poll_records to 500

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -42,7 +42,7 @@ type MessageResponse<MessageType extends string> = Awaited<
   ReturnType<Extract<MessageSender, (type: MessageType, body: any) => any>>
 >;
 
-const DEFAULT_MAX_POLL_RECORDS = 250;
+const DEFAULT_MAX_POLL_RECORDS = 500;
 const DEFAULT_RECORDS_CAPACITY = 100_000;
 
 const DEFAULT_CONSUME_PARAMS = {


### PR DESCRIPTION
To make it faster to consume require total number of retained messages.

<img width="657" alt="image" src="https://github.com/user-attachments/assets/33a02d54-3481-424b-9cbb-0400c4691660">
