### PR TITLE
Upgrade inertial to 0.4.1; use abortsignal if possible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "vscode-confluent",
       "version": "0.16.0-15",
-      "license": "https://www.confluent.io/software-evaluation-license/",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@segment/analytics-node": "^2.1.2",
         "@sentry/node": "^8.17.0",
@@ -19,7 +19,7 @@
         "dataclass": "^3.0.0-beta.1",
         "gql.tada": "^1.8.3",
         "graphql": "^16.8.2",
-        "inertial": "^0.2.2",
+        "inertial": "^0.4.1",
         "tail": "^2.2.6",
         "unzipit": "^1.4.3"
       },
@@ -6801,9 +6801,9 @@
       }
     },
     "node_modules/inertial": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/inertial/-/inertial-0.2.2.tgz",
-      "integrity": "sha512-mB8luV19CPPZegnXrrr7f8YCp8gO+kNw2tX2Dab+P13CVsihGsEQboTxy8gXp66f5gkl4D2GjHnV7b6RMUTCZg=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/inertial/-/inertial-0.4.1.tgz",
+      "integrity": "sha512-o99R5Tux9KumQja0fUHIGpZV1z40mam+9jZDUnJirdkWurKRcB/RNEfnpxwgrUczk2eJIyx9REASPq5Nkdslfw=="
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -733,7 +733,7 @@
     "dataclass": "^3.0.0-beta.1",
     "gql.tada": "^1.8.3",
     "graphql": "^16.8.2",
-    "inertial": "^0.2.2",
+    "inertial": "^0.4.1",
     "tail": "^2.2.6",
     "unzipit": "^1.4.3"
   }

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -48,16 +48,12 @@ type ConsumeMode = "latest" | "beginning" | "timestamp";
  */
 class MessageViewerViewModel extends ViewModel {
   /** This timestamp updates everytime the host environment wants UI to update. */
-  timestamp = this.observe(
-    () => Date.now(),
-    (cb) => {
-      function handle(event: MessageEvent<any[]>) {
-        if (event.data[0] === "Timestamp") cb();
-      }
-      addEventListener("message", handle);
-      return () => removeEventListener("message", handle);
-    },
-  );
+  timestamp = this.produce(Date.now(), (ts, signal) => {
+    function handle(event: MessageEvent<any[]>) {
+      if (event.data[0] === "Timestamp") ts(Date.now());
+    }
+    addEventListener("message", handle, { signal });
+  });
 
   page = this.signal(storage.get()?.page ?? 0);
   pageSize = this.signal(100);

--- a/src/webview/scaffold-form.spec.ts
+++ b/src/webview/scaffold-form.spec.ts
@@ -43,7 +43,7 @@ test.use({
   ],
 });
 
-test.only("dummy form submission", async ({ execute, page }) => {
+test("dummy form submission", async ({ execute, page }) => {
   const sendWebviewMessage = await execute(async () => {
     const { sendWebviewMessage } = await import("./comms/comms");
     return sendWebviewMessage as SinonStub;

--- a/src/webview/timer/timer.ts
+++ b/src/webview/timer/timer.ts
@@ -6,9 +6,9 @@ const SECOND = 1000;
 
 export class Timer extends HTMLElement {
   os = ObservableScope();
-  now = this.os.observe(Date.now, (cb) => {
-    let timer = setInterval(cb, SECOND / TIMER_REFRESH_RATE);
-    return () => clearInterval(timer);
+  now = this.os.produce(Date.now(), (ts, signal) => {
+    let timer = setInterval(() => ts(Date.now()), SECOND / TIMER_REFRESH_RATE);
+    signal.onabort = () => clearInterval(timer);
   });
   timer = this.os.signal<{ start: number; offset: number } | null>(null, (a, b) => {
     return a == null || b == null ? a === b : a.start === b.start && a.offset === b.offset;


### PR DESCRIPTION
I've done some upgrades in [`inertial`](https://github.com/UnknownPrinciple/inertial) over the weekend, upgrading our code with the latest version.

The only breaking changes in the latest version is switch from cleanup callback to AbortSignal provided to `watch()` function. I often had to create an abort signal manually and control it via cleanup callback like this:

```js
os.watch(() => {
  const ctl = new AbortController();

  doAsyncStuff(ctl.signal);
  doAnotherAsyncThing(ctl.signal);

  return () => ctl.abort();
});
```

Which is now simplified to:

```js
os.watch((signal) => {
  doAsyncStuff(signal);
  doAnotherAsyncThing(signal);
})
```

Network requests support signal directly: `fetch(url, { signal })`, same goes to event listeners: `target.addEventListener("event", handler, { signal })`. If the old pattern still needed, it can be described as:

```diff
-os.watch(() => {
+os.watch((signal) => {
  // ...
-  return () => {/* cleanup */}
+  signal.onabort = () => {/* cleanup */}
});
```

Watchers and derivatives now track dependencies dynamically (ie on each update). This means you can introduce dependencies in conditional branches, when they make sense. In following example, the watcher not going to do unnecessary logs when `count` updates while `enabled` set to `false`.

```js
const enabled = os.signal(false);
const count = os.signal(0);

os.watch(() => {
  if (enabled()) {
    console.log(`The count is ${count()}.`);
  } else {
    console.log("Nothing to see here!");
  }
});
```

Another notable change is the new `produce()` verb. It's going to replace `observe()` and provide more flexibility for async producers:

```js
produce(/* initial value */ navigator.onLine, (value, signal) => {
  // value is a function that you push new values to
  const update = () => value(navigator.onLine);
  window.addEventListener("offline", update, { signal });
});
```

Unlike `observe()`, `produce()` can also track dependencies inside producer function:

```js
const enabled = signal(true);
const size = produce(/* initial value */ 0, (value, signal) => {
  // only track document width if flat enabled set to true
  if (enabled()) {
    window.addEventListener("resize", () => value(document.body.offsetWidth), { signal });
  }
});
```
