### PR TITLE
[v0.18.x] filter `ENOENT: no such file or directory, lstat` from Sentry errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ if (process.env.SENTRY_DSN) {
     ],
     ignoreErrors: [
       "The request failed and the interceptors did not return an alternative response",
+      "ENOENT: no such file or directory, lstat",
     ],
   });
 }


### PR DESCRIPTION
https://docs.sentry.io/platforms/javascript/configuration/filtering/