### PR TITLE
Avoid unnecessary locking due to long running tasks

### DIFF
--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -1,11 +1,8 @@
 import { equal, rejects } from "assert/strict";
 import sinon from "sinon";
 import { scheduler, semaphore } from "./scheduler";
-import { performance } from "perf_hooks";
 
 describe("scheduler", () => {
-  const perf = sinon.stub(performance);
-
   it("should execute tasks in sequence", async () => {
     const promise = sinon.promise();
     const setTimeout = sinon.stub(global, "setTimeout");
@@ -13,38 +10,39 @@ describe("scheduler", () => {
     const schedule = scheduler(1, 100);
 
     const taskA = sinon.promise();
-    perf.now.returns(0);
     const resultA = schedule(() => taskA);
-    // task was complete within defined time window
-    perf.now.returns(75);
-    await taskA.resolve(0);
+    // delay requested to unblock the queue
+    equal(setTimeout.callCount, 1);
+    equal(setTimeout.getCall(0).args[1], 100);
 
+    await taskA.resolve(0);
     // task completed
     equal(await resultA, 0);
-    // delay requested for remaining of time window
-    equal(setTimeout.callCount, 1);
-    equal(setTimeout.getCall(0).args[1], 25);
-    // perform delay
-    await promise.resolve(0);
 
     const taskB = sinon.promise();
-    perf.now.returns(0);
     const resultB = schedule(() => taskB);
-    // task took longer than defined time window
-    perf.now.returns(200);
+    // not yet called for release since the task is pending
+    equal(setTimeout.callCount, 1);
+
+    // perform delay
+    await promise.resolve(0);
     await taskB.resolve(1);
 
     // task completed
     equal(await resultB, 1);
-    // no extra calls to delay
-    equal(setTimeout.callCount, 1);
+    equal(setTimeout.callCount, 2);
+    equal(setTimeout.getCall(1).args[1], 100);
     setTimeout.restore();
   });
 
   it("should not execute more concurrent tasks than defined by limit", async () => {
-    const promise = sinon.promise();
+    const queue: (() => void)[] = [];
+    const progressQueue = async () => {
+      const cb = queue.shift();
+      if (cb != null) cb();
+    };
     const setTimeout = sinon.stub(global, "setTimeout");
-    setTimeout.callsFake((fn: () => void) => (promise.then(fn), 0 as any));
+    setTimeout.callsFake((fn: () => void) => (queue.push(fn), 0 as any));
     const schedule = scheduler(2, 100);
 
     const promiseA = sinon.promise();
@@ -56,45 +54,38 @@ describe("scheduler", () => {
     const promiseD = sinon.promise();
     const taskD = sinon.fake(() => promiseD);
 
-    perf.now.returns(0);
     const resultA = schedule(taskA);
     const resultB = schedule(taskB);
     const resultC = schedule(taskC);
     const resultD = schedule(taskD);
 
+    equal(queue.length, 2);
     equal(taskA.callCount, 1);
     equal(taskB.callCount, 1);
     equal(taskC.callCount, 0);
+    equal(taskD.callCount, 0);
 
-    perf.now.returns(85);
     await promiseA.resolve("a");
-    equal(setTimeout.callCount, 1);
-    equal(setTimeout.getCall(0).args[1], 15);
-    equal(taskC.callCount, 0);
     equal(await resultA, "a");
-
-    perf.now.returns(110);
-    await promiseB.resolve("b");
-    // second task didn't require delay
-    equal(setTimeout.callCount, 1);
-    // the pending task should be executed on the next tick
-    await Promise.resolve();
+    await progressQueue();
     equal(taskC.callCount, 1);
+    equal(taskD.callCount, 0);
 
+    await progressQueue();
+    equal(taskC.callCount, 1);
+    equal(taskD.callCount, 1);
+    equal(queue.length, 2);
+
+    await promiseB.resolve("b");
     equal(await resultB, "b");
+    equal(taskC.callCount, 1);
+    equal(taskD.callCount, 1);
 
     await promiseC.resolve("c");
     equal(await resultC, "c");
-
-    // still waiting for the delay after first task completion
-    equal(taskD.callCount, 0);
-    await promise.resolve(0);
-    equal(taskD.callCount, 0);
-    // the pending task should be executed on the next tick
-    await Promise.resolve();
-    equal(taskD.callCount, 1);
     await promiseD.resolve("d");
     equal(await resultD, "d");
+
     setTimeout.restore();
   });
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,5 +1,3 @@
-import { performance } from "perf_hooks";
-
 /**
  * Create a function that schedules async functions by given parameters:
  * 1. No more than `concurrency` functions being invoked at one moment
@@ -17,14 +15,8 @@ export function scheduler(concurrency: number, interval: number) {
       release();
       throw new Error(signal.reason);
     }
-    const start = performance.now();
-    try {
-      return await cb();
-    } finally {
-      const delta = performance.now() - start;
-      if (delta < interval) setTimeout(release, interval - delta);
-      else release();
-    }
+    setTimeout(release, interval);
+    return cb();
   };
 }
 


### PR DESCRIPTION
The scheduler implementation I introduced in https://github.com/confluentinc/vscode/pull/309 mainly assumed the requests not going to take longer than the scheduler's interval and that we should await for the whole async task to complete before switching to the next task in the queue.

For the first thing, I think I overcomplicated the implementation: if "at least" an `interval` should pass before releasing the semaphore, we might as well just explicitly schedule release for the `interval` timeout, without any math. And because of the second thing, the requests that do run longer than the `interval` (e.g. awaiting for new messages appear in the topic) can lead to starvation: other active message viewer may not be able to proceed because of some other MVs waiting for new messages. The case is very rare (you gotta open >4 MVs at the same time to run in `latest` mode), but when happens will cause unnecessary UX issues.

Switching to simply scheduling a release after `interval` regardless of how long an async task took makes the implementation a lot easier to understand and fixes potential issue.
