### PR TITLE
improve(CI): add other platform/arch agents 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,25 +32,61 @@ global_job_config:
         - make store-test-results-to-semaphore
 
 blocks:
-  - name: "Build & Test"
+  # --- Build & Test (multi-platform/-arch) ---
+  - name: "Build & Test (linux x64)"
     dependencies: []
     # Skip when:
     # - change in the release.svg file, signaling a `chore: none version bump vN.N.N` commit.
     # - change in the .versions/next.txt file, signaling a release PR merge commit.
-    skip:
+    skip: &build-test-skip
       when: "change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
-      jobs:
+      agent:
+        machine:
+          type: s1-prod-ubuntu20-04-amd64-1
+      jobs: &build-test-jobs
         - name: "Build & Test"
           commands:
             - make test
-      epilogue:
+      epilogue: &build-test-epilogue
         always:
           commands:
             - make remove-test-env
 
+  - name: "Build & Test (linux arm64)"
+    dependencies: []
+    skip: *build-test-skip
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu20-04-arm64-1
+      jobs: *build-test-jobs
+      epilogue: *build-test-epilogue
+  
+  - name: "Build & Test (darwin x64)"
+    dependencies: []
+    skip: *build-test-skip
+    task:
+      agent:
+        machine:
+          type: s1-prod-macos-13-5-amd64
+      jobs: *build-test-jobs
+      epilogue: *build-test-epilogue
+
+  - name: "Build & Test (darwin arm64)"
+    dependencies: []
+    skip: *build-test-skip
+    task:
+      agent:
+        machine:
+          type: s1-prod-macos-13-5-arm64
+      jobs: *build-test-jobs
+      epilogue: *build-test-epilogue
+
+  # --- End Build & Test (multi-platform/-arch) ---
+
   - name: "Bump microversion"
-    dependencies: ["Build & Test"]
+    dependencies: ["Build & Test (linux x64)", "Build & Test (linux arm64)", "Build & Test (darwin x64)", "Build & Test (darwin arm64)"]
     skip:
       # For main branch:    Always bump microversion on every commit (except those that bump next.txt
       #                       to set the next version under development)
@@ -68,7 +104,7 @@ blocks:
             - make bump-microversion
 
   - name: "Set next version under development"
-    dependencies: ["Build & Test"]
+    dependencies: ["Build & Test (linux x64)", "Build & Test (linux arm64)", "Build & Test (darwin x64)", "Build & Test (darwin arm64)"]
     run:
       when: "branch = 'main' and change_in('/.versions/next.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -70,6 +70,11 @@ blocks:
       agent:
         machine:
           type: s1-prod-macos-13-5-amd64
+      env_vars:
+        - name: "ELECTRON_ENABLE_LOGGING"
+          value: "true"
+        - name: "ELECTRON_ENABLE_STACK_DUMPING"
+          value: "true"
       jobs: *build-test-jobs
       epilogue: *build-test-epilogue
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
 SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)
 
 # Get the OS and architecture combination for the sidecar executable
-SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/')" )
+SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aaarch64/arm64/')" )
 
 IDE_SIDECAR_REPO := confluentinc/ide-sidecar
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ remove-test-env:
 test: setup-test-env install-dependencies
 	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb || true
 	npx gulp ci
-	export ELECTRON_ENABLE_LOGGING=true ;\
-  	export ELECTRON_ENABLE_STACK_DUMPING=true ;\
 	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || npx gulp test
 	npx gulp functional
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ remove-test-env:
 test: setup-test-env install-dependencies
 	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb || true
 	npx gulp ci
+	export ELECTRON_ENABLE_LOGGING=true ;\
+  	export ELECTRON_ENABLE_STACK_DUMPING=true ;\
 	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || npx gulp test
 	npx gulp functional
 

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ remove-test-env:
 # ref: https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions
 .PHONY: test
 test: setup-test-env install-dependencies
