### PR TITLE
[0.16.x] fix: remove throwing auth error

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -5,18 +5,22 @@ import { Logger } from "../logging";
 
 const logger = new Logger("commands.connections");
 
-/**
- * Allow creating a session via the auth provider outside of the Accounts section of the VS Code UI.
- */
+/** Allow CCloud sign-in via the auth provider outside of the Accounts section of the VS Code UI. */
 async function createConnectionCommand() {
   try {
     await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
       createIfNone: true,
     });
   } catch (error) {
+    logger.error("error creating CCloud connection", { error });
     if (error instanceof Error) {
-      logger.error("error handling CCloud auth flow", { error });
-      throw new Error("Failed to create new connection. Please try again.");
+      // if the user clicks "Cancel" on the modal before the sign-in process, we don't need to do anything
+      if (error.message === "User did not consent to login.") {
+        return;
+      }
+      // any other errors will be caught by the error handler in src/commands/index.ts as part of the
+      // registerCommandWithLogging wrapper
+      throw error;
     }
   }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { Logger } from "../logging";
 import { getTelemetryLogger } from "../telemetry";
 
-const logger = new Logger("registered-commands");
+const logger = new Logger("commands");
 
 export function registerCommandWithLogging(
   commandName: string,
@@ -14,9 +14,18 @@ export function registerCommandWithLogging(
     try {
       await command(...args);
     } catch (e) {
-      logger.error(`Error invoking command "${commandName}"`, e);
-      // In production, log error invocation in Sentry also
-      if (process.env.NODE_ENV === "production") Sentry.captureException(e);
+      const msg = `Error invoking command "${commandName}":`;
+      logger.error(msg, e);
+      if (e instanceof Error) {
+        // capture error with Sentry (only enabled in production builds)
+        Sentry.captureException(e, { tags: { command: commandName } });
+        // also show error notification to the user
+        vscode.window.showErrorMessage(`${msg} ${e.message}`, "Open Logs").then(async (action) => {
+          if (action !== undefined) {
+            await vscode.commands.executeCommand("confluent.showOutputChannel");
+          }
+        });
+      }
     }
   };
   return vscode.commands.registerCommand(commandName, wrappedCommand);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Forwards non-"User did not consent to login" errors through to our main command error-catching flow instead of throwing that generic "Failed to create new connection. Please try again." error.

Also adds an error notification for any thrown errors during command invocation to allow the user to show the output channel and get some more information before filing an issue. If it gets too spammy, we can remove the notification or guard against specific (frequent) error scenarios.

https://github.com/user-attachments/assets/78b04ce3-731b-4d72-9fef-f34e56275128



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
