### PR TITLE
remove stub restore() since `sandbox.restore()` handles it

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -42,8 +42,6 @@ describe("authz.schemaRegistry", function () {
     sandbox.restore();
     // clear out the existing Schema Registry after each test
     await resourceManager.deleteCCloudSchemaRegistries(TEST_SCHEMA_REGISTRY.environmentId);
-    // restore `getConfiguration()` to its original implementation
-    getConfigurationStub.restore();
   });
 
   // FIXME: canAccessSchemaForTopic() tests


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/vscode/pull/391 since we're still getting some errors:

![image](https://github.com/user-attachments/assets/d3804299-c6ff-4e7a-abbe-04ef48d9d000)

In this case, there's no need to `.restore()` this stub since it's already being restored a couple lines up from `sandbox.restore()`
