### PR TITLE
Cache CCloud schema registries more efficiently (#215)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Welcome to the Confluent for VS Code contributing guide
 
 Thanks for your interest in contributing to this project! Our goal for the
-[Confluent for VS Code project](https://github.com/confluentinc/vscode) is to help make it
-very easy for developers to build stream processing applications using Confluent.
+[Confluent for VS Code project](https://github.com/confluentinc/vscode) is to help make it very easy
+for developers to build stream processing applications using Confluent.
 
 Anyone can contribute, and here are some ways to do so:
 

--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -23,7 +23,7 @@ describe("authz.schemaRegistry", function () {
     // preload the schema registry in extension state
     await getExtensionContext();
     resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+    await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
 
     sandbox = sinon.createSandbox();
     // create the stubs for the sidecar + service client

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -28,6 +28,7 @@ import {
   CCloudSchemaRegistryByEnv,
   getResourceManager,
 } from "./resourceManager";
+import { get } from "http";
 
 describe("ResourceManager (CCloud) environment methods", function () {
   let storageManager: StorageManager;
@@ -309,43 +310,45 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
     await storageManager.clearWorkspaceState();
   });
 
-  it("CCLOUD: setCCloudSchemaRegistryCluster() should correctly store Schema Registry clusters", async () => {
-    await getResourceManager().setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+  it("CCLOUD: setCCloudSchemaRegistryClusters() should correctly store Schema Registry clusters", async () => {
+    const secondCloudEnvironment = { ...TEST_CCLOUD_ENVIRONMENT, id: "second-cloud-env-id" };
+    const secondSchemaRegistry = SchemaRegistryCluster.create({
+      ...TEST_SCHEMA_REGISTRY,
+      environmentId: secondCloudEnvironment.id,
+      id: "second-schema-registry-id",
+    });
+    const testClusters: SchemaRegistryCluster[] = [TEST_SCHEMA_REGISTRY, secondSchemaRegistry];
+
+    const rm = getResourceManager();
+    await rm.setCCloudSchemaRegistryClusters(testClusters);
     // verify the cluster was stored correctly by checking through the StorageManager instead of the ResourceManager
-    let storedClusters: CCloudSchemaRegistryByEnv | undefined =
-      await storageManager.getWorkspaceState(StateSchemaRegistry.CCLOUD);
+    let storedClusters: CCloudSchemaRegistryByEnv = await rm.getCCloudSchemaRegistryClusters();
     assert.ok(storedClusters);
     assert.ok(storedClusters instanceof Map);
     assert.ok(storedClusters.has(TEST_CCLOUD_ENVIRONMENT.id));
+    assert.ok(storedClusters.has(secondCloudEnvironment.id));
     assert.deepStrictEqual(storedClusters.get(TEST_CCLOUD_ENVIRONMENT.id), TEST_SCHEMA_REGISTRY);
   });
 
-  it("CCLOUD: setCCloudSchemaRegistryCluster() should add new environment keys if they don't exist", async () => {
-    // set the first cluster from the first environment
-    await getResourceManager().setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
-    // create and set the second cluster for the new environment
-    const newEnvironmentId = "new-environment-id";
-    const newCluster: SchemaRegistryCluster = {
-      ...TEST_SCHEMA_REGISTRY,
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      id: "new-sr-cluster-id-1",
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      environmentId: newEnvironmentId,
-    };
-    await getResourceManager().setCCloudSchemaRegistryCluster(newCluster);
-    // verify the clusters were stored correctly by checking through the StorageManager instead of the ResourceManager
-    let storedClusters: CCloudSchemaRegistryByEnv | undefined =
-      await storageManager.getWorkspaceState(StateSchemaRegistry.CCLOUD);
-    assert.ok(storedClusters);
-    // make sure both environments exist and the first wasn't overwritten
-    assert.deepStrictEqual(storedClusters.get(newEnvironmentId), newCluster);
-    assert.deepStrictEqual(storedClusters.get(TEST_CCLOUD_ENVIRONMENT.id), TEST_SCHEMA_REGISTRY);
+  it("CCLOUD: setCCloudSchemaRegistryClusters() setting with empty array should overwrite existing clusters", async () => {
+    // set the clusters in the StorageManager before setting them again
+    const rm = getResourceManager();
+    await rm.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
+    // fetching now should return the stored cluster
+    let storedClusters: CCloudSchemaRegistryByEnv = await rm.getCCloudSchemaRegistryClusters();
+    assert.ok(storedClusters.get(TEST_CCLOUD_ENVIRONMENT.id));
+
+    // set the clusters again with an empty array
+    await rm.setCCloudSchemaRegistryClusters([]);
+    // verify the clusters were overwritten correctly
+    storedClusters = await rm.getCCloudSchemaRegistryClusters();
+    assert.deepStrictEqual(storedClusters, new Map());
   });
 
   it("CCLOUD: getCCloudSchemaRegistryClusters() should correctly retrieve Schema Registry clusters", async () => {
     const resourceManager = getResourceManager();
     // preload a cluster before retrieving it
-    await resourceManager.setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+    await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
     // verify the clusters were stored correctly
     const envClusters: CCloudSchemaRegistryByEnv =
       await resourceManager.getCCloudSchemaRegistryClusters();
@@ -360,18 +363,9 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
     assert.deepStrictEqual(envClusters, new Map());
   });
 
-  it("CCLOUD: getCCloudSchemaRegistryCluster() should correctly retrieve a Schema Registry cluster", async () => {
-    // set the cluster
-    await getResourceManager().setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
-    // verify the cluster was retrieved correctly
-    const cluster: SchemaRegistryCluster | null =
-      await getResourceManager().getCCloudSchemaRegistryCluster(TEST_CCLOUD_ENVIRONMENT.id);
-    assert.deepStrictEqual(cluster, TEST_SCHEMA_REGISTRY);
-  });
-
   it("CCLOUD: getCCloudSchemaRegistryCluster() should return null if the parent environment ID is not found", async () => {
     // set the clusters
-    await getResourceManager().setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+    await getResourceManager().setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
     // verify the cluster was not found because the environment ID is incorrect
     const missingCluster: SchemaRegistryCluster | null =
       await getResourceManager().getCCloudSchemaRegistryCluster("nonexistent-env-id");
@@ -381,7 +375,7 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
   it("CCLOUD: deleteCCloudSchemaRegistryClusters() should correctly delete Schema Registry clusters", async () => {
     // set the clusters in the StorageManager before deleting them
     const resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+    await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
     await resourceManager.deleteCCloudSchemaRegistryClusters();
     // verify the clusters were deleted correctly
     const missingClusters = await storageManager.getWorkspaceState(StateSchemaRegistry.CCLOUD);
@@ -844,7 +838,7 @@ describe("ResourceManager general utility methods", function () {
     // set the CCloud resources before deleting them
     const resourceManager = getResourceManager();
     await resourceManager.setCCloudKafkaClusters([TEST_CCLOUD_KAFKA_CLUSTER]);
-    await resourceManager.setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+    await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
     await resourceManager.setTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER, ccloudTopics);
     await resourceManager.setCCloudSchemas(ccloudSchemas);
     // also set some local resources to make sure they aren't deleted

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -28,7 +28,6 @@ import {
   CCloudSchemaRegistryByEnv,
   getResourceManager,
 } from "./resourceManager";
-import { get } from "http";
 
 describe("ResourceManager (CCloud) environment methods", function () {
   let storageManager: StorageManager;

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -232,17 +232,13 @@ export class ResourceManager {
 
   // SCHEMA REGISTRY
 
-  /**
-   * Set the list of available Schema Registry clusters in extension state.
-   * @param clusters The list of {@link SchemaRegistryCluster}s to set
-   */
-  async setCCloudSchemaRegistryCluster(cluster: SchemaRegistryCluster): Promise<void> {
-    // get any existing map of <environmentId, SchemaRegistryCluster>
-    const envClusters: Map<string, SchemaRegistryCluster> =
-      (await this.getCCloudSchemaRegistryClusters()) ?? new Map();
-    const envId: string = cluster.environmentId;
-    envClusters.set(envId, cluster);
-    await this.storage.setWorkspaceState(StateSchemaRegistry.CCLOUD, envClusters);
+  /** Cache all of the CCloud schema registries at once. */
+  async setCCloudSchemaRegistryClusters(clusters: SchemaRegistryCluster[]): Promise<void> {
+    const clustersByEnv: CCloudSchemaRegistryByEnv = new Map();
+    clusters.forEach((cluster) => {
+      clustersByEnv.set(cluster.environmentId, cluster);
+    });
+    await this.storage.setWorkspaceState(StateSchemaRegistry.CCLOUD, clustersByEnv);
   }
 
   /**

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -82,7 +82,7 @@ describe("TopicViewProvider helper functions", () => {
   it("loadTopicSchemas() should return schemas for CCloud Kafka topics when available", async () => {
     // preload SR cluster + schemas (usually done when loading environments)
     const resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemaRegistryCluster(TEST_SCHEMA_REGISTRY);
+    await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
     await resourceManager.setCCloudSchemas(preloadedSchemas);
     // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
     const topic = TEST_CCLOUD_KAFKA_TOPIC.copy({ name: topicName });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Streamline the caching of the ccloud schema registries -- make one single round trip to the storage manager instead of one per schema registry: `resourceManager.setCCloudSchemaRegistryCluster(single_cluster)` is now `resourceManager.setCCloudSchemaRegistryClusters(array_of_clusters)`.
-  https://github.com/confluentinc/vscode/issues/215
- Tests pass, check, lint, and format tasks run.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
