### PR TITLE
cleanup: handle `contextValue` management better

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "icon": "$(diff)",
         "title": "Compare with Selected",
         "category": "Confluent: Compare Resources",
-        "enablement": "resourceSelectedForCompare"
+        "enablement": "confluent.resourceSelectedForCompare"
       },
       {
         "command": "confluent.organizations.use",
@@ -492,7 +492,7 @@
         },
         {
           "command": "confluent.diff.compareWithSelected",
-          "when": "resourceSelectedForCompare && viewItem in confluent.readOnlyDiffableResources",
+          "when": "confluent.resourceSelectedForCompare && viewItem in confluent.readOnlyDiffableResources",
           "group": "3_compare"
         },
         {

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -2,6 +2,7 @@ import { homedir } from "os";
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { StateDiffs } from "../constants";
+import { ContextValues, setContextValue } from "../context";
 import { SchemaDocumentProvider } from "../documentProviders/schema";
 import { Logger } from "../logging";
 import { Schema } from "../models/schema";
@@ -17,7 +18,7 @@ async function selectForCompareCommand(item: any) {
   logger.info("Selected item for compare", uri);
   await getStorageManager().setWorkspaceState(StateDiffs.SELECTED_RESOURCE, uri);
   // allows the "Compare with Selected" command to be used
-  await vscode.commands.executeCommand("setContext", "resourceSelectedForCompare", true);
+  await setContextValue(ContextValues.resourceSelectedForCompare, true);
 }
 
 async function compareWithSelectedCommand(item: any) {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,0 +1,48 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { commands } from "vscode";
+import { ContextValues, getContextValue, setContextValue } from "./context";
+
+describe("ContextValue functions", () => {
+  let executeCommandStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    executeCommandStub = sinon.stub(commands, "executeCommand");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("setContextValue() should correctly context value and execute the setContext command", async () => {
+    const key = ContextValues.READONLY_DIFFABLE_RESOURCES;
+    const value = ["resource1", "resource2"];
+
+    await setContextValue(key, value);
+
+    assert.ok(executeCommandStub.calledWith("setContext", key, value));
+    assert.deepStrictEqual(getContextValue<string[]>(key), value);
+  });
+
+  it("setContextValue() should throw an error for an untracked context value", async () => {
+    await assert.rejects(
+      () => setContextValue("invalidKey" as ContextValues, "value"),
+      new Error(
+        'Unknown contextValue "invalidKey"; ensure this is added to src/context.ts::ContextValues before using in package.json',
+      ),
+    );
+  });
+
+  it("getContextValue() should return the correct context value", async () => {
+    const key = ContextValues.CCLOUD_RESOURCES;
+    const value = ["resource1", "resource2"];
+
+    await setContextValue(key, value);
+
+    assert.deepStrictEqual(getContextValue<string[]>(key), value);
+  });
+
+  it("getContextValue() should return undefined for a non-existent context value", () => {
+    assert.strictEqual(getContextValue<string>("nonExistentKey"), undefined);
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { type ExtensionContext } from "vscode";
+import { type ExtensionContext, commands } from "vscode";
 
 let context: ExtensionContext;
 
@@ -9,3 +9,58 @@ export function setExtensionContext(value: ExtensionContext) {
 export function getExtensionContext(): ExtensionContext {
   return context;
 }
+
+/**
+ * Sets the context value and updates the VS Code UI.
+ * @param key The key of the context value (must be defined in {@link ContextValues})
+ * @param value The value to set
+ */
+export async function setContextValue(key: ContextValues, value: any): Promise<void> {
+  if (!Object.values(ContextValues).includes(key)) {
+    throw new Error(
+      `Unknown contextValue "${key}"; ensure this is added to src/context.ts::ContextValues before using in package.json`,
+    );
+  }
+  contextValues[key] = value;
+  await commands.executeCommand("setContext", key, value);
+}
+
+/**
+ * Gets the value from the locally-stored contextValues since there is no `getContext` command
+ * exposed by the VS Code API.
+ */
+export function getContextValue<T>(key: string): T | undefined {
+  return contextValues[key] as T | undefined;
+}
+
+export enum ContextValues {
+  // -- CONTEXT VALUES ONLY SET DURING EXTENSION ACTIVATION --
+  /** Array of contextValues from `src/models` that support "Select for Compare"/"Compare with
+   * Selected" operations in our sidebar. */
+  READONLY_DIFFABLE_RESOURCES = "confluent.readOnlyDiffableResources",
+  /** Array of resources that support the "View in CCloud" action. */
+  CCLOUD_RESOURCES = "confluent.ccloudResources",
+  /** Array of view IDs that contain Confluent/Kafka resources. */
+  VIEWS_WITH_RESOURCES = "confluent.viewsWithResources",
+  /** Array of resources that have an `id` property for enabling the `Copy ID` action. */
+  RESOURCES_WITH_ID = "confluent.resourcesWithIDs",
+  /** Array of resources that have a `name` property for enabling the `Copy Name` action. */
+  RESOURCES_WITH_NAMES = "confluent.resourcesWithNames",
+
+  // -- ADJUSTABLE CONTEXT VALUES --
+  /** The user has a valid, authenticated connection to Confluent Cloud.
+   * NOTE: this is only controlled by our auth provider. */
+  ccloudConnectionAvailable = "confluent.ccloudConnectionAvailable",
+  /** A local connection has been made and a local Kafka cluster is available for selecting in the Topics view. */
+  localKafkaClusterAvailable = "confluent.localKafkaClusterAvailable",
+  /** A resource has been selected for comparison. */
+  resourceSelectedForCompare = "confluent.resourceSelectedForCompare",
+  /** The user clicked a Kafka cluster tree item. */
+  kafkaClusterSelected = "confluent.kafkaClusterSelected",
+  /** The user clicked a Schema Registry cluster tree item. */
+  schemaRegistrySelected = "confluent.schemaRegistrySelected",
+}
+
+// This is a local cache of the context values since there is no `getContext` command exposed by the
+// VS Code API.
+const contextValues: Record<string, any> = {};

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -1,7 +1,7 @@
 import { graphql } from "gql.tada";
-import { commands } from "vscode";
 import { Connection, ConnectionsResourceApi } from "../clients/sidecar";
 import { LOCAL_CONNECTION_ID, LOCAL_CONNECTION_SPEC } from "../constants";
+import { ContextValues, setContextValue } from "../context";
 import { Logger } from "../logging";
 import { LocalKafkaCluster } from "../models/kafkaCluster";
 import { getSidecar } from "../sidecar";
@@ -56,11 +56,7 @@ export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
     });
   }
   // indicate to the UI that we have at least one local Kafka cluster available
-  await commands.executeCommand(
-    "setContext",
-    "confluent.localKafkaClusterAvailable",
-    localKafkaClusters.length > 0,
-  );
+  await setContextValue(ContextValues.localKafkaClusterAvailable, localKafkaClusters.length > 0);
   return localKafkaClusters;
 }
 

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Schema as ResponseSchema, SchemasV1Api } from "../clients/schemaRegistryRest";
-import { getExtensionContext } from "../context";
+import { ContextValues, getExtensionContext, setContextValue } from "../context";
 import { ccloudConnected, currentSchemaRegistryChanged } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
@@ -56,7 +56,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
       if (!schemaRegistry) {
         this.reset();
       } else {
-        vscode.commands.executeCommand("setContext", "confluent.schemaRegistrySelected", true);
+        setContextValue(ContextValues.schemaRegistrySelected, true);
         this.schemaRegistry = schemaRegistry;
         const environment: CCloudEnvironment | null =
           await getResourceManager().getCCloudEnvironment(this.schemaRegistry.environmentId);
@@ -76,7 +76,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
 
   /** Convenience method to revert this view to its original state. */
   reset(): void {
-    vscode.commands.executeCommand("setContext", "confluent.schemaRegistrySelected", false);
+    setContextValue(ContextValues.schemaRegistrySelected, false);
     this.schemaRegistry = null;
     this.ccloudEnvironment = null;
     this.treeView.description = "";

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { toKafkaTopicOperations } from "../authz/types";
 import { ResponseError, TopicDataList, TopicV3Api } from "../clients/kafkaRest";
-import { getExtensionContext } from "../context";
+import { ContextValues, getExtensionContext, setContextValue } from "../context";
 import { ccloudConnected, currentKafkaClusterChanged } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
@@ -12,8 +12,8 @@ import { Schema, SchemaTreeItem, generateSchemaSubjectGroups } from "../models/s
 import { SchemaRegistryCluster } from "../models/schemaRegistry";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
 import { getSidecar } from "../sidecar";
-import { getResourceManager } from "../storage/resourceManager";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
+import { getResourceManager } from "../storage/resourceManager";
 
 const logger = new Logger("viewProviders.topics");
 
@@ -63,10 +63,9 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
     });
     currentKafkaClusterChanged.event(async (cluster: KafkaCluster | null) => {
       if (!cluster) {
-        vscode.commands.executeCommand("setContext", "confluent.kafkaClusterSelected", false);
         this.reset();
       } else {
-        vscode.commands.executeCommand("setContext", "confluent.kafkaClusterSelected", true);
+        setContextValue(ContextValues.kafkaClusterSelected, true);
         this.kafkaCluster = cluster;
         // update the tree view title to show the currently-focused Kafka cluster and repopulate the tree
         if (cluster.isLocal) {
@@ -94,7 +93,7 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
 
   /** Convenience method to revert this view to its original state. */
   reset(): void {
-    vscode.commands.executeCommand("setContext", "confluent.kafkaClusterSelected", false);
+    setContextValue(ContextValues.kafkaClusterSelected, false);
     this.kafkaCluster = null;
     this.ccloudEnvironment = null;
     this.treeView.description = "";


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes https://github.com/confluentinc/vscode/issues/253

Removes all usage of `vscode.commands.executeCommand("setContext", key, value)` (aside from `src/context.ts`) to instead use an enum with per-value documentation so we have a better handle of what each `contextValue` is used for / affects.

Also enforces adjusting the `ccloudConnectionAvailable` context value through the auth provider during its different connectivity checks, which ensures the auth provider updates the correct CCloud-connection state for the views regardless of workspace and whether or not any views are currently expanded or whether an auth session changed event was fired.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
