### PR TITLE
cleanup(IntervalPoller): standardize slow/fast naming usage and prevent multiple `restart()` calls when calling `useSlowFrequency()` and `useHighFrequency()` repeatedly

### DIFF
--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,13 +1,11 @@
 import { Logger } from "../logging";
 
-const IDLE_POLLING_FREQUENCY = 10 * 1000; // 10s
-const WAITING_FOR_EVENT_FREQUENCY = 2 * 1000; // 2s
+const SLOW_POLLING_FREQUENCY = 10 * 1000; // 10s
+const FAST_POLLING_FREQUENCY = 2 * 1000; // 2s
 
 const logger = new Logger("utils.timing");
 
-/**
- * Pause for a random amount of time between minMs and maxMs.
- */
+/** Pause for a random amount of time between minMs and maxMs. */
 export async function pauseWithJitter(minMs: number, maxMs: number): Promise<void> {
   if (minMs < 0 || maxMs < 0) {
     throw new Error(`minMs (${minMs}) and maxMs (${maxMs}) must be >= 0`);
@@ -21,43 +19,51 @@ export async function pauseWithJitter(minMs: number, maxMs: number): Promise<voi
 }
 
 /**
- * Class to manage calling a function periodically either at a regular or a higher frequency interval.
+ * Class to manage calling a function periodically either at a slower or a faster frequency interval.
  *
  * If `runImmediately` is set to `true`, the callback will be called immediately when the poller is
  * started. Otherwise, the callback will be called after the first interval has passed.
  */
 export class IntervalPoller {
   private name: string;
-  readonly idleFrequency: number;
-  readonly activeFrequency: number;
+
+  readonly slowFrequency: number;
+  readonly fastFrequency: number;
+  currentFrequency: number;
+
   readonly runImmediately: boolean = false;
 
   private callback: () => void;
+  /** The current interval timer, if it is currently running. */
   private registeredInterval: NodeJS.Timeout | undefined;
 
   constructor(
     name: string,
     callback: () => void,
-    idleFrequency: number = IDLE_POLLING_FREQUENCY,
-    activeFrequency: number = WAITING_FOR_EVENT_FREQUENCY,
+    slowFrequency: number = SLOW_POLLING_FREQUENCY,
+    fastFrequency: number = FAST_POLLING_FREQUENCY,
     runImmediately: boolean = false,
   ) {
-    if (idleFrequency < 1) {
-      throw new Error("Idle frequency must be at least 1ms");
+    if (slowFrequency < 1) {
+      throw new Error("Slow frequency must be at least 1ms");
     }
 
-    if (activeFrequency < 1) {
-      throw new Error("Active frequency must be at least 1ms");
+    if (fastFrequency < 1) {
+      throw new Error("Fast frequency must be at least 1ms");
     }
 
-    if (idleFrequency <= activeFrequency) {
-      throw new Error("Idle frequency must be greater than active frequency");
+    if (slowFrequency <= fastFrequency) {
+      throw new Error("Slow frequency must be greater than high frequency");
     }
 
     this.name = name;
     this.callback = callback;
-    this.idleFrequency = idleFrequency;
-    this.activeFrequency = activeFrequency;
+
+    this.slowFrequency = slowFrequency;
+    this.fastFrequency = fastFrequency;
+    // set slow to start
+    this.currentFrequency = slowFrequency;
+
     this.runImmediately = runImmediately;
   }
 
@@ -67,14 +73,14 @@ export class IntervalPoller {
   public start(): boolean {
     // Only start if not already started.
     if (!this.registeredInterval) {
-      this.restart(this.idleFrequency);
+      this.restart(this.currentFrequency);
       return true;
     }
 
     return false;
   }
 
-  /**  Stop this poller. Returns true if stopped the interval timer
+  /** Stop this poller. Returns true if stopped the interval timer
    * this call (i.e. was actually running).
    */
   public stop(): boolean {
@@ -92,32 +98,41 @@ export class IntervalPoller {
     return this.registeredInterval !== undefined;
   }
 
-  /** Switch to the high-frequency interval. Will start() the
-   * poller if it's not already running.
+  /** Switch to the faster interval polling. Will start() the poller if it's not already running.
+   * Will not take any action if the poller is already running at the fast frequency.
    */
-  public useHighFrequency() {
-    // If we're expecting a connection to be created, we should poll the reconciler
-    // more frequently to catch the new connection as soon as possible.
-    logger.info(`${this.name}: polling more frequently`);
-    this.restart(this.activeFrequency);
+  public useFastFrequency() {
+    logger.debug(`${this.name}: using fast frequency polling interval`, {
+      fastFrequency: `${this.fastFrequency}ms`,
+      slowFrequency: `${this.slowFrequency}ms`,
+    });
+    // only restart if we're not already running or we're changing from slow->fast frequency
+    if (!this.isRunning() || this.currentFrequency !== this.fastFrequency) {
+      this.restart(this.fastFrequency);
+    }
   }
 
-  /** Switch (back) to the regular idle frequency. Will start() the
-   * poller if it's not already running.
+  /** Switch to the slower interval polling. Will start() the poller if it's not already running.
+   * Will not take any action if the poller is already running at the slow frequency.
    */
-  public useRegularFrequency() {
-    // Go back to the normal idle polling frequency. Either found what we were looking for
-    // or the user canceled the make new connection flow.
-    logger.info(`${this.name}: back to regular frequency`);
-    this.restart(this.idleFrequency);
+  public useSlowFrequency() {
+    logger.debug(`${this.name}: using slow frequency polling interval`, {
+      fastFrequency: `${this.fastFrequency}ms`,
+      slowFrequency: `${this.slowFrequency}ms`,
+    });
+    // only restart if we aren't running or we're changing from fast->slow frequency
+    if (!this.isRunning() || this.currentFrequency !== this.slowFrequency) {
+      this.restart(this.slowFrequency);
+    }
   }
 
   /**
-   * Start (or restart) calling our polling function with the given frequency.
-   * @param frequency The frequency at which to interval call. Will be either
-   * the idle frequency or the active frequency.
+   * Start (or restart) calling our function with the given frequency interval.
+   * @param frequency The frequency at which to interval call. Will be either the slow frequency or
+   * the fast frequency.
    */
   private restart(frequency: number): void {
+    this.currentFrequency = frequency;
     // Out with the old interval?
     if (this.registeredInterval) {
       clearInterval(this.registeredInterval);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Cleans up naming/references around polling frequency:
- "active" / "high" updated to "fast"
- "idle" / "regular" updated to "slow"

Adds checks in `useFastFrequency()` and `useSlowFrequency()` methods to make sure we don't `restart()` multiple times if already running at that interval.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
