### PR TITLE
Use curl to download sidecar to avoid dependency on gh cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,19 @@ download-sidecar-executable:
 ifeq ($(SKIP_DOWNLOAD_EXECUTABLE),true)
 	@echo "Skipping download of sidecar executable since it already exists at $(EXECUTABLE_DOWNLOAD_PATH)"
 else
+ifeq ($(CI),true)
 	mkdir -p bin && \
 	export EXECUTABLE_PATH=ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH) && \
-    gh release download $(IDE_SIDECAR_VERSION) --repo $(IDE_SIDECAR_REPO) --pattern=$${EXECUTABLE_PATH} --output $(EXECUTABLE_DOWNLOAD_PATH) --clobber && \
-    chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
-    echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH)"
+		gh release download $(IDE_SIDECAR_VERSION) --repo $(IDE_SIDECAR_REPO) --pattern=$${EXECUTABLE_PATH} --output $(EXECUTABLE_DOWNLOAD_PATH) --clobber && \
+		chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
+		echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH)"
+else
+	mkdir -p bin && \
+	export EXECUTABLE_PATH=ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH) && \
+		curl -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
+		chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
+		echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH)"
+endif
 endif
 
 VSIX_MULTIARCH_ARCHIVE_FILENAME := confluent-vscode-extension-multiarch-$(LATEST_VERSION_NO_V).zip


### PR DESCRIPTION
A direct link to the assets can be constructed to download publicly available files without the need to install GH cli and authorize.
