### PR TITLE
Use workspace cache for topic list. (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Rely on the resource manager / workspace storage cache for topics within a cluster. Selecting a kafka cluster will consult this cache before opting to deep-fetch from sidecar (and then it cascading through to CCloud or local kafka rest). The 'refresh' button in the topics view title bar can be used to force a deep fetch. Creating or deleting a topic will also result in a deep fetch.
+
 ## 0.15.2
 
 ### Fixed

--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -124,10 +124,10 @@ async function deleteTopicCommand(topic: KafkaTopic) {
         // Another 1/3 way done now.
         progress.report({ increment: 33 });
 
-        // explicitly refresh the topics view after deleting a topic, so that repainting
+        // explicitly deep refresh the topics view after deleting a topic, so that repainting
         // ommitting the newly deleted topic is a foreground task we block on before
         // closing the progress window.
-        getTopicViewProvider().refresh();
+        getTopicViewProvider().refresh(true);
       } catch (error) {
         const errorMessage = `Failed to delete topic: ${error}`;
         logger.error(errorMessage);
@@ -212,7 +212,9 @@ async function createTopicCommand(item?: KafkaCluster) {
 
         // Refresh in the foreground after creating a topic, so that the new topic is visible
         // immediately after the progress window closes.
-        getTopicViewProvider().refresh();
+
+        // @param true to force a deep fetch of the topics list, observing the newly created
+        getTopicViewProvider().refresh(true);
       } catch (error) {
         if (!(error instanceof ResponseError)) {
           // generic error handling

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,7 +261,8 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
     const topicViewProvider = TopicViewProvider.getInstance();
     context.subscriptions.push(
       registerCommandWithLogging("confluent.topics.refresh", () => {
-        topicViewProvider.refresh();
+        // Force a deep refresh from sidecar.
+        topicViewProvider.refresh(true);
       }),
     );
     logger.info("Topics view provider created");


### PR DESCRIPTION
- Rely on the resource manager / workspace storage cache for topics within a cluster. Selecting a kafka cluster will consult this cache before opting to deep-fetch from sidecar (and then it cascading through to CCloud or local kafka rest). The 'refresh' button in the topics view title bar can be used to force a deep fetch. Creating or deleting a topic will also result in a deep fetch (and write into the cache).
- Did so through integrating the local vs ccloud variant ResourceManager topics methods, making two new topics-related methods:
  - `setTopicsForCluster(cluster, topics[])`: Determines the right storage manager key to use to fetch either the ccloud or local map from storage, sets (new or overwrite) entry within that map given the cluster id, then writes back to the storage manager. Can now cache knowledge that cluster X has zero topics, something impossible in the old API.
  - `getTopicsForCluster(cluster)`:  Determines the right storage manager key to use to fetch either the ccloud or local map from storage, looks up the value for the cluster id, returns either undefined if nothing was found cached, or returns the result of promoting the vanilla json list entries up to our KafkaTopic dataclass instances. Return values differentiate between 'we do not know' (`undefined`) vs 'known empty list of topics' (`[]`) vs nonempty list of topics.
- This adjusts the strategy used in `src/viewProviders/topics.ts::getTopicsForCluster()` to look like general "consult cache and use its results or do a deep fetch (and store into cache) upon cache miss."
- Supporting user-forced deep reads via the 'refresh' button (as well as forcing deep reads after either creating or deleting a topic) is a little awkward due to the indirectness of being driven by event emitter firing. Now have a data member boolean `forceDeepRefresh` in class `TopicViewProvider` to remember if a deep refresh is being requested.  
- Got rid of unused methods in ResourceManager.
- Prior to this we were writing into the cluster topics caches, but never reading from.
- https://github.com/confluentinc/vscode/issues/120

- Clicktesting video ...
![clicktest](https://github.com/user-attachments/assets/879724ee-36f3-4e74-b415-2b2524d013f2)
