### PR TITLE
Separation of concerns: shared task scheduler for message viewer API requests

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -152,7 +152,7 @@ function messageViewerStartPollingCommand(
           panel.webview.postMessage(["Timestamp", "Success", Date.now()]);
         }
       } catch {
-        // panel might be disposed which cases `panel.visible` getter to throw
+        // panel might be disposed which causes `panel.visible` getter to throw
       }
     });
   };

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -10,7 +10,6 @@ describe("scheduler", () => {
     const promise = sinon.promise();
     const setTimeout = sinon.stub(global, "setTimeout");
     setTimeout.callsFake((fn: () => void) => (promise.then(fn), 0 as any));
-    // const delay = sinon.fake((fn: () => void, delay: number) => promise.then(fn));
     const schedule = scheduler(1, 100);
 
     const taskA = sinon.promise();

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -1,0 +1,127 @@
+import { equal, rejects } from "assert/strict";
+import sinon from "sinon";
+import { scheduler, semaphore } from "./scheduler";
+import { performance } from "perf_hooks";
+
+describe("scheduler", () => {
+  const perf = sinon.stub(performance);
+
+  it("should execute tasks in sequence", async () => {
+    const promise = sinon.promise();
+    const setTimeout = sinon.stub(global, "setTimeout");
+    setTimeout.callsFake((fn: () => void) => (promise.then(fn), 0 as any));
+    // const delay = sinon.fake((fn: () => void, delay: number) => promise.then(fn));
+    const schedule = scheduler(1, 100);
+
+    const taskA = sinon.promise();
+    perf.now.returns(0);
+    const resultA = schedule(() => taskA);
+    // task was complete within defined time window
+    perf.now.returns(75);
+    await taskA.resolve(0);
+
+    // task completed
+    equal(await resultA, 0);
+    // delay requested for remaining of time window
+    equal(setTimeout.callCount, 1);
+    equal(setTimeout.getCall(0).args[1], 25);
+    // perform delay
+    await promise.resolve(0);
+
+    const taskB = sinon.promise();
+    perf.now.returns(0);
+    const resultB = schedule(() => taskB);
+    // task took longer than defined time window
+    perf.now.returns(200);
+    await taskB.resolve(1);
+
+    // task completed
+    equal(await resultB, 1);
+    // no extra calls to delay
+    equal(setTimeout.callCount, 1);
+    setTimeout.restore();
+  });
+
+  it("should not execute more concurrent tasks than defined by limit", async () => {
+    const promise = sinon.promise();
+    const setTimeout = sinon.stub(global, "setTimeout");
+    setTimeout.callsFake((fn: () => void) => (promise.then(fn), 0 as any));
+    const schedule = scheduler(2, 100);
+
+    const promiseA = sinon.promise();
+    const taskA = sinon.fake(() => promiseA);
+    const promiseB = sinon.promise();
+    const taskB = sinon.fake(() => promiseB);
+    const promiseC = sinon.promise();
+    const taskC = sinon.fake(() => promiseC);
+    const promiseD = sinon.promise();
+    const taskD = sinon.fake(() => promiseD);
+
+    perf.now.returns(0);
+    const resultA = schedule(taskA);
+    const resultB = schedule(taskB);
+    const resultC = schedule(taskC);
+    const resultD = schedule(taskD);
+
+    equal(taskA.callCount, 1);
+    equal(taskB.callCount, 1);
+    equal(taskC.callCount, 0);
+
+    perf.now.returns(85);
+    await promiseA.resolve("a");
+    equal(setTimeout.callCount, 1);
+    equal(setTimeout.getCall(0).args[1], 15);
+    equal(taskC.callCount, 0);
+    equal(await resultA, "a");
+
+    perf.now.returns(110);
+    await promiseB.resolve("b");
+    // second task didn't require delay
+    equal(setTimeout.callCount, 1);
+    // the pending task should be executed on the next tick
+    await Promise.resolve();
+    equal(taskC.callCount, 1);
+
+    equal(await resultB, "b");
+
+    await promiseC.resolve("c");
+    equal(await resultC, "c");
+
+    // still waiting for the delay after first task completion
+    equal(taskD.callCount, 0);
+    await promise.resolve(0);
+    equal(taskD.callCount, 0);
+    // the pending task should be executed on the next tick
+    await Promise.resolve();
+    equal(taskD.callCount, 1);
+    await promiseD.resolve("d");
+    equal(await resultD, "d");
+    setTimeout.restore();
+  });
+
+  it("should skip aborted tasks", async () => {
+    const promise = sinon.promise();
+    const setTimeout = sinon.stub(global, "setTimeout");
+    setTimeout.callsFake((fn: () => void) => (promise.then(fn), 0 as any));
+    const schedule = scheduler(1, 100);
+    const signal = AbortSignal.abort();
+    await rejects(() => schedule(() => Promise.resolve(), signal));
+    setTimeout.restore();
+  });
+});
+
+describe("semaphore", () => {
+  it("should acquire immediately", () => {
+    const { acquire } = semaphore(1);
+    equal(acquire(), true);
+  });
+
+  it("should await for release", async () => {
+    const { acquire, release } = semaphore(1);
+    acquire();
+    setTimeout(() => release(), 0);
+    const pending = acquire();
+    equal(pending instanceof Promise, true);
+    equal(await pending, true);
+  });
+});

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,50 @@
+import { performance } from "perf_hooks";
+
+/**
+ * Create a function that schedules async functions by given parameters:
+ * 1. No more than `concurrency` functions being invoked at one moment
+ * 2. At least `interval` time pass between calls within a single "thread"
+ */
+export function scheduler(concurrency: number, interval: number) {
+  const { acquire, release } = semaphore(concurrency);
+  return async function schedule<Result>(
+    cb: () => Promise<Result>,
+    signal?: AbortSignal,
+  ): Promise<Result> {
+    const handle = acquire();
+    if (handle instanceof Promise) await handle;
+    if (signal != null && signal.aborted) {
+      release();
+      throw new Error(signal.reason);
+    }
+    const start = performance.now();
+    try {
+      return await cb();
+    } finally {
+      const delta = performance.now() - start;
+      if (delta < interval) setTimeout(release, interval - delta);
+      else release();
+    }
+  };
+}
+
+/** @link https://en.wikipedia.org/wiki/Semaphore_(programming) */
+export function semaphore(max: number) {
+  let value = max;
+  let queue: Array<() => void> = [];
+
+  function acquire() {
+    if (value > 0) return value-- > 0;
+    return new Promise<boolean>((resolve) => {
+      queue.push(() => resolve(acquire()));
+    });
+  }
+
+  function release() {
+    value++;
+    let resolve = queue.shift();
+    if (resolve != null) resolve();
+  }
+
+  return { acquire, release };
+}


### PR DESCRIPTION
Message Viewer talks a lot to the Consume API. It makes one request at a time, but there can be multiple message viewers opened at once. Initially, to avoid rate limiting, I made it so there's a 500ms delay between requests (if previous request was complete sooner than 500ms) plus some random 0-500ms sleep time so multiple active message viewers don't synchronize and hit rate limiting.

I made a better solution that not only keeps multiple MVs resilient to rate limiting, but also boosts request frequency for a single message viewer (which is now very visible when you consumed retained data). I've implemented a basic scheduling mechanism that ensures at most N async tasks can start within T milliseconds. With current settings, it means active message viewers can make no more than 4 requests each 500ms.

I'll keep playing with the parameters later, don't want to be too optimistic. But now, for a single topic, consuming retained messages becomes a lot better experience: orders_avro, first 100k messages, before it was 4:16, with the new scheduler it is 1:23.

When it comes to separation of concerns, this PR removes API timeouts from the consume module and creates a separate layer that handles them in robust way. The scheduler can possibly be used for other asynchronous requests, in case we get another API that is used frequently and may be used by different views at the same time.
