### PR TITLE
[0.15.x] fix: prevent view providers' creation before extension activation

### DIFF
--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -3,6 +3,7 @@ import { Connection } from "./clients/sidecar";
 import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID } from "./constants";
 import { getExtensionContext } from "./context";
 import { ccloudAuthSessionInvalidated, ccloudConnected } from "./emitters";
+import { ExtensionContextNotSetError } from "./errors";
 import { Logger } from "./logging";
 import { openExternal, pollCCloudConnectionAuth } from "./sidecar/authStatusPolling";
 import {
@@ -38,7 +39,8 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
   private constructor() {
     const context: vscode.ExtensionContext = getExtensionContext();
     if (!context) {
-      throw new Error("ExtensionContext not set yet");
+      // extension context required for keeping up with secrets changes
+      throw new ExtensionContextNotSetError("ConfluentCloudAuthProvider");
     }
 
     const resourceManager = getResourceManager();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,6 @@
+/** Thrown when attempting to get the ExtensionContext before extension activation. */
+export class ExtensionContextNotSetError extends Error {
+  constructor(source: string, message: string = "ExtensionContext not set yet") {
+    super(`${source}: ${message}`);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ import { getUriHandler } from "./uriHandler";
 import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SupportViewProvider } from "./viewProviders/support";
-import { getTopicViewProvider } from "./viewProviders/topics";
+import { TopicViewProvider } from "./viewProviders/topics";
 
 const logger = new Logger("extension");
 
@@ -203,7 +203,7 @@ async function setupContextValues() {
 async function setupStorage(context: vscode.ExtensionContext): Promise<vscode.ExtensionContext> {
   // initialize singleton storage manager instance so other parts of the extension can access the
   // globalState, workspaceState, and secrets without needing to pass the extension context around
-  const manager = StorageManager.getOrCreateInstance();
+  const manager = StorageManager.getInstance();
   // Handle any storage migrations that need to happen before the extension can proceed.
   await migrateStorageIfNeeded(manager);
   logger.info("Storage manager initialized and migrations completed");
@@ -246,7 +246,7 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
   logger.info("Creating view providers...");
 
   try {
-    const resourceViewProvider = new ResourceViewProvider();
+    const resourceViewProvider = ResourceViewProvider.getInstance();
     context.subscriptions.push(
       registerCommandWithLogging("confluent.resources.refresh", () => {
         resourceViewProvider.refresh();
@@ -258,7 +258,7 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
   }
 
   try {
-    const topicViewProvider = getTopicViewProvider();
+    const topicViewProvider = TopicViewProvider.getInstance();
     context.subscriptions.push(
       registerCommandWithLogging("confluent.topics.refresh", () => {
         topicViewProvider.refresh();
@@ -270,7 +270,7 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
   }
 
   try {
-    const schemasViewProvider = new SchemasViewProvider();
+    const schemasViewProvider = SchemasViewProvider.getInstance();
     context.subscriptions.push(
       registerCommandWithLogging("confluent.schemas.refresh", () => {
         schemasViewProvider.refresh();

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,23 +1,24 @@
 import * as vscode from "vscode";
 import { getExtensionContext } from "../context";
+import { ExtensionContextNotSetError } from "../errors";
 
 export class StorageManager {
-  private static instance: StorageManager;
   private globalState: vscode.Memento;
   private workspaceState: vscode.Memento;
   private secrets: vscode.SecretStorage;
 
-  constructor() {
+  private static instance: StorageManager | null = null;
+  private constructor() {
     const context = getExtensionContext();
     if (!context) {
-      throw new Error("ExtensionContext not set yet");
+      throw new ExtensionContextNotSetError("StorageManager");
     }
     this.globalState = context.globalState;
     this.workspaceState = context.workspaceState;
     this.secrets = context.secrets;
   }
 
-  static getOrCreateInstance(): StorageManager {
+  static getInstance(): StorageManager {
     if (!StorageManager.instance) {
       StorageManager.instance = new StorageManager();
     }
@@ -83,5 +84,5 @@ export class StorageManager {
 
 export function getStorageManager(): StorageManager {
   // should only be called after extension activation and context is set
-  return StorageManager.getOrCreateInstance();
+  return StorageManager.getInstance();
 }

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -38,13 +38,13 @@ export type CCloudSchemaBySchemaRegistryCluster = Map<string, Schema[]>;
  * Singleton helper for interacting with Confluent-/Kafka-specific global/workspace state items and secrets.
  */
 export class ResourceManager {
-  private static instance: ResourceManager;
-
+  static instance: ResourceManager | null = null;
   private constructor(private storage: StorageManager) {}
 
-  static getInstance(storageManager: StorageManager): ResourceManager {
+  static getInstance(): ResourceManager {
     if (!ResourceManager.instance) {
-      ResourceManager.instance = new ResourceManager(storageManager);
+      // will throw an ExtensionContextNotSetError if the context isn't available for StorageManager
+      ResourceManager.instance = new ResourceManager(getStorageManager());
     }
     return ResourceManager.instance;
   }
@@ -599,9 +599,5 @@ export class ResourceManager {
  * @returns The ResourceManager singleton instance
  */
 export function getResourceManager(): ResourceManager {
-  const manager = getStorageManager();
-  if (!manager) {
-    throw new Error("Can't get ResourceManager until StorageManager is initialized");
-  }
-  return ResourceManager.getInstance(manager);
+  return ResourceManager.getInstance();
 }

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -1,7 +1,9 @@
 import * as vscode from "vscode";
 import { toKafkaTopicOperations } from "../authz/types";
 import { ResponseError, TopicDataList, TopicV3Api } from "../clients/kafkaRest";
+import { getExtensionContext } from "../context";
 import { ccloudConnected, currentKafkaClusterChanged } from "../emitters";
+import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
@@ -36,7 +38,12 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
   /** The focused Kafka cluster; set by clicking a Kafka cluster item in the Resources view. */
   public kafkaCluster: KafkaCluster | null = null;
 
-  constructor() {
+  private static instance: TopicViewProvider | null = null;
+  private constructor() {
+    if (!getExtensionContext()) {
+      // getChildren() will fail without the extension context
+      throw new ExtensionContextNotSetError("TopicViewProvider");
+    }
     // instead of calling `.registerTreeDataProvider`, we're creating a TreeView to dynamically
     // update the tree view as needed (e.g. displaying the current Kafka cluster name in the title)
     this.treeView = vscode.window.createTreeView("confluent-topics", { treeDataProvider: this });
@@ -71,6 +78,13 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
         this.refresh();
       }
     });
+  }
+
+  static getInstance(): TopicViewProvider {
+    if (!TopicViewProvider.instance) {
+      TopicViewProvider.instance = new TopicViewProvider();
+    }
+    return TopicViewProvider.instance;
   }
 
   /** Convenience method to revert this view to its original state. */
@@ -118,10 +132,9 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
   }
 }
 
-var topicViewProvider = new TopicViewProvider();
 /** Get the singleton instance of the {@link TopicViewProvider} */
 export function getTopicViewProvider() {
-  return topicViewProvider;
+  return TopicViewProvider.getInstance();
 }
 
 export async function getTopicsForCluster(cluster: KafkaCluster): Promise<KafkaTopic[]> {

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -50,5 +50,5 @@ export async function getExtensionContext(
 export async function getTestStorageManager(): Promise<StorageManager> {
   // the extension needs to be activated before we can use the StorageManager
   await getExtensionContext();
-  return StorageManager.getOrCreateInstance();
+  return StorageManager.getInstance();
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes https://github.com/confluentinc/vscode/issues/172

Adds a test for the new ExtensionContextNotSetError over the singletons that require it, since testing for the instance properties was giving very strange results and starting turning more into a mocking exercise.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
