### PR TITLE
improve: change primary button on project scaffolding notification

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -155,15 +155,25 @@ async function applyTemplate(
     templateName: pickedTemplate.spec.display_name,
   });
   // Notify the user that the project was generated successfully
+  const newWindowButton = "Open New Window for Project";
   const selection = await vscode.window.showInformationMessage(
     `🎉 Generated "${pickedTemplate.spec.display_name}" in ${destination.path}`,
-    "Open Folder",
+    newWindowButton,
+    "Switch to Project",
   );
-  if (selection === "Open Folder") {
+  if (selection !== undefined) {
     getTelemetryLogger().logUsage("Scaffold Folder Opened", {
       templateName: pickedTemplate.spec.display_name,
+      newWindow: selection === newWindowButton,
     });
-    vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(destination.path));
+    // if "true" is set in the `vscode.openFolder` command, it will open a new window instead of
+    // reusing the current one
+    const keepsExistingWindow = selection === newWindowButton;
+    vscode.commands.executeCommand(
+      "vscode.openFolder",
+      vscode.Uri.file(destination.path),
+      keepsExistingWindow,
+    );
   }
 }
 

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -155,20 +155,20 @@ async function applyTemplate(
     templateName: pickedTemplate.spec.display_name,
   });
   // Notify the user that the project was generated successfully
-  const newWindowButton = "Open New Window for Project";
+  const newWindowButton = "Open Project in New Window";
   const selection = await vscode.window.showInformationMessage(
     `🎉 Generated "${pickedTemplate.spec.display_name}" in ${destination.path}`,
     newWindowButton,
     "Switch to Project",
   );
   if (selection !== undefined) {
-    getTelemetryLogger().logUsage("Scaffold Folder Opened", {
-      templateName: pickedTemplate.spec.display_name,
-      newWindow: selection === newWindowButton,
-    });
     // if "true" is set in the `vscode.openFolder` command, it will open a new window instead of
     // reusing the current one
     const keepsExistingWindow = selection === newWindowButton;
+    getTelemetryLogger().logUsage("Scaffold Folder Opened", {
+      templateName: pickedTemplate.spec.display_name,
+      keepsExistingWindow,
+    });
     vscode.commands.executeCommand(
       "vscode.openFolder",
       vscode.Uri.file(destination.path),


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes https://github.com/confluentinc/vscode/issues/195

Replaces the current "Open Folder" button with an "Open New Window for Project" primary button and "Switch to Project" secondary button to add a boolean argument to the `openFolder` command.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
