### PR TITLE
Comparison is the thief of performance

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -242,8 +242,8 @@ function messageViewerStartPollingCommand(
       if (curr === next && i === limit) total++;
       // remaining inclusive filtered item
       if (includes(curr)) filter++;
-      const x0 = i === 0 ? ts.getValue(ts.tail)! : ticks[i - 1];
-      const x1 = i === limit ? ts.getValue(ts.head)! : ticks[i];
+      const x0 = i === 0 ? d0 : ticks[i - 1];
+      const x1 = i === limit ? d1 : ticks[i];
       bins.unshift({ x0, x1, total, filter: bits != null ? filter : null });
     }
 


### PR DESCRIPTION
Two things I'm aiming for fixing here.

1. The old algorithm has linear time complexity and performs way too many comparisons as number of messages grow. It significantly affects how filtering feels to the user for large volumes of messages
2. For some reason the old algorithm has weird bins calculation for first bunch of requests, at least in our testing topics

### Histogram calculation performance

I finally got to make use of skiplist's `find()` method that behaves like binary search, or at least has similar time complexity. See the chart comparing duration to compute the histogram in old and new algorithms. The weird drop down in the New algo data coming from smaller number of bins that histogram starts using at some point as it gets wider range of time (tested on orders_avro since it has higher throughput of messages). Videos below show how much it affects the actual UX given that the viewer applies filter continuously as the user moves the selection on histogram.

<img width="684" alt="image" src="https://github.com/user-attachments/assets/ab34bd5e-d571-4895-9ba5-06da591eb967">


Before


https://github.com/user-attachments/assets/9b627ef0-75c4-41e6-b4f6-6be7b572e8d1

After



https://github.com/user-attachments/assets/c2c58eca-649b-40be-8c66-a853d738e35a


### Calculation issue

An accidental fix happened here as I changed the way how items are counted. For most of the time, the results are the same for both old and new algorithms, but it was something about first N records that made the old algorithm skip a bunch of bins completely. The new algorithm dismisses any chance this may happen.

Before:

<img width="920" alt="Screenshot 2024-09-25 at 11 38 08" src="https://github.com/user-attachments/assets/be82ae8f-0cbd-4b2a-9768-334ba7ac6e59">

After:

<img width="920" alt="Screenshot 2024-09-25 at 11 38 39" src="https://github.com/user-attachments/assets/1faf54f4-0275-4c05-b2d8-3aec4e935f34">
