### PR TITLE
chore: Use `Confluent for VS Code` when referencing the VS Code extension

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
 name: 'Report a bug'
-description: Report a bug with the Confluent extension for VS Code.
+description: Report a bug with Confluent for VS Code.
 labels:
   - 'bug'
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to tell us about your issue using the Confluent extension for VS Code!
+        Thanks for taking the time to tell us about your issue using Confluent for VS Code!
 
         Requests for features and improvements to the extension or documentation should be opened in [discussions](https://github.com/confluentinc/vscode/discussions/new?category=ideas). For more information about opening a feature request, [read more](https://github.com/confluentinc/vscode/blob/main/CONTRIBUTING.md).
 
@@ -42,7 +42,7 @@ body:
     id: contact
     attributes:
       label: Version of Confluent extension
-      description: What version of Confluent extension for VS Code did you use?
+      description: What version of Confluent for VS Code did you use?
       placeholder: ex. v0.10.0
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -1,5 +1,5 @@
 name: 'Report a documentation issue'
-description: Report an issue with the Confluent extension for VS Code documentation.
+description: Report an issue with the Confluent for VS Code documentation.
 title: 'Docs: '
 labels:
   - 'docs'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
-# Welcome to the Confluent extension for VS Code contributing guide
+# Welcome to the Confluent for VS Code contributing guide
 
 Thanks for your interest in contributing to this project! Our goal for the
-[Confluent extension for VS Code project](https://github.com/confluentinc/vscode) is to help make it
+[Confluent for VS Code project](https://github.com/confluentinc/vscode) is to help make it
 very easy for developers to build stream processing applications using Confluent.
 
 Anyone can contribute, and here are some ways to do so:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Confluent, and read the docs at the [Confluent documentation](https://docs.confl
 
 ## Features
 
-The Confluent extension for VS Code provides a number of features for working with your Kafka
+Confluent for VS Code provides a number of features for working with your Kafka
 clusters, topics and schemas.
 
 ### Command Palette
@@ -31,7 +31,7 @@ In the Sidebar, click the Confluent logo to open the extension and show the foll
 
 #### Connect to your streams
 
-The Confluent extension for VS Code supports accessing your Apache Kafka® clusters locally or on
+Confluent for VS Code supports accessing your Apache Kafka® clusters locally or on
 Confluent Cloud.
 
 - To start a local Kafka cluster,
@@ -116,7 +116,7 @@ Currently, Windows is not supported, but you can use Windows Subsystem for Linux
 [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) with one of the above Linux .vsix
 files.
 
-> The Confluent extension for VS Code is available for Early Access, and some Confluent features may
+> Confluent for VS Code is available for Early Access, and some Confluent features may
 > not be available. Consider installing the
 > [Confluent CLI](https://docs.confluent.io/confluent-cli/current/overview.html) to access all
 > features of Confluent Cloud.

--- a/package.json
+++ b/package.json
@@ -670,7 +670,7 @@
           {
             "id": "give-feedback",
             "title": "Provide Feedback",
-            "description": "The Confluent extension for VS Code is available for Early Access, and your feedback has a direct impact on the evolution of the product.\n[Give Feedback](https://forms.gle/V4aWAa1PWJRBtGgGA)",
+            "description": "Confluent for VS Code is available for Early Access, and your feedback has a direct impact on the evolution of the product.\n[Give Feedback](https://forms.gle/V4aWAa1PWJRBtGgGA)",
             "media": {
               "markdown": "resources/walkthrough/feedback.md"
             },

--- a/src/sidecar/checkArchitecture.ts
+++ b/src/sidecar/checkArchitecture.ts
@@ -12,7 +12,7 @@ export function checkSidecarOsAndArch(sidecarPath: string): void {
 
   if (!ourBuild.equals(sidecarBuild)) {
     throw new Error(
-      `This Confluent extension for VS Code component is built for a different platform (${sidecarBuild}), whereas your VS Code is on ${ourBuild}. Please uninstall the Confluent extension for VS Code and install the ${ourBuild} build.`,
+      `This Confluent for VS Code component is built for a different platform (${sidecarBuild}), whereas your VS Code is on ${ourBuild}. Please uninstall the Confluent extension for VS Code and install the ${ourBuild} build.`,
     );
   }
 }


### PR DESCRIPTION
## Summary of Changes

This PR makes sure that we use `Confluent for VS Code` when referencing the VS Code extension.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
