### PR TITLE
feat(Docker): add "Stop Local Resources" command/action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this extension will be documented in this file.
 - "Start Local Resources" functionality to run `confluentinc/confluent-local` Kafka locally as a
   Docker container (or up to four containers). Available from the Resources view's "Local" item, as
   well as the command palette.
+- "Stop Local Resources" functionality to stop running `confluentinc/confluent-local` Kafka Docker
+  containers. Available from the Resources view's "Local" item, as well as the command palette.
 
 ## 0.20.1
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,12 @@
         "category": "Confluent: Docker"
       },
       {
+        "command": "confluent.docker.shutdownLocalKafka",
+        "icon": "$(docker)",
+        "title": "Stop Local Kafka Cluster",
+        "category": "Confluent: Docker"
+      },
+      {
         "command": "confluent.schemas.diffMostRecentVersions",
         "title": "Show Latest Changes",
         "category": "Confluent: Compare Resources"

--- a/package.json
+++ b/package.json
@@ -106,9 +106,9 @@
         "category": "Confluent: Docker"
       },
       {
-        "command": "confluent.docker.shutdownLocalKafka",
+        "command": "confluent.docker.stopLocalResources",
         "icon": "$(docker)",
-        "title": "Stop Local Kafka Cluster",
+        "title": "Stop Local Resources",
         "category": "Confluent: Docker"
       },
       {
@@ -622,6 +622,11 @@
           "command": "confluent.docker.startLocalResources",
           "when": "view == confluent-resources && viewItem =~ /local-container.*/ && !confluent.localKafkaClusterAvailable",
           "group": "inline"
+        },
+        {
+          "command": "confluent.docker.stopLocalResources",
+          "when": "view == confluent-resources && viewItem == local-container-connected && confluent.localKafkaClusterAvailable",
+          "group": "local@2"
         },
         {
           "command": "confluent.schemas.diffMostRecentVersions",

--- a/package.json
+++ b/package.json
@@ -626,7 +626,7 @@
         {
           "command": "confluent.docker.stopLocalResources",
           "when": "view == confluent-resources && viewItem == local-container-connected && confluent.localKafkaClusterAvailable",
-          "group": "local@2"
+          "group": "inline"
         },
         {
           "command": "confluent.schemas.diffMostRecentVersions",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
       },
       {
         "command": "confluent.docker.stopLocalResources",
-        "icon": "$(stop)",
+        "icon": "$(debug-stop)",
         "title": "Stop Local Resources",
         "category": "Confluent: Docker"
       },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
       },
       {
         "command": "confluent.docker.stopLocalResources",
-        "icon": "$(docker)",
+        "icon": "$(stop)",
         "title": "Stop Local Resources",
         "category": "Confluent: Docker"
       },

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -14,6 +14,10 @@ async function startLocalResourcesWithProgress() {
   await runWorkflowWithProgress();
 }
 
+async function stopLocalResourcesWithProgress() {
+  await runWorkflowWithProgress(false);
+}
+
 /** Run the local resource workflow(s) with a progress notification. */
 export async function runWorkflowWithProgress(start: boolean = true) {
   const dockerAvailable = await isDockerAvailable();
@@ -130,6 +134,10 @@ export function registerDockerCommands(): Disposable[] {
     registerCommandWithLogging(
       "confluent.docker.startLocalResources",
       startLocalResourcesWithProgress,
+    ),
+    registerCommandWithLogging(
+      "confluent.docker.stopLocalResources",
+      stopLocalResourcesWithProgress,
     ),
   ];
 }

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -120,6 +120,7 @@ export async function stopContainer(id: string) {
   const init: RequestInit = defaultRequestInit();
 
   try {
+    logger.debug("Stopping container", { id });
     await client.containerStop({ id }, init);
   } catch (error) {
     if (error instanceof ResponseError) {

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -114,3 +114,23 @@ export async function getContainer(id: string): Promise<ContainerInspectResponse
     throw error;
   }
 }
+
+export async function stopContainer(id: string) {
+  const client = new ContainerApi();
+  const init: RequestInit = defaultRequestInit();
+
+  try {
+    await client.containerStop({ id }, init);
+  } catch (error) {
+    if (error instanceof ResponseError) {
+      const body = await streamToString(error.response.clone().body);
+      logger.error("Error response stopping container:", {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        body: body,
+      });
+    } else {
+      logger.error("Error stopping container:", error);
+    }
+  }
+}

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -134,3 +134,23 @@ export async function stopContainer(id: string) {
     }
   }
 }
