### PR TITLE
[v0.15.x] cleanup: update walkthrough + output channel log references

### DIFF
--- a/package.json
+++ b/package.json
@@ -657,7 +657,7 @@
           {
             "id": "give-feedback",
             "title": "Provide Feedback",
-            "description": "The Confluent VS Code Extension is available for Early Access, and your feedback has a direct impact on the evolution of the product.\n[Give Feedback](https://forms.gle/V4aWAa1PWJRBtGgGA)",
+            "description": "The Confluent extension for VS Code is available for Early Access, and your feedback has a direct impact on the evolution of the product.\n[Give Feedback](https://forms.gle/V4aWAa1PWJRBtGgGA)",
             "media": {
               "markdown": "resources/walkthrough/feedback.md"
             },

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -396,7 +396,7 @@ export class SidecarManager {
     this.logTailer = new Tail(SIDECAR_LOGFILE_PATH);
 
     sidecarOutputChannel.appendLine(
-      `Tailing Confluent VS Code extension sidecar logs from "${SIDECAR_LOGFILE_PATH}" ...`,
+      `Tailing the extension's sidecar logs from "${SIDECAR_LOGFILE_PATH}" ...`,
     );
 
     // Take note of the start of exception lines in the log file, show as toast (if user has allowed via config)


### PR DESCRIPTION
Removing some more "Confluent VS Code Extension" uses.