### PR TITLE
Unify cached schema use between topics and schemas (issue 214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this extension will be documented in this file.
 
 - Use cached information to populate the Resources view Confluent Cloud single environment children,
   [issue #254](https://github.com/confluentinc/vscode/issues/254).
+- Integrate and synchronize use of cached schemas information between Topics and Schemas panels,
+  [issue #214](https://github.com/confluentinc/vscode/issues/214).
 
 ### Fixed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,7 +263,8 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
     const schemasViewProvider = SchemasViewProvider.getInstance();
     context.subscriptions.push(
       registerCommandWithLogging("confluent.schemas.refresh", () => {
-        schemasViewProvider.refresh();
+        // ask for a deep refresh of the schemas for the selected schema registry
+        schemasViewProvider.refresh(true);
       }),
     );
     logger.info("Schemas view provider created");

--- a/src/storage/ccloudPreloader.ts
+++ b/src/storage/ccloudPreloader.ts
@@ -1,3 +1,4 @@
+import { get } from "node:http";
 import { Schema as ResponseSchema, SchemasV1Api } from "../clients/schemaRegistryRest";
 import { ccloudConnected } from "../emitters";
 import { getEnvironments } from "../graphql/environments";
@@ -12,13 +13,35 @@ const logger = new Logger("storage.ccloudPreloader");
 /**
  * Singleton class responsible for preloading Confluent Cloud resources into the resource manager.
  * View providers and/or other consumers of CCloud resources stored in the resource manager should
- * call {@link ensureResourcesLoaded} to ensure that the resources are cached before attempting to
+ * call {@link ensureCoarseResourcesLoaded} to ensure that the resources are cached before attempting to
  * access them from the resource manager.
+ *
+ * The preloader handles loading the following "coarse" resources via ${link ensureCoarseResourcesLoaded}:
+ *  - CCloud Environments (ResourceManager.getCCloudEnvironments())
+ *  - CCloud Kafka Clusters (ResourceManager.getCCloudKafkaClusters())
+ *  - CCloud Schema Registries (ResourceManager.getCCloudSchemaRegistryClusters())
+ *
+ * Also handles loading the schemas for a single schema registry cluster via {@link ensureSchemasLoaded}, but
+ * only after when the coarse resources have been loaded. Because there may be "many" schemas in a schema registry,
+ * this is considered a 'fine grained resource' and is not loaded until requested.
  */
 export class CCloudResourcePreloader {
   private static instance: CCloudResourcePreloader | null = null;
-  private loadingComplete: boolean = false;
-  private currentlyLoadingPromise: Promise<void> | null = null;
+
+  /** Have the course resources been cached already? */
+  private coarseLoadingComplete: boolean = false;
+
+  /** If in progress of loading the coarse resources, the promise doing so. */
+  private currentlyCoarseLoadingPromise: Promise<void> | null = null;
+
+  /**
+   * Known state of resource manager cache for each schema registry's schemas by schema registry id:
+   *  * Undefined: unknown schema registry, call {@link ensureSchemasLoaded} to fetch and cache.
+   *  * False: known schema registry, but its schemas not yet fetched, call  {@link ensureSchemasLoaded} to fetch and cache.
+   *  * True: Fully cached. Go ahead and make use of resourceManager.getCCloudSchemasForCluster(id)
+   *  * Promise<void>: in progress of fetching, join awaiting this promise to know when it's safe to use resourceManager.getCCloudSchemasForCluster(id).
+   */
+  private schemaRegistryClusterCacheStates: Map<string, boolean | Promise<void>> = new Map();
 
   public static getInstance(): CCloudResourcePreloader {
     if (!CCloudResourcePreloader.instance) {
@@ -28,18 +51,21 @@ export class CCloudResourcePreloader {
   }
 
   private constructor() {
-    // Register to listen for ccloud connection events.
+    // When the ccloud connection state changes, reset the preloader's state.
     ccloudConnected.event(async (connected: boolean) => {
-      this.reset();
+      this.coarseLoadingComplete = false;
+      this.currentlyCoarseLoadingPromise = null;
+      this.schemaRegistryClusterCacheStates.clear();
+
       if (connected) {
-        // Start the preloading process if we think we have a ccloud connection.
-        await this.ensureResourcesLoaded();
+        // Start the coarse preloading process if we think we have a ccloud connection.
+        await this.ensureCoarseResourcesLoaded();
       }
     });
   }
 
   /**
-   * Promise ensuring that all the ccloud resources are cached into the resource manager.
+   * Promise ensuring that the "coarse" ccloud resources are cached into the resource manager.
    *
    * Fired off when CCloud edges to connected, and/or when any view controller needs to get at
    * any of the following CCloud resources stored in ResourceManager. Is safe to call multiple times
@@ -51,39 +77,52 @@ export class CCloudResourcePreloader {
    * are left in the resource manager, however the preloader will reset its state to not having fetched
    * the resources, so that the next call to ensureResourcesLoaded() will re-fetch the resources.
    *
+   * Coarse resources are:
    *   - CCloud Environments (ResourceManager.getCCloudEnvironments())
    *   - CCloud Kafka Clusters (ResourceManager.getCCloudKafkaClusters())
    *   - CCloud Schema Registries (ResourceManager.getCCloudSchemaRegistryClusters())
-   *   - CCloud Schemas (ResourceManager.getCCloudSchemas())
+   *
+   * They do not include topics within a cluster or schemas within a schema registry, which are fetched
+   * and cached more closely to when they are needed.
    */
-  public async ensureResourcesLoaded(): Promise<void> {
+  public async ensureCoarseResourcesLoaded(forceDeepRefresh: boolean = false): Promise<void> {
+    // If caller requested a deep refresh, reset the preloader's state so that we fall through to
+    // re-fetching the coarse resources.
+    if (forceDeepRefresh) {
+      logger.info("Deep refreshing CCloud resources, forgetting all ccloud cached resources.");
+      this.coarseLoadingComplete = false;
+      this.currentlyCoarseLoadingPromise = null;
+      // Also implies forgetting any cached schemas so that they will be re-fetched upon demand.
+      this.schemaRegistryClusterCacheStates.clear();
+      getResourceManager().deleteCCloudResources();
+    }
+
     // If the resources are already loaded, nothing to wait on.
-    if (this.loadingComplete) {
+    if (this.coarseLoadingComplete) {
       return;
     }
 
     // If in progress of loading, have the caller await the promise that is currently loading the resources.
-    if (this.currentlyLoadingPromise) {
-      return this.currentlyLoadingPromise;
+    if (this.currentlyCoarseLoadingPromise) {
+      return this.currentlyCoarseLoadingPromise;
     }
 
     // This caller is the first to request the preload, so do the work in the foreground,
     // but also store the promise so that any other concurrent callers can await it.
-    this.currentlyLoadingPromise = this.doLoadResources();
-    await this.currentlyLoadingPromise;
+    this.currentlyCoarseLoadingPromise = this.doLoadCoarseResources();
+    await this.currentlyCoarseLoadingPromise;
   }
 
   /**
-   * Load the {@link CCloudEnvironment}s and their children (Kafka clusters, schema registry, schemas) into
-   * the resource manager  for general use.
+   * Load the {@link CCloudEnvironment}s and their direct children (Kafka clusters, schema registry) into
+   * the resource manager.
    */
-  private async doLoadResources(): Promise<void> {
+  private async doLoadCoarseResources(): Promise<void> {
     // Start loading the ccloud-related resources from sidecar API into the resource manager for local caching.
     // If the loading fails at any time (including, say, the user logs out of CCloud while in progress), then
     // an exception will be thrown and the loadingComplete flag will remain false.
     try {
       const resourceManager = getResourceManager();
-      const sidecar = await getSidecar();
 
       // Fetch the from-sidecar-API list of triplets of (environment, kafkaClusters, schemaRegistry)
       const envGroups = await getEnvironments();
@@ -106,29 +145,16 @@ export class CCloudResourcePreloader {
 
       await resourceManager.setCCloudSchemaRegistryClusters(schemaRegistries);
 
-      // For each environment, if there's a schema registry, queue up fetching (and caching) its schemas.
-      // Is safe to fetch + cache each environment's schemas in parallel.
-      const promises: Promise<Schema[]>[] = [];
-
-      for (const envGroup of envGroups) {
-        const schemaRegistry = envGroup.schemaRegistry;
-        if (schemaRegistry !== undefined) {
-          // queue up to fetch all the schemas. Returns a promise that resolves to the array of schemas
-          // within that cluster.
-          promises.push(fetchSchemas(envGroup.environment, schemaRegistry.id, sidecar));
-        }
-      }
-      // Fetch all the schemas in each registry concurrently.
-      const schemas_per_cluster = await Promise.all(promises);
-      const schemas = schemas_per_cluster.flat();
-
-      // Put into resource manager all at once.
-      await resourceManager.setCCloudSchemas(schemas);
+      // Mark each schema registry as existing, but schemas not yet loaded.
+      this.schemaRegistryClusterCacheStates.clear();
+      schemaRegistries.forEach((schemaRegistry) => {
+        this.schemaRegistryClusterCacheStates.set(schemaRegistry.id, false);
+      });
 
       // TODO: add flink compute pools here?
 
-      // If made it to this point, all the resources have been fetched and cached and can be trusted.
-      this.loadingComplete = true;
+      // If made it to this point, all the coarse resources have been fetched and cached and can be trusted.
+      this.coarseLoadingComplete = true;
     } catch (error) {
       // Perhaps the user logged out of CCloud while the preloading was in progress, or some other API-level error.
       logger.error("Error while preloading CCloud resources", { error });
@@ -136,16 +162,86 @@ export class CCloudResourcePreloader {
     } finally {
       // Regardless of success or failure, clear the currently loading promise so that the next call to
       // ensureResourcesLoaded() can start again from scratch if needed.
-      this.currentlyLoadingPromise = null;
+      this.currentlyCoarseLoadingPromise = null;
     }
   }
 
-  /** Reset the preloader to its initial state: not currently fetching, have not fetched,
-   * so that the next call to {@link ensureResourcesLoaded} will start from scratch.
-   */
-  public reset(): void {
-    this.loadingComplete = false;
-    this.currentlyLoadingPromise = null;
+  /** Ensure that this single schema registry cluster's schemas have been loaded. */
+  public async ensureSchemasLoaded(
+    schemaRegistryClusterId: string,
+    forceDeepRefresh: boolean = false,
+  ): Promise<void> {
+    if (forceDeepRefresh) {
+      // If the caller wants to force a deep refresh, then reset this cluster's state to not having
+      // fetched the schemas yet, so that we'll ignore any prior cached schemas and fetch them anew.
+      this.schemaRegistryClusterCacheStates.set(schemaRegistryClusterId, false);
+    }
+
+    const schemaClusterCacheState =
+      this.schemaRegistryClusterCacheStates.get(schemaRegistryClusterId);
+
+    // Ensure is a valid schema registry cluster id. See doLoadResources() for initial setting
+    // of these keys.
+    if (schemaClusterCacheState === undefined) {
+      throw new Error(
+        `Schema registry cluster with id ${schemaRegistryClusterId} is unknown to the preloader.`,
+      );
+    }
+
+    // If schemas for this cluster are already loaded, nothing to wait on.
+    if (schemaClusterCacheState === true) {
+      return;
+    }
+
+    // If in progress of loading, have the caller await the promise that is currently loading the schemas.
+    if (schemaClusterCacheState instanceof Promise) {
+      return schemaClusterCacheState;
+    }
+
+    // This caller is the first to request the preload of the schemas in this registry,
+    // so do the work in the foreground, but also store the promise so that any other
+    // concurrent callers can await it.
+    const schemaLoadingPromise = this.doLoadSchemas(schemaRegistryClusterId);
+    this.schemaRegistryClusterCacheStates.set(schemaRegistryClusterId, schemaLoadingPromise);
+    await schemaLoadingPromise;
+  }
+
+  /** Load the schemas for this single schema registry cluster into the resource manager. */
+  private async doLoadSchemas(schemaRegistryClusterId: string): Promise<void> {
+    try {
+      logger.info("Deep loading schemas for schema registry cluster", { schemaRegistryClusterId });
+      const rm = getResourceManager();
+      // Need to fetch the schema registry cluster to get the environment.
+      const schemaRegistry = await rm.getCCloudSchemaRegistryClusterById(schemaRegistryClusterId);
+
+      if (!schemaRegistry) {
+        throw new Error(
+          `Schema registry cluster with id ${schemaRegistryClusterId} is unknown to the resource manager.`,
+        );
+      }
+
+      const environment = await rm.getCCloudEnvironment(schemaRegistry.environmentId);
+      if (!environment) {
+        throw new Error(
+          `Environment with id ${schemaRegistry.environmentId} is unknown to the resource manager.`,
+        );
+      }
+
+      // Fetch from sidecar API and store into resource manager.
+      const schemas = await fetchSchemas(environment, schemaRegistry.id);
+      await rm.setSchemasForRegistry(schemaRegistry.id, schemas);
+
+      // Mark this cluster as having its schemas loaded.
+      this.schemaRegistryClusterCacheStates.set(schemaRegistryClusterId, true);
+    } catch (error) {
+      // Perhaps the user logged out of CCloud while the preloading was in progress, or some other API-level error.
+      logger.error("Error while preloading CCloud schemas", { error });
+
+      // Forget the current promise, make next call to ensureSchemasLoaded() start from scratch.
+      this.schemaRegistryClusterCacheStates.set(schemaRegistryClusterId, false);
+
+      throw error;
+    }
   }
 }
 
@@ -159,11 +255,8 @@ export class CCloudResourcePreloader {
 export async function fetchSchemas(
   environment: CCloudEnvironment,
   schemaRegistryClusterId: string,
-  sidecar: SidecarHandle | null = null,
 ): Promise<Schema[]> {
-  if (!sidecar) {
-    sidecar = await getSidecar();
-  }
+  const sidecar = await getSidecar();
 
   const client: SchemasV1Api = sidecar.getSchemasV1Api(
     schemaRegistryClusterId,

--- a/src/storage/ccloudPreloader.ts
+++ b/src/storage/ccloudPreloader.ts
@@ -1,4 +1,3 @@
-import { get } from "node:http";
 import { Schema as ResponseSchema, SchemasV1Api } from "../clients/schemaRegistryRest";
 import { ccloudConnected } from "../emitters";
 import { getEnvironments } from "../graphql/environments";
@@ -6,7 +5,7 @@ import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { Schema, SchemaType } from "../models/schema";
 import { SchemaRegistryCluster } from "../models/schemaRegistry";
-import { getSidecar, SidecarHandle } from "../sidecar";
+import { getSidecar } from "../sidecar";
 import { getResourceManager } from "./resourceManager";
 
 const logger = new Logger("storage.ccloudPreloader");

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -391,6 +391,25 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
     assert.strictEqual(missingCluster, null);
   });
 
+  it("CCLOUD: getCCloudSchemaRegistryClusterById() should correctly retrieve a Schema Registry cluster by its ID", async () => {
+    // set the clusters
+    await getResourceManager().setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
+    // verify the cluster was retrieved correctly
+    const cluster: SchemaRegistryCluster | null =
+      await getResourceManager().getCCloudSchemaRegistryClusterById(TEST_SCHEMA_REGISTRY.id);
+
+    assert.deepStrictEqual(cluster, TEST_SCHEMA_REGISTRY);
+  });
+
+  it("CCLOUD: getCCloudSchemaRegistryClusterById() should return null if the cluster is not found", async () => {
+    // set the clusters
+    await getResourceManager().setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
+    // verify the cluster was not found
+    const missingCluster: SchemaRegistryCluster | null =
+      await getResourceManager().getCCloudSchemaRegistryClusterById("nonexistent-cluster-id");
+    assert.strictEqual(missingCluster, null);
+  });
+
   it("CCLOUD: deleteCCloudSchemaRegistryClusters() should correctly delete Schema Registry clusters", async () => {
     // set the clusters in the StorageManager before deleting them
     const resourceManager = getResourceManager();
@@ -607,12 +626,24 @@ describe("ResourceManager schema tests", function () {
     // extension needs to be activated before storage manager can be used
     storageManager = await getTestStorageManager();
     ccloudSchemas = [
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, id: "100001", subject: "test-ccloud-topic-xyz-value", version: 1 },
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, id: "100055", subject: "test-ccloud-topic-xyz-value", version: 2 },
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, id: "100055", subject: "test-ccloud-topic-abc-value", version: 1 },
+      Schema.create({
+        ...TEST_SCHEMA,
+        id: "100001",
+        subject: "test-ccloud-topic-xyz-value",
+        version: 1,
+      }),
+      Schema.create({
+        ...TEST_SCHEMA,
+        id: "100055",
+        subject: "test-ccloud-topic-xyz-value",
+        version: 2,
+      }),
+      Schema.create({
+        ...TEST_SCHEMA,
+        id: "100055",
+        subject: "test-ccloud-topic-abc-value",
+        version: 1,
+      }),
     ];
   });
 
@@ -626,192 +657,28 @@ describe("ResourceManager schema tests", function () {
     await storageManager.clearWorkspaceState();
   });
 
-  it("CCLOUD: setCCloudSchemas() should correctly store schemas", async () => {
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schemas were stored correctly by checking through the StorageManager instead of the ResourceManager
-    let storedSchemasByCluster: CCloudSchemaBySchemaRegistryCluster | undefined =
-      await storageManager.getWorkspaceState(StateSchemas.CCLOUD);
-    assert.ok(storedSchemasByCluster);
-    assert.ok(storedSchemasByCluster instanceof Map);
-    assert.ok(storedSchemasByCluster.has(ccloudSchemas[0].schemaRegistryId));
-    assert.deepStrictEqual(
-      storedSchemasByCluster.get(ccloudSchemas[0].schemaRegistryId),
-      ccloudSchemas,
-    );
+  it("CCLOUD: setSchemasForRegistry() should correctly store schemas", async () => {
+    const rm = getResourceManager();
+    await rm.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, ccloudSchemas);
+
+    // fetch back from resource manager
+    const storedSchemas = await rm.getSchemasForRegistry(TEST_SCHEMA_REGISTRY.id);
+    assert.ok(storedSchemas);
+    assert.deepStrictEqual(storedSchemas, ccloudSchemas);
   });
 
-  it("CCLOUD: setCCloudSchemas() should add new Schema Registry cluster keys if they don't exist", async () => {
-    // set the first batch of schemas from the first cluster
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // create and set the second batch of schemas for the new cluster
-    const newSchemaRegistryId = "new-schema-registry-id";
-    const newSchemas: Schema[] = [
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, subject: "new-schema-1", schemaRegistryId: newSchemaRegistryId },
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, subject: "new-schema-2", schemaRegistryId: newSchemaRegistryId },
-    ];
-    await getResourceManager().setCCloudSchemas(newSchemas);
+  it("CCLOUD: setSchemasForRegistry() should complain if not all schemas share expected registry id", async () => {
+    const rm = getResourceManager();
+    await assert.rejects(async () => {
+      await rm.setSchemasForRegistry("wrong-registry-id", ccloudSchemas);
+    }, /Schema registry ID mismatch in schemas/);
   });
 
-  it("CCLOUD: setCCloudSchemas() shouldn't duplicate schemas if the same schema ID+version already exists", async () => {
-    // set the first batch of schemas from the first cluster
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // create and set the second batch of schemas for the same cluster
-    const duplicateSchemas: Schema[] = [...ccloudSchemas];
-    await getResourceManager().setCCloudSchemas(duplicateSchemas);
-    // verify the schemas were stored correctly by checking through the StorageManager instead of the ResourceManager
-    let storedSchemasByCluster: CCloudSchemaBySchemaRegistryCluster | undefined =
-      await storageManager.getWorkspaceState(StateSchemas.CCLOUD);
-    assert.ok(storedSchemasByCluster);
-    assert.ok(storedSchemasByCluster instanceof Map);
-    assert.ok(storedSchemasByCluster.has(ccloudSchemas[0].schemaRegistryId));
-    assert.deepStrictEqual(
-      storedSchemasByCluster.get(ccloudSchemas[0].schemaRegistryId),
-      ccloudSchemas,
-    );
-  });
-
-  it("CCLOUD: getCCloudSchemas() should correctly retrieve schemas", async () => {
-    const resourceManager = getResourceManager();
-    // preload some schemas before retrieving them
-    await resourceManager.setCCloudSchemas(ccloudSchemas);
-    // verify the schemas were stored correctly
-    const schemasByCluster: CCloudSchemaBySchemaRegistryCluster =
-      await resourceManager.getCCloudSchemas();
-    const retrievedSchemas = schemasByCluster.get(ccloudSchemas[0].schemaRegistryId);
-    // casting to JSON strings so we don't have to `.equals()` compare each array element
-    assert.equal(JSON.stringify(retrievedSchemas), JSON.stringify(ccloudSchemas));
-  });
-
-  it("CCLOUD: getCCloudSchemas() should return an empty map if no schemas are found", async () => {
-    // verify no schemas are found
-    const schemasByCluster: CCloudSchemaBySchemaRegistryCluster =
-      await getResourceManager().getCCloudSchemas();
-    assert.deepStrictEqual(schemasByCluster, new Map());
-  });
-
-  it("CCLOUD: getCCloudSchemas() should return Schema (dataclass) instances instead of plain objects", async () => {
-    const resourceManager = getResourceManager();
-    // preload some schemas before retrieving them
-    await resourceManager.setCCloudSchemas(ccloudSchemas);
-    // verify the schemas were stored correctly
-    const schemasByCluster: CCloudSchemaBySchemaRegistryCluster =
-      await resourceManager.getCCloudSchemas();
-    const retrievedSchemas = schemasByCluster.get(ccloudSchemas[0].schemaRegistryId);
-    assert.ok(retrievedSchemas);
-    const sampleSchema: Schema = retrievedSchemas[0];
-    // if this fails, we didn't properly convert the object to the dataclass Schema instance
-    assert.ok(typeof sampleSchema.fileName() === "string");
-  });
-
-  it("CCLOUD: getCCloudSchemasById() should correctly retrieve schemas by their ID", async () => {
-    // set the schemas
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schema was retrieved correctly
-    const schemas: Schema[] = await getResourceManager().getCCloudSchemasById(
-      ccloudSchemas[0].schemaRegistryId,
-      ccloudSchemas[1].id,
-    );
-    assert.ok(schemas);
-    console.error("getCCloudSchemasById schemas:", JSON.stringify(schemas));
-    // two schemas matching this schema ID, with two different subjects and versions
-    assert.ok(schemas.length === 2);
-    assert.ok(schemas[0]?.equals(ccloudSchemas[2])); // "test-ccloud-topic-abc-value" v1
-    assert.ok(schemas[1]?.equals(ccloudSchemas[1])); // "test-ccloud-topic-xyz-value" v2
-  });
-
-  it("CCLOUD: getCCloudSchemasById() should return an empty array if the parent Schema Registry ID is not found", async () => {
-    // set the schemas
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schema was not found because the cluster ID is incorrect
-    const missingSchemas: Schema[] = await getResourceManager().getCCloudSchemasById(
-      "nonexistent-cluster-id",
-      ccloudSchemas[0].id,
-    );
-    assert.deepStrictEqual(missingSchemas, []);
-  });
-
-  it("CCLOUD: getCCloudSchemasById() should return an empty array if the schema ID is not found", async () => {
-    // set the schemas
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schema was not found
-    const missingSchemas: Schema[] = await getResourceManager().getCCloudSchemasById(
-      ccloudSchemas[0].schemaRegistryId,
-      "99999999",
-    );
-    assert.deepStrictEqual(missingSchemas, []);
-  });
-
-  it("CCLOUD: getCCloudSchemasBySubject() should correctly retrieve schemas by their subject", async () => {
-    // set the schemas
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schema was retrieved correctly
-    const schemas: Schema[] = await getResourceManager().getCCloudSchemasBySubject(
-      ccloudSchemas[0].schemaRegistryId,
-      ccloudSchemas[0].subject,
-    );
-    assert.ok(schemas);
-    // two versions for this schema subject
-    assert.ok(schemas.length === 2);
-    assert.ok(schemas[0]?.equals(ccloudSchemas[1])); // "test-ccloud-topic-xyz-value" v2
-    assert.ok(schemas[1]?.equals(ccloudSchemas[0])); // "test-ccloud-topic-xyz-value" v1
-  });
-
-  it("CCLOUD: getCCloudSchemasBySubject() should return an empty array if the parent Schema Registry ID is not found", async () => {
-    // set the schemas
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schema was not found because the cluster ID is incorrect
-    const missingSchemas: Schema[] = await getResourceManager().getCCloudSchemasBySubject(
-      "nonexistent-cluster-id",
-      ccloudSchemas[0].subject,
-    );
-    assert.deepStrictEqual(missingSchemas, []);
-  });
-
-  it("CCLOUD: getCCloudSchemasBySubject() should return an empty array if the schema subject is not found", async () => {
-    // set the schemas
-    await getResourceManager().setCCloudSchemas(ccloudSchemas);
-    // verify the schema was not found
-    const missingSchemas: Schema[] = await getResourceManager().getCCloudSchemasBySubject(
-      ccloudSchemas[0].schemaRegistryId,
-      "nonexistent-subject-value",
-    );
-    assert.deepStrictEqual(missingSchemas, []);
-  });
-
-  it("CCLOUD: deleteCCloudSchemas() should correctly delete schemas", async () => {
-    // set the schemas in the StorageManager before deleting them
-    const resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemas(ccloudSchemas);
-    await resourceManager.deleteCCloudSchemas();
-    // verify the schemas were deleted correctly
-    const missingSchemas = await storageManager.getWorkspaceState(StateSchemas.CCLOUD);
-    assert.deepStrictEqual(missingSchemas, undefined);
-  });
-
-  it("CCLOUD: deleteCCloudSchemas() should delete all schemas for a specific Schema Registry cluster", async () => {
-    // set the schemas in the StorageManager before deleting them
-    const resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemas(ccloudSchemas);
-
-    // add some more schemas for a different cluster
-    const newSchemaRegistryId = "new-schema-registry-id";
-    const newSchemas: Schema[] = [
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, subject: "new-schema-1", schemaRegistryId: newSchemaRegistryId },
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, subject: "new-schema-2", schemaRegistryId: newSchemaRegistryId },
-    ];
-    await resourceManager.setCCloudSchemas(newSchemas);
-
-    // delete the first batch
-    await resourceManager.deleteCCloudSchemas(ccloudSchemas[0].schemaRegistryId);
-
-    // verify the schemas were deleted correctly
-    const missingSchemas = await storageManager.getWorkspaceState(StateSchemas.CCLOUD);
-    assert.ok(missingSchemas instanceof Map);
-    assert.strictEqual(missingSchemas.get(ccloudSchemas[0].schemaRegistryId), undefined);
+  it("CCLOUD: setSchemasForRegistry() can store empty array of schemas", async () => {
+    const rm = getResourceManager();
+    await rm.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, []);
+    const storedSchemas = await rm.getSchemasForRegistry(TEST_SCHEMA_REGISTRY.id);
+    assert.deepStrictEqual(storedSchemas, []);
   });
 });
 
@@ -859,7 +726,7 @@ describe("ResourceManager general utility methods", function () {
     await resourceManager.setCCloudKafkaClusters([TEST_CCLOUD_KAFKA_CLUSTER]);
     await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
     await resourceManager.setTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER, ccloudTopics);
-    await resourceManager.setCCloudSchemas(ccloudSchemas);
+    await resourceManager.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, ccloudSchemas);
     // also set some local resources to make sure they aren't deleted
     await resourceManager.setLocalKafkaClusters([TEST_LOCAL_KAFKA_CLUSTER]);
     await resourceManager.setTopicsForCluster(TEST_LOCAL_KAFKA_CLUSTER, localTopics);
@@ -873,8 +740,8 @@ describe("ResourceManager general utility methods", function () {
     assert.deepStrictEqual(missingSchemaRegistries, new Map());
     const missingTopics = await resourceManager.getTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER);
     assert.deepStrictEqual(missingTopics, undefined);
-    const missingSchemas = await resourceManager.getCCloudSchemas();
-    assert.deepStrictEqual(missingSchemas, new Map());
+    const missingSchemas = await resourceManager.getSchemasForRegistry(TEST_SCHEMA_REGISTRY.id);
+    assert.deepStrictEqual(missingSchemas, undefined);
 
     // local resources should still be there
     const existinglocalClusters: LocalKafkaCluster[] =

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -15,7 +15,6 @@ import {
   StateKafkaClusters,
   StateKafkaTopics,
   StateSchemaRegistry,
-  StateSchemas,
 } from "../constants";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
@@ -24,7 +23,6 @@ import { SchemaRegistryCluster } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
 import {
   CCloudKafkaClustersByEnv,
-  CCloudSchemaBySchemaRegistryCluster,
   CCloudSchemaRegistryByEnv,
   getResourceManager,
 } from "./resourceManager";

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -16,6 +16,7 @@ import { ContainerTreeItem } from "../models/main";
 import { SchemaRegistryCluster, SchemaRegistryClusterTreeItem } from "../models/schemaRegistry";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 import { getResourceManager } from "../storage/resourceManager";
+import { hasCCloudAuthSession } from "../sidecar/connections";
 
 const logger = new Logger("viewProviders.resources");
 
@@ -132,7 +133,7 @@ async function loadResources(
 
   const preloader = CCloudResourcePreloader.getInstance();
 
-  if (preloader.hasCCloudConnection()) {
+  if (await hasCCloudAuthSession()) {
     if (forceDeepRefresh) {
       // force a deep refresh of the resources next call to ensureResourcesLoaded()
       preloader.reset();

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -83,7 +83,7 @@ describe("TopicViewProvider helper functions", () => {
     // preload SR cluster + schemas (usually done when loading environments)
     const resourceManager = getResourceManager();
     await resourceManager.setCCloudSchemaRegistryClusters([TEST_SCHEMA_REGISTRY]);
-    await resourceManager.setCCloudSchemas(preloadedSchemas);
+    await resourceManager.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, preloadedSchemas);
     // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
     const topic = TEST_CCLOUD_KAFKA_TOPIC.copy({ name: topicName });
     const schemas = await loadTopicSchemas(topic);
@@ -95,7 +95,7 @@ describe("TopicViewProvider helper functions", () => {
   });
 
   it("loadTopicSchemas() should not return schemas for CCloud Kafka topics if none are available in extension state", async () => {
-    await getResourceManager().setCCloudSchemas(preloadedSchemas);
+    await getResourceManager().setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, preloadedSchemas);
     // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
     const topic = TEST_CCLOUD_KAFKA_TOPIC.copy({ name: topicName });
     const schemas = await loadTopicSchemas(topic);

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -173,7 +173,7 @@ export async function getTopicsForCluster(
 
   // Otherwise make a deep fetch, cache in resource manager, and return.
   let environmentId: string | null = null;
-  let schemas: Schema[] = [];
+  let schemas: Schema[] | undefined = [];
 
   if (cluster instanceof CCloudKafkaCluster) {
     environmentId = cluster.environmentId;
@@ -181,6 +181,12 @@ export async function getTopicsForCluster(
     const schemaRegistry = await resourceManager.getCCloudSchemaRegistryCluster(environmentId);
     if (schemaRegistry) {
       schemas = await resourceManager.getCCloudSchemasForCluster(schemaRegistry.id);
+      if (schemas === undefined) {
+        logger.error("WIP schemas === undefined. Handle this case here, James. Fail this review!", {
+          cluster,
+        });
+        schemas = [];
+      }
     }
   }
 
@@ -209,7 +215,7 @@ export async function getTopicsForCluster(
 
   // Promote each from-response TopicData representation in topicsResp to an internal KafkaTopic object
   const topics: KafkaTopic[] = topicsResp.data.map((topic) => {
-    const hasMatchingSchema: boolean = schemas.some((schema) =>
+    const hasMatchingSchema: boolean = schemas!.some((schema) =>
       schema.matchesTopicName(topic.topic_name),
     );
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Unify cached schema use between topics and schemas view providers.
- Make the preloader keep track of 'coarse' vs 'fine grained' resources, with 'coarse' being the environments, kafka clusters, and schema registries. Schemas are now fine-grained cached (and refresh-able)  per schema registry cluster id. Stop pre-loading all of the schemas at ccloud log in time, but instead do it on demand whenever either any topics are loaded for a cluster, or the schema registry is selected and we need to show all of the schemas.
- Fix premature clearing of the deepRefresh flags: ensure it gets cleared after the refreshing is completed, not right after the repaint event fires (but probably before the flag has been observed).
- Simplify the public schema-related methods from ResourceManager, removing un-called methods and their tests.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- When selecting a schema registry to view for the second time, or after when one of its peer kafka clusters has had its topics loaded, then displaying them a subsequent time will draw from cache.
- Completing the deep fetch for the `Resources` panel is now faster, given that it no longer deep fetches all of the schemas from all of the reachable ccloud schema registries.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
