### PR TITLE
fix: convert command registration constants into functions and call at extension activation time

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -1,3 +1,4 @@
+import { Disposable } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { Logger } from "../logging";
 import { getCCloudAuthSession } from "../sidecar/connections";
@@ -22,6 +23,6 @@ async function createConnectionCommand() {
   }
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.connections.create", createConnectionCommand),
-];
+export function registerConnectionCommands(): Disposable[] {
+  return [registerCommandWithLogging("confluent.connections.create", createConnectionCommand)];
+}

--- a/src/commands/debugtools.ts
+++ b/src/commands/debugtools.ts
@@ -181,19 +181,21 @@ async function showOutputChannelCommand() {
   outputChannel.show();
 }
 
-export const commands = [
-  registerCommandWithLogging(
-    "confluent.debugtools.globalState.showWebView",
-    showGlobalStateCommand,
-  ),
-  registerCommandWithLogging(
-    "confluent.debugtools.workspaceState.showWebView",
-    showWorkspaceStateCommand,
-  ),
-  registerCommandWithLogging("confluent.debugtools.globalState.reset", resetGlobalStateCommand),
-  registerCommandWithLogging(
-    "confluent.debugtools.workspaceState.reset",
-    resetWorkspaceStateCommand,
-  ),
-  registerCommandWithLogging("confluent.showOutputChannel", showOutputChannelCommand),
-];
+export function registerDebugCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging(
+      "confluent.debugtools.globalState.showWebView",
+      showGlobalStateCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.debugtools.workspaceState.showWebView",
+      showWorkspaceStateCommand,
+    ),
+    registerCommandWithLogging("confluent.debugtools.globalState.reset", resetGlobalStateCommand),
+    registerCommandWithLogging(
+      "confluent.debugtools.workspaceState.reset",
+      resetWorkspaceStateCommand,
+    ),
+    registerCommandWithLogging("confluent.showOutputChannel", showOutputChannelCommand),
+  ];
+}

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -44,10 +44,12 @@ async function compareWithSelectedCommand(item: any) {
   vscode.commands.executeCommand("vscode.diff", uri1, uri2, title);
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.diff.selectForCompare", selectForCompareCommand),
-  registerCommandWithLogging("confluent.diff.compareWithSelected", compareWithSelectedCommand),
-];
+export function registerDiffCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.diff.selectForCompare", selectForCompareCommand),
+    registerCommandWithLogging("confluent.diff.compareWithSelected", compareWithSelectedCommand),
+  ];
+}
 
 /**
  * Converts a resource item to a URI for comparison.

--- a/src/commands/environments.ts
+++ b/src/commands/environments.ts
@@ -16,6 +16,6 @@ async function renameEnvironmentCommand(item?: CCloudEnvironment | undefined) {
   vscode.window.showInformationMessage("COMING SOON: Renaming environments is not yet supported.");
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.resources.item.rename", renameEnvironmentCommand),
-];
+export function registerEnvironmentCommands(): vscode.Disposable[] {
+  return [registerCommandWithLogging("confluent.resources.item.rename", renameEnvironmentCommand)];
+}

--- a/src/commands/extra.ts
+++ b/src/commands/extra.ts
@@ -33,8 +33,10 @@ async function copyResourceName(item: any) {
   vscode.window.showInformationMessage(`Copied "${item.name}" to clipboard.`);
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.openCCloudLink", openCCloudLink),
-  registerCommandWithLogging("confluent.copyResourceId", copyResourceId),
-  registerCommandWithLogging("confluent.copyResourceName", copyResourceName),
-];
+export function registerExtraCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.openCCloudLink", openCCloudLink),
+    registerCommandWithLogging("confluent.copyResourceId", copyResourceId),
+    registerCommandWithLogging("confluent.copyResourceName", copyResourceName),
+  ];
+}

--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -320,13 +320,18 @@ async function copyBootstrapServers(item: KafkaCluster) {
   vscode.window.showInformationMessage(`Copied "${bootstrapServers}" to clipboard.`);
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.kafka-clusters.item.rename", renameKafkaClusterCommand),
-  registerCommandWithLogging("confluent.resources.kafka-cluster.select", selectKafkaClusterCommand),
-  registerCommandWithLogging("confluent.topics.create", createTopicCommand),
-  registerCommandWithLogging("confluent.topics.delete", deleteTopicCommand),
-  registerCommandWithLogging(
-    "confluent.resources.kafka-cluster.copyBootstrapServers",
-    copyBootstrapServers,
-  ),
-];
+export function registerKafkaClusterCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.kafka-clusters.item.rename", renameKafkaClusterCommand),
+    registerCommandWithLogging(
+      "confluent.resources.kafka-cluster.select",
+      selectKafkaClusterCommand,
+    ),
+    registerCommandWithLogging("confluent.topics.create", createTopicCommand),
+    registerCommandWithLogging("confluent.topics.delete", deleteTopicCommand),
+    registerCommandWithLogging(
+      "confluent.resources.kafka-cluster.copyBootstrapServers",
+      copyBootstrapServers,
+    ),
+  ];
+}

--- a/src/commands/organizations.ts
+++ b/src/commands/organizations.ts
@@ -58,7 +58,9 @@ async function copyOrganizationId() {
   vscode.window.showInformationMessage(`Copied "${currentOrg.id}" to clipboard.`);
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.organizations.use", useOrganizationCommand),
-  registerCommandWithLogging("confluent.copyOrganizationId", copyOrganizationId),
-];
+export function registerOrganizationCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.organizations.use", useOrganizationCommand),
+    registerCommandWithLogging("confluent.copyOrganizationId", copyOrganizationId),
+  ];
+}

--- a/src/commands/schemaRegistry.ts
+++ b/src/commands/schemaRegistry.ts
@@ -17,9 +17,11 @@ async function selectSchemaRegistryCommand(cluster?: SchemaRegistryCluster) {
   vscode.commands.executeCommand("confluent-schemas.focus");
 }
 
-export const commands = [
-  registerCommandWithLogging(
-    "confluent.resources.schema-registry.select",
-    selectSchemaRegistryCommand,
-  ),
-];
+export function registerSchemaRegistryCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging(
+      "confluent.resources.schema-registry.select",
+      selectSchemaRegistryCommand,
+    ),
+  ];
+}

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -55,13 +55,15 @@ function uploadVersionCommand(item: any) {
   );
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.schemaViewer.refresh", refreshCommand),
-  registerCommandWithLogging("confluent.schemaViewer.validate", validateCommand),
-  registerCommandWithLogging("confluent.schemaViewer.uploadVersion", uploadVersionCommand),
-  registerCommandWithLogging("confluent.schemaViewer.viewLocally", viewLocallyCommand),
-  registerCommandWithLogging("confluent.schemas.copySchemaRegistryId", copySchemaRegistryId),
-];
+export function registerSchemaCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.schemaViewer.refresh", refreshCommand),
+    registerCommandWithLogging("confluent.schemaViewer.validate", validateCommand),
+    registerCommandWithLogging("confluent.schemaViewer.uploadVersion", uploadVersionCommand),
+    registerCommandWithLogging("confluent.schemaViewer.viewLocally", viewLocallyCommand),
+    registerCommandWithLogging("confluent.schemas.copySchemaRegistryId", copySchemaRegistryId),
+  ];
+}
 
 /**
  * Convert a {@link Schema} to a URI and render via the {@link SchemaDocumentProvider} as a read-

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -18,11 +18,13 @@ function issueCommand() {
   vscode.commands.executeCommand("vscode.openIssueReporter", "confluentinc.vscode-confluent");
 }
 
-export const commands = [
-  registerCommandWithLogging(
-    "confluent.support.confluent-walkthrough.launch",
-    openWalkthroughCommand,
-  ),
-  registerCommandWithLogging("confluent.support.feedback", feedbackCommand),
-  registerCommandWithLogging("confluent.support.issue", issueCommand),
-];
+export function registerSupportCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging(
+      "confluent.support.confluent-walkthrough.launch",
+      openWalkthroughCommand,
+    ),
+    registerCommandWithLogging("confluent.support.feedback", feedbackCommand),
+    registerCommandWithLogging("confluent.support.issue", issueCommand),
+  ];
+}

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -33,11 +33,13 @@ async function copyKafkaClusterBootstrapUrl() {
   vscode.window.showInformationMessage(`Copied "${cluster.bootstrapServers}" to clipboard.`);
 }
 
-export const commands = [
-  registerCommandWithLogging("confluent.topics.copyKafkaClusterId", copyKafkaClusterId),
-  registerCommandWithLogging("confluent.topics.copyKafkaClusterName", copyKafkaClusterName),
-  registerCommandWithLogging(
-    "confluent.topics.copyKafkaClusterBootstrapServers",
-    copyKafkaClusterBootstrapUrl,
-  ),
-];
+export function registerTopicCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.topics.copyKafkaClusterId", copyKafkaClusterId),
+    registerCommandWithLogging("confluent.topics.copyKafkaClusterName", copyKafkaClusterName),
+    registerCommandWithLogging(
+      "confluent.topics.copyKafkaClusterBootstrapServers",
+      copyKafkaClusterBootstrapUrl,
+    ),
+  ];
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,17 +36,17 @@ if (process.env.SENTRY_DSN) {
 
 import { ConfluentCloudAuthProvider, getAuthProvider } from "./authProvider";
 import { registerCommandWithLogging } from "./commands";
-import { commands as connectionCommands } from "./commands/connections";
-import { commands as debugCommands } from "./commands/debugtools";
-import { commands as diffCommands } from "./commands/diffs";
-import { commands as environmentCommands } from "./commands/environments";
-import { commands as extraCommands } from "./commands/extra";
-import { commands as kafkaClusterCommands } from "./commands/kafkaClusters";
-import { commands as organizationCommands } from "./commands/organizations";
-import { commands as schemaRegistryCommands } from "./commands/schemaRegistry";
-import { commands as schemaCommands } from "./commands/schemas";
-import { commands as supportCommands } from "./commands/support";
-import { commands as topicCommands } from "./commands/topics";
+import { registerConnectionCommands } from "./commands/connections";
+import { registerDebugCommands } from "./commands/debugtools";
+import { registerDiffCommands } from "./commands/diffs";
+import { registerEnvironmentCommands } from "./commands/environments";
+import { registerExtraCommands } from "./commands/extra";
+import { registerKafkaClusterCommands } from "./commands/kafkaClusters";
+import { registerOrganizationCommands } from "./commands/organizations";
+import { registerSchemaRegistryCommands } from "./commands/schemaRegistry";
+import { registerSchemaCommands } from "./commands/schemas";
+import { registerSupportCommands } from "./commands/support";
+import { registerTopicCommands } from "./commands/topics";
 import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL } from "./constants";
 import { activateMessageViewer } from "./consume";
 import { ContextValues, setContextValue, setExtensionContext } from "./context";
@@ -132,7 +132,7 @@ async function setupDebugHelpers(
   logger.info("Output channel disposables added");
   // set up debugging commands before anything else, in case we need to reset global/workspace state
   // or there's a problem further down with extension activation
-  context.subscriptions.push(...debugCommands);
+  context.subscriptions.push(...registerDebugCommands());
   logger.info("Debug command disposables added");
   return context;
 }
@@ -290,16 +290,16 @@ function setupViewProviders(context: vscode.ExtensionContext): vscode.ExtensionC
 function setupCommands(context: vscode.ExtensionContext): vscode.ExtensionContext {
   logger.info("Storing main command disposables...");
   context.subscriptions.push(
-    ...connectionCommands,
-    ...organizationCommands,
-    ...kafkaClusterCommands,
-    ...environmentCommands,
-    ...schemaRegistryCommands,
-    ...schemaCommands,
-    ...supportCommands,
-    ...topicCommands,
-    ...diffCommands,
-    ...extraCommands,
+    ...registerConnectionCommands(),
+    ...registerOrganizationCommands(),
+    ...registerKafkaClusterCommands(),
+    ...registerEnvironmentCommands(),
+    ...registerSchemaRegistryCommands(),
+    ...registerSchemaCommands(),
+    ...registerSupportCommands(),
+    ...registerTopicCommands(),
+    ...registerDiffCommands(),
+    ...registerExtraCommands(),
   );
   logger.info("Main command disposables stored");
   return context;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Discovered while triaging why tests were failing in https://github.com/confluentinc/vscode/pull/301: registering commands before extension activation just causes all sorts of problems in the test suite.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
