### PR TITLE
[v0.18.x] add additional logging/hardening around CCloud resource loading

### DIFF
--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -1,7 +1,10 @@
 import { graphql } from "gql.tada";
 import { CCLOUD_CONNECTION_ID } from "../constants";
+import { Logger } from "../logging";
 import { CCloudOrganization } from "../models/organization";
 import { getSidecar } from "../sidecar";
+
+const logger = new Logger("graphql.organizations");
 
 export async function getOrganizations(): Promise<CCloudOrganization[]> {
   let orgResponse: CCloudOrganization[] = [];
@@ -19,11 +22,20 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   `);
 
   const sidecar = await getSidecar();
-  const response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
-  if (response.ccloudConnectionById?.organizations) {
-    response.ccloudConnectionById.organizations.forEach((org: any) => {
-      orgResponse.push(CCloudOrganization.create(org));
-    });
+
+  try {
+    const response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
+    if (response.ccloudConnectionById?.organizations) {
+      response.ccloudConnectionById.organizations.forEach((org: any) => {
+        try {
+          orgResponse.push(CCloudOrganization.create(org));
+        } catch (e) {
+          logger.error("Failed to create organization:", e);
+        }
+      });
+    }
+  } catch (e) {
+    logger.error("Failed to fetch organizations:", e);
   }
 
   return orgResponse;

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
 import { IconNames } from "../constants";
 import { getExtensionContext } from "../context";
@@ -135,28 +136,44 @@ async function loadResources(
   // - an unexpandable item with a "No connection" description where the user can connect to CCloud
   // - a "connected" expandable item with a description of the current connection name and the ability
   //   to add a new connection or switch connections
-
-  const preloader = CCloudResourcePreloader.getInstance();
-
   if (await hasCCloudAuthSession()) {
-    // Ensure all of the preloading is complete before referencing resource manager ccloud resources.
-    await preloader.ensureCoarseResourcesLoaded(forceDeepRefresh);
+    const preloader = CCloudResourcePreloader.getInstance();
+    // TODO: have this cached in the resource manager  via the preloader
+    const currentOrg = await getCurrentOrganization();
 
-    const resourceManager = getResourceManager();
+    let ccloudEnvironments: CCloudEnvironment[] = [];
+    try {
+      // Ensure all of the preloading is complete before referencing resource manager CCloud resources.
+      await preloader.ensureCoarseResourcesLoaded(forceDeepRefresh);
+      const resourceManager = getResourceManager();
+      ccloudEnvironments = await resourceManager.getCCloudEnvironments();
+    } catch (e) {
+      // if we fail to load CCloud environments, we need to get as much information as possible as to
+      // what went wrong since the user is effectively locked out of the CCloud resources for this org
+      const msg = `Failed to load Confluent Cloud environments for the "${currentOrg?.name}" organization.`;
+      logger.error(msg, e);
+      Sentry.captureException(e);
+      vscode.window.showErrorMessage(msg, "Open Logs", "File Issue").then(async (action) => {
+        if (action === "Open Logs") {
+          vscode.commands.executeCommand("confluent.showOutputChannel");
+        } else if (action === "File Issue") {
+          vscode.commands.executeCommand("confluent.support.issue");
+        }
+      });
+    }
 
-    const ccloudEnvironments: CCloudEnvironment[] = await resourceManager.getCCloudEnvironments();
-
+    const collapsibleState =
+      ccloudEnvironments.length > 0
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.None;
     const cloudContainerItem = new ContainerTreeItem<CCloudEnvironment>(
       "Confluent Cloud",
-      vscode.TreeItemCollapsibleState.Expanded,
+      collapsibleState,
       ccloudEnvironments,
     );
     cloudContainerItem.id = "ccloud-container-connected";
     // removes the "Add Connection" action on hover and enables the "Change Organization" action
     cloudContainerItem.contextValue = "resources-ccloud-container-connected";
-
-    // TODO: have this cached in the resource manager  via the preloader
-    const currentOrg = await getCurrentOrganization();
     cloudContainerItem.description = currentOrg?.name ?? "";
     cloudContainerItem.iconPath = CONFLUENT_ICON;
     resources.push(cloudContainerItem);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Mainly aiming to get more information about what's going wrong on in https://github.com/confluentinc/vscode/issues/224.

We've tried a couple different scenarios:
- an account with no associated organization (if they deleted it after account creation) won't be able to complete the CCloud auth flow and will get an authentication failed page in their browser
- an account with no accesses to any resources should see an empty array of organizations and/or environments (but this PR also fixes the `CollapsedState` of the "Confluent Cloud" item)

Based on what we're able to find/see from this update, we can provide a follow-on fix for the above issue (that will also include new tests).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
