### PR TITLE
Fix ignore list in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
   },
   {
     files: ["src/**/*.ts", "src/**/*.mts"],
-    ignores: ["src/kafkaRestClient/**", "src/schemaRegistryRestClient/**", "src/sidecarClient/**"],
+    ignores: ["src/clients/**"],
     plugins: { "@typescript-eslint": ts },
     rules: {
       ...js.configs.recommended.rules,


### PR DESCRIPTION
We didn't update these paths after consolidating clients into a single folder.
