### PR TITLE
chore: use `getCCloudAuthSession()` for logging in & checking status

### DIFF
--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -373,7 +373,9 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
    */
   private async handleSessionSecretChange() {
     logger.debug("handleSessionSecretChange()");
-    const session = await getAuthSession();
+    const session = await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
+      createIfNone: false,
+    });
     if (!session) {
       // SCENARIO 1: user logged out / auth session was removed
       // if we had a session before, we need to remove it and stop polling for auth status, as well
@@ -419,14 +421,6 @@ function convertToAuthSession(connection: Connection): vscode.AuthenticationSess
     scopes: [],
   };
   return session;
-}
-
-/** Convenience function to get the latest CCloud session via the Authentication API. */
-export async function getAuthSession(): Promise<vscode.AuthenticationSession | undefined> {
-  // Will immediately cascade call into ConfluentCloudAuthProvider.getSessions().
-  return await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
-    createIfNone: false,
-  });
 }
 
 export function getAuthProvider(): ConfluentCloudAuthProvider {

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -1,16 +1,13 @@
-import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
-import { AUTH_PROVIDER_ID } from "../constants";
 import { Logger } from "../logging";
+import { getCCloudAuthSession } from "../sidecar/connections";
 
 const logger = new Logger("commands.connections");
 
 /** Allow CCloud sign-in via the auth provider outside of the Accounts section of the VS Code UI. */
 async function createConnectionCommand() {
   try {
-    await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
-      createIfNone: true,
-    });
+    await getCCloudAuthSession(true);
   } catch (error) {
     logger.error("error creating CCloud connection", { error });
     if (error instanceof Error) {

--- a/src/commands/organizations.ts
+++ b/src/commands/organizations.ts
@@ -7,10 +7,10 @@ import { getCurrentOrganization } from "../graphql/organizations";
 import { CCloudOrganization } from "../models/organization";
 import { organizationQuickPick } from "../quickpicks/organizations";
 import { getSidecar } from "../sidecar";
-import { clearCurrentCCloudResources, getCCloudConnection } from "../sidecar/connections";
+import { clearCurrentCCloudResources, hasCCloudAuthSession } from "../sidecar/connections";
 
 async function useOrganizationCommand() {
-  if (!(await getCCloudConnection())) {
+  if (!(await hasCCloudAuthSession())) {
     return;
   }
   const organization: CCloudOrganization | undefined = await organizationQuickPick();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ if (process.env.SENTRY_DSN) {
   Sentry.addEventProcessor(checkTelemetrySettings);
 }
 
-import { ConfluentCloudAuthProvider, getAuthProvider, getAuthSession } from "./authProvider";
+import { ConfluentCloudAuthProvider, getAuthProvider } from "./authProvider";
 import { registerCommandWithLogging } from "./commands";
 import { commands as connectionCommands } from "./commands/connections";
 import { commands as debugCommands } from "./commands/debugtools";
@@ -54,6 +54,7 @@ import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { Logger, outputChannel } from "./logging";
 import { registerProjectGenerationCommand } from "./scaffold";
 import { sidecarOutputChannel } from "./sidecar";
+import { getCCloudAuthSession } from "./sidecar/connections";
 import { StorageManager } from "./storage";
 import { CCloudResourcePreloader } from "./storage/ccloudPreloader";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
@@ -224,7 +225,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
   ]);
 
   // attempt to get a session to trigger the initial auth badge for signing in
-  await getAuthSession();
+  await getCCloudAuthSession();
 
   return disposables;
 }

--- a/src/quickpicks/environments.ts
+++ b/src/quickpicks/environments.ts
@@ -2,14 +2,14 @@ import * as vscode from "vscode";
 import { IconNames } from "../constants";
 import { getEnvironments } from "../graphql/environments";
 import { CCloudEnvironment } from "../models/environment";
-import { getCCloudConnection } from "../sidecar/connections";
+import { hasCCloudAuthSession } from "../sidecar/connections";
 
 export async function environmentQuickPick(): Promise<CCloudEnvironment | undefined> {
   // Convenience function to get the name of a cloud environment if a command was triggered through
   // the command palette instead of through the view->item->context menu
   let cloudEnvironments: CCloudEnvironment[] = [];
 
-  if (!(await getCCloudConnection())) {
+  if (!(await hasCCloudAuthSession())) {
     vscode.window.showInformationMessage("No Confluent Cloud connection found.");
     return undefined;
   }

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -5,7 +5,7 @@ import { getLocalKafkaClusters } from "../graphql/local";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
-import { getCCloudConnection } from "../sidecar/connections";
+import { hasCCloudAuthSession } from "../sidecar/connections";
 
 const logger = new Logger("quickpicks.kafkaClusters");
 
@@ -44,7 +44,7 @@ async function generateKafkaClusterQuickPick(
   if (includeCCloud) {
     // list all Kafka clusters for all CCloud environments for the given connection; to be separated
     // further by environment in the quickpick menu below
-    if (await getCCloudConnection()) {
+    if (await hasCCloudAuthSession()) {
       const envGroups = await getEnvironments();
       cloudEnvironments = envGroups.map((group) => group.environment);
       cloudKafkaClusters = envGroups.map((group) => group.kafkaClusters).flat();

--- a/src/quickpicks/schemaRegistryClusters.ts
+++ b/src/quickpicks/schemaRegistryClusters.ts
@@ -4,7 +4,7 @@ import { getEnvironments } from "../graphql/environments";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { SchemaRegistryCluster } from "../models/schemaRegistry";
-import { getCCloudConnection } from "../sidecar/connections";
+import { hasCCloudAuthSession } from "../sidecar/connections";
 import { getResourceManager } from "../storage/resourceManager";
 
 const logger = new Logger("quickpicks.schemaRegistryClusters");
@@ -30,7 +30,7 @@ export async function schemaRegistryQuickPick(): Promise<SchemaRegistryCluster |
 async function generateSchemaRegistryClusterQuickPick(): Promise<
   SchemaRegistryCluster | undefined
 > {
-  if (!(await getCCloudConnection())) {
+  if (!(await hasCCloudAuthSession())) {
     return undefined;
   }
   // list all Schema Registry clusters for all CCloud environments for the given connection; to be

--- a/src/sidecar/authStatusPolling.ts
+++ b/src/sidecar/authStatusPolling.ts
@@ -1,10 +1,10 @@
 import * as vscode from "vscode";
 import { AuthErrors, Connection } from "../clients/sidecar";
-import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID } from "../constants";
+import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudAuthSessionInvalidated } from "../emitters";
 import { Logger } from "../logging";
 import { IntervalPoller } from "../utils/timing";
-import { getCCloudConnection } from "./connections";
+import { getCCloudAuthSession, getCCloudConnection } from "./connections";
 
 const logger = new Logger("sidecar.authStatusPolling");
 
@@ -222,9 +222,7 @@ async function handleExpiredAuth(expirationString: string) {
         // go through the auth provider's `createSession()` instead of trying to create a new CCloud
         // connection via the sidecar and hooking it back up to the auth provider state. this will
         // create the new CCloud connection and trigger the browser-based login with new sign-in URI
-        await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
-          createIfNone: true,
-        });
+        await getCCloudAuthSession(true);
       }
     });
 }
@@ -264,9 +262,7 @@ export function checkAuthErrors(connection: Connection) {
       if (response === authButton) {
         // if we got to this point, we likely cleared out the existing connection via the
         // `ccloudAuthSessionInvalidated` emitter, so we need to create a new session to re-auth
-        await vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
-          createIfNone: true,
-        });
+        await getCCloudAuthSession(true);
       }
     });
 }

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -1,6 +1,7 @@
+import { AuthenticationSession, authentication } from "vscode";
 import { getSidecar } from ".";
 import { Connection, ConnectionsResourceApi, ResponseError } from "../clients/sidecar";
