### PR TITLE
Refactor resource loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ All notable changes to this extension will be documented in this file.
 ### Changed
 
 - Multi-workspace operation improved. Having three or more workspaces with the extension activated
-  may encounter 429 responses from CCLoud via sidecar, which will be mitigated in the near future.
+  may encounter 429 responses from CCloud via sidecar, which will be mitigated in the near future.
 - If we notice are running inside of WSL, then hint sidecar to bind to 0.0.0.0 instead of 127.0.0.1
   so as to make it possible for Windows-side browsers to complete the OAuth flow. It is expected
   that the port will still be protected by the Windows firewall.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ All notable changes to this extension will be documented in this file.
 ### Fixed
 
 - Hardened improper sidecar process id handling edge case when currently running sidecar is the
-  wrong version and is also configured to be in internal development mode.
+  wrong version and is also configured to be in internal development mode,
+  [issue #216](https://github.com/confluentinc/vscode/issues/216).
+- Unified the loading of common CCloud resources backing the Resources and Topics panels, improving
+  performance and consistency, [issue #147](https://github.com/confluentinc/vscode/issues/147).
 
 ## 0.16.2
 

--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -204,6 +204,14 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       ccloudConnected.fire(!!connection);
     }
 
+    // Inform the UI as to if the user is signed in or not.
+    // (Currently only controls topics / schema view empty states.)
+    vscode.commands.executeCommand(
+      "setContext",
+      "confluent.ccloudConnectionAvailable",
+      !!connection,
+    );
+
     if (!connection) {
       if (changedToDisconnected) {
         // NOTE: this will mainly happen if something goes wrong with the connection or the sidecar

--- a/src/authz/constants.ts
+++ b/src/authz/constants.ts
@@ -1,4 +1,4 @@
-/** Possible / allowed operations on CCLoud Kafka topics
+/** Possible / allowed operations on CCloud Kafka topics
  * @see https://docs.confluent.io/platform/current/security/authorization/acls/overview.html#topic-resource-type-operations
  **/
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ import { StorageManager } from "./storage";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
 import { getTelemetryLogger } from "./telemetry";
 import { getUriHandler } from "./uriHandler";
-import { ResourceViewProvider } from "./viewProviders/resources";
+import { ResourceViewProvider, CCLoudResourcePreloader } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SupportViewProvider } from "./viewProviders/support";
 import { TopicViewProvider } from "./viewProviders/topics";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,8 @@ import { StorageManager } from "./storage";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
 import { getTelemetryLogger } from "./telemetry";
 import { getUriHandler } from "./uriHandler";
-import { ResourceViewProvider, CCLoudResourcePreloader } from "./viewProviders/resources";
+import { CCLoudResourcePreloader } from "./storage/ccloudPreloader";
+import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SupportViewProvider } from "./viewProviders/support";
 import { TopicViewProvider } from "./viewProviders/topics";
@@ -110,6 +111,9 @@ async function _activateExtension(
   // these are also just handling command registration and setting disposables
   activateMessageViewer(context);
   registerProjectGenerationCommand(context);
+
+  // Construct the singleton, let it register its event listener.
+  CCLoudResourcePreloader.getInstance();
 
   return context;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ import { StorageManager } from "./storage";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
 import { getTelemetryLogger } from "./telemetry";
 import { getUriHandler } from "./uriHandler";
-import { CCLoudResourcePreloader } from "./storage/ccloudPreloader";
+import { CCloudResourcePreloader } from "./storage/ccloudPreloader";
 import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SupportViewProvider } from "./viewProviders/support";
@@ -113,7 +113,7 @@ async function _activateExtension(
   registerProjectGenerationCommand(context);
 
   // Construct the singleton, let it register its event listener.
-  CCLoudResourcePreloader.getInstance();
+  CCloudResourcePreloader.getInstance();
 
   return context;
 }

--- a/src/models/topic.test.ts
+++ b/src/models/topic.test.ts
@@ -14,7 +14,7 @@ describe("Test KafkaTopic methods", () => {
     assert.strictEqual(true, TEST_LOCAL_KAFKA_TOPIC.isLocalTopic());
   });
 
-  it("CCLoud topics should not smell local", () => {
+  it("CCloud topics should not smell local", () => {
     assert.strictEqual(false, TEST_CCLOUD_KAFKA_TOPIC.isLocalTopic());
   });
 });

--- a/src/quickpicks/topics.ts
+++ b/src/quickpicks/topics.ts
@@ -11,7 +11,7 @@ export async function topicQuickPick(cluster: KafkaCluster): Promise<KafkaTopic 
   };
   return window.withProgress(options, async () => {
     const topics: KafkaTopic[] = await getTopicsForCluster(cluster, true);
-    if (topics.length == 0) {
+    if (topics.length === 0) {
       window.showInformationMessage("No topics found in the cluster " + cluster.name);
       return;
     }

--- a/src/storage/ccloudPreloader.ts
+++ b/src/storage/ccloudPreloader.ts
@@ -10,17 +10,17 @@ import { getResourceManager } from "./resourceManager";
  * call {@link ensureResourcesLoaded} to ensure that the resources are cached before attempting to
  * access them from the resource manager.
  */
-export class CCLoudResourcePreloader {
-  private static instance: CCLoudResourcePreloader | null = null;
+export class CCloudResourcePreloader {
+  private static instance: CCloudResourcePreloader | null = null;
   private loadingComplete: boolean = false;
   private currentlyLoadingPromise: Promise<void> | null = null;
   private _hasCCloudConnection: boolean = false;
 
-  public static getInstance(): CCLoudResourcePreloader {
-    if (!CCLoudResourcePreloader.instance) {
-      CCLoudResourcePreloader.instance = new CCLoudResourcePreloader();
+  public static getInstance(): CCloudResourcePreloader {
+    if (!CCloudResourcePreloader.instance) {
+      CCloudResourcePreloader.instance = new CCloudResourcePreloader();
     }
-    return CCLoudResourcePreloader.instance;
+    return CCloudResourcePreloader.instance;
   }
 
   private constructor() {
@@ -49,7 +49,7 @@ export class CCLoudResourcePreloader {
    * are being fetched will await the same promise. Subsequent calls after completion will return
    * immediately.
    *
-   * Currently, when the CCLoud connection / authentication session is closed/ended, the resources
+   * Currently, when the CCloud connection / authentication session is closed/ended, the resources
    * are left in the resource manager, however the preloader will reset its state to not having fetched
    * the resources, so that the next call to ensureResourcesLoaded() will re-fetch the resources.
    *

--- a/src/storage/ccloudPreloader.ts
+++ b/src/storage/ccloudPreloader.ts
@@ -1,0 +1,107 @@
+import { ccloudConnected } from "../emitters";
+import { getEnvironments } from "../graphql/environments";
+import { Schema } from "../models/schema";
+import { getSchemas } from "../viewProviders/schemas";
+import { getResourceManager } from "./resourceManager";
+
+/**
+ * Singleton class responsible for preloading Confluent Cloud resources into the extension state.
+ */
+export class CCLoudResourcePreloader {
+  private static instance: CCLoudResourcePreloader | null = null;
+  private loadingComplete: boolean = false;
+  private currentlyLoadingPromise: Promise<void> | null = null;
+
+  public static getInstance(): CCLoudResourcePreloader {
+    if (!CCLoudResourcePreloader.instance) {
+      CCLoudResourcePreloader.instance = new CCLoudResourcePreloader();
+    }
+    return CCLoudResourcePreloader.instance;
+  }
+
+  private constructor() {
+    // Register to listen for ccloud connection events.
+    ccloudConnected.event(async (connected: boolean) => {
+      if (connected) {
+        this.reset();
+        await this.preloadEnvironmentResources();
+      } else {
+        this.reset();
+      } 
+    });
+  }
+
+  /** Reset the preloader to its initial state: not currently fetching, have not fetched,
+   * so that the next call to preloadEnvironmentResources() will start from scratch.
+   */
+  reset(): void {
+    this.loadingComplete = false;
+    this.currentlyLoadingPromise = null;
+  }
+
+  /**
+   * Fired off when ccloud edges to connected., and/or when a view controller needs to get at the
+   * resources stored in ResourceManager and needs to ensure they are all preloaded.
+   */
+  public async preloadEnvironmentResources(): Promise<void> {
+    // If the resources are already loaded, nothing to wait on.
+    if (this.loadingComplete) {
+      return;
+    }
+
+    // If in progress of loading, await the promise that is currently loading the resources.
+    if (this.currentlyLoadingPromise) {
+      return this.currentlyLoadingPromise;
+    }
+
+    // This caller is the first to request the preload, so do the work in the foreground,
+    // but also store the promise so that any other concurrent callers can await it.
+    this.currentlyLoadingPromise = this.doPreloadEnvironmentResources();
+    await this.currentlyLoadingPromise;
+
+    // All done, clear the promise and mark the loading as complete.
+    this.currentlyLoadingPromise = null;
+    this.loadingComplete = true;
+  }
+
+  /**
+   * Preload the {@link CCloudEnvironment}s and their children (Kafka clusters, Schema Registry) into
+   * the extension state for general use.
+   * @remarks this is called after a successful connection to Confluent Cloud, and is done in order to
+   * avoid having to fetch each environment's resources on-demand and speed up topic/schema browsing.
+   */
+  private async doPreloadEnvironmentResources(): Promise<void> {
+    const resourceManager = getResourceManager();
+
+    // Fetch the from-sidecar-API list of triplets of (environment, kafkaClusters, schemaRegistry)
+    const envGroups = await getEnvironments();
+
+    // Queue up to store the environments in the resource manager
+    const environments = envGroups.map((envGroup) => envGroup.environment);
+    await resourceManager.setCCloudEnvironments(environments);
+
+    // Collect all of the Kafka clusters into a single array and queue up to store them in the resource manager.
+    // (Each environment may have many clusters.)
+    const kafkaClusters = envGroups.flatMap((envGroup) => envGroup.kafkaClusters);
+    await resourceManager.setCCloudKafkaClusters(kafkaClusters);
+
+    // For each environment, if there's a schema registry, queue up fetching (and caching) its schemas.
+    // Is safe to fetch + cache each environment's schemas in parallel.
+    const promises: Promise<Schema[]>[] = [];
+    for (const envGroup of envGroups) {
+      const schemaRegistry = envGroup.schemaRegistry;
+      if (schemaRegistry !== undefined) {
+        await resourceManager.setCCloudSchemaRegistryCluster(schemaRegistry);
+        // queue up to fetch all the schemas plus mainly tickle the side effect of
+        // storing those schemas into the resource manager.
+        promises.push(getSchemas(envGroup.environment, schemaRegistry.id));
+      }
+    }
+    await Promise.all(promises);
+
+    // Mark the loading as complete
+    this.loadingComplete = true;
+
+    // TODO: add flink compute pools here?
+  }
+}

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -3,11 +3,7 @@ import { IconNames } from "../constants";
 import { getExtensionContext } from "../context";
 import { ccloudConnected, ccloudOrganizationChanged } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
-import {
-  CCloudEnvironmentGroup,
-  getClustersByCCloudEnvironment,
-  getEnvironments,
-} from "../graphql/environments";
+import { CCloudEnvironmentGroup, getClustersByCCloudEnvironment } from "../graphql/environments";
 import { getLocalKafkaClusters } from "../graphql/local";
 import { getCurrentOrganization } from "../graphql/organizations";
 import { Logger } from "../logging";
@@ -18,11 +14,10 @@ import {
   LocalKafkaCluster,
 } from "../models/kafkaCluster";
 import { ContainerTreeItem } from "../models/main";
-import { Schema } from "../models/schema";
 import { SchemaRegistryCluster, SchemaRegistryClusterTreeItem } from "../models/schemaRegistry";
 import { getCCloudConnection } from "../sidecar/connections";
 import { getResourceManager } from "../storage/resourceManager";
-import { getSchemas } from "./schemas";
+import { CCLoudResourcePreloader } from "../storage/ccloudPreloader";
 
 const logger = new Logger("viewProviders.resources");
 
@@ -51,8 +46,6 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
   }
 
   private treeView: vscode.TreeView<vscode.TreeItem>;
-  /** The {@link CCloudEnvironment} and any associated clusters available from this view provider. */
-  public ccloudEnvGroups: CCloudEnvironmentGroup[] = [];
 
   private static instance: ResourceViewProvider | null = null;
   private constructor() {
@@ -65,10 +58,23 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
     // update the tree view as needed (e.g. displaying the current connection label in the title)
     this.treeView = vscode.window.createTreeView("confluent-resources", { treeDataProvider: this });
 
-    ccloudConnected.event((connected: boolean) => {
-      logger.debug("ccloudConnected event fired", { connected });
+    ccloudConnected.event(async (connected: boolean) => {
       this.refresh();
+      // toggle Topics/Schemas views' visibility based on connection status
+      vscode.commands.executeCommand(
+        "setContext",
+        "confluent.ccloudConnectionAvailable",
+        connected,
+      );
+
+      if (connected) {
+        // preload the CCloud environments and their children (Kafka clusters, Schema Registry)
+        // so that ResourceManager has them cached for general use (say, for fulfilling a schema request
+        // when browsing topics)
+        await CCLoudResourcePreloader.getInstance().preloadEnvironmentResources();
+      }
     });
+
     ccloudOrganizationChanged.event(() => {
       this.refresh();
     });
@@ -127,15 +133,10 @@ async function loadResources(): Promise<ResourceViewProviderData[]> {
   // - an unexpandable item with a "No connection" description where the user can connect to CCloud
   // - a "connected" expandable item with a description of the current connection name and the ability
   //   to add a new connection or switch connections
-  const ccloudConnection = await getCCloudConnection();
-  // toggle Topics/Schemas views' visibility based on connection status
-  vscode.commands.executeCommand(
-    "setContext",
-    "confluent.ccloudConnectionAvailable",
-    !!ccloudConnection,
-  );
-  if (ccloudConnection) {
-    const ccloudEnvironments: CCloudEnvironment[] = await preloadEnvironmentResources();
+  if (await getCCloudConnection()) {
+    const resourceManager = getResourceManager();
+    const ccloudEnvironments: CCloudEnvironment[] = await resourceManager.getCCloudEnvironments();
+
     const cloudContainerItem = new ContainerTreeItem<CCloudEnvironment>(
       "Confluent Cloud",
       vscode.TreeItemCollapsibleState.Expanded,
@@ -182,39 +183,6 @@ async function loadResources(): Promise<ResourceViewProviderData[]> {
   }
 
   return resources;
-}
-
-/**
- * Preload the {@link CCloudEnvironment}s and their children (Kafka clusters, Schema Registry) into
- * the extension state for general use.
- * @remarks this is called after a successful connection to Confluent Cloud, and is done in order to
- * avoid having to fetch each environment's resources on-demand and speed up topic/schema browsing.
- */
-async function preloadEnvironmentResources(): Promise<CCloudEnvironment[]> {
-  const envGroups = await getEnvironments();
-  // also attach it to the tree view provider for later use
-  getResourceViewProvider().ccloudEnvGroups = envGroups;
-
-  const resourceManager = getResourceManager();
-  const environments = envGroups.map((envGroup) => envGroup.environment);
-  resourceManager.setCCloudEnvironments(environments);
-
-  const kafkaClusters = envGroups.flatMap((envGroup) => envGroup.kafkaClusters);
-  resourceManager.setCCloudKafkaClusters(kafkaClusters);
-
-  const promises: Promise<Schema[] | void>[] = [];
-  for (const envGroup of envGroups) {
-    const schemaRegistry = envGroup.schemaRegistry;
-    if (schemaRegistry !== undefined) {
-      await resourceManager.setCCloudSchemaRegistryCluster(schemaRegistry);
-      promises.push(getSchemas(envGroup.environment, schemaRegistry.id));
-    }
-  }
-  await Promise.all(promises);
-
-  // TODO: add flink compute pools here
-
-  return environments;
 }
 
 async function loadCCloudEnvironmentChildren(environment: CCloudEnvironment) {

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -15,10 +15,10 @@ import {
 } from "../models/kafkaCluster";
 import { ContainerTreeItem } from "../models/main";
 import { SchemaRegistryCluster, SchemaRegistryClusterTreeItem } from "../models/schemaRegistry";
-import { getCCloudConnection } from "../sidecar/connections";
 import { getResourceManager } from "../storage/resourceManager";
 import { CCLoudResourcePreloader } from "../storage/ccloudPreloader";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const logger = new Logger("viewProviders.resources");
 
 const CONFLUENT_ICON = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);
@@ -131,7 +131,7 @@ async function loadResources(): Promise<ResourceViewProviderData[]> {
 
   if (preloader.hasCCloudConnection()) {
     // Ensure all of the preloading is complete before referencing resource manager ccloud resources.
-    await preloader.preloadEnvironmentResources();
+    await preloader.ensureResourcesLoaded();
 
     const resourceManager = getResourceManager();
 

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -59,13 +59,8 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
     this.treeView = vscode.window.createTreeView("confluent-resources", { treeDataProvider: this });
 
     ccloudConnected.event(async (connected: boolean) => {
+      logger.debug("ccloudConnected event fired", { connected });
       this.refresh();
-      // toggle Topics/Schemas views' visibility based on connection status
-      vscode.commands.executeCommand(
-        "setContext",
-        "confluent.ccloudConnectionAvailable",
-        connected,
-      );
     });
 
     ccloudOrganizationChanged.event(() => {

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -18,7 +18,6 @@ import { SchemaRegistryCluster, SchemaRegistryClusterTreeItem } from "../models/
 import { getResourceManager } from "../storage/resourceManager";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const logger = new Logger("viewProviders.resources");
 
 const CONFLUENT_ICON = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -16,7 +16,7 @@ import {
 import { ContainerTreeItem } from "../models/main";
 import { SchemaRegistryCluster, SchemaRegistryClusterTreeItem } from "../models/schemaRegistry";
 import { getResourceManager } from "../storage/resourceManager";
-import { CCLoudResourcePreloader } from "../storage/ccloudPreloader";
+import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const logger = new Logger("viewProviders.resources");
@@ -122,7 +122,7 @@ async function loadResources(): Promise<ResourceViewProviderData[]> {
   // - a "connected" expandable item with a description of the current connection name and the ability
   //   to add a new connection or switch connections
 
-  const preloader = CCLoudResourcePreloader.getInstance();
+  const preloader = CCloudResourcePreloader.getInstance();
 
   if (preloader.hasCCloudConnection()) {
     // Ensure all of the preloading is complete before referencing resource manager ccloud resources.

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -126,10 +126,12 @@ export function getSchemasViewProvider() {
   return SchemasViewProvider.getInstance();
 }
 
+// XXX Move this out of viewProviders/schemas.ts into ... elsewhere.
 export async function getSchemas(
   environment: CCloudEnvironment,
   schemaRegistryClusterId: string,
 ): Promise<Schema[]> {
+
   const client: SchemasV1Api = (await getSidecar()).getSchemasV1Api(
     schemaRegistryClusterId,
     environment.connectionId,

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -131,7 +131,6 @@ export async function getSchemas(
   environment: CCloudEnvironment,
   schemaRegistryClusterId: string,
 ): Promise<Schema[]> {
-
   const client: SchemasV1Api = (await getSidecar()).getSchemasV1Api(
     schemaRegistryClusterId,
     environment.connectionId,

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -160,7 +160,7 @@ export async function getTopicsForCluster(
     const preloader = CCLoudResourcePreloader.getInstance();
     // Ensure all of the ccloud preloading is complete before referencing resource manager ccloud resources,
     // most importantly the schema registry and its schemas.
-    await preloader.preloadEnvironmentResources();
+    await preloader.ensureResourcesLoaded();
   }
 
   const resourceManager = getResourceManager();

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -229,7 +229,7 @@ export async function getTopicsForCluster(
   });
 
   logger.debug(`Deep fetched ${topics.length} topics for cluster ${cluster.id}`);
-  await getResourceManager().setTopicsForCluster(cluster, topics);
+  await resourceManager.setTopicsForCluster(cluster, topics);
 
   return topics;
 }

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -160,9 +160,7 @@ export async function getTopicsForCluster(
     const preloader = CCLoudResourcePreloader.getInstance();
     // Ensure all of the ccloud preloading is complete before referencing resource manager ccloud resources,
     // most importantly the schema registry and its schemas.
-    logger.warn("getTopicsForCluster ccloud preloading starting");
     await preloader.preloadEnvironmentResources();
-    logger.warn("getTopicsForCluster ccloud preloading complete");
   }
 
   const resourceManager = getResourceManager();
@@ -175,13 +173,12 @@ export async function getTopicsForCluster(
   }
 
   // Otherwise make a deep fetch, cache in resource manager, and return.
-
   let environmentId: string | null = null;
   let schemas: Schema[] = [];
 
   if (cluster instanceof CCloudKafkaCluster) {
     environmentId = cluster.environmentId;
-    const resourceManager = getResourceManager();
+
     const schemaRegistry = await resourceManager.getCCloudSchemaRegistryCluster(environmentId);
     if (schemaRegistry) {
       schemas = await resourceManager.getCCloudSchemasForCluster(schemaRegistry.id);

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -13,7 +13,7 @@ import { SchemaRegistryCluster } from "../models/schemaRegistry";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
 import { getSidecar } from "../sidecar";
 import { getResourceManager } from "../storage/resourceManager";
-import { CCLoudResourcePreloader } from "../storage/ccloudPreloader";
+import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 
 const logger = new Logger("viewProviders.topics");
 
@@ -157,7 +157,7 @@ export async function getTopicsForCluster(
   forceRefresh: boolean = false,
 ): Promise<KafkaTopic[]> {
   if (cluster instanceof CCloudKafkaCluster) {
-    const preloader = CCLoudResourcePreloader.getInstance();
+    const preloader = CCloudResourcePreloader.getInstance();
     // Ensure all of the ccloud preloading is complete before referencing resource manager ccloud resources,
     // most importantly the schema registry and its schemas.
     await preloader.ensureResourcesLoaded();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Unified the loading of common CCloud resources backing the Resources and Topics panels, improving
  performance and consistency, [issue #147](https://github.com/confluentinc/vscode/issues/147)
- Did so via new CCLoudResourcePreloader singleton class
   - Listens for ccloud login events. When connected, immediately starts populating the non-topic-level ccloud resources.
   - Method `ensureResourcesLoaded()` allows either the Resources or Topics view controllers to block on the loading having been completed prior to consulting the `ResourceManager` cache for those elements. If the loading has been completed already, will not block.
   - Fixes https://github.com/confluentinc/vscode/issues/147 , might possibly also improve https://github.com/confluentinc/vscode/issues/224 .  

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

![ccloud_resource_loader_demo](https://github.com/user-attachments/assets/943c9b87-531e-4e70-bef7-81ec406edc06)

All tests passing locally.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