-	[[ $$(uname -s) == "Linux"]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb
+	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb
 	npx gulp ci
-	[[ $$(uname -s) == "Linux"]] && xvfb-run -a npx gulp test || npx gulp test
+	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || npx gulp test
 	npx gulp functional
 
 # Validates bump based on current version (in package.json)

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,13 @@ remove-test-env:
 	@echo "Removing .env file"
 	@rm -f .env
 
-# Install additional dependencies to run VSCode testing in headless mode
+# Install additional test dependencies to run VSCode testing in headless mode (on Linux)
 # ref: https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions
 .PHONY: test
 test: setup-test-env install-dependencies
-	sudo apt-get update
-	sudo apt install -y libgbm1 libgtk-3-0 xvfb
+	[[ $$(uname -s) == "Linux"]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb
 	npx gulp ci
-	xvfb-run -a npx gulp test
+	[[ $$(uname -s) == "Linux"]] && xvfb-run -a npx gulp test || npx gulp test
 	npx gulp functional
 
 # Validates bump based on current version (in package.json)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
 SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)
 
 # Get the OS and architecture combination for the sidecar executable
-SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aaarch64/arm64/')" )
+SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')" )
 
 IDE_SIDECAR_REPO := confluentinc/ide-sidecar
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ remove-test-env:
 test: setup-test-env install-dependencies
 	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb || true
 	npx gulp ci
-	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || npx gulp test
+	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || ELECTRON_RUN_AS_NODE=1 npx gulp test
 	npx gulp functional
 
 # Validates bump based on current version (in package.json)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ remove-test-env:
 test: setup-test-env install-dependencies
 	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb || true
 	npx gulp ci
-	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || ELECTRON_RUN_AS_NODE=1 npx gulp test
+	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || npx gulp test
 	npx gulp functional
 
 # Validates bump based on current version (in package.json)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ remove-test-env:
 # ref: https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions
 .PHONY: test
 test: setup-test-env install-dependencies
-	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb
+	[[ $$(uname -s) == "Linux" ]] && sudo apt-get update && sudo apt install -y libgbm1 libgtk-3-0 xvfb || true
 	npx gulp ci
 	[[ $$(uname -s) == "Linux" ]] && xvfb-run -a npx gulp test || npx gulp test
 	npx gulp functional

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -5,6 +5,7 @@ SEM_CACHE_DURATION_DAYS ?= 7
 current_time := $(shell date +"%s")
 # OS Name
 os_name := $(shell uname -s)
+os_name_and_arch := $(shell echo $$(uname -s)-$$(uname -m) | tr '[:upper:]' '[:lower:]')
 
 .PHONY: store-test-results-to-semaphore
 store-test-results-to-semaphore:
@@ -23,10 +24,10 @@ endif
 ci-bin-sem-cache-store:
 ifneq ($(SEMAPHORE_GIT_REF_TYPE),pull-request)
 	@echo "Storing semaphore caches"
-	$(MAKE) _ci-bin-sem-cache-store SEM_CACHE_KEY=$(os_name)_npm_cache SEM_CACHE_PATH=$(HOME)/.npm
+	$(MAKE) _ci-bin-sem-cache-store SEM_CACHE_KEY=$(os_name_and_arch)_npm_cache SEM_CACHE_PATH=$(HOME)/.npm
 # Cache packages installed by `npx playwright install`
-	[[ $(os_name) == "Darwin" ]] && $(MAKE) _ci-bin-sem-cache-store SEM_CACHE_KEY=$(os_name)_playwright_cache SEM_CACHE_PATH=$(HOME)/Library/Caches/ms-playwright || true
-	[[ $(os_name) == "Linux" ]] && $(MAKE) _ci-bin-sem-cache-store SEM_CACHE_KEY=$(os_name)_playwright_cache SEM_CACHE_PATH=$(HOME)/.cache/ms-playwright || true
+	[[ $(os_name) == "Darwin" ]] && $(MAKE) _ci-bin-sem-cache-store SEM_CACHE_KEY=$(os_name_and_arch)_playwright_cache SEM_CACHE_PATH=$(HOME)/Library/Caches/ms-playwright || true
+	[[ $(os_name) == "Linux" ]] && $(MAKE) _ci-bin-sem-cache-store SEM_CACHE_KEY=$(os_name_and_arch)_playwright_cache SEM_CACHE_PATH=$(HOME)/.cache/ms-playwright || true
 endif
 
 # cache restore allows fuzzy matching. When it finds multiple matches, it will select the most recent cache archive.
@@ -54,5 +55,5 @@ _ci-bin-sem-cache-store:
 .PHONY: ci-bin-sem-cache-restore
 ci-bin-sem-cache-restore:
 	@echo "Restoring semaphore caches"
-	cache restore $(os_name)_npm_cache
-	cache restore $(os_name)_playwright_cache || true
+	cache restore $(os_name_and_arch)_npm_cache
+	cache restore $(os_name_and_arch)_playwright_cache || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@types/tail": "^2.2.3",
         "@types/vscode": "^1.87.0",
         "@vscode/test-cli": "^0.0.6",
-        "@vscode/test-electron": "^2.3.9",
+        "@vscode/test-electron": "^2.4.1",
         "dotenv": "^16.4.5",
         "esbuild": "^0.21.4",
         "eslint": "^9.4.0",
@@ -3572,19 +3572,32 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.0.tgz",
-      "integrity": "sha512-yojuDFEjohx6Jb+x949JRNtSn6Wk2FAh4MldLE3ck9cfvCqzwxF32QsNy1T9Oe4oT+ZfFcg0uPUCajJzOmPlTA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
+      "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.4",
+        "https-proxy-agent": "^7.0.5",
         "jszip": "^3.10.1",
         "ora": "^7.0.1",
         "semver": "^7.6.2"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@vscode/webview-ui-toolkit": {

--- a/package.json
+++ b/package.json
@@ -688,7 +688,7 @@
     "@types/tail": "^2.2.3",
     "@types/vscode": "^1.87.0",
     "@vscode/test-cli": "^0.0.6",
-    "@vscode/test-electron": "^2.3.9",
+    "@vscode/test-electron": "^2.4.1",
     "dotenv": "^16.4.5",
     "esbuild": "^0.21.4",
     "eslint": "^9.4.0",


### PR DESCRIPTION
Breaks up our main `Build & Test` pipeline task into platform/arch specific tasks with different agents to allow testing extension activation (and the rest of the test suite) in more than just `linux amd64`.

Other Make-related updates for handling dependencies, caching, and pulling the sidecar executable.

Some related issues to the MacOS agent errors:
- https://github.com/search?q=org%3Amicrosoft+ClientCallsAuxiliary&type=issues