### PR TITLE
Make message viewer available via command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this extension will be documented in this file.
 ### Added
 
 - Add Windows x64 support
+- Message Viewer can be opened directly through the command palette.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -206,9 +206,8 @@
       {
         "command": "confluent.topic.consume",
         "icon": "$(debug-start)",
-        "title": "Open message viewer",
-        "category": "Confluent: Topic",
-        "enablement": "view == confluent-topics"
+        "title": "Browse Messages",
+        "category": "Confluent: Topic"
       },
       {
         "command": "confluent.topics.create",

--- a/src/quickpicks/topics.ts
+++ b/src/quickpicks/topics.ts
@@ -1,0 +1,43 @@
+import { ProgressOptions, ThemeColor, ThemeIcon, window } from "vscode";
+import { KafkaTopic } from "../models/topic";
+import { getSchemasForTopicEnv, getTopicsForCluster } from "../viewProviders/topics";
+import { KafkaCluster } from "../models/kafkaCluster";
+import { IconNames } from "../constants";
+
+export async function topicQuickPick(cluster: KafkaCluster): Promise<KafkaTopic | undefined> {
+  const options: ProgressOptions = {
+    location: { viewId: "confluent-topics" },
+    title: "Loading topics...",
+  };
+  return window.withProgress(options, async () => {
+    const topics: KafkaTopic[] = await getTopicsForCluster(cluster, true);
+    if (topics.length == 0) {
+      window.showInformationMessage("No topics found in the cluster " + cluster.name);
+      return;
+    }
+
+    const schemas = await getSchemasForTopicEnv(topics[0]);
+    const subjectSet = new Set(
+      schemas.map((schema) => schema.subject.replace(/-key$|-value$/, "")),
+    );
+
+    const choices = topics.map((topic) => ({
+      label: topic.name,
+      iconPath: subjectSet.has(topic.name)
+        ? new ThemeIcon(IconNames.TOPIC)
+        : new ThemeIcon(
+            IconNames.TOPIC_WITHOUT_SCHEMA,
+            new ThemeColor("problemsWarningIcon.foreground"),
+          ),
+      // reference the topic entity so we can acquire it from the picked object
+      topic,
+    }));
+
+    const choice = await window.showQuickPick(choices, {
+      placeHolder: "Select a topic",
+      ignoreFocusOut: true,
+    });
+
+    return choice?.topic;
+  });
+}


### PR DESCRIPTION
For a while now the message viewer was only available via tree item action, mainly because it was bound to the context of a topic entity. In the spirit of vscode-like editors, any kind of repetitive work should be possible to be done via keyboard. Enabling message viewer via command palette means the user doesn't need to get out of their current context, look for the extension in the sidebar or wherever they left topics panel at. In this PR I add a condition to the consume command that uses quick picks for cluster/topic in case if topic entity is not present (which happens if command is used via the command palette, instead of a tree item action).

If a cluster doesn't have any topics, an info message appears on the screen. I'm not quite sure yet what to do if the command is used by unauthorized user.

EDIT: this part should cover unauthorized case https://github.com/confluentinc/vscode/blob/8548f963f715071c81c502418c2da1e6c828e33d/src/quickpicks/kafkaClusters.ts#L60

https://github.com/user-attachments/assets/7b706088-11db-4a73-ba45-5c07746fa455

Closes #168 