### PR TITLE
Fix markdown link

### DIFF
--- a/src/clients/sidecar-openapi-specs/README.md
+++ b/src/clients/sidecar-openapi-specs/README.md
@@ -23,4 +23,4 @@ said behavior. We carry the patches so that when we update the base document, we
 
 | OpenAPI Spec | Patch | Reason |
 | ------------ | ----- | ------ |
-| [ce-kafka-rest.openapi.yaml](./ce-kafka-rest.openapi.yaml) | [add_included_operations_to_list_topics_route.patch]](./add_included_operations_to_list_topics_route.patch) | Expose the `includeAuthorizedOperations` parameter for the list topics route |
+| [ce-kafka-rest.openapi.yaml](./ce-kafka-rest.openapi.yaml) | [add_included_operations_to_list_topics_route.patch](./add_included_operations_to_list_topics_route.patch) | Expose the `includeAuthorizedOperations` parameter for the list topics route |


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix markdown link formatting in the openapi docs readme. Too many ']'.

