### PR TITLE
add `runImmediately` flag to `IntervalPoller`

### DIFF
--- a/src/utils/timing.test.ts
+++ b/src/utils/timing.test.ts
@@ -114,6 +114,25 @@ describe("IntervalPoller", () => {
       new IntervalPoller("test", () => {}, 1, 1);
     });
   });
+
+  it("should run the callback immediately if `runImmediately` is true", async () => {
+    let callCount = 0;
+    const func = () => {
+      callCount += 1;
+    };
+    const poller = new IntervalPoller("test", func, 10, 5, true);
+    poller.start();
+    // don't wait at all, callback should have run as soon as start() was called
+    assert.strictEqual(callCount, 1, "Callback wasn't called immediately on start");
+
+    await sleep(20);
+    poller.stop();
+    assert.strictEqual(
+      callCount >= 2,
+      true,
+      "Callback should be called at least once more after the initial call",
+    );
+  });
 });
 
 async function sleep(ms: number) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Before:
- Any callbacks run through the IntervalPoller would wait their initial polling time (whether set to regular/high frequency) before being called

After:
- If `runImmediately` is set to `true`, the callback is called once before getting into the `setInterval` flow

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
