### PR TITLE
Do not automatically invalidate the session on 401 response

### DIFF
--- a/src/sidecar/middlewares.ts
+++ b/src/sidecar/middlewares.ts
@@ -100,12 +100,6 @@ export class ErrorResponseMiddleware implements Middleware {
       });
       // don't throw an error because our openapi-generator client code will throw ResponseError by
       // default if status >= 400
-
-      // TODO: we may need to handle this for the kafkaRest and schemaRegistryRest clients as well
-      if (context.response.status === 401) {
-        // inform the auth provider that the auth session is no longer valid
-        ccloudAuthSessionInvalidated.fire();
-      }
     }
   }
 }


### PR DESCRIPTION
There are two ways we invalidate the session on the extension side when it seems to be expired: 401s coming from any API (see https://github.com/confluentinc/vscode/pull/109) and by occasionally polling sidecar (see https://github.com/confluentinc/vscode/pull/110). 

Reported by #336 the first case seems to be triggered by a valid session. When the user attempts to create a topic from the extension for the cluster that already doesn't exist (but the extension hasn't updated its cache yet), the API returns 401 Unauthorized. I've been meaning to do another check in `ccloudAuthSessionInvalidated.event()` to see if the session actually expired, but @flippingbits suggested that we don't really need to invalidate the session in case of 401s at all, since we already have a poller that will it for us regardless of the API usage. So let's continue with this assumption here.

cc @shouples for context.

Closes https://github.com/confluentinc/vscode/issues/336.

