### PR TITLE
[v0.15.x] hotfix: add `includeAuthorizedOperations` param back in for list topics

### DIFF
--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -132,6 +132,7 @@ export async function getTopicsForCluster(cluster: KafkaCluster): Promise<KafkaT
   try {
     topicsResp = await client.listKafkaTopics({
       cluster_id: cluster.id,
+      includeAuthorizedOperations: true,
     });
   } catch (error) {
     if (error instanceof ResponseError) {


### PR DESCRIPTION
Re-enables checking authz operations to get read/delete actions back