### PR TITLE
feat: add "Open Settings" command and Support view item for easy access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- "Open Settings" command to quickly access the Confluent for VS Code extension settings.
+
 ## 0.18.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -220,6 +220,11 @@
         "category": "Confluent: Support"
       },
       {
+        "command": "confluent.support.openSettings",
+        "title": "Open Settings",
+        "category": "Confluent: Support"
+      },
+      {
         "command": "confluent.topic.consume",
         "icon": "$(debug-start)",
         "title": "Browse Messages",

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -18,6 +18,13 @@ function issueCommand() {
   vscode.commands.executeCommand("vscode.openIssueReporter", "confluentinc.vscode-confluent");
 }
 
+function openSettings() {
+  vscode.commands.executeCommand(
+    "workbench.action.openSettings",
+    "@ext:confluentinc.vscode-confluent",
+  );
+}
+
 export function registerSupportCommands(): vscode.Disposable[] {
   return [
     registerCommandWithLogging(
@@ -26,5 +33,6 @@ export function registerSupportCommands(): vscode.Disposable[] {
     ),
     registerCommandWithLogging("confluent.support.feedback", feedbackCommand),
     registerCommandWithLogging("confluent.support.issue", issueCommand),
+    registerCommandWithLogging("confluent.support.openSettings", openSettings),
   ];
 }

--- a/src/viewProviders/support.ts
+++ b/src/viewProviders/support.ts
@@ -50,7 +50,15 @@ export class SupportViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         tooltip: "Click to generate a project from a pre-defined template",
       };
 
-      children.push(walkthroughItem, feedbackItem, issueItem, scaffoldItem);
+      const settingsItem: vscode.TreeItem = new vscode.TreeItem("Open Settings");
+      settingsItem.iconPath = new vscode.ThemeIcon("gear");
+      settingsItem.command = {
+        command: "confluent.support.openSettings",
+        title: "Open Settings",
+        tooltip: "Click to open the Confluent Extension settings",
+      };
+
+      children.push(walkthroughItem, feedbackItem, issueItem, scaffoldItem, settingsItem);
     }
 
     return children;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Pretty minor change overall since we're just wrapping the `workbench.action.openSettings`, but this mainly helps with getting to our extension's settings quickly and easily from anywhere in the UI (command palette or Support view).


https://github.com/user-attachments/assets/8f69af01-548e-4192-8178-28b4384637c6


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