+
+export async function deleteContainer(id: string) {
+  const client = new ContainerApi();
+  const init: RequestInit = defaultRequestInit();
+
+  try {
+    await client.containerDelete({ id }, init);
+  } catch (error) {
+    if (error instanceof ResponseError) {
+      const body = await streamToString(error.response.clone().body);
+      logger.error("Error response deleting container:", {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        body: body,
+      });
+    } else {
+      logger.error("Error removing container:", error);
+    }
+  }
+}

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -135,21 +135,7 @@ export async function stopContainer(id: string) {
   }
 }
 
-export async function deleteContainer(id: string) {
-  const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
-
-  try {
-    await client.containerDelete({ id }, init);
-  } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response deleting container:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().json(),
-      });
-    } else {
-      logger.error("Error removing container:", error);
-    }
-  }
+export async function restartContainer(id: string) {
+  await stopContainer(id);
+  await startContainer(id);
 }

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -95,6 +95,32 @@ export async function startContainer(containerId: string): Promise<void> {
   }
 }
 
+export async function stopContainer(id: string): Promise<void> {
+  const client = new ContainerApi();
+  const init: RequestInit = defaultRequestInit();
+
+  try {
+    logger.debug("Stopping container", { id });
+    await client.containerStop({ id }, init);
+  } catch (error) {
+    if (error instanceof ResponseError) {
+      logger.error("Error response stopping container:", {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        body: await error.response.clone().json(),
+      });
+    } else {
+      logger.error("Error stopping container:", error);
+    }
+    throw error;
+  }
+}
+
+export async function restartContainer(id: string) {
+  await stopContainer(id);
+  await startContainer(id);
+}
+
 export async function getContainer(id: string): Promise<ContainerInspectResponse> {
   const client = new ContainerApi();
   const init: RequestInit = defaultRequestInit();
@@ -113,29 +139,4 @@ export async function getContainer(id: string): Promise<ContainerInspectResponse
     }
     throw error;
   }
