### PR TITLE
Never try to kill pid zero even if sidecar asks for it

### DIFF
--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -133,7 +133,6 @@ export class SidecarManager {
             logger.info(`${logPrefix}:  Wrong access token, restarting sidecar`);
             // Kill the process, pause an iota, restart it, then try again.
             try {
-              // TODO: How to do this on Windows also?
               this.killSidecar(e.sidecar_process_id);
             } catch (e: any) {
               logger.error(

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -236,10 +236,20 @@ export class SidecarManager {
         const sidecar_pid = response.headers.get(SIDECAR_PROCESS_ID_HEADER);
         if (sidecar_pid) {
           const sidecar_pid_int = parseInt(sidecar_pid);
-          throw new WrongAuthSecretError(
-            `GET ${SIDECAR_BASE_URL}/gateway/v1/health/live returned 401.`,
-            sidecar_pid_int,
-          );
+          if (sidecar_pid_int > 0) {
+            // Have enough trustworthy info to throw a specific error that will cause
+            // us to kill the sidecar process and start a new one.
+            throw new WrongAuthSecretError(
+              `GET ${SIDECAR_BASE_URL}/gateway/v1/health/live returned 401.`,
+              sidecar_pid_int,
+            );
+          } else {
+            // sidecar quarkus dev mode may skip initialization and still return 401 and this header, but
+            // with PID 0, which we will never want to try to kill -- kills whole process group!
+            throw new Error(
+              `GET ${SIDECAR_BASE_URL}/gateway/v1/health/live returned 401, but claimed PID ${sidecar_pid_int} in the response headers!`,
+            );
+          }
         } else {
           throw new Error(
             `GET ${SIDECAR_BASE_URL}/gateway/v1/health/live returned 401, but without a PID in the response headers!`,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- If an extension dev happens to be manually running the sidecar in 'dev' mode, it won't have done its full initialization and may return 401 from the health check route, but claiming to be PID 0 in the response headers. `kill(0)` is 'special' and asks the kernel to kill then entire `process group', which then unfortunately essentially logs you out.
- Guard against that by noticing if <= 0, then not raising the exception that will lead us to try to `kill()`.

The only way we could reproduce this codepath is if the sidecar port was being used by a web server that knew our routes, responded 401 to the healthcheck route but also with claiming to be pid 0. This would only happen if the user has startup up the sidecar from source code in `quarkus dev` mode, where it runs with a profile that has it skip some parts of initialization, namely snapshotting its pid into a variable.

Having non-web servers or random web servers on the sidecar port would not go down this path.
