### PR TITLE
[0.16.x] fix: set `confluent.ccloudConnectionAvailable` during Resources view loading to correct Topic & Schemas view states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Opening a new window/workspace after connecting to CCloud will now show the correct states in the
+  Topics & Schemas views instead of the "Connect to Confluent Cloud" button
+
 ## 0.16.0
 
 ### Added
@@ -13,8 +18,8 @@ All notable changes to this extension will be documented in this file.
 ### Changed
 
 - Implemented caching when loading topics into the Topics view for the first time to improve
-  performance. Manually refreshing the view or creating/deleting a topic will re-fetch topics
-  and not rely on the cache.
+  performance. Manually refreshing the view or creating/deleting a topic will re-fetch topics and
+  not rely on the cache.
 
 ## 0.15.2
 

--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -195,7 +195,9 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       cachedSessionExists,
       changedToConnected,
       changedToDisconnected,
+      sessionSecretExists,
     };
+    logger.debug("getSessions() local auth state change check", logBody);
     if (changedToConnected || changedToDisconnected) {
       logger.debug("getSessions() auth state changed, firing ccloudConnected event", logBody);
       // inform any listeners whether or not we have a CCloud connection (auth session)

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -47,7 +47,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
     ccloudConnected.event((connected: boolean) => {
       // TODO(shoup): check this for CCloud vs local once we start supporting local SR; check the
       // TopicViewProvider for a similar check
-      logger.debug("ccloudConnected event fired, resetting", connected);
+      logger.debug("ccloudConnected event fired, resetting", { connected });
       // any transition of CCloud connection state should reset the tree view
       this.reset();
     });

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -53,7 +53,7 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
     this.treeView = vscode.window.createTreeView("confluent-topics", { treeDataProvider: this });
 
     ccloudConnected.event((connected: boolean) => {
-      logger.debug("ccloudConnected event fired, resetting", connected);
+      logger.debug("ccloudConnected event fired, resetting", { connected });
       if (this.ccloudEnvironment && this.kafkaCluster?.isCCloud) {
         // any transition of CCloud connection state should reset the tree view if we're focused on
         // a CCloud Kafka Cluster


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes #225 by setting `confluent.ccloudConnectionAvailable` whenever we check for a CCloud connection during the loading of the Resource view's tree items.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