-}
-
-export async function stopContainer(id: string) {
-  const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
-
-  try {
-    logger.debug("Stopping container", { id });
-    await client.containerStop({ id }, init);
-  } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response stopping container:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().json(),
-      });
-    } else {
-      logger.error("Error stopping container:", error);
-    }
-  }
-}
-
-export async function restartContainer(id: string) {
-  await stopContainer(id);
-  await startContainer(id);
 }

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -124,11 +124,10 @@ export async function stopContainer(id: string) {
     await client.containerStop({ id }, init);
   } catch (error) {
     if (error instanceof ResponseError) {
-      const body = await streamToString(error.response.clone().body);
       logger.error("Error response stopping container:", {
         status: error.response.status,
         statusText: error.response.statusText,
-        body: body,
+        body: await error.response.clone().json(),
       });
     } else {
       logger.error("Error stopping container:", error);
@@ -144,11 +143,10 @@ export async function deleteContainer(id: string) {
     await client.containerDelete({ id }, init);
   } catch (error) {
     if (error instanceof ResponseError) {
-      const body = await streamToString(error.response.clone().body);
       logger.error("Error response deleting container:", {
         status: error.response.status,
         statusText: error.response.statusText,
-        body: body,
+        body: await error.response.clone().json(),
       });
     } else {
       logger.error("Error removing container:", error);

--- a/src/docker/workflows/base.test.ts
+++ b/src/docker/workflows/base.test.ts
@@ -25,6 +25,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
   // docker/containers.ts+images.ts wrapper function stubs
   let getContainerStub: sinon.SinonStub;
   let startContainerStub: sinon.SinonStub;
+  let restartContainerStub: sinon.SinonStub;
   let imageExistsStub: sinon.SinonStub;
   let pullImageStub: sinon.SinonStub;
 
@@ -37,6 +38,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     getContainerStub = sandbox.stub(dockerContainers, "getContainer");
     startContainerStub = sandbox.stub(dockerContainers, "startContainer");
+    restartContainerStub = sandbox.stub(dockerContainers, "restartContainer");
     imageExistsStub = sandbox.stub(dockerImages, "imageExists");
     pullImageStub = sandbox.stub(dockerImages, "pullImage");
 
@@ -148,25 +150,25 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
     );
   });
 
-  // TODO(shoup): update this in downstream branch
-  // it("handleExistingContainers() should handle 'running' containers and prompt the user to restart them", async () => {
-  //   const fakeContainers: ContainerSummary[] = [
-  //     { Id: "1", Names: ["/container1"], Image: "image1", State: "running" },
-  //   ];
-  //   // stub the user clicking the 'Restart' button
-  //   const button = "Restart";
-  //   showErrorMessageStub.resolves(button);
+  it("handleExistingContainers() should handle 'running' containers and prompt the user to restart them", async () => {
+    const fakeContainers: ContainerSummary[] = [
+      { Id: "1", Names: ["/container1"], Image: "image1", State: "running" },
+    ];
+    // stub the user clicking the 'Restart' button
+    const button = "Restart";
+    showErrorMessageStub.resolves(button);
 
-  //   await workflow.handleExistingContainers(fakeContainers);
+    await workflow.handleExistingContainers(fakeContainers);
 
-  //   assert.ok(
-  //     showErrorMessageStub.calledOnceWith(
-  //       "Existing test container found. Please restart or remove it and try again.",
-  //       button,
-  //     ),
-  //   );
-  //   assert.ok(startContainerStub.notCalled);
-  // });
+    assert.ok(
+      showErrorMessageStub.calledOnceWith(
+        "Existing test container found. Please restart or remove it and try again.",
+        button,
+      ),
+    );
+    assert.ok(startContainerStub.notCalled);
+    assert.ok(restartContainerStub.calledOnceWith(fakeContainers[0].Id!));
+  });
 
   it("startContainer() should start a container and return its inspect response", async () => {
     const fakeContainer: LocalResourceContainer = { id: "1", name: "test-container" };

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -172,7 +172,7 @@ export abstract class LocalResourceWorkflow {
     let buttonLabel = "";
     const anyRunning = containerStates.includes("running");
     if (anyRunning) {
-      buttonLabel = ""; // doesn't actually show a button; TODO(shoup): set in downstream branch
+      buttonLabel = containers.length > 1 ? "Restart All" : "Restart";
     } else {
       buttonLabel = count > 1 ? "Start All" : "Start";
     }

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -2,7 +2,7 @@ import { CancellationToken, commands, Progress, window } from "vscode";
 import { ContainerInspectResponse, ContainerSummary, ResponseError } from "../../clients/docker";
 import { Logger } from "../../logging";
 import { getTelemetryLogger } from "../../telemetry/telemetryLogger";
-import { getContainer, startContainer } from "../containers";
+import { getContainer, restartContainer, startContainer } from "../containers";
 import { imageExists, pullImage } from "../images";
 
 /** Basic container information for a local resource. */
@@ -198,7 +198,7 @@ export abstract class LocalResourceWorkflow {
               continue;
             }
             if (anyRunning) {
-              // TODO: implement stop+start in downstream branch
+              await restartContainer(container.Id);
             } else {
               await this.startContainer({ id: container.Id, name: container.Names[0] });
             }

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -2,7 +2,7 @@ import { CancellationToken, commands, Progress, window } from "vscode";
 import { ContainerInspectResponse, ContainerSummary, ResponseError } from "../../clients/docker";
 import { Logger } from "../../logging";
 import { getTelemetryLogger } from "../../telemetry/telemetryLogger";
-import { getContainer, restartContainer, startContainer } from "../containers";
+import { getContainer, restartContainer, startContainer, stopContainer } from "../containers";
 import { imageExists, pullImage } from "../images";
 
 /** Basic container information for a local resource. */
@@ -95,6 +95,32 @@ export abstract class LocalResourceWorkflow {
     token: CancellationToken,
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void>;
+
+  /** Common flow for attempting to stop a container for a workflow. If the container is not found,
+   * a warning will be logged and no action will be taken. */
+  async stopContainer(container: LocalResourceContainer): Promise<void> {
+    // names may start with a leading slash, so try to remove it
+    const containerName = container.name.replace(/^\/+/, "");
+    // check container status before deleting
+    const existingContainer: ContainerInspectResponse | undefined = await getContainer(
+      container.id,
+    );
+    if (!existingContainer) {
+      // assume it was cleaned up some other way
+      this.logger.warn("Container not found, skipping stop and delete steps.", {
+        id: container.id,
+        name: containerName,
+      });
+      return;
+    }
+
+    if (existingContainer.State?.Status === "running") {
+      await stopContainer(container.id);
+      this.sendTelemetryEvent("Docker Container Stopped", {
+        dockerContainerName: container.name,
+      });
+    }
+  }
 
   // instance method to allow calling `this.imageRepo` along with the static `<WorkflowName>.imageRepo`
   get imageRepo(): string {

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -176,19 +176,20 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
   }
 
   private async stopAndRemoveContainer(container: LocalResourceContainer): Promise<void> {
-    // check if container is running, and if so, stop it before deleting
+    // check container status before deleting
     this.progress?.report({ message: `Stopping container "${container.name}"...` });
     const existingContainer: ContainerInspectResponse | undefined = await getContainer(
       container.id,
     );
     if (!existingContainer) {
       // assume it was cleaned up some other way
-      this.logger.warn("Container not found, skipping stop and remove steps.", {
+      this.logger.warn("Container not found, skipping stop and delete steps.", {
         id: container.id,
         name: container.name,
       });
       return;
     }
+
     if (existingContainer.State?.Status === "running") {
       await stopContainer(container.id);
     }

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -160,19 +160,25 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
     this.progress = progress;
-    const containers: ContainerSummary[] = await getContainersForImage(
-      ConfluentLocalWorkflow.imageRepo,
-      this.imageTag,
-    );
-    if (containers.length === 0) {
+
+    const repoTag = `${ConfluentLocalWorkflow.imageRepo}:${this.imageTag}`;
+    const listImagesRequest: ContainerListRequest = {
+      all: true,
+      filters: JSON.stringify({
+        ancestor: [repoTag],
+        label: [MANAGED_CONTAINER_LABEL],
+      }),
+    };
+    const existingContainers: ContainerSummary[] = await getContainersForImage(listImagesRequest);
+    if (existingContainers.length === 0) {
       return;
     }
 
-    const stopMsg = `Stopping ${containers.length} container(s)...`;
+    const stopMsg = `Stopping ${existingContainers.length} container(s)...`;
     this.logger.debug(stopMsg);
     this.progress?.report({ message: stopMsg });
     const promises: Promise<void>[] = [];
-    for (const container of containers) {
+    for (const container of existingContainers) {
       if (!container.Id || !container.Names) {
         this.logger.error("Container missing ID or name", {
           id: container.Id,

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -162,14 +162,15 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     this.progress = progress;
 
     const repoTag = `${ConfluentLocalWorkflow.imageRepo}:${this.imageTag}`;
-    const listImagesRequest: ContainerListRequest = {
+    const containerListRequest: ContainerListRequest = {
       all: true,
       filters: JSON.stringify({
         ancestor: [repoTag],
         label: [MANAGED_CONTAINER_LABEL],
       }),
     };
-    const existingContainers: ContainerSummary[] = await getContainersForImage(listImagesRequest);
+    const existingContainers: ContainerSummary[] =
+      await getContainersForImage(containerListRequest);
     if (existingContainers.length === 0) {
       return;
     }

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -159,6 +159,20 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     token: CancellationToken,
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
+    token.onCancellationRequested(() => {
+      this.logger.debug("cancellation requested, exiting stop() early");
+      getTelemetryLogger().logUsage("Notification Button Clicked", {
+        extensionUserFlow: "Local Resource Management",
+        localResourceWorkflow: this.constructor.name,
+        localResourceKind: this.resourceKind,
+        dockerImage: this.imageRepoTag,
+        buttonLabel: "Cancel",
+        start: false,
+        notificationType: "progress",
+      });
+      // early returns handled below depending on the stage of the workflow
+    });
+
     this.progress = progress;
 
     const repoTag = `${ConfluentLocalWorkflow.imageRepo}:${this.imageTag}`;
@@ -171,13 +185,13 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     };
     const existingContainers: ContainerSummary[] =
       await getContainersForImage(containerListRequest);
+    const count = existingContainers.length;
+    const plural = count > 1 ? "s" : "";
     if (existingContainers.length === 0) {
       return;
     }
 
-    const stopMsg = `Stopping ${existingContainers.length} container(s)...`;
-    this.logger.debug(stopMsg);
-    this.progress?.report({ message: stopMsg });
+    this.logAndUpdateProgress(`Stopping ${count} ${this.resourceKind} container${plural}...`);
     const promises: Promise<void>[] = [];
     for (const container of existingContainers) {
       if (!container.Id || !container.Names) {
@@ -191,7 +205,22 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     }
     await Promise.all(promises);
 
+    // only allow exiting from here since awaiting each stopContainer() call and allowing cancellation
+    // there would introduce a delay
+    if (token.isCancellationRequested) return;
+
+    this.logAndUpdateProgress(
+      `Waiting for ${count} ${this.resourceKind} container${plural} to stop...`,
+    );
     await this.waitForLocalResourceEventChange();
+
+    getTelemetryLogger().logUsage("Workflow Finished", {
+      extensionUserFlow: "Local Resource Management",
+      localResourceWorkflow: this.constructor.name,
+      localResourceKind: this.resourceKind,
+      dockerImage: this.imageRepoTag,
+      start: false,
+    });
   }
 
   /** Block until we see the {@link localKafkaConnected} event fire. (Controlled by the EventListener
@@ -349,6 +378,13 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
 
     if (existingContainer.State?.Status === "running") {
       await stopContainer(container.id);
+      getTelemetryLogger().logUsage("Docker Container Stopped", {
+        extensionUserFlow: "Local Resource Management",
+        localResourceWorkflow: this.constructor.name,
+        localResourceKind: this.resourceKind,
+        dockerImage: this.imageRepoTag,
+        dockerContainerName: container.name,
+      });
     }
   }
 }

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -159,20 +159,6 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     token: CancellationToken,
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
-    token.onCancellationRequested(() => {
-      this.logger.debug("cancellation requested, exiting stop() early");
-      getTelemetryLogger().logUsage("Notification Button Clicked", {
-        extensionUserFlow: "Local Resource Management",
-        localResourceWorkflow: this.constructor.name,
-        localResourceKind: this.resourceKind,
-        dockerImage: this.imageRepoTag,
-        buttonLabel: "Cancel",
-        start: false,
-        notificationType: "progress",
-      });
-      // early returns handled below depending on the stage of the workflow
-    });
-
     this.progress = progress;
 
     const repoTag = `${ConfluentLocalWorkflow.imageRepo}:${this.imageTag}`;
@@ -201,7 +187,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
         });
         continue;
       }
-      promises.push(this.stopContainer({ id: container.Id, name: container.Names[0] }));
+      promises.push(this.stopKafkaContainer({ id: container.Id, name: container.Names[0] }));
     }
     await Promise.all(promises);
 
@@ -213,14 +199,6 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
       `Waiting for ${count} ${this.resourceKind} container${plural} to stop...`,
     );
     await this.waitForLocalResourceEventChange();
-
-    getTelemetryLogger().logUsage("Workflow Finished", {
-      extensionUserFlow: "Local Resource Management",
-      localResourceWorkflow: this.constructor.name,
-      localResourceKind: this.resourceKind,
-      dockerImage: this.imageRepoTag,
-      start: false,
-    });
   }
 
   /** Block until we see the {@link localKafkaConnected} event fire. (Controlled by the EventListener
@@ -360,7 +338,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     return envVars;
   }
 
-  private async stopContainer(container: LocalResourceContainer): Promise<void> {
+  private async stopKafkaContainer(container: LocalResourceContainer): Promise<void> {
     // names may start with a leading slash, so try to remove it
     const containerName = container.name.replace(/^\/+/, "");
     // check container status before deleting
@@ -378,11 +356,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
 
     if (existingContainer.State?.Status === "running") {
       await stopContainer(container.id);
-      getTelemetryLogger().logUsage("Docker Container Stopped", {
-        extensionUserFlow: "Local Resource Management",
-        localResourceWorkflow: this.constructor.name,
-        localResourceKind: this.resourceKind,
-        dockerImage: this.imageRepoTag,
+      this.sendTelemetryEvent("Docker Container Stopped", {
         dockerContainerName: container.name,
       });
     }

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -180,6 +180,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
       }
       promises.push(this.stopContainer({ id: container.Id, name: container.Names[0] }));
     }
+    await Promise.all(promises);
 
     await this.waitForLocalResourceEventChange();
   }
@@ -322,8 +323,10 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
   }
 
   private async stopContainer(container: LocalResourceContainer): Promise<void> {
+    // names may start with a leading slash, so try to remove it
+    const containerName = container.name.replace(/^\/+/, "");
+    this.progress?.report({ message: `Stopping container "${containerName}"...` });
     // check container status before deleting
-    this.progress?.report({ message: `Stopping container "${container.name}"...` });
     const existingContainer: ContainerInspectResponse | undefined = await getContainer(
       container.id,
     );
@@ -331,7 +334,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
       // assume it was cleaned up some other way
       this.logger.warn("Container not found, skipping stop and delete steps.", {
         id: container.id,
-        name: container.name,
+        name: containerName,
       });
       return;
     }

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -22,13 +22,7 @@ import { Logger } from "../../logging";
 import { LOCAL_KAFKA_REST_HOST } from "../../preferences/constants";
 import { getLocalKafkaImageTag } from "../configs";
 import { MANAGED_CONTAINER_LABEL } from "../constants";
-import {
-  createContainer,
-  deleteContainer,
-  getContainer,
-  getContainersForImage,
-  stopContainer,
-} from "../containers";
+import { createContainer, getContainer, getContainersForImage, stopContainer } from "../containers";
 import { createNetwork } from "../networks";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
@@ -167,35 +161,27 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
   ): Promise<void> {
     this.progress = progress;
     this.logger.debug(`Stopping "confluent-local" workflow...`);
-
-    const promises: Promise<void>[] = [];
-
-    // TODO: list containers for this image and stop them
-
-    await this.waitForLocalResourceEventChange();
-  }
-
-  private async stopAndRemoveContainer(container: LocalResourceContainer): Promise<void> {
-    // check container status before deleting
-    this.progress?.report({ message: `Stopping container "${container.name}"...` });
-    const existingContainer: ContainerInspectResponse | undefined = await getContainer(
-      container.id,
+    const containers: ContainerSummary[] = await getContainersForImage(
+      ConfluentLocalWorkflow.imageRepo,
+      this.imageTag,
     );
-    if (!existingContainer) {
-      // assume it was cleaned up some other way
-      this.logger.warn("Container not found, skipping stop and delete steps.", {
-        id: container.id,
-        name: container.name,
-      });
+    if (containers.length === 0) {
       return;
     }
 
-    if (existingContainer.State?.Status === "running") {
-      await stopContainer(container.id);
+    const promises: Promise<void>[] = [];
+    for (const container of containers) {
+      if (!container.Id || !container.Names) {
+        this.logger.error("Container missing ID or name", {
+          id: container.Id,
+          names: container.Names,
+        });
+        continue;
+      }
+      promises.push(this.stopContainer({ id: container.Id, name: container.Names[0] }));
     }
 
-    this.progress?.report({ message: `Removing container "${container.name}"...` });
-    await deleteContainer(container.id);
+    await this.waitForLocalResourceEventChange();
   }
 
   /** Block until we see the {@link localKafkaConnected} event fire. (Controlled by the EventListener
@@ -333,6 +319,26 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
       );
     }
     return envVars;
+  }
+
+  private async stopContainer(container: LocalResourceContainer): Promise<void> {
+    // check container status before deleting
+    this.progress?.report({ message: `Stopping container "${container.name}"...` });
+    const existingContainer: ContainerInspectResponse | undefined = await getContainer(
+      container.id,
+    );
+    if (!existingContainer) {
+      // assume it was cleaned up some other way
+      this.logger.warn("Container not found, skipping stop and delete steps.", {
+        id: container.id,
+        name: container.name,
+      });
+      return;
+    }
+
+    if (existingContainer.State?.Status === "running") {
+      await stopContainer(container.id);
+    }
   }
 }
 

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -160,7 +160,6 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
     this.progress = progress;
-    this.logger.debug(`Stopping "confluent-local" workflow...`);
     const containers: ContainerSummary[] = await getContainersForImage(
       ConfluentLocalWorkflow.imageRepo,
       this.imageTag,
@@ -169,6 +168,9 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
       return;
     }
 
+    const stopMsg = `Stopping ${containers.length} container(s)...`;
+    this.logger.debug(stopMsg);
+    this.progress?.report({ message: stopMsg });
     const promises: Promise<void>[] = [];
     for (const container of containers) {
       if (!container.Id || !container.Names) {
@@ -325,7 +327,6 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
   private async stopContainer(container: LocalResourceContainer): Promise<void> {
     // names may start with a leading slash, so try to remove it
     const containerName = container.name.replace(/^\/+/, "");
-    this.progress?.report({ message: `Stopping container "${containerName}"...` });
     // check container status before deleting
     const existingContainer: ContainerInspectResponse | undefined = await getContainer(
       container.id,

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -22,7 +22,13 @@ import { Logger } from "../../logging";
 import { LOCAL_KAFKA_REST_HOST } from "../../preferences/constants";
 import { getLocalKafkaImageTag } from "../configs";
 import { MANAGED_CONTAINER_LABEL } from "../constants";
-import { createContainer, getContainersForImage } from "../containers";
+import {
+  createContainer,
+  deleteContainer,
+  getContainer,
+  getContainersForImage,
+  stopContainer,
+} from "../containers";
 import { createNetwork } from "../networks";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
@@ -160,8 +166,35 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
     this.progress = progress;
-    this.logger.debug("Stopping ...");
-    // TODO(shoup): implement
+    this.logger.debug(`Stopping "confluent-local" workflow...`);
+
+    const promises: Promise<void>[] = [];
+
+    // TODO: list containers for this image and stop them
+
+    await this.waitForLocalResourceEventChange();
+  }
+
+  private async stopAndRemoveContainer(container: LocalResourceContainer): Promise<void> {
+    // check if container is running, and if so, stop it before deleting
+    this.progress?.report({ message: `Stopping container "${container.name}"...` });
+    const existingContainer: ContainerInspectResponse | undefined = await getContainer(
+      container.id,
+    );
+    if (!existingContainer) {
+      // assume it was cleaned up some other way
+      this.logger.warn("Container not found, skipping stop and remove steps.", {
+        id: container.id,
+        name: container.name,
+      });
+      return;
+    }
+    if (existingContainer.State?.Status === "running") {
+      await stopContainer(container.id);
+    }
+
+    this.progress?.report({ message: `Removing container "${container.name}"...` });
+    await deleteContainer(container.id);
   }
 
   /** Block until we see the {@link localKafkaConnected} event fire. (Controlled by the EventListener

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -165,6 +165,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     progress?: Progress<{ message?: string; increment?: number }>,
   ): Promise<void> {
     this.progress = progress;
+    this.imageTag = getLocalKafkaImageTag();
 
     this.logAndUpdateProgress(`Checking existing ${this.resourceKind} containers...`);
     const repoTag = `${ConfluentLocalWorkflow.imageRepo}:${this.imageTag}`;

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -605,6 +605,27 @@ describe("ResourceManager Kafka topic methods", function () {
     assert.deepStrictEqual(localTopicsAfter, localTopics);
   });
 
+  it("deleteLocalTopics() should correctly delete only local Kafka topics", async () => {
+    // set the topics in the StorageManager before deleting them
+    const resourceManager = getResourceManager();
+    await resourceManager.setTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER, ccloudTopics);
+    await resourceManager.setTopicsForCluster(otherCcloudCluster, otherCcloudClusterTopics);
+    await resourceManager.setTopicsForCluster(TEST_LOCAL_KAFKA_CLUSTER, localTopics);
+
+    // only the local topics should be deleted
+    await resourceManager.deleteLocalTopics();
+
+    // verify the local topics were deleted correctly.
+    const localTopicsAfter = await resourceManager.getTopicsForCluster(TEST_LOCAL_KAFKA_CLUSTER);
+    assert.deepStrictEqual(localTopicsAfter, undefined);
+
+    // verify the cloud topics were not deleted.
+    for (const cluster of [TEST_CCLOUD_KAFKA_CLUSTER, otherCcloudCluster]) {
+      const shouldBeUndefined = await resourceManager.getTopicsForCluster(cluster);
+      assert.ok(shouldBeUndefined);
+    }
+  });
+
   it("topicKeyForCluster() tests", () => {
     const manager = getResourceManager();
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -381,6 +381,14 @@ export class ResourceManager {
     return await this.storage.deleteWorkspaceState(StateKafkaTopics.CCLOUD);
   }
 
+  /**
+   * Delete all local topics from workspace state, such as when we notice that the local cluster has been deleted.
+   * or we just started up a new local cluster.
+   */
+  async deleteLocalTopics(): Promise<void> {
+    return await this.storage.deleteWorkspaceState(StateKafkaTopics.LOCAL);
+  }
+
   /** Return the use-with-storage StateKafkaTopics key for this type of cluster.
    *
    * (not private only for testing)


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The other side of https://github.com/confluentinc/vscode/pull/396, adding general functionality to stop containers as part of the local resource workflows.

<img width="409" alt="image" src="https://github.com/user-attachments/assets/ae2dfde3-cd14-4df4-8a4d-5847613f7a1e">

There is no user input here; based on the Kafka image repo+tag settings, we're listing containers that are currently available, and then explicitly stopping any in a `running` state.

> [!NOTE]  
> If broker containers were started via `confluent local kafka start [--brokers #]`, they will likely not be stoppable by the extension due to different Docker image tags. (The CLI uses `7.6.0`, whereas the extension uses `latest`.)
> <img width="1177" alt="image" src="https://github.com/user-attachments/assets/b8cc7eb3-4018-4579-933a-58e16005b2f9">

### Associated PRs

- https://github.com/confluentinc/vscode/pull/396 
  - https://github.com/confluentinc/vscode/pull/399 👈
    - https://github.com/confluentinc/vscode/pull/446
      - https://github.com/confluentinc/vscode/pull/400
        - https://github.com/confluentinc/vscode/pull/401


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
