### PR TITLE
fix: guard against non-cluster types being passed in "Select ___" commands

### DIFF
--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -55,7 +55,11 @@ async function renameKafkaClusterCommand(item?: CCloudKafkaCluster | undefined) 
 }
 
 async function selectKafkaClusterCommand(cluster?: KafkaCluster) {
-  const kafkaCluster: KafkaCluster | undefined = cluster || (await kafkaClusterQuickPick());
+  // ensure whatever was passed in is some form of KafkaCluster; if not, prompt the user to pick one
+  const kafkaCluster: KafkaCluster | undefined =
+    cluster instanceof CCloudKafkaCluster || cluster instanceof LocalKafkaCluster
+      ? cluster
+      : await kafkaClusterQuickPick();
   if (!kafkaCluster) {
     return;
   }

--- a/src/commands/schemaRegistry.ts
+++ b/src/commands/schemaRegistry.ts
@@ -5,7 +5,9 @@ import { SchemaRegistryCluster } from "../models/schemaRegistry";
 import { schemaRegistryQuickPick } from "../quickpicks/schemaRegistryClusters";
 
 async function selectSchemaRegistryCommand(cluster?: SchemaRegistryCluster) {
-  const schemaRegistry = cluster || (await schemaRegistryQuickPick());
+  // ensure whatever was passed in is a SchemaRegistryCluster; if not, prompt the user to pick one
+  const schemaRegistry =
+    cluster instanceof SchemaRegistryCluster ? cluster : await schemaRegistryQuickPick();
   if (!schemaRegistry) {
     return;
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes https://github.com/confluentinc/vscode/issues/282.

The above issue happens whenever an item in a view is highlighted and the view (nav) action is triggered; instead of passing `undefined`, we get whatever the type was that was selected. In this case, we attempted to handle a non-Kafka/-SR cluster during the "Select ____" command logic.

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/72a94827-ea09-4d8c-b743-54d288d35a4b">

(See `cluster = KafkaTopic` up in the Variables section of the debugger.)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
