### PR TITLE
Move the pre-commit hooks config to the right section in `service.yml`

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -3,10 +3,10 @@ lang: node
 lang_version: 18.12.0
 git:
   enable: true
-github:
-  enable: true
   hook:
     enable: true
+github:
+  enable: true
 codeowners:
   enable: true
 semaphore:


### PR DESCRIPTION
#98 incorrectly placed the confirmation in the correct section. This fixes that.