### PR TITLE
[0.16.x] fix(Windows): home dir lookup for document content provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- [Windows] Schema definitions and diff views will now appear as expected in the editor area.
+
 ## 0.16.2
 
 ### Fixed

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -1,3 +1,4 @@
+import { homedir } from "os";
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { StateDiffs } from "../constants";
@@ -35,8 +36,8 @@ async function compareWithSelectedCommand(item: any) {
   }
 
   // replace fsPaths with ~ if they contain $HOME
-  const uri1Path = uri1.fsPath.replace(process.env["HOME"]!, "~");
-  const uri2Path = uri2.fsPath.replace(process.env["HOME"]!, "~");
+  const uri1Path = uri1.fsPath.replace(homedir(), "~");
+  const uri2Path = uri2.fsPath.replace(homedir(), "~");
   const title = `${uri1Path} ↔ ${uri2Path}`;
   logger.info("Comparing resources", uri1, uri2, title);
   vscode.commands.executeCommand("vscode.diff", uri1, uri2, title);

--- a/src/documentProviders/index.ts
+++ b/src/documentProviders/index.ts
@@ -1,3 +1,4 @@
+import { homedir } from "os";
 import { join } from "path";
 import * as vscode from "vscode";
 
@@ -21,7 +22,7 @@ export abstract class ResourceDocumentProvider implements vscode.TextDocumentCon
   resourceToUri(resource: any, filename: string): vscode.Uri {
     return vscode.Uri.from({
       scheme: this.scheme,
-      path: join(process.env["HOME"]!, filename),
+      path: join(homedir(), filename),
       query: encodeURIComponent(JSON.stringify(resource)),
     });
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Use `os.homedir()` instead of looking specifically for the `HOME` env var:
> Returns the string path of the current user's home directory.
> On POSIX, it uses the `$HOME` environment variable if defined. Otherwise it uses the [effective UID](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to look up the user's home directory.
> On Windows, it uses the `USERPROFILE` environment variable if defined. Otherwise it uses the path to the profile directory of the current user.

✅ `gulp clicktest`ed on `darwin arm64` and `win32 x64`

Resolves https://github.com/confluentinc/vscode/issues/241

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
