### PR TITLE
[v0.18.x] add error notification for unexpected error responses during message consume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- "Show Sidecar Output Channel" command for direct access to the sidecar logs via the Output panel.
+
 ## 0.18.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -205,6 +205,12 @@
         "category": "Confluent"
       },
       {
+        "command": "confluent.showSidecarOutputChannel",
+        "title": "Show Sidecar Output Channel",
+        "icon": "$(output)",
+        "category": "Confluent"
+      },
+      {
         "command": "confluent.support.confluent-walkthrough.launch",
         "title": "Get Started with Kafka",
         "category": "Confluent: Support"

--- a/src/commands/debugtools.ts
+++ b/src/commands/debugtools.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { Logger, outputChannel } from "../logging";
+import { sidecarOutputChannel } from "../sidecar";
 import { getStorageManager } from "../storage";
 
 const logger = new Logger("commands.debugtools");
@@ -181,6 +182,12 @@ async function showOutputChannelCommand() {
   outputChannel.show();
 }
 
+async function showSidecarOutputChannelCommand() {
+  // make sure the Output panel is visible first
+  await vscode.commands.executeCommand("workbench.panel.output.focus");
+  sidecarOutputChannel.show();
+}
+
 export function registerDebugCommands(): vscode.Disposable[] {
   return [
     registerCommandWithLogging(
@@ -197,5 +204,9 @@ export function registerDebugCommands(): vscode.Disposable[] {
       resetWorkspaceStateCommand,
     ),
     registerCommandWithLogging("confluent.showOutputChannel", showOutputChannelCommand),
+    registerCommandWithLogging(
+      "confluent.showSidecarOutputChannel",
+      showSidecarOutputChannelCommand,
+    ),
   ];
 }

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -2,10 +2,7 @@ import { randomBytes } from "crypto";
 import { utcTicks } from "d3-time";
 import { Data } from "dataclass";
 import { ObservableScope } from "inertial";
-import { ExtensionContext, Uri, ViewColumn, window, workspace } from "vscode";
-import { type KafkaTopic } from "./models/topic";
-import { type post } from "./webview/message-viewer";
-import messageViewerTemplate from "./webview/message-viewer.html";
+import { commands, ExtensionContext, Uri, ViewColumn, window, workspace } from "vscode";
 import {
   canAccessSchemaForTopic,
   showNoSchemaAccessWarningNotification,
@@ -19,13 +16,16 @@ import {
 } from "./clients/sidecar";
 import { registerCommandWithLogging } from "./commands";
 import { Logger } from "./logging";
-import { getTelemetryLogger } from "./telemetry";
-import { getSidecar, type SidecarHandle } from "./sidecar";
-import { BitSet, Stream, includesSubstring } from "./stream/stream";
-import { handleWebviewMessage } from "./webview/comms/comms";
+import { type KafkaTopic } from "./models/topic";
 import { kafkaClusterQuickPick } from "./quickpicks/kafkaClusters";
 import { topicQuickPick } from "./quickpicks/topics";
 import { scheduler } from "./scheduler";
+import { getSidecar, type SidecarHandle } from "./sidecar";
+import { BitSet, includesSubstring, Stream } from "./stream/stream";
+import { getTelemetryLogger } from "./telemetry";
+import { handleWebviewMessage } from "./webview/comms/comms";
+import { type post } from "./webview/message-viewer";
+import messageViewerTemplate from "./webview/message-viewer.html";
 
 export function activateMessageViewer(context: ExtensionContext) {
   /* All active message viewer instances share the same scheduler to perform API
@@ -389,6 +389,13 @@ function messageViewerStartPollingCommand(
             }
             default: {
               reportable = { message: "Something went wrong." };
+              window
+                .showErrorMessage("Error response while consuming messages.", "Open Logs")
+                .then((action) => {
+                  if (action === "Open Logs") {
+                    commands.executeCommand("confluent.showSidecarOutputChannel");
+                  }
+                });
               break;
             }
           }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Adds a `Show Sidecar Output Channel` command (similar to our `Show Output Channel` command) for easy access, mainly to help with debugging.

First use of it is for unexpected error responses while consuming messages, tested with a local ide-sidecar build with a 20% chance of throwing a `RuntimeException` before returning the `SimpleConsumeMultiPartitionResponse`:

https://github.com/user-attachments/assets/aad691de-5cfb-47f3-b1ed-df6787aacf71


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
