### PR TITLE
security: bump `sinon` to `18.0.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollwright": "^0.0.6",
-        "sinon": "^18.0.0",
+        "sinon": "^18.0.1",
         "typescript": "^5.4.2",
         "typescript-eslint": "^8.0.0-alpha.28"
       },
@@ -10202,13 +10202,13 @@
       }
     },
     "node_modules/sinon": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
-      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/fake-timers": "11.2.2",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.2.0",
         "nise": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -705,7 +705,7 @@
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-esbuild": "^6.1.1",
     "rollwright": "^0.0.6",
-    "sinon": "^18.0.0",
+    "sinon": "^18.0.1",
     "typescript": "^5.4.2",
     "typescript-eslint": "^8.0.0-alpha.28"
   },


### PR DESCRIPTION
From dependabot:
```
sinon@18.0.0 requires path-to-regexp@^6.2.1 via nise@6.0.0
@openapitools/openapi-generator-cli@2.13.5 requires path-to-regexp@3.2.0 via @nestjs/core@10.3.0
No patched version available for path-to-regexp
```

[18.0.1](https://sinonjs.org/releases/changelog) Includes `path-to-regexp` bump for dependabot vulnerability.

`openapitools/openapi-generator-cli` still needs an update to address the issue: https://github.com/OpenAPITools/openapi-generator-cli/releases

