### PR TITLE
MINOR: add "Open Logs" button for sidecar debug (error) notifications

### DIFF
--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -462,7 +462,13 @@ export class SidecarManager {
           false,
         );
         if (notifySidecarExceptions) {
-          vscode.window.showErrorMessage(`Sidecar error: ${errorMatch[2]}`);
+          vscode.window
+            .showErrorMessage(`Sidecar error: ${errorMatch[2]}`, "Open Logs")
+            .then((action) => {
+              if (action === "Open Logs") {
+                vscode.commands.executeCommand("confluent.showSidecarOutputChannel");
+              }
+            });
         }
       }
       sidecarOutputChannel.appendLine(line);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Continuation of https://github.com/confluentinc/vscode/pull/378. Only applicable when the user has the `confluent.debugging.showSidecarExceptions` setting enabled and sees the error notifications:

<img width="1323" alt="image" src="https://github.com/user-attachments/assets/650420b1-a8d1-479a-9dac-52327f8bb751">


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
