### PR TITLE
chore: add convenience functions for CCloud auth session checks

### DIFF
--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -373,7 +373,9 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
    */
   private async handleSessionSecretChange() {
     logger.debug("handleSessionSecretChange()");
-    const session = await getAuthSession();
+    const session = await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
+      createIfNone: false,
+    });
     if (!session) {
       // SCENARIO 1: user logged out / auth session was removed
       // if we had a session before, we need to remove it and stop polling for auth status, as well
@@ -419,14 +421,6 @@ function convertToAuthSession(connection: Connection): vscode.AuthenticationSess
     scopes: [],
   };
   return session;
-}
-
-/** Convenience function to get the latest CCloud session via the Authentication API. */
-export async function getAuthSession(): Promise<vscode.AuthenticationSession | undefined> {
-  // Will immediately cascade call into ConfluentCloudAuthProvider.getSessions().
-  return await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
-    createIfNone: false,
-  });
 }
 
 export function getAuthProvider(): ConfluentCloudAuthProvider {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ if (process.env.SENTRY_DSN) {
   Sentry.addEventProcessor(checkTelemetrySettings);
 }
 
-import { ConfluentCloudAuthProvider, getAuthProvider, getAuthSession } from "./authProvider";
+import { ConfluentCloudAuthProvider, getAuthProvider } from "./authProvider";
 import { registerCommandWithLogging } from "./commands";
 import { commands as connectionCommands } from "./commands/connections";
 import { commands as debugCommands } from "./commands/debugtools";
@@ -54,6 +54,7 @@ import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { Logger, outputChannel } from "./logging";
 import { registerProjectGenerationCommand } from "./scaffold";
 import { sidecarOutputChannel } from "./sidecar";
+import { getCCloudAuthSession } from "./sidecar/connections";
 import { StorageManager } from "./storage";
 import { CCloudResourcePreloader } from "./storage/ccloudPreloader";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
@@ -224,7 +225,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
   ]);
 
   // attempt to get a session to trigger the initial auth badge for signing in
-  await getAuthSession();
+  await getCCloudAuthSession();
 
   return disposables;
 }

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -1,6 +1,7 @@
+import { AuthenticationSession, authentication } from "vscode";
 import { getSidecar } from ".";
 import { Connection, ConnectionsResourceApi, ResponseError } from "../clients/sidecar";
-import { CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../constants";
+import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../constants";
 import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
 import { Logger } from "../logging";
 import { getResourceManager } from "../storage/resourceManager";
@@ -60,4 +61,24 @@ export async function clearCurrentCCloudResources() {
   await getResourceManager().deleteCCloudResources();
   currentKafkaClusterChanged.fire(null);
   currentSchemaRegistryChanged.fire(null);
+}
+
+/** Convenience function to check with the authentication API and get a CCloud auth session, if
+ * one exists.
+ *
+ * NOTE: If any callers need to check for general CCloud connection status, they should do it here.
+ * Any reactions to CCloud connection change should also use an event listener for the
+ * `ccloudConnected` event emitter.
+ *
+ * @param createIfNone If `true`, create a new session if one doesn't exist. This starts the
+ * browser-based sign-in flow to CCloud. (default: `false`)
+ */
+export async function getCCloudAuthSession(
+  createIfNone: boolean = false,
+): Promise<AuthenticationSession | undefined> {
+  return await authentication.getSession(AUTH_PROVIDER_ID, [], { createIfNone: createIfNone });
+}
+
+export async function hasCCloudAuthSession(): Promise<boolean> {
+  return !!(await getCCloudAuthSession());
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Should make it easier for other callers to get an "internal" view of whether or not we have a valid CCloud connection.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