-import { CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../constants";
+import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../constants";
 import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
 import { Logger } from "../logging";
 import { getResourceManager } from "../storage/resourceManager";
@@ -60,4 +61,24 @@ export async function clearCurrentCCloudResources() {
   await getResourceManager().deleteCCloudResources();
   currentKafkaClusterChanged.fire(null);
   currentSchemaRegistryChanged.fire(null);
+}
+
+/** Convenience function to check with the authentication API and get a CCloud auth session, if
+ * one exists.
+ *
+ * NOTE: If any callers need to check for general CCloud connection status, they should do it here.
+ * Any reactions to CCloud connection change should also use an event listener for the
+ * `ccloudConnected` event emitter.
+ *
+ * @param createIfNone If `true`, create a new session if one doesn't exist. This starts the
+ * browser-based sign-in flow to CCloud. (default: `false`)
+ */
+export async function getCCloudAuthSession(
+  createIfNone: boolean = false,
+): Promise<AuthenticationSession | undefined> {
+  return await authentication.getSession(AUTH_PROVIDER_ID, [], { createIfNone: createIfNone });
+}
+
+export async function hasCCloudAuthSession(): Promise<boolean> {
+  return !!(await getCCloudAuthSession());
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Wrap our previous implementations for signing in
- Replace our previous calls to check for true/false on whether we were connected to CCloud -- remaining `getCCloudConnection()` calls explicitly want to check with the sidecar for auth purposes and/or to reuse the `Connection` object

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
