### PR TITLE
Have service-bot manage git pre-commit hooks

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -5,6 +5,8 @@ git:
   enable: true
 github:
   enable: true
+  hook:
+    enable: true
 codeowners:
   enable: true
 semaphore:


### PR DESCRIPTION
## Summary of Changes

Change the service-bot configuration to manage the pre-commit hooks automatically.

This does not change the application code.

