### PR TITLE
UX improvement for opening new project after generating from template

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -155,16 +155,17 @@ async function applyTemplate(
     templateName: pickedTemplate.spec.display_name,
   });
   // Notify the user that the project was generated successfully
-  const newWindowButton = "Open Project in New Window";
   const selection = await vscode.window.showInformationMessage(
-    `🎉 Generated "${pickedTemplate.spec.display_name}" in ${destination.path}`,
-    newWindowButton,
-    "Switch to Project",
+    `🎉 Project Generated`,
+    { modal: true, detail: `Location: ${destination.path}` },
+    { title: "Open in New Window" },
+    { title: "Open in Current Window" },
+    { title: "Dismiss", isCloseAffordance: true },
   );
   if (selection !== undefined) {
     // if "true" is set in the `vscode.openFolder` command, it will open a new window instead of
     // reusing the current one
-    const keepsExistingWindow = selection === newWindowButton;
+    const keepsExistingWindow = selection.title === "Open in New Window";
     getTelemetryLogger().logUsage("Scaffold Folder Opened", {
       templateName: pickedTemplate.spec.display_name,
       keepsExistingWindow,
@@ -183,7 +184,7 @@ async function extractZipContents(buffer: ArrayBuffer, destination: vscode.Uri) 
     // TODO: report progress here while writing files
     for (const [name, entry] of Object.entries(entries)) {
       const entryBuffer = await entry.arrayBuffer();
-      vscode.workspace.fs.writeFile(
+      await vscode.workspace.fs.writeFile(
         vscode.Uri.file(posix.join(destination.path, name)),
         new Uint8Array(entryBuffer),
       );


### PR DESCRIPTION
## Summary of Changes

-  For project scaffolding (`Generate Project from Template`) we need it to be more obvious how to open your project folder after generating it. Several users have mentioned it's easy to lose track of where files were saved or miss the small info message that currently helps you open the folder in VSCode. With this PR we'll make it a bigger dialog that users can't miss (or dismiss) without taking action. 

## Any additional details or context that should be provided?

- ✅ Design approved! I paired with @alexeyraspopov and @katehollowayconfluent on this solution.
- Fixes issue #312 
- The actions themselves haven't changed, only the presentation of them
- I did confirm that neither new nor current window logs me out of Confluent Cloud in the extension. Yay 🎉 

| Before | After |
| -- | -- |
| <img width="1664" alt="before" src="https://github.com/user-attachments/assets/b2ad0ded-fcba-480d-be50-28a5d5f20a80"> | <img width="1665" alt="after" src="https://github.com/user-attachments/assets/26db19de-c1d0-4738-b631-946313d0cd4a"> |

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
