### PR TITLE
cleanup(tests): make Sinon stubs belong to Sinon sandboxes

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -35,7 +35,7 @@ describe("authz.schemaRegistry", function () {
     sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
     // mock the workspace configuration until we can solve this in the test runner:
     // "Unable to write to Workspace Settings because no workspace is opened. Please open a workspace first and try again.: CodeExpectedError: Unable to write to Workspace Settings because no workspace is opened. Please open a workspace first and try again."
-    getConfigurationStub = sinon.stub(workspace, "getConfiguration");
+    getConfigurationStub = sandbox.stub(workspace, "getConfiguration");
   });
 
   afterEach(async function () {
@@ -131,7 +131,7 @@ describe("authz.schemaRegistry", function () {
   // showNoSchemaAccessWarningNotification() tests
   it("showNoSchemaAccessWarningNotification() should show warning if warnings are enabled", function () {
     const mockConfig = {
-      get: sinon.stub().callsFake((key: string) => {
+      get: sandbox.stub().callsFake((key: string) => {
         if (key === SCHEMA_RBAC_WARNINGS_ENABLED) return true;
       }),
     };
@@ -144,7 +144,7 @@ describe("authz.schemaRegistry", function () {
 
   it("showNoSchemaAccessWarningNotification() should not show warning if warnings are disabled", function () {
     const mockConfig = {
-      get: sinon.stub().callsFake((key: string) => {
+      get: sandbox.stub().callsFake((key: string) => {
         if (key === SCHEMA_RBAC_WARNINGS_ENABLED) return false;
       }),
     };

--- a/src/commands/schemas.test.ts
+++ b/src/commands/schemas.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
-import * as vscode from "vscode";
 import sinon from "sinon";
+import * as vscode from "vscode";
 import { commands } from "vscode";
 import {
   TEST_CCLOUD_KAFKA_TOPIC,
@@ -8,25 +8,27 @@ import {
   TEST_SCHEMA,
   TEST_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
+import { ContainerTreeItem } from "../models/main";
 import { Schema } from "../models/schema";
 import { KafkaTopic } from "../models/topic";
 import { ResourceManager } from "../storage/resourceManager";
 import {
   CannotLoadSchemasError,
-  getLatestSchemasForTopic,
   diffLatestSchemasCommand,
+  getLatestSchemasForTopic,
 } from "./schemas";
-import { ContainerTreeItem } from "../models/main";
 
 describe("commands/schemas.ts diffLatestSchemasCommand tests", function () {
+  let sandbox: sinon.SinonSandbox;
   let executeCommandStub: sinon.SinonStub;
 
   beforeEach(() => {
-    executeCommandStub = sinon.stub(commands, "executeCommand");
+    sandbox = sinon.createSandbox();
+    executeCommandStub = sandbox.stub(commands, "executeCommand");
   });
 
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   it("diffLatestSchemasCommand should execute the correct commands when invoked on a proper schema group", async () => {

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -4,14 +4,16 @@ import { commands } from "vscode";
 import { ContextValues, getContextValue, setContextValue } from "./context";
 
 describe("ContextValue functions", () => {
+  let sandbox: sinon.SinonSandbox;
   let executeCommandStub: sinon.SinonStub;
 
   beforeEach(() => {
-    executeCommandStub = sinon.stub(commands, "executeCommand");
+    sandbox = sinon.createSandbox();
+    executeCommandStub = sandbox.stub(commands, "executeCommand");
   });
 
   afterEach(() => {
-    sinon.restore();
+    sandbox.restore();
   });
 
   it("setContextValue() should correctly context value and execute the setContext command", async () => {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -147,17 +147,18 @@ describe("ExtensionContext subscription tests", () => {
 });
 
 describe("Sentry user settings check", () => {
+  let sandbox: sinon.SinonSandbox;
   let getConfigurationStub: sinon.SinonStub;
   let isTelemetryEnabledStub: sinon.SinonStub;
 
   before(() => {
-    getConfigurationStub = sinon.stub(vscode.workspace, "getConfiguration");
-    isTelemetryEnabledStub = sinon.stub(vscode.env, "isTelemetryEnabled");
+    sandbox = sinon.createSandbox();
+    getConfigurationStub = sandbox.stub(vscode.workspace, "getConfiguration");
+    isTelemetryEnabledStub = sandbox.stub(vscode.env, "isTelemetryEnabled");
   });
 
   after(() => {
-    getConfigurationStub.restore();
-    isTelemetryEnabledStub.restore();
+    sandbox.restore();
   });
 
   it("should return null when telemetry is disabled", () => {

--- a/src/preferences/listener.test.ts
+++ b/src/preferences/listener.test.ts
@@ -23,7 +23,7 @@ describe("preferences/listener", function () {
 
   it("should call updatePreferences() with 'tls_pem_paths' when the SSL_PEM_PATHS config changes", async function () {
     const mockConfig = {
-      get: sinon.stub().withArgs(SSL_PEM_PATHS).returns(["path/to/pem"]),
+      get: sandbox.stub().withArgs(SSL_PEM_PATHS).returns(["path/to/pem"]),
     };
     getConfigurationStub.returns(mockConfig);
     const updatePreferencesStub = sandbox.stub(updates, "updatePreferences").resolves();
@@ -41,7 +41,7 @@ describe("preferences/listener", function () {
 
   it("should call updatePreferences() with 'trust_all_certificates' when the SSL_VERIFY_SERVER_CERT_DISABLED config changes", async function () {
     const mockConfig = {
-      get: sinon.stub().withArgs(SSL_VERIFY_SERVER_CERT_DISABLED).returns(true),
+      get: sandbox.stub().withArgs(SSL_VERIFY_SERVER_CERT_DISABLED).returns(true),
     };
     getConfigurationStub.returns(mockConfig);
     const updatePreferencesStub = sandbox.stub(updates, "updatePreferences").resolves();

--- a/src/sidecar/authStatusPolling.test.ts
+++ b/src/sidecar/authStatusPolling.test.ts
@@ -27,19 +27,21 @@ function createFakeConnection(expiresInMinutes: number | undefined): Connection 
 }
 
 describe("CCloud auth expiration checks", () => {
+  let sandbox: sinon.SinonSandbox;
   let showWarningMessageStub: sinon.SinonStub;
   let showErrorMessageStub: sinon.SinonStub;
 
   beforeEach(() => {
+    sandbox = sinon.createSandbox();
     // REAUTH_BUTTON_TEXT is the only option that doesn't adjust the AuthPromptTracker's
     // `reauthWarningPromptOpen`, so if we don't use that, we'll see weird state changes
     const warningMessageThenable = Promise.resolve(REAUTH_BUTTON_TEXT);
-    showWarningMessageStub = sinon.stub(vscode.window, "showWarningMessage");
+    showWarningMessageStub = sandbox.stub(vscode.window, "showWarningMessage");
     showWarningMessageStub.returns(warningMessageThenable);
 
     // we don't need to handle any specific return value for this stub
     const errorMessageThenable = Promise.resolve("test");
-    showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+    showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
     showErrorMessageStub.returns(errorMessageThenable);
 
     // reset the auth prompt tracker state
@@ -49,8 +51,7 @@ describe("CCloud auth expiration checks", () => {
   });
 
   afterEach(() => {
-    showWarningMessageStub.restore();
-    showErrorMessageStub.restore();
+    sandbox.restore();
   });
 
   /** Reusable helper function to check that our "reauth warning" notification was called as expected. */


### PR DESCRIPTION
Attempting to fix some issues with occasional test errors in CI like:
```
TypeError: Cannot read properties of undefined (reading 'restore')
	at Context.<anonymous> (out/src/authz/schemaRegistry.test.js:56:13)
	at process.processImmediate (node:internal/timers:483:21)
	at process.callbackTrampoline (node:internal/async_hooks:130:17)
```