### PR TITLE
Report unique error messages that occurred during loading messages

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -125,7 +125,7 @@ function messageViewerStartPollingCommand(
   /** Most recent response payload from Consume API. */
   const latestResult = os.signal<SimpleConsumeMultiPartitionResponse | null>(null);
   /** Most recent failure info */
-  const latestError = os.signal<string[] | null>(null);
+  const latestError = os.signal<{ message: string } | null>(null);
   /** Timestamp of the most recent successful consumption request. */
   const latestFetch = os.signal<number>(0);
 
@@ -324,10 +324,11 @@ function messageViewerStartPollingCommand(
           flushMessages(stream);
           latestResult(result);
           latestFetch(Date.now());
+          latestError(null);
           notifyUI();
         });
       } catch (error) {
-        let reportable: any = null;
+        let reportable: { message: string } | null = null;
         let shouldPause = false;
         /* Async operations can be aborted by provided AbortController that is
         controlled by the watcher. Nothing to log in this case. */
@@ -338,15 +339,42 @@ function messageViewerStartPollingCommand(
           const payload = await error.response.json();
           // FIXME: this response error coming from the middleware that has to be present to avoid openapi error about missing middlewares
           if (!payload?.aborted) {
-            shouldPause = error.response.status >= 400 && error.response.status < 500;
-            reportable = JSON.stringify(payload);
+            const status = error.response.status;
+            shouldPause = status >= 400;
+            switch (status) {
+              case 401: {
+                reportable = { message: "Authentication required." };
+                break;
+              }
+              case 403: {
+                reportable = { message: "Insufficient permissions to read from topic." };
+                break;
+              }
+              case 404: {
+                if (String(payload?.title).startsWith("Error fetching the messages")) {
+                  reportable = { message: "Topic not found." };
+                } else {
+                  reportable = { message: "Unable to connect to the server." };
+                }
+                break;
+              }
+              case 429: {
+                reportable = { message: "Too many requests. Try again later." };
+                break;
+              }
+              default: {
+                reportable = { message: "Something went wrong." };
+                break;
+              }
+            }
             logger.error(
               `An error occurred during messages consumption. Status ${error.response.status}`,
             );
           }
         } else if (error instanceof Error) {
           logger.error(error.message);
-          reportable = error.message;
+          reportable = { message: "An internal error occurred." };
+          shouldPause = true;
         }
 
         os.batch(() => {
@@ -357,9 +385,7 @@ function messageViewerStartPollingCommand(
             timer((timer) => timer.pause());
           }
           if (reportable != null) {
-            latestError((errors) => {
-              return errors == null ? [reportable] : [reportable].concat(errors).slice(0, 10);
-            });
+            latestError(reportable);
           }
           notifyUI();
         });

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -136,9 +136,7 @@
 
                 <div popover id="errorLog" class="partition-control">
                   <div class="flex-column">
-                    <template data-for="error of this.streamError()">
-                      <p data-text="this.error()"></p>
-                    </template>
+                    <p data-text="this.streamError().message"></p>
                   </div>
                 </div>
               </div>
@@ -235,9 +233,18 @@
       </section>
 
       <section class="content">
-        <template data-if="this.waitingForMessages()">
+        <template data-if="this.waitingForMessages() && this.streamError() == null">
           <div class="grid-banner">
             <vscode-progress-ring></vscode-progress-ring>
+            <label>Waiting for messages…</label>
+          </div>
+        </template>
+
+        <template data-if="this.waitingForMessages() && this.streamError() != null">
+          <div class="grid-banner">
+            <span class="codicon codicon-error banner-error"></span>
+            <label>Failed to load messages.</label>
+            <label data-text="this.streamError().message"></label>
           </div>
         </template>
 
@@ -539,9 +546,15 @@
 
       .grid-banner {
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
         min-height: 10rem;
+        gap: 1rem;
+      }
+      .codicon.banner-error {
+        font-size: 28px;
+        color: var(--vscode-editorError-foreground);
       }
       .grid-settings-control {
         grid-column: -1;

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -598,7 +598,7 @@ class MessageViewerViewModel extends ViewModel {
 }
 
 export function post(type: "GetStreamState", body: { timestamp?: number }): Promise<StreamState>;
-export function post(type: "GetStreamError", body: object): Promise<string[] | null>;
+export function post(type: "GetStreamError", body: object): Promise<{ message: string } | null>;
 export function post(
   type: "GetStreamTimer",
   body: { timestamp?: number },


### PR DESCRIPTION
If the error happens during loading, it is placed into the "An error occurred" popover. If an error happens during loading spinner, it replaces the loading spinner. The user still able to retry by clicking Resume. 



<img width="918" alt="image" src="https://github.com/user-attachments/assets/15307e1f-0599-43de-a47b-5b024f4d9f3c">


Also loading spinner now has a message. Soon it will tell if the topic is empty.

<img width="362" alt="image" src="https://github.com/user-attachments/assets/829393cd-c9b5-40f9-90e5-170fe15c18f4">
