### PR TITLE
Recognize TopicRecordNameStrategy-based schemas and correlate to topics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Topic -> Schema correlation now recognizes schemas using `TopicRecordNameStrategy` in addition to
+  `TopicNameStrategy`, [issue #298](https://github.com/confluentinc/vscode/issues/298).
+
 ## 0.18.0
 
 ### Added
 
 - New context menu item "View Latest Schema Version(s)" to quickly open the highest versioned value
-  and / or key schemas for a CCloud topic, based on TopicNameStrategy,
+  and / or key schemas for a CCloud topic,
   [issue #261](https://github.com/confluentinc/vscode/issues/261).
 - New context menu item "Show Latest Changes" attached to schema registry schema subject groups
   having more than one version of the schema. Opens up a diff view between the current and prior

--- a/src/authz/schemaRegistry.ts
+++ b/src/authz/schemaRegistry.ts
@@ -12,8 +12,13 @@ const logger = new Logger("authz.schemaRegistry");
 export async function canAccessSchemaForTopic(topic: KafkaTopic): Promise<boolean> {
   // even if the topic only has one schema type or the other, we'll see a 403 if we can't access
   // across both (key & value subject) request responses
+
   // NOTE: if the subject doesn't follow the TopicNameStrategy, we won't be able to track it via
-  // other extension features
+  // other extension features.
+
+  // TopicRecordNameStrategy complicates this, in that those schema
+  // subject names aren't  predictable from just the topic name like for TopicNameStrategy.
+
   const [keyAccess, valueAccess] = await Promise.all([
     canAccessSchemaTypeForTopic(topic, "key"),
     canAccessSchemaTypeForTopic(topic, "value"),

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -148,8 +148,8 @@ async function loadOrCreateSchemaViewer(schema: Schema) {
 }
 
 /**
- * Get the highest versioned schema(s) related to a single topic from the schema registry
- * as decided by TopicNameStrategy. May return two schemas if the topic has both key and value schemas.
+ * Get the highest versioned schema(s) related to a single topic from the schema registry.
+ * May return two schemas if the topic has both key and value schemas.
  */
 export async function getLatestSchemasForTopic(topic: KafkaTopic): Promise<Schema[]> {
   // These two checks indicate programming errors, not a user or external system contents issues ...
@@ -184,7 +184,7 @@ export async function getLatestSchemasForTopic(topic: KafkaTopic): Promise<Schem
     );
   }
 
-  // Filter by TopicNameStrategy for this topic.
+  // Filter for schemas related to this topic.
   const topicSchemas = allSchemas.filter((schema) => schema.matchesTopicName(topic.name));
 
   // Now make map of schema subject -> highest version'd schema for said subject

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -9,6 +9,12 @@ export enum SchemaType {
   Protobuf = "PROTOBUF",
 }
 
+const extensionMap: { [key in SchemaType]: string } = {
+  [SchemaType.Avro]: "avsc",
+  [SchemaType.Json]: "json",
+  [SchemaType.Protobuf]: "proto",
+};
+
 // Main class representing CCloud Schema Registry schemas, matching key/value pairs returned
 // by the `confluent schema-registry schema list` command.
 export class Schema extends Data {
@@ -23,20 +29,21 @@ export class Schema extends Data {
   schemaRegistryId!: Enforced<string>;
   environmentId!: Enforced<string>;
 
-  /** Returns true if this schema subject corresponds to the topic name per TopicNameStrategy */
+  /** Returns true if this schema subject corresponds to the topic name per TopicNameStrategy or TopicRecordNameStrategy*/
   matchesTopicName(topicName: string): boolean {
-    // strip off the -key/-value suffixes to match the topic name exactly based on TopicNameStrategy
-    // since we can't use `startsWith` due to the potential for multiple topics with the same prefix
-    const suffixlessSubject = this.subject.replace(/-key$|-value$/, "");
-    return suffixlessSubject === topicName;
+    if (this.subject.endsWith("-key")) {
+      // TopicNameStrategy key schema
+      return this.subject === `${topicName}-key`;
+    } else if (this.subject.endsWith("-value")) {
+      // TopicNameStrategy value schema
+      return this.subject === `${topicName}-value`;
+    } else {
+      // only other possibility is a matching TopicRecordNameStrategy (value) schema
+      return this.subject.startsWith(`${topicName}-`);
+    }
   }
 
   fileExtension(): string {
-    const extensionMap: { [key in SchemaType]: string } = {
-      [SchemaType.Avro]: "avsc",
-      [SchemaType.Json]: "json",
-      [SchemaType.Protobuf]: "proto",
-    };
     return extensionMap[this.type];
   }
 

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -261,8 +261,8 @@ export async function getTopicsForCluster(
 }
 
 /**
- * Load the schemas for a given topic from extension state by using the `TopicNameStrategy` to match
- * schema subjects with the topic name.
+ * Load the schemas related to the given topic from extension state by using either `TopicNameStrategy`
+ * or `TopicRecordNameStrategy` to match schema subjects with the topic's name.
  * @param topic The Kafka topic to load schemas for.
  * @returns An array of {@link ContainerTreeItem} objects representing the topic's schemas, grouped
  * by subject as {@link ContainerTreeItem}s, with the {@link Schema}s in version-descending order.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Topic -> Schema correlation now recognizes schemas using `TopicRecordNameStrategy` in addition to `TopicNameStrategy`, [issue #298](https://github.com/confluentinc/vscode/issues/298).

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
