### PR TITLE
Jlr/358 silence errors about local kafka not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
 - New context menu item "View Latest Schema Version(s)" to quickly open the highest versioned value
   and / or key schemas for a CCloud topic, based on TopicNameStrategy,
   [issue #261](https://github.com/confluentinc/vscode/issues/261).
 - New context menu item "Show Latest Changes" attached to schema registry schema subject groups
   having more than one version of the schema. Opens up a diff view between the current and prior
   versions, [issue #354](https://github.com/confluentinc/vscode/issues/354).
+
+### Changed
+
+- Do not error log when the sidecar 404s either the local or ccloud connection. This is expected to
+  happen, [issue #358](https://github.com/confluentinc/vscode/issues/358).
 
 ## 0.17.1
 

--- a/src/sidecar/middlewares.ts
+++ b/src/sidecar/middlewares.ts
@@ -90,11 +90,14 @@ export class DebugRequestResponseMiddleware implements Middleware {
 export class ErrorResponseMiddleware implements Middleware {
   async post(context: ResponseContext): Promise<void> {
     if (context.response.status >= 400) {
-      // Special case: if we recieved a 404 about either ccloud or local kafka connection, no need to log it. Is expected.
+      // Special case: if we recieved a 404 about either ccloud or local kafka connection, speak softly. Is expected.
       if (
         context.response.status === 404 &&
         /gateway\/v1\/connections\/vscode-(confluent-cloud|local)-connection/.test(context.url)
       ) {
+        const localOrCcloud = context.url.includes("local") ? "local kafka" : "Confluent Cloud";
+
+        logger.debug(`Received 404 for ${localOrCcloud} connection.`);
         return;
       }
 

--- a/src/sidecar/middlewares.ts
+++ b/src/sidecar/middlewares.ts
@@ -90,6 +90,14 @@ export class DebugRequestResponseMiddleware implements Middleware {
 export class ErrorResponseMiddleware implements Middleware {
   async post(context: ResponseContext): Promise<void> {
     if (context.response.status >= 400) {
+      // Special case: if we recieved a 404 about either ccloud or local kafka connection, no need to log it. Is expected.
+      if (
+        context.response.status === 404 &&
+        /gateway\/v1\/connections\/vscode-(confluent-cloud|local)-connection/.test(context.url)
+      ) {
+        return;
+      }
+
       const requestLogString = contextToRequestLogString(context);
       const responseLogString = await contextToResponseLogString(context);
 

--- a/src/sidecar/middlewares.ts
+++ b/src/sidecar/middlewares.ts
@@ -95,7 +95,7 @@ export class ErrorResponseMiddleware implements Middleware {
         context.response.status === 404 &&
         /gateway\/v1\/connections\/vscode-(confluent-cloud|local)-connection/.test(context.url)
       ) {
-        const localOrCcloud = context.url.includes("local") ? "local kafka" : "Confluent Cloud";
+        const localOrCcloud = context.url.includes("local") ? "local" : "Confluent Cloud";
 
         logger.debug(`Received 404 for ${localOrCcloud} connection.`);
         return;

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -394,7 +394,7 @@ export class SidecarManager {
             );
 
             accessToken = await this.doHandshake();
-            logger.warn(`${logPrefix}(attempt ${i}): handshake successful, got auth token.`);
+            logger.info(`${logPrefix}(attempt ${i}): handshake successful, got auth token.`);
             break;
           } catch (e) {
             // We expect ECONNREFUSED while the sidecar is coming up, but log other unexpected errors.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Do not error log when the sidecar 404s either the local or ccloud connection. This is expected to
  happen, [issue #358](https://github.com/confluentinc/vscode/issues/358).

Quieter, less error-spammy startup now:

<img width="1513" alt="image" src="https://github.com/user-attachments/assets/b961e920-c7a5-41c7-99e1-c5e11aac5f7c">


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
