### PR TITLE
Quickly diff the two most recent versions of a schema (subject)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this extension will be documented in this file.
 ## Unreleased
 
 - New context menu item "View Latest Schema Version(s)" to quickly open the highest versioned value
-  and / or key schemas for a CCloud topic according to TopicNameStrategy,
+  and / or key schemas for a CCloud topic, based on TopicNameStrategy,
   [issue #261](https://github.com/confluentinc/vscode/issues/261).
+- New context menu item "Show Latest Changes" attached to schema registry schema subject groups
+  having more than one version of the schema. Opens up a diff view between the current and prior
+  versions, [issue #354](https://github.com/confluentinc/vscode/issues/354).
 
 ## 0.17.1
 

--- a/package.json
+++ b/package.json
@@ -445,6 +445,10 @@
         {
           "command": "confluent.topics.copyKafkaClusterBootstrapServers",
           "when": "false"
+        },
+        {
+          "command": "confluent.schemas.diffMostRecentVersions",
+          "when": "false"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
         "category": "Confluent: Debug Tools"
       },
       {
+        "command": "confluent.schemas.diffMostRecentVersions",
+        "title": "Show Latest Changes",
+        "category": "Confluent: Compare Resources"
+      },
+      {
         "command": "confluent.diff.selectForCompare",
         "icon": "$(pass-filled)",
         "title": "Select for Compare",
@@ -521,6 +526,11 @@
           "command": "confluent.copyResourceName",
           "when": "view in confluent.viewsWithResources && viewItem in confluent.resourcesWithNames",
           "group": "2_copy@2"
+        },
+        {
+          "command": "confluent.schemas.diffMostRecentVersions",
+          "when": "view == confluent-schemas && viewItem =~ /.*multiple-versions.*/",
+          "group": "3_compare"
         },
         {
           "command": "confluent.diff.selectForCompare",

--- a/src/commands/schemas.test.ts
+++ b/src/commands/schemas.test.ts
@@ -29,7 +29,7 @@ describe("commands/schemas.ts diffLatestSchemasCommand tests", function () {
     sinon.restore();
   });
 
-  it("diffLatestSchemasCommand should execute the correct commands when ", async () => {
+  it("diffLatestSchemasCommand should execute the correct commands when invoked on a proper schema group", async () => {
     // Make a 3-version schema group ...
     const oldestSchemaVersion = Schema.create({
       ...TEST_SCHEMA,
@@ -63,6 +63,7 @@ describe("commands/schemas.ts diffLatestSchemasCommand tests", function () {
   });
 
   it("diffLatestSchemasCommand should not execute commands if there are fewer than two schemas in the group", async () => {
+    // (this should not happen if the schema group was generated correctly, but diffLatestSchemasCommand guards against it)
     const schemaGroup = new ContainerTreeItem<Schema>(
       "my-topic-value",
       vscode.TreeItemCollapsibleState.Collapsed,

--- a/src/commands/schemas.test.ts
+++ b/src/commands/schemas.test.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert";
+import * as vscode from "vscode";
 import sinon from "sinon";
+import { commands } from "vscode";
 import {
   TEST_CCLOUD_KAFKA_TOPIC,
   TEST_LOCAL_KAFKA_TOPIC,
@@ -9,7 +11,68 @@ import {
 import { Schema } from "../models/schema";
 import { KafkaTopic } from "../models/topic";
 import { ResourceManager } from "../storage/resourceManager";
-import { CannotLoadSchemasError, getLatestSchemasForTopic } from "./schemas";
+import {
+  CannotLoadSchemasError,
+  getLatestSchemasForTopic,
+  diffLatestSchemasCommand,
+} from "./schemas";
+import { ContainerTreeItem } from "../models/main";
+
+describe("commands/schemas.ts diffLatestSchemasCommand tests", function () {
+  let executeCommandStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    executeCommandStub = sinon.stub(commands, "executeCommand");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("diffLatestSchemasCommand should execute the correct commands when ", async () => {
+    // Make a 3-version schema group ...
+    const oldestSchemaVersion = Schema.create({
+      ...TEST_SCHEMA,
+      subject: "my-topic-value",
+      version: 0,
+    });
+
+    const olderSchemaVersion = Schema.create({
+      ...TEST_SCHEMA,
+      subject: "my-topic-value",
+      version: 1,
+    });
+    const latestSchemaVersion = Schema.create({
+      ...TEST_SCHEMA,
+      subject: "my-topic-value",
+      version: 2,
+    });
+    const schemaGroup = new ContainerTreeItem<Schema>(
+      "my-topic-value",
+      vscode.TreeItemCollapsibleState.Collapsed,
+      [latestSchemaVersion, olderSchemaVersion, oldestSchemaVersion],
+    );
+
+    // directly call what command "confluent.schemas.diffMostRecentVersions" would call (made harder to invoke
+    // because it's a command, and we've stubbed out vscode command execution)
+    await diffLatestSchemasCommand(schemaGroup);
+    assert.ok(executeCommandStub.calledWith("confluent.diff.selectForCompare", olderSchemaVersion));
+    assert.ok(
+      executeCommandStub.calledWith("confluent.diff.compareWithSelected", latestSchemaVersion),
+    );
+  });
+
+  it("diffLatestSchemasCommand should not execute commands if there are fewer than two schemas in the group", async () => {
+    const schemaGroup = new ContainerTreeItem<Schema>(
+      "my-topic-value",
+      vscode.TreeItemCollapsibleState.Collapsed,
+      [Schema.create({ ...TEST_SCHEMA, subject: "my-topic-value", version: 1 })],
+    );
+
+    await diffLatestSchemasCommand(schemaGroup);
+    assert.ok(executeCommandStub.notCalled);
+  });
+});
 
 describe("commands/schemas.ts getLatestSchemasForTopic tests", function () {
   let sandbox: sinon.SinonSandbox;

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -59,7 +59,7 @@ function uploadVersionCommand(item: any) {
 }
 
 /** Diff the most recent two versions of schemas bound to a subject. */
-async function diffLatestSchemasCommand(schemaGroup: ContainerTreeItem<Schema>) {
+export async function diffLatestSchemasCommand(schemaGroup: ContainerTreeItem<Schema>) {
   if (schemaGroup.children.length < 2) {
     // Should not happen if the context value was set correctly over in generateSchemaSubjectGroups().
     logger.warn("diffLatestSchemasCommand called with less than two schemas", schemaGroup);

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -58,6 +58,7 @@ function uploadVersionCommand(item: any) {
   );
 }
 
+/** Diff the most recent two versions of schemas bound to a subject. */
 async function diffLatestSchemasCommand(schemaGroup: ContainerTreeItem<Schema>) {
   if (schemaGroup.children.length < 2) {
     // Should not happen if the context value was set correctly over in generateSchemaSubjectGroups().
@@ -65,11 +66,13 @@ async function diffLatestSchemasCommand(schemaGroup: ContainerTreeItem<Schema>) 
     return;
   }
 
-  // generateSchemaSubjectGroups will have set up children as the most rececnt first
+  // generateSchemaSubjectGroups() will have set up `children` in reverse order ([0] is highest version).
   const latestSchema = schemaGroup.children[0];
   const priorVersionSchema = schemaGroup.children[1];
 
-  logger.info("Comparing most recent schemas", latestSchema, priorVersionSchema);
+  logger.info(
+    `Comparing most recent schema versions, subject ${latestSchema.subject}, versions (${latestSchema.version}, ${priorVersionSchema.version})`,
+  );
 
   // Select the latest, then compare against the prior version.
   await vscode.commands.executeCommand("confluent.diff.selectForCompare", priorVersionSchema);

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -7,6 +7,7 @@ import { SchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
 import { ResourceManager } from "../storage/resourceManager";
 import { getSchemasViewProvider } from "../viewProviders/schemas";
+import { ContainerTreeItem } from "../models/main";
 
 const logger = new Logger("commands.schemas");
 
@@ -57,6 +58,24 @@ function uploadVersionCommand(item: any) {
   );
 }
 
+async function diffLatestSchemasCommand(schemaGroup: ContainerTreeItem<Schema>) {
+  if (schemaGroup.children.length < 2) {
+    // Should not happen if the context value was set correctly over in generateSchemaSubjectGroups().
+    logger.warn("diffLatestSchemasCommand called with less than two schemas", schemaGroup);
+    return;
+  }
+
+  // generateSchemaSubjectGroups will have set up children as the most rececnt first
+  const latestSchema = schemaGroup.children[0];
+  const priorVersionSchema = schemaGroup.children[1];
+
+  logger.info("Comparing most recent schemas", latestSchema, priorVersionSchema);
+
+  // Select the latest, then compare against the prior version.
+  await vscode.commands.executeCommand("confluent.diff.selectForCompare", priorVersionSchema);
+  await vscode.commands.executeCommand("confluent.diff.compareWithSelected", latestSchema);
+}
+
 async function openLatestSchemasCommand(topic: KafkaTopic) {
   let highestVersionedSchemas: Schema[] | null = null;
 
@@ -103,6 +122,10 @@ export function registerSchemaCommands(): vscode.Disposable[] {
     registerCommandWithLogging("confluent.schemaViewer.viewLocally", viewLocallyCommand),
     registerCommandWithLogging("confluent.schemas.copySchemaRegistryId", copySchemaRegistryId),
     registerCommandWithLogging("confluent.topics.openlatestschemas", openLatestSchemasCommand),
+    registerCommandWithLogging(
+      "confluent.schemas.diffMostRecentVersions",
+      diffLatestSchemasCommand,
+    ),
   ];
 }
 

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -150,6 +150,18 @@ describe("Schema helper functions", () => {
     );
   });
 
+  it("generateSchemaSubjectGroups() should set the context value to 'multiple-versions' if a subject has more than one schema", () => {
+    const groups = generateSchemaSubjectGroups(schemas);
+
+    // valueSubject has two schema versions, so it should have the context value.
+    const testTopicGroup = groups.find((group) => group.label === valueSubject);
+    assert.equal(testTopicGroup?.contextValue, "multiple-versions");
+
+    // Only one version, so no context value.
+    const anotherTopicGroup = groups.find((group) => group.label === keySubject);
+    assert.equal(anotherTopicGroup?.contextValue, undefined);
+  });
+
   it("generateSchemaSubjectGroups() should assign the correct icon based on schema subject suffix", () => {
     const groups = generateSchemaSubjectGroups(schemas);
 

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -148,7 +148,7 @@ export function generateSchemaSubjectGroups(
     // override description to show schema types + count
     schemaContainerItem.description = `${schemaTypes} (${schemaGroup.length})`;
     if (schemaGroup.length > 1) {
-      // set context key indiciating this group has multiple versions (so can be quickly diff'd, etc.)
+      // set context key indicating this group has multiple versions (so can be quickly diff'd, etc.)
       schemaContainerItem.contextValue = "multiple-versions";
     }
     schemaGroups.push(schemaContainerItem);

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -147,6 +147,10 @@ export function generateSchemaSubjectGroups(
     }
     // override description to show schema types + count
     schemaContainerItem.description = `${schemaTypes} (${schemaGroup.length})`;
+    if (schemaGroup.length > 1) {
+      // set context key indiciating this group has multiple versions (so can be quickly diff'd, etc.)
+      schemaContainerItem.contextValue = "multiple-versions";
+    }
     schemaGroups.push(schemaContainerItem);
   }
   return schemaGroups;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- New context menu item "Show Latest Changes" attached to schema registry schema subject groups
  having more than one version of the schema. Opens up a diff view between the current and prior
  versions, [issue #354](https://github.com/confluentinc/vscode/issues/354).

## Any additional details or context that should be provided?
![diff_latest_schemas](https://github.com/user-attachments/assets/7175f077-c57e-4458-80c5-8dd26db2edf9)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
