### PR TITLE
Harden sidecar killing. (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Hardened improper sidecar process id handling edge case when currently running sidecar is the
+  wrong version and is also configured to be in internal development mode.
+
 ## 0.16.2
 
 ### Fixed

--- a/src/sidecar/sidecarHandle.test.ts
+++ b/src/sidecar/sidecarHandle.test.ts
@@ -1,0 +1,93 @@
+import sinon from "sinon";
+import "mocha";
+import * as assert from "assert";
+import { MicroProfileHealthApi, ResponseError } from "../clients/sidecar";
+import * as sidecar from "../sidecar";
+import { SIDECAR_PROCESS_ID_HEADER } from "./constants";
+
+describe("getSidecarPid() tests", () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockClient: sinon.SinonStubbedInstance<MicroProfileHealthApi>;
+  let sidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle>;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    // create the stubs for the sidecar + service client
+    sidecarHandle = sandbox.createStubInstance(sidecar.SidecarHandle);
+    mockClient = sandbox.createStubInstance(MicroProfileHealthApi);
+
+    sidecarHandle.getMicroProfileHealthApi.returns(mockClient);
+
+    // Want to call through to the actual implementation of getSidecarPid
+    sidecarHandle.getSidecarPid.callThrough();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("getSidecarPid() should return the sidecar pid when health check rejection includes header", async function () {
+    mockClient.microprofileHealthLiveness.throws(
+      new ResponseError(
+        new Response(null, {
+          headers: new Headers([[SIDECAR_PROCESS_ID_HEADER, "1234"]]),
+          status: 401,
+          statusText: "Wrong access token",
+        }),
+      ),
+    );
+
+    const pid = await sidecarHandle.getSidecarPid();
+    assert.strictEqual(pid, 1234);
+  });
+
+  it("getSidecarPid() should raise exception if claimed pid <= 1 or not an integer", async function () {
+    for (const badPidStr of ["-1", "0", "notAnInt"]) {
+      mockClient.microprofileHealthLiveness.throws(
+        new ResponseError(
+          new Response(null, {
+            headers: new Headers([[SIDECAR_PROCESS_ID_HEADER, badPidStr]]),
+            status: 401,
+            statusText: "Wrong access token",
+          }),
+        ),
+      );
+
+      console.log("Trying bad pid: " + badPidStr);
+
+      await assert.rejects(sidecarHandle.getSidecarPid(), /Failed to parse sidecar PID/);
+    }
+  });
+
+  it("getSidecarPid() should raise exception if health check rejection does not include header", async function () {
+    mockClient.microprofileHealthLiveness.throws(
+      new ResponseError(
+        new Response(null, {
+          status: 401,
+          statusText: "Wrong access token",
+        }),
+      ),
+    );
+
+    await assert.rejects(
+      sidecarHandle.getSidecarPid(),
+      /Failed to get sidecar PID: unexpected error/,
+    );
+  });
+
+  it("getSidecarPid() should raise exception if health check rejection is not a ResponseError", async function () {
+    mockClient.microprofileHealthLiveness.throws(new Error("Some other error"));
+
+    await assert.rejects(sidecarHandle.getSidecarPid(), /Some other error/);
+  });
+
+  // This one is for us here at home.
+  it("getSidecarPid() should raise exception if microprofileHealthLiveness() call succeeds (quarkus dev mode)", async function () {
+    mockClient.microprofileHealthLiveness.resolves({});
+
+    await assert.rejects(
+      sidecarHandle.getSidecarPid(),
+      /Failed to get sidecar PID: healthcheck did not raise 401 Unauthorized/,
+    );
+  });
+});

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -230,7 +230,14 @@ export class SidecarHandle {
     return payload.data;
   }
 
-  // Return the PID of the sidecar process.
+  public getMicroProfileHealthApi(config: Configuration): MicroProfileHealthApi {
+    // Factored out of getSidecarPid() to allow for test mocking.
+    return new MicroProfileHealthApi(config);
+  }
+
+  /** Return the PID of the sidecar process by provoking it to raise a 401 Unauthorized error.
+   * with the PID in the response header.
+   * */
   public async getSidecarPid(): Promise<number> {
     // coax the sidecar to yield its pid by sending a bad auth token request to the
     // healthcheck route.
@@ -240,26 +247,40 @@ export class SidecarHandle {
       // Need to prevent the default ErrorResponseMiddleware from catching the error we expect.
       middleware: [],
     });
-    const health_api = new MicroProfileHealthApi(config);
 
-    var pid: number = -1;
+    const health_api = this.getMicroProfileHealthApi(config);
 
     // hit the healthcheck route with a bad token to get the sidecar to reveal its pid
     // as a header when it raises 401 Unauthorized.
     try {
       await health_api.microprofileHealthLiveness();
+      // If ths didn't raise, then the sidecar is in a very strange state, not enabled its
+      // auth token filter!
+      logger.error(
+        "getSidecarPid(): Failed to get sidecar PID: healthcheck did not raise 401 Unauthorized",
+      );
+      throw new Error("Failed to get sidecar PID: healthcheck did not raise 401 Unauthorized");
     } catch (e) {
       if (e instanceof ResponseError && e.response.status === 401) {
         const pid_str = e.response.headers.get(SIDECAR_PROCESS_ID_HEADER);
         if (pid_str) {
-          pid = parseInt(pid_str);
+          const pid = parseInt(pid_str);
+          if (isNaN(pid) || pid <= 0) {
+            logger.error(
+              `getSidecarPid(): Failed to parse valid sidecar PID from response header: ${pid_str}`,
+            );
+            throw new Error(`Failed to parse sidecar PID from header: ${pid_str}`);
+          }
+          // Our expected return path.
+          return pid!;
         }
       } else {
-        logger.error("Failed to get sidecar PID", e);
+        logger.error("getSidecarPid(): Failed to get sidecar PID", e);
         throw e;
       }
     }
 
-    return pid;
+    logger.error("getSidecarPid(): Failed to get sidecar PID: unexpected error");
+    throw new Error("Failed to get sidecar PID: unexpected error");
   }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fix for hardening sidecar killing due to mismatched sidecar version vs `quarkus dev`, when the access token filter doesn't kick in like we expect. It is the access token filter that includes the process id of sidecar in the rejection header.

All tests (including new) pass locally.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

<img width="1023" alt="Screenshot 2024-09-18 at 3 28 42 PM" src="https://github.com/user-attachments/assets/ae118117-7f43-4214-bded-8b2495d67fb7">

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
