### PR TITLE
Implement 'Copy Organization ID' context menu item, issue #213.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- New context menu item "Copy Organization ID" for the logged-in "Confluent Cloud" resource,
+  [issue #213](https://github.com/confluentinc/vscode/issues/213).
+
 ### Changed
 
 - Use cached information to populate the Resources view Confluent Cloud single environment children,

--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
         "category": "Confluent: Organizations"
       },
       {
+        "command": "confluent.copyOrganizationId",
+        "title": "Copy Organization ID",
+        "category": "Confluent: Resources"
+      },
+      {
         "command": "confluent.resources.refresh",
         "icon": "$(sync)",
         "title": "Refresh",
@@ -337,6 +342,10 @@
           "when": "!confluent.ccloudConnectionAvailable"
         },
         {
+          "command": "confluent.copyOrganizationId",
+          "when": "false"
+        },
+        {
           "command": "confluent.copyResourceId",
           "when": "false"
         },
@@ -509,6 +518,11 @@
           "command": "confluent.organizations.use",
           "when": "viewItem == resources-ccloud-container-connected",
           "group": "inline@2"
+        },
+        {
+          "command" : "confluent.copyOrganizationId",
+          "when" : "viewItem == resources-ccloud-container-connected",
+          "group" : "2_copy@1"
         },
         {
           "command": "confluent.resources.item.rename",

--- a/src/commands/organizations.ts
+++ b/src/commands/organizations.ts
@@ -48,6 +48,17 @@ async function useOrganizationCommand() {
   );
 }
 
+async function copyOrganizationId() {
+  const currentOrg = await getCurrentOrganization();
+  if (!currentOrg) {
+    return;
+  }
+
+  await vscode.env.clipboard.writeText(currentOrg.id);
+  vscode.window.showInformationMessage(`Copied "${currentOrg.id}" to clipboard.`);
+}
+
 export const commands = [
   registerCommandWithLogging("confluent.organizations.use", useOrganizationCommand),
+  registerCommandWithLogging("confluent.copyOrganizationId", copyOrganizationId),
 ];


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Implement context menu item for the logged-in "Confluent Cloud" resource to copy the user's organization ID to the clipboard.
- https://github.com/confluentinc/vscode/issues/213

## Any additional details or context that should be provided?

![copy-organization-id](https://github.com/user-attachments/assets/0d6b04aa-c0f8-4771-8759-71f62cf25d31)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
