### PR TITLE
Minor cleanups.

### DIFF
--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -127,7 +127,7 @@ async function deleteTopicCommand(topic: KafkaTopic) {
         // explicitly deep refresh the topics view after deleting a topic, so that repainting
         // ommitting the newly deleted topic is a foreground task we block on before
         // closing the progress window.
-        getTopicViewProvider().refresh(true);
+        getTopicViewProvider().refresh(true, cluster.id);
       } catch (error) {
         const errorMessage = `Failed to delete topic: ${error}`;
         logger.error(errorMessage);
@@ -211,10 +211,9 @@ async function createTopicCommand(item?: KafkaCluster) {
         progress.report({ increment: 33 });
 
         // Refresh in the foreground after creating a topic, so that the new topic is visible
-        // immediately after the progress window closes.
+        // immediately after the progress window closes (assuming topics view is showing this cluster).
 
-        // @param true to force a deep fetch of the topics list, observing the newly created
-        getTopicViewProvider().refresh(true);
+        getTopicViewProvider().refresh(true, cluster.id);
       } catch (error) {
         if (!(error instanceof ResponseError)) {
           // generic error handling

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,7 +250,7 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
     const topicViewProvider = TopicViewProvider.getInstance();
     context.subscriptions.push(
       registerCommandWithLogging("confluent.topics.refresh", () => {
-        // Force a deep refresh of the topic data for this cluster from sidecar.
+        // Force a deep refresh of the topic data for its current cluster from sidecar.
         topicViewProvider.refresh(true);
       }),
     );


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

  * When asking the topics view panel to reset due to a known change to the topics in a cluster, provide the cluster id to the reset() call so that the view panel can filter out repaint requests if not viewing said cluster's topics.

  * No need for data member TopicViewProvider.ccloudEnvironment, can be simplified away since its primary use we have a local var that's just as good. One fewer moving part to track then.

## Any additional details or context that should be provided?

Originally stemmed from https://github.com/confluentinc/vscode/issues/247, but we decided that what is prescribed in that ticket is wrong, since at this time only exactly one listener would react, and the contexts at which we want it to react we want to keep synchronous, so remain direct calls to its reset().

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
