### PR TITLE
add `LocalSchemaRegistry` class and update general SR handling for local instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,17 +394,17 @@
       {
         "view": "confluent-schemas",
         "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.create)",
-        "when": "!confluent.ccloudConnectionAvailable"
+        "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable)"
       },
       {
         "view": "confluent-schemas",
         "contents": "No Schema Registry selected. Click below to get started.\n[Select Schema Registry](command:confluent.resources.schema-registry.select)",
-        "when": "confluent.ccloudConnectionAvailable && !confluent.schemaRegistrySelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable) && !confluent.schemaRegistrySelected"
       },
       {
         "view": "confluent-schemas",
         "contents": "No schemas found.",
-        "when": "confluent.ccloudConnectionAvailable && confluent.schemaRegistrySelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable) && confluent.schemaRegistrySelected"
       },
       {
         "view": "confluent-topics",

--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -3,8 +3,8 @@ import sinon from "sinon";
 import { window, workspace } from "vscode";
 import {
   TEST_CCLOUD_KAFKA_TOPIC,
+  TEST_CCLOUD_SCHEMA_REGISTRY,
   TEST_LOCAL_KAFKA_TOPIC,
-  TEST_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import { getExtensionContext } from "../../tests/unit/testUtils";
 import { ResponseError, SubjectsV1Api } from "../clients/schemaRegistryRest";
@@ -23,7 +23,7 @@ describe("authz.schemaRegistry", function () {
     // preload the schema registry in extension state
     await getExtensionContext();
     resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await resourceManager.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
 
     sandbox = sinon.createSandbox();
     // create the stubs for the sidecar + service client
@@ -41,7 +41,7 @@ describe("authz.schemaRegistry", function () {
   afterEach(async function () {
     sandbox.restore();
     // clear out the existing Schema Registry after each test
-    await resourceManager.deleteCCloudSchemaRegistries(TEST_SCHEMA_REGISTRY.environmentId);
+    await resourceManager.deleteCCloudSchemaRegistries(TEST_CCLOUD_SCHEMA_REGISTRY.environmentId);
   });
 
   // FIXME: canAccessSchemaForTopic() tests
@@ -81,7 +81,7 @@ describe("authz.schemaRegistry", function () {
 
   it("canAccessSchemaTypeForTopic() should return true if schemaRegistry is not found", async function () {
     // clear out the existing Schema Registry before checking schema access
-    await resourceManager.deleteCCloudSchemaRegistries(TEST_SCHEMA_REGISTRY.environmentId);
+    await resourceManager.deleteCCloudSchemaRegistries(TEST_CCLOUD_SCHEMA_REGISTRY.environmentId);
 
     const result = await schemaRegistry.canAccessSchemaTypeForTopic(TEST_CCLOUD_KAFKA_TOPIC, "key");
     assert.strictEqual(result, true);

--- a/src/commands/schemaRegistry.ts
+++ b/src/commands/schemaRegistry.ts
@@ -1,15 +1,18 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { currentSchemaRegistryChanged } from "../emitters";
-import { CCloudSchemaRegistry, SchemaRegistry } from "../models/schemaRegistry";
+import {
+  CCloudSchemaRegistry,
+  LocalSchemaRegistry,
+  SchemaRegistry,
+} from "../models/schemaRegistry";
 import { schemaRegistryQuickPickWithViewProgress } from "../quickpicks/schemaRegistries";
 
-async function selectSchemaRegistryCommand(cluster?: SchemaRegistry) {
+async function selectSchemaRegistryCommand(item?: SchemaRegistry) {
   // ensure whatever was passed in is a SchemaRegistry instance; if not, prompt the user to pick one
-  // TODO(shoup): update to support LocalSchemaRegistry
   const schemaRegistry =
-    cluster instanceof CCloudSchemaRegistry
-      ? cluster
+    item instanceof CCloudSchemaRegistry || item instanceof LocalSchemaRegistry
+      ? item
       : await schemaRegistryQuickPickWithViewProgress();
   if (!schemaRegistry) {
     return;

--- a/src/commands/schemas.test.ts
+++ b/src/commands/schemas.test.ts
@@ -4,9 +4,9 @@ import * as vscode from "vscode";
 import { commands } from "vscode";
 import {
   TEST_CCLOUD_KAFKA_TOPIC,
+  TEST_CCLOUD_SCHEMA,
+  TEST_CCLOUD_SCHEMA_REGISTRY,
   TEST_LOCAL_KAFKA_TOPIC,
-  TEST_SCHEMA,
-  TEST_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import { ContainerTreeItem } from "../models/main";
 import { Schema } from "../models/schema";
@@ -34,18 +34,18 @@ describe("commands/schemas.ts diffLatestSchemasCommand tests", function () {
   it("diffLatestSchemasCommand should execute the correct commands when invoked on a proper schema group", async () => {
     // Make a 3-version schema group ...
     const oldestSchemaVersion = Schema.create({
-      ...TEST_SCHEMA,
+      ...TEST_CCLOUD_SCHEMA,
       subject: "my-topic-value",
       version: 0,
     });
 
     const olderSchemaVersion = Schema.create({
-      ...TEST_SCHEMA,
+      ...TEST_CCLOUD_SCHEMA,
       subject: "my-topic-value",
       version: 1,
     });
     const latestSchemaVersion = Schema.create({
-      ...TEST_SCHEMA,
+      ...TEST_CCLOUD_SCHEMA,
       subject: "my-topic-value",
       version: 2,
     });
@@ -69,7 +69,7 @@ describe("commands/schemas.ts diffLatestSchemasCommand tests", function () {
     const schemaGroup = new ContainerTreeItem<Schema>(
       "my-topic-value",
       vscode.TreeItemCollapsibleState.Collapsed,
-      [Schema.create({ ...TEST_SCHEMA, subject: "my-topic-value", version: 1 })],
+      [Schema.create({ ...TEST_CCLOUD_SCHEMA, subject: "my-topic-value", version: 1 })],
     );
 
     await diffLatestSchemasCommand(schemaGroup);
@@ -129,7 +129,7 @@ describe("commands/schemas.ts getLatestSchemasForTopic tests", function () {
   });
 
   it("hates empty schema registry", async function () {
-    resourceManager.getCCloudSchemaRegistry.resolves(TEST_SCHEMA_REGISTRY);
+    resourceManager.getCCloudSchemaRegistry.resolves(TEST_CCLOUD_SCHEMA_REGISTRY);
     resourceManager.getSchemasForRegistry.resolves([]);
     await assert.rejects(
       async () => {
@@ -142,9 +142,9 @@ describe("commands/schemas.ts getLatestSchemasForTopic tests", function () {
   });
 
   it("hates when no schemas match topic", async function () {
-    resourceManager.getCCloudSchemaRegistry.resolves(TEST_SCHEMA_REGISTRY);
+    resourceManager.getCCloudSchemaRegistry.resolves(TEST_CCLOUD_SCHEMA_REGISTRY);
     resourceManager.getSchemasForRegistry.resolves([
-      Schema.create({ ...TEST_SCHEMA, subject: "some-other-topic-value" }),
+      Schema.create({ ...TEST_CCLOUD_SCHEMA, subject: "some-other-topic-value" }),
     ]);
     await assert.rejects(
       async () => {
@@ -155,11 +155,11 @@ describe("commands/schemas.ts getLatestSchemasForTopic tests", function () {
   });
 
   it("loves and returns highest versioned schemas for topic with key and value topics", async function () {
-    resourceManager.getCCloudSchemaRegistry.resolves(TEST_SCHEMA_REGISTRY);
+    resourceManager.getCCloudSchemaRegistry.resolves(TEST_CCLOUD_SCHEMA_REGISTRY);
     resourceManager.getSchemasForRegistry.resolves([
-      Schema.create({ ...TEST_SCHEMA, subject: "test-topic-value", version: 1 }),
-      Schema.create({ ...TEST_SCHEMA, subject: "test-topic-value", version: 2 }),
-      Schema.create({ ...TEST_SCHEMA, subject: "test-topic-key", version: 1 }),
+      Schema.create({ ...TEST_CCLOUD_SCHEMA, subject: "test-topic-value", version: 1 }),
+      Schema.create({ ...TEST_CCLOUD_SCHEMA, subject: "test-topic-value", version: 2 }),
+      Schema.create({ ...TEST_CCLOUD_SCHEMA, subject: "test-topic-key", version: 1 }),
     ]);
 
     const fetchedLatestSchemas = await getLatestSchemasForTopic(TEST_CCLOUD_KAFKA_TOPIC);

--- a/src/context.ts
+++ b/src/context.ts
@@ -55,6 +55,8 @@ export enum ContextValues {
   ccloudConnectionAvailable = "confluent.ccloudConnectionAvailable",
   /** A local connection has been made and a local Kafka cluster is available for selecting in the Topics view. */
   localKafkaClusterAvailable = "confluent.localKafkaClusterAvailable",
+  /** A local connection has been made and a local Schema Registry is available for selecting in the Schemas view. */
+  localSchemaRegistryAvailable = "confluent.localSchemaRegistryAvailable",
   /** A resource has been selected for comparison. */
   resourceSelectedForCompare = "confluent.resourceSelectedForCompare",
   /** The user clicked a Kafka cluster tree item. */

--- a/src/documentProviders/schema.ts
+++ b/src/documentProviders/schema.ts
@@ -8,7 +8,9 @@ export class SchemaDocumentProvider extends ResourceDocumentProvider {
   scheme = "confluent.schema";
 
   public async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
-    const schema = this.parseUriQueryBody(uri.query) as Schema;
+    const schemaObj: Schema = this.parseUriQueryBody(uri.query) as Schema;
+    // recreate the Schema instance so we can access the .connectionId getter
+    const schema = Schema.create(schemaObj);
     // fetch the schema definition from the sidecar and attempt to prettify it before displaying
     const client: SchemasV1Api = (await getSidecar()).getSchemasV1Api(
       schema.schemaRegistryId,

--- a/src/documentProviders/schemaDocProvider.test.ts
+++ b/src/documentProviders/schemaDocProvider.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import sinon from "sinon";
-import { TEST_SCHEMA } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_SCHEMA } from "../../tests/unit/testResources";
 import { SchemaString, SchemasV1Api } from "../clients/schemaRegistryRest";
 import * as sidecar from "../sidecar";
 import { SchemaDocumentProvider } from "./schema";
@@ -27,7 +27,7 @@ describe("DiffableReadOnlyDocumentProvider tests", function () {
   it("should return a schema definition from a schema URI", async () => {
     const provider = new SchemaDocumentProvider();
 
-    const uri = provider.resourceToUri(TEST_SCHEMA, TEST_SCHEMA.fileName());
+    const uri = provider.resourceToUri(TEST_CCLOUD_SCHEMA, TEST_CCLOUD_SCHEMA.fileName());
 
     const schemaResp: SchemaString = { schema: '{"foo": "bar"}', schemaType: "JSON" };
     mockClient.getSchema.resolves(schemaResp);

--- a/src/documentProviders/schemaDocProvider.test.ts
+++ b/src/documentProviders/schemaDocProvider.test.ts
@@ -33,6 +33,13 @@ describe("DiffableReadOnlyDocumentProvider tests", function () {
     mockClient.getSchema.resolves(schemaResp);
 
     const schemaDefinition = await provider.provideTextDocumentContent(uri);
+
+    assert.ok(
+      mockSidecarHandle.getSchemasV1Api.calledOnceWithExactly(
+        TEST_CCLOUD_SCHEMA.schemaRegistryId,
+        TEST_CCLOUD_SCHEMA.connectionId,
+      ),
+    );
     assert.strictEqual(schemaDefinition, JSON.stringify(JSON.parse('{"foo": "bar"}'), null, 2));
   });
 });

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -15,6 +15,7 @@ export const ccloudAuthSessionInvalidated = new vscode.EventEmitter<void>();
 export const ccloudOrganizationChanged = new vscode.EventEmitter<void>();
 
 export const localKafkaConnected = new vscode.EventEmitter<boolean>();
+export const localSchemaRegistryConnected = new vscode.EventEmitter<boolean>();
 
 /**
  * Fired whenever a Kafka cluster is selected from the Resources view, chosen from the "Select Kafka

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,12 +250,14 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
 
   // set the initial connection states of our main views; these will be adjusted by the following:
   // - ccloudConnectionAvailable: `true/false` if the auth provider has a valid CCloud connection
-  // - localKafkaClusterAvailable: `true/false` if the Resources view loads/refreshes and can find a
-  //   local Kafka cluster (and CCloud connection changes will refresh the Resources view via the
-  //   `ccloudConnected` event emitter)
+  // - localKafkaClusterAvailable: `true/false` if the Resources view loads/refreshes and we can
+  //  discover a local Kafka cluster
+  // - localSchemaRegistryAvailable: `true/false` if the Resources view loads/refreshes and we can
+  //  discover a local Schema Registry
   await Promise.all([
     setContextValue(ContextValues.ccloudConnectionAvailable, false),
     setContextValue(ContextValues.localKafkaClusterAvailable, false),
+    setContextValue(ContextValues.localSchemaRegistryAvailable, false),
   ]);
 
   // attempt to get a session to trigger the initial auth badge for signing in

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -1,6 +1,5 @@
 import { graphql } from "gql.tada";
 import { LOCAL_CONNECTION_ID } from "../constants";
-import { ContextValues, setContextValue } from "../context";
 import { Logger } from "../logging";
 import { LocalKafkaCluster } from "../models/kafkaCluster";
 import { LocalSchemaRegistry } from "../models/schemaRegistry";
@@ -84,7 +83,5 @@ export async function getLocalResources(): Promise<LocalResourceGroup[]> {
       });
     });
   }
-  // indicate to the UI that we have at least one local Kafka cluster available
-  await setContextValue(ContextValues.localKafkaClusterAvailable, localResources.length > 0);
   return localResources;
 }

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -26,7 +26,7 @@ export async function getLocalResources(): Promise<LocalResourceGroup[]> {
     } catch {
       // error should be caught+logged in createLocalConnection
       // TODO: window.showErrorMessage here? might get noisy since this is triggered from refreshes
-      return localKafkaClusters;
+      return localResources;
     }
   }
 

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -3,13 +3,20 @@ import { LOCAL_CONNECTION_ID } from "../constants";
 import { ContextValues, setContextValue } from "../context";
 import { Logger } from "../logging";
 import { LocalKafkaCluster } from "../models/kafkaCluster";
+import { LocalSchemaRegistry } from "../models/schemaRegistry";
 import { getSidecar } from "../sidecar";
 import { createLocalConnection, getLocalConnection } from "../sidecar/connections";
 
 const logger = new Logger("graphql.local");
 
-export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
-  let localKafkaClusters: LocalKafkaCluster[] = [];
+export interface LocalResourceGroup {
+  kafkaClusters: LocalKafkaCluster[];
+  schemaRegistry?: LocalSchemaRegistry;
+  // TODO: Add Flink compute pool as cluster type eventually
+}
+
+export async function getLocalResources(): Promise<LocalResourceGroup[]> {
+  let localResources: LocalResourceGroup[] = [];
 
   // this is a bit odd, but we need to have a local "connection" to the sidecar before we can query
   // it for local Kafka clusters, so check if we have a connection first
@@ -33,6 +40,10 @@ export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
           bootstrapServers
           uri
         }
+        schemaRegistry {
+          id
+          uri
+        }
       }
     }
   `);
@@ -44,7 +55,7 @@ export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
     response = await sidecar.query(query, LOCAL_CONNECTION_ID);
   } catch (error) {
     logger.error("Error fetching local connections", error);
-    return localKafkaClusters;
+    return localResources;
   }
 
   const localConnections = response.localConnections;
@@ -54,16 +65,26 @@ export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
     const localConnectionsWithKafkaClusters = localConnections.filter(
       (connection) => connection !== null && connection.kafkaCluster !== null,
     );
-    localKafkaClusters = localConnectionsWithKafkaClusters.map((connection) => {
-      return LocalKafkaCluster.create({
+    localConnectionsWithKafkaClusters.forEach((connection) => {
+      const kafkaCluster: LocalKafkaCluster = LocalKafkaCluster.create({
         id: connection!.kafkaCluster!.id,
         name: connection!.kafkaCluster!.name,
         bootstrapServers: connection!.kafkaCluster!.bootstrapServers,
         uri: connection!.kafkaCluster!.uri,
       });
+      const schemaRegistry: LocalSchemaRegistry | undefined = connection!.schemaRegistry
+        ? LocalSchemaRegistry.create({
+            id: connection!.schemaRegistry.id,
+            uri: connection!.schemaRegistry.uri,
+          })
+        : undefined;
+      localResources.push({
+        kafkaClusters: [kafkaCluster],
+        schemaRegistry: schemaRegistry,
+      });
     });
   }
   // indicate to the UI that we have at least one local Kafka cluster available
-  await setContextValue(ContextValues.localKafkaClusterAvailable, localKafkaClusters.length > 0);
-  return localKafkaClusters;
+  await setContextValue(ContextValues.localKafkaClusterAvailable, localResources.length > 0);
+  return localResources;
 }

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -1,13 +1,14 @@
 import * as assert from "assert";
 import "mocha";
 import * as vscode from "vscode";
-import { TEST_SCHEMA } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_SCHEMA } from "../../tests/unit/testResources";
 import { IconNames } from "../constants";
 import { Schema, SchemaType, generateSchemaSubjectGroups, getSubjectIcon } from "./schema";
 
 describe("Schema model methods", () => {
   it(".matchesTopicName() success / fail tests", () => {
-    for (const [subject, topic, expected] of [
+    type SchemaProperties = [string, string, boolean];
+    const testSchemas: SchemaProperties[] = [
       // schemas named in TopicNameStrategy format
       ["test-topic-value", "test-topic", true], // matching on TopicNameStrategy for value schemas
       ["test-topic-key", "test-topic", true], // matching on TopicNameStrategy for key schemas
@@ -20,13 +21,11 @@ describe("Schema model methods", () => {
       ["test-topic-MyOtherRecordSchema", "test-topic", true], // say, a different record schema for same topic
       ["test-topic-MyRecordSchema", "test-topic-other-topic", false], // not matching on TopicRecordNameStrategy
       ["test-topic-MyRecordSchema", "test-topic-MyRecordSchema", false], // isn't TopicRecordNameStrategy, but exact match, which is nothing.
-    ]) {
-      const schema = TEST_SCHEMA.copy({
-        // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-        subject,
-      });
+    ];
+    for (const [subject, topic, expected] of testSchemas) {
+      const schema = Schema.create({ ...TEST_CCLOUD_SCHEMA, subject });
       assert.equal(
-        schema.matchesTopicName(topic as string),
+        schema.matchesTopicName(topic),
         expected,
         `subject: ${subject}, topic: ${topic}`,
       );
@@ -34,28 +33,28 @@ describe("Schema model methods", () => {
   });
 
   it(".fileExtension() should return the correct file extension for type=AVRO schemas", () => {
-    const schema = TEST_SCHEMA.copy({
+    const schema = TEST_CCLOUD_SCHEMA.copy({
       type: SchemaType.Avro,
     });
     assert.equal(schema.fileExtension(), "avsc");
   });
 
   it(".fileExtension() should return the correct file extension for type=JSON schemas", () => {
-    const schema = TEST_SCHEMA.copy({
+    const schema = TEST_CCLOUD_SCHEMA.copy({
       type: SchemaType.Json,
     });
     assert.equal(schema.fileExtension(), "json");
   });
 
   it(".fileExtension() should return the correct file extension for type=PROTOBUF schemas", () => {
-    const schema = TEST_SCHEMA.copy({
+    const schema = TEST_CCLOUD_SCHEMA.copy({
       type: SchemaType.Protobuf,
     });
     assert.equal(schema.fileExtension(), "proto");
   });
 
   it(".filename() should return the correct file name", () => {
-    const schema = TEST_SCHEMA.copy({
+    const schema = TEST_CCLOUD_SCHEMA.copy({
       // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
       subject: "test-topic",
       // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
@@ -73,18 +72,42 @@ describe("Schema helper functions", () => {
   const keySubject = "test-topic-key";
   const otherSubject = "test-topic";
   const schemas: Schema[] = [
-    // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-    TEST_SCHEMA.copy({ subject: valueSubject, version: 1, type: SchemaType.Avro }),
-    // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-    TEST_SCHEMA.copy({ subject: valueSubject, version: 2, type: SchemaType.Avro }),
-    // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-    TEST_SCHEMA.copy({ subject: keySubject, version: 1, type: SchemaType.Protobuf }),
-    // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-    TEST_SCHEMA.copy({ subject: otherSubject, version: 1, type: SchemaType.Json }),
-    // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-    TEST_SCHEMA.copy({ subject: otherSubject, version: 3, type: SchemaType.Json }),
-    // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-    TEST_SCHEMA.copy({ subject: otherSubject, version: 2, type: SchemaType.Json }),
+    Schema.create({
+      ...TEST_CCLOUD_SCHEMA,
+      subject: valueSubject,
+      version: 1,
+      type: SchemaType.Avro,
+    }),
+    Schema.create({
+      ...TEST_CCLOUD_SCHEMA,
+      subject: valueSubject,
+      version: 2,
+      type: SchemaType.Avro,
+    }),
+    Schema.create({
+      ...TEST_CCLOUD_SCHEMA,
+      subject: keySubject,
+      version: 1,
+      type: SchemaType.Protobuf,
+    }),
+    Schema.create({
+      ...TEST_CCLOUD_SCHEMA,
+      subject: otherSubject,
+      version: 1,
+      type: SchemaType.Json,
+    }),
+    Schema.create({
+      ...TEST_CCLOUD_SCHEMA,
+      subject: otherSubject,
+      version: 3,
+      type: SchemaType.Json,
+    }),
+    Schema.create({
+      ...TEST_CCLOUD_SCHEMA,
+      subject: otherSubject,
+      version: 2,
+      type: SchemaType.Json,
+    }),
   ];
 
   it("generateSchemaSubjectGroups() should group schemas under a subject-labeled container item", () => {

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -1,6 +1,6 @@
 import { Data, type Require as Enforced } from "dataclass";
 import * as vscode from "vscode";
-import { CCLOUD_CONNECTION_ID, IconNames } from "../constants";
+import { CCLOUD_CONNECTION_ID, IconNames, LOCAL_CONNECTION_ID } from "../constants";
 import { ContainerTreeItem, CustomMarkdownString } from "./main";
 
 export enum SchemaType {
@@ -18,16 +18,13 @@ const extensionMap: { [key in SchemaType]: string } = {
 // Main class representing CCloud Schema Registry schemas, matching key/value pairs returned
 // by the `confluent schema-registry schema list` command.
 export class Schema extends Data {
-  // TODO: this will need to be updated once we split this class into LocalSchema and CCloudSchema
-  readonly connectionId = CCLOUD_CONNECTION_ID;
-
   id!: Enforced<string>;
   subject!: Enforced<string>;
   version!: Enforced<number>;
   type!: SchemaType;
   // added separately from the response data, used for follow-on API calls
   schemaRegistryId!: Enforced<string>;
-  environmentId!: Enforced<string>;
+  environmentId?: Enforced<string>;
 
   /** Returns true if this schema subject corresponds to the topic name per TopicNameStrategy or TopicRecordNameStrategy*/
   matchesTopicName(topicName: string): boolean {
@@ -52,12 +49,22 @@ export class Schema extends Data {
   }
 
   get ccloudUrl(): string {
+    if (this.isLocalSchema()) {
+      return "";
+    }
     return `https://confluent.cloud/environments/${this.environmentId}/schema-registry/schemas/${this.subject}`;
+  }
+
+  isLocalSchema(): boolean {
+    return this.environmentId == null;
+  }
+
+  get connectionId(): string {
+    return this.isLocalSchema() ? LOCAL_CONNECTION_ID : CCLOUD_CONNECTION_ID;
   }
 }
 
 // Tree item representing a CCloud Schema Registry schema
-// TODO: SIDECAR UPDATE
 export class SchemaTreeItem extends vscode.TreeItem {
   resource: Schema;
 
@@ -78,18 +85,20 @@ export class SchemaTreeItem extends vscode.TreeItem {
 }
 
 function createSchemaTooltip(resource: Schema): vscode.MarkdownString {
-  // TODO(shoup) update for local SR once available
   const tooltip = new CustomMarkdownString()
     .appendMarkdown("#### $(primitive-square) Schema")
     .appendMarkdown("\n\n---\n\n")
     .appendMarkdown(`ID: \`${resource.id}\`\n\n`)
     .appendMarkdown(`Subject: \`${resource.subject}\`\n\n`)
     .appendMarkdown(`Version: \`${resource.version}\`\n\n`)
-    .appendMarkdown(`Type: \`${resource.type}\``)
-    .appendMarkdown("\n\n---\n\n")
-    .appendMarkdown(
-      `[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${resource.ccloudUrl})`,
-    );
+    .appendMarkdown(`Type: \`${resource.type}\``);
+  if (!resource.isLocalSchema()) {
+    tooltip
+      .appendMarkdown("\n\n---\n\n")
+      .appendMarkdown(
+        `[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${resource.ccloudUrl})`,
+      );
+  }
   return tooltip;
 }
 

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { IconNames } from "../constants";
 import { getEnvironments } from "../graphql/environments";
-import { getLocalKafkaClusters } from "../graphql/local";
+import { getLocalResources, LocalResourceGroup } from "../graphql/local";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
@@ -39,7 +39,10 @@ export async function kafkaClusterQuickPick(
   // first we grab all available (local+CCloud) Kafka Clusters
   let localKafkaClusters: LocalKafkaCluster[] = [];
   if (includeLocal) {
-    localKafkaClusters = await getLocalKafkaClusters();
+    const localResources: LocalResourceGroup[] = await getLocalResources();
+    localKafkaClusters = localResources.flatMap(
+      (group): LocalKafkaCluster[] => group.kafkaClusters,
+    );
   }
   let cloudKafkaClusters: CCloudKafkaCluster[] = [];
   let cloudEnvironments: CCloudEnvironment[] = [];

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -9,9 +9,7 @@ import { hasCCloudAuthSession } from "../sidecar/connections";
 
 const logger = new Logger("quickpicks.kafkaClusters");
 
-/** Progress wrapper for the Kafka Cluster quickpick to accomodate data-fetching time.
- * Highlights the topics view while the quickpick is awaited.
- */
+/** Wrapper for the Kafka Cluster quickpick to accomodate data-fetching time and display a progress indicator on the Topics view. */
 export async function kafkaClusterQuickPickWithViewProgress(
   includeLocal: boolean = true,
   includeCCloud: boolean = true,

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -15,10 +15,8 @@ import { getSchemasViewProvider } from "../viewProviders/schemas";
 
 const logger = new Logger("quickpicks.schemaRegistry");
 
-/**
- * Runs the schemaRegistryQuickPick with a view progress indicator
- * on the schemas view.
- */
+/** Wrapper for the Schema Registry quickpick to accomodate data-fetching time and display a progress
+ * indicator on the Schemas view. */
 export async function schemaRegistryQuickPickWithViewProgress(): Promise<
   SchemaRegistry | undefined
 > {
@@ -137,7 +135,15 @@ async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefined> {
   });
   logger.debug(`Found ${cloudEnvironmentIds.length} environments`);
 
-  let lastEnvName: string = "";
+  if (cloudSchemaRegistries.length > 0) {
+    // show a top-level separator for CCloud Schema Registries (unlike the Kafka cluster quickpick,
+    // we don't need to split by CCloud environments since each Schema Registry is tied to a single
+    // environment)
+    quickPickItems.push({
+      kind: vscode.QuickPickItemKind.Separator,
+      label: `Confluent Cloud`,
+    });
+  }
   cloudSchemaRegistries.forEach((schemaRegistry: CCloudSchemaRegistry) => {
     const environment: CCloudEnvironment | undefined = environmentMap.get(
       schemaRegistry.environmentId,
@@ -147,15 +153,6 @@ async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefined> {
         `No environment found for Schema Registry envId "${schemaRegistry.environmentId}"`,
       );
       return;
-    }
-    // show a separator by environment to make it easier to differentiate between local+CCloud and
-    // also to make it clear which environment the CCloud clusters are associated with
-    if (lastEnvName !== environment.name) {
-      quickPickItems.push({
-        kind: vscode.QuickPickItemKind.Separator,
-        label: `Confluent Cloud: ${environment.name}`,
-      });
-      lastEnvName = environment.name;
     }
     quickPickItems.push({
       label: environment.name,

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -116,6 +116,10 @@ export async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefi
 
   // make a map of all environment IDs to environments for easy lookup below
   const environmentMap: Map<string, CCloudEnvironment> = new Map();
+  const cloudEnvironments: CCloudEnvironment[] = await getResourceManager().getCCloudEnvironments();
+  cloudEnvironments.forEach((env) => {
+    environmentMap.set(env.id, env);
+  });
 
   // sort the Schema Registries by (is the selected one, environment name)
   cloudSchemaRegistries.sort((a, b) => {

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -32,13 +32,11 @@ export async function schemaRegistryQuickPickWithViewProgress(): Promise<
 }
 
 /**
- * Create a quickpick to let the user choose a Schema Registry (listed by CCloud environment
- * separators). Mainly used in the event a command was triggered through the command palette instead
- * of through the view->item->context menu.
+ * Create a quickpick to let the user choose a Schema Registry, named by environment.
  *
  * @returns The selected Schema Registry, or undefined if none was selected.
  */
-async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefined> {
+export async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefined> {
   const localSchemaRegistries: LocalSchemaRegistry[] = [];
   let cloudSchemaRegistries: CCloudSchemaRegistry[] = [];
 

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -4,10 +4,10 @@ import {
   TEST_CCLOUD_ENVIRONMENT,
   TEST_CCLOUD_KAFKA_CLUSTER,
   TEST_CCLOUD_KAFKA_TOPIC,
+  TEST_CCLOUD_SCHEMA,
+  TEST_CCLOUD_SCHEMA_REGISTRY,
   TEST_LOCAL_KAFKA_CLUSTER,
   TEST_LOCAL_KAFKA_TOPIC,
-  TEST_SCHEMA,
-  TEST_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import { getTestStorageManager } from "../../tests/unit/testUtils";
 import { CCloudEnvironment } from "../models/environment";
@@ -330,12 +330,12 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
   it("CCLOUD: setCCloudSchemaRegistries() should correctly store Schema Registries", async () => {
     const secondCloudEnvironment = { ...TEST_CCLOUD_ENVIRONMENT, id: "second-cloud-env-id" };
     const secondSchemaRegistry = CCloudSchemaRegistry.create({
-      ...TEST_SCHEMA_REGISTRY,
+      ...TEST_CCLOUD_SCHEMA_REGISTRY,
       environmentId: secondCloudEnvironment.id,
       id: "second-schema-registry-id",
     });
     const testSchemaRegistries: CCloudSchemaRegistry[] = [
-      TEST_SCHEMA_REGISTRY,
+      TEST_CCLOUD_SCHEMA_REGISTRY,
       secondSchemaRegistry,
     ];
 
@@ -349,14 +349,14 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
     assert.ok(storedSchemaRegistries.has(secondCloudEnvironment.id));
     assert.deepStrictEqual(
       storedSchemaRegistries.get(TEST_CCLOUD_ENVIRONMENT.id),
-      TEST_SCHEMA_REGISTRY,
+      TEST_CCLOUD_SCHEMA_REGISTRY,
     );
   });
 
   it("CCLOUD: setCCloudSchemaRegistries() setting with empty array should overwrite existing Schema Registries", async () => {
     // set the Schema Registry in the StorageManager before setting them again
     const rm = getResourceManager();
-    await rm.setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await rm.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     // fetching now should return the stored Schema Registry
     let storedSchemaRegistries: CCloudSchemaRegistryByEnv = await rm.getCCloudSchemaRegistries();
     assert.ok(storedSchemaRegistries.get(TEST_CCLOUD_ENVIRONMENT.id));
@@ -371,12 +371,12 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
   it("CCLOUD: getCCloudSchemaRegistries() should correctly retrieve Schema Registries", async () => {
     const resourceManager = getResourceManager();
     // preload a Schema Registry before retrieving it
-    await resourceManager.setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await resourceManager.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     // verify the Schema Registry was stored correctly
     const envSchemaRegistries: CCloudSchemaRegistryByEnv =
       await resourceManager.getCCloudSchemaRegistries();
     const retrievedSchemaRegistries = envSchemaRegistries.get(TEST_CCLOUD_ENVIRONMENT.id);
-    assert.deepStrictEqual(retrievedSchemaRegistries, TEST_SCHEMA_REGISTRY);
+    assert.deepStrictEqual(retrievedSchemaRegistries, TEST_CCLOUD_SCHEMA_REGISTRY);
   });
 
   it("CCLOUD: getCCloudSchemaRegistries() should return an empty map if no Schema Registries are found", async () => {
@@ -388,7 +388,7 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
 
   it("CCLOUD: getCCloudSchemaRegistry() should return null if the parent environment ID is not found", async () => {
     // set the Schema Registry
-    await getResourceManager().setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await getResourceManager().setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     // verify the Schema Registry was not found because the environment ID is incorrect
     const missingSchemaRegistry: CCloudSchemaRegistry | null =
       await getResourceManager().getCCloudSchemaRegistry("nonexistent-env-id");
@@ -397,17 +397,17 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
 
   it("CCLOUD: getCCloudSchemaRegistryById() should correctly retrieve a Schema Registry by its ID", async () => {
     // set the Schema Registry
-    await getResourceManager().setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await getResourceManager().setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     // verify the Schema Registry was retrieved correctly
     const schemaRegistry: CCloudSchemaRegistry | null =
-      await getResourceManager().getCCloudSchemaRegistryById(TEST_SCHEMA_REGISTRY.id);
+      await getResourceManager().getCCloudSchemaRegistryById(TEST_CCLOUD_SCHEMA_REGISTRY.id);
 
-    assert.deepStrictEqual(schemaRegistry, TEST_SCHEMA_REGISTRY);
+    assert.deepStrictEqual(schemaRegistry, TEST_CCLOUD_SCHEMA_REGISTRY);
   });
 
   it("CCLOUD: getCCloudSchemaRegistryById() should return null if the Schema Registry is not found", async () => {
     // set the Schema Registry
-    await getResourceManager().setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await getResourceManager().setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     // verify the Schema Registry was not found
     const missingSchemaRegistry: CCloudSchemaRegistry | null =
       await getResourceManager().getCCloudSchemaRegistryById("nonexistent-cluster-id");
@@ -417,7 +417,7 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
   it("CCLOUD: deleteCCloudSchemaRegistries() should correctly delete Schema Registries", async () => {
     // set the Schema Registry in the StorageManager before deleting them
     const resourceManager = getResourceManager();
-    await resourceManager.setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await resourceManager.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     await resourceManager.deleteCCloudSchemaRegistries();
     // verify the Schema Registry was deleted correctly
     const missingClusters = await storageManager.getWorkspaceState(StateSchemaRegistry.CCLOUD);
@@ -652,19 +652,19 @@ describe("ResourceManager schema tests", function () {
     storageManager = await getTestStorageManager();
     ccloudSchemas = [
       Schema.create({
-        ...TEST_SCHEMA,
+        ...TEST_CCLOUD_SCHEMA,
         id: "100001",
         subject: "test-ccloud-topic-xyz-value",
         version: 1,
       }),
       Schema.create({
-        ...TEST_SCHEMA,
+        ...TEST_CCLOUD_SCHEMA,
         id: "100055",
         subject: "test-ccloud-topic-xyz-value",
         version: 2,
       }),
       Schema.create({
-        ...TEST_SCHEMA,
+        ...TEST_CCLOUD_SCHEMA,
         id: "100055",
         subject: "test-ccloud-topic-abc-value",
         version: 1,
@@ -684,10 +684,10 @@ describe("ResourceManager schema tests", function () {
 
   it("CCLOUD: setSchemasForRegistry() should correctly store schemas", async () => {
     const rm = getResourceManager();
-    await rm.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, ccloudSchemas);
+    await rm.setSchemasForRegistry(TEST_CCLOUD_SCHEMA_REGISTRY.id, ccloudSchemas);
 
     // fetch back from resource manager
-    const storedSchemas = await rm.getSchemasForRegistry(TEST_SCHEMA_REGISTRY.id);
+    const storedSchemas = await rm.getSchemasForRegistry(TEST_CCLOUD_SCHEMA_REGISTRY.id);
     assert.ok(storedSchemas);
     assert.deepStrictEqual(storedSchemas, ccloudSchemas);
   });
@@ -701,8 +701,8 @@ describe("ResourceManager schema tests", function () {
 
   it("CCLOUD: setSchemasForRegistry() can store empty array of schemas", async () => {
     const rm = getResourceManager();
-    await rm.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, []);
-    const storedSchemas = await rm.getSchemasForRegistry(TEST_SCHEMA_REGISTRY.id);
+    await rm.setSchemasForRegistry(TEST_CCLOUD_SCHEMA_REGISTRY.id, []);
+    const storedSchemas = await rm.getSchemasForRegistry(TEST_CCLOUD_SCHEMA_REGISTRY.id);
     assert.deepStrictEqual(storedSchemas, []);
   });
 });
@@ -726,12 +726,24 @@ describe("ResourceManager general utility methods", function () {
     localTopics = [KafkaTopic.create({ ...TEST_LOCAL_KAFKA_TOPIC, name: "test-local-topic-1" })];
 
     ccloudSchemas = [
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, id: "100001", subject: "test-ccloud-topic-xyz-value", version: 1 },
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, id: "100055", subject: "test-ccloud-topic-xyz-value", version: 2 },
-      // @ts-expect-error: update dataclass so we don't have to add `T as Require<T>`
-      { ...TEST_SCHEMA, id: "100055", subject: "test-ccloud-topic-abc-value", version: 1 },
+      Schema.create({
+        ...TEST_CCLOUD_SCHEMA,
+        id: "100001",
+        subject: "test-ccloud-topic-xyz-value",
+        version: 1,
+      }),
+      Schema.create({
+        ...TEST_CCLOUD_SCHEMA,
+        id: "100055",
+        subject: "test-ccloud-topic-xyz-value",
+        version: 2,
+      }),
+      Schema.create({
+        ...TEST_CCLOUD_SCHEMA,
+        id: "100055",
+        subject: "test-ccloud-topic-abc-value",
+        version: 1,
+      }),
     ];
   });
 
@@ -749,9 +761,9 @@ describe("ResourceManager general utility methods", function () {
     // set the CCloud resources before deleting them
     const resourceManager = getResourceManager();
     await resourceManager.setCCloudKafkaClusters([TEST_CCLOUD_KAFKA_CLUSTER]);
-    await resourceManager.setCCloudSchemaRegistries([TEST_SCHEMA_REGISTRY]);
+    await resourceManager.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     await resourceManager.setTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER, ccloudTopics);
-    await resourceManager.setSchemasForRegistry(TEST_SCHEMA_REGISTRY.id, ccloudSchemas);
+    await resourceManager.setSchemasForRegistry(TEST_CCLOUD_SCHEMA_REGISTRY.id, ccloudSchemas);
     // also set some local resources to make sure they aren't deleted
     await resourceManager.setLocalKafkaClusters([TEST_LOCAL_KAFKA_CLUSTER]);
     await resourceManager.setTopicsForCluster(TEST_LOCAL_KAFKA_CLUSTER, localTopics);
@@ -765,7 +777,9 @@ describe("ResourceManager general utility methods", function () {
     assert.deepStrictEqual(missingSchemaRegistries, new Map());
     const missingTopics = await resourceManager.getTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER);
     assert.deepStrictEqual(missingTopics, undefined);
-    const missingSchemas = await resourceManager.getSchemasForRegistry(TEST_SCHEMA_REGISTRY.id);
+    const missingSchemas = await resourceManager.getSchemasForRegistry(
+      TEST_CCLOUD_SCHEMA_REGISTRY.id,
+    );
     assert.deepStrictEqual(missingSchemas, undefined);
 
     // local resources should still be there

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -4,7 +4,7 @@ import { IconNames } from "../constants";
 import { getExtensionContext } from "../context";
 import { ccloudConnected, ccloudOrganizationChanged, localKafkaConnected } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
-import { getLocalKafkaClusters } from "../graphql/local";
+import { getLocalResources, LocalResourceGroup } from "../graphql/local";
 import { getCurrentOrganization } from "../graphql/organizations";
 import { Logger } from "../logging";
 import { CCloudEnvironment, CCloudEnvironmentTreeItem } from "../models/environment";
@@ -14,7 +14,11 @@ import {
   LocalKafkaCluster,
 } from "../models/kafkaCluster";
 import { ContainerTreeItem } from "../models/main";
-import { CCloudSchemaRegistry, SchemaRegistryTreeItem } from "../models/schemaRegistry";
+import {
+  CCloudSchemaRegistry,
+  LocalSchemaRegistry,
+  SchemaRegistryTreeItem,
+} from "../models/schemaRegistry";
 import { hasCCloudAuthSession } from "../sidecar/connections";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 import { getResourceManager } from "../storage/resourceManager";
@@ -30,8 +34,9 @@ type ResourceViewProviderData =
   | CCloudEnvironment
   | CCloudKafkaCluster
   | CCloudSchemaRegistry
-  | ContainerTreeItem<LocalKafkaCluster>
-  | LocalKafkaCluster;
+  | ContainerTreeItem<LocalKafkaCluster | LocalSchemaRegistry>
+  | LocalKafkaCluster
+  | LocalSchemaRegistry;
 
 export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceViewProviderData> {
   private _onDidChangeTreeData = new vscode.EventEmitter<
@@ -90,8 +95,7 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
       return new CCloudEnvironmentTreeItem(element);
     } else if (element instanceof LocalKafkaCluster || element instanceof CCloudKafkaCluster) {
       return new KafkaClusterTreeItem(element);
-    } else if (element instanceof CCloudSchemaRegistry) {
-      // TODO(shoup): update ^ for local SR once available
+    } else if (element instanceof LocalSchemaRegistry || element instanceof CCloudSchemaRegistry) {
       return new SchemaRegistryTreeItem(element);
     }
     // should only be left with ContainerTreeItems
@@ -207,8 +211,10 @@ export async function loadCCloudResources(
  *
  * @returns A container tree item with the local Kafka clusters as children
  */
-export async function loadLocalResources(): Promise<ContainerTreeItem<LocalKafkaCluster>> {
-  const localContainerItem = new ContainerTreeItem<LocalKafkaCluster>(
+export async function loadLocalResources(): Promise<
+  ContainerTreeItem<LocalKafkaCluster | LocalSchemaRegistry>
+> {
+  const localContainerItem = new ContainerTreeItem<LocalKafkaCluster | LocalSchemaRegistry>(
     "Local",
     vscode.TreeItemCollapsibleState.None,
     [],
@@ -226,8 +232,8 @@ export async function loadLocalResources(): Promise<ContainerTreeItem<LocalKafka
     "Local Kafka clusters discoverable at port `8082` are shown here.",
   );
 
-  const localClusters: LocalKafkaCluster[] = await getLocalKafkaClusters();
-  if (localClusters.length > 0) {
+  const localResources: LocalResourceGroup[] = await getLocalResources();
+  if (localResources.length > 0) {
     const connectedId = "local-container-connected";
     // XXX: if we don't adjust the ID, we'll see weird collapsibleState behavior
     localContainerItem.id = connectedId;
@@ -235,12 +241,20 @@ export async function loadLocalResources(): Promise<ContainerTreeItem<LocalKafka
     localContainerItem.contextValue = connectedId;
 
     localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+    // Kafka cluster first
+    const localKafkaClusters: LocalKafkaCluster[] = localResources.flatMap(
+      (group) => group.kafkaClusters,
+    );
+    // ...then Schema Registry
+    const localSchemaRegistries: LocalSchemaRegistry[] = localResources
+      .flatMap((group): LocalSchemaRegistry | undefined => group.schemaRegistry)
+      .filter((schemaRegistry: LocalSchemaRegistry | undefined) => schemaRegistry !== undefined);
     // override the default "child item count" description
-    localContainerItem.description = localClusters.map((cluster) => cluster.uri).join(", ");
+    localContainerItem.description = localKafkaClusters.map((cluster) => cluster.uri).join(", ");
     // TODO: this should be handled in the preloader once it (and ResourceManager) start handling
     // local resources
-    getResourceManager().setLocalKafkaClusters(localClusters);
-    localContainerItem.children = localClusters;
+    getResourceManager().setLocalKafkaClusters(localKafkaClusters);
+    localContainerItem.children = [...localKafkaClusters, ...localSchemaRegistries];
   }
 
   return localContainerItem;

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -243,12 +243,16 @@ export async function loadLocalResources(): Promise<
     localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     // Kafka cluster first
     const localKafkaClusters: LocalKafkaCluster[] = localResources.flatMap(
-      (group) => group.kafkaClusters,
+      (group): LocalKafkaCluster[] => group.kafkaClusters,
     );
     // ...then Schema Registry
     const localSchemaRegistries: LocalSchemaRegistry[] = localResources
-      .flatMap((group): LocalSchemaRegistry | undefined => group.schemaRegistry)
-      .filter((schemaRegistry: LocalSchemaRegistry | undefined) => schemaRegistry !== undefined);
+      .flatMap((group: LocalResourceGroup): LocalSchemaRegistry | undefined => group.schemaRegistry)
+      .filter(
+        (schemaRegistry: LocalSchemaRegistry | undefined): schemaRegistry is LocalSchemaRegistry =>
+          schemaRegistry !== undefined,
+      );
+    localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     // override the default "child item count" description
     localContainerItem.description = localKafkaClusters.map((cluster) => cluster.uri).join(", ");
     // TODO: this should be handled in the preloader once it (and ResourceManager) start handling

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { TEST_SCHEMA } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_SCHEMA } from "../../tests/unit/testResources";
 import { ContainerTreeItem } from "../models/main";
 import { Schema, SchemaTreeItem } from "../models/schema";
 import { SchemasViewProvider } from "./schemas";
@@ -9,11 +9,11 @@ describe("SchemasViewProvider methods", () => {
   let provider: SchemasViewProvider;
 
   before(() => {
-    provider = new SchemasViewProvider();
+    provider = SchemasViewProvider.getInstance();
   });
 
   it("getTreeItem() should return a SchemaTreeItem for a Schema instance", () => {
-    const treeItem = provider.getTreeItem(TEST_SCHEMA);
+    const treeItem = provider.getTreeItem(TEST_CCLOUD_SCHEMA);
     assert.ok(treeItem instanceof SchemaTreeItem);
   });
 
@@ -21,7 +21,7 @@ describe("SchemasViewProvider methods", () => {
     const container = new ContainerTreeItem<Schema>(
       "test",
       vscode.TreeItemCollapsibleState.Collapsed,
-      [TEST_SCHEMA],
+      [TEST_CCLOUD_SCHEMA],
     );
     const treeItem = provider.getTreeItem(container);
     assert.deepStrictEqual(treeItem, container);

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -6,7 +6,7 @@ import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { ContainerTreeItem } from "../models/main";
 import { Schema, SchemaTreeItem, generateSchemaSubjectGroups } from "../models/schema";
-import { SchemaRegistry } from "../models/schemaRegistry";
+import { CCloudSchemaRegistry, SchemaRegistry } from "../models/schemaRegistry";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 import { getResourceManager } from "../storage/resourceManager";
 
@@ -85,10 +85,18 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
       } else {
         setContextValue(ContextValues.schemaRegistrySelected, true);
         this.schemaRegistry = schemaRegistry;
-        const environment: CCloudEnvironment | null =
-          await getResourceManager().getCCloudEnvironment(this.schemaRegistry.environmentId);
-        this.ccloudEnvironment = environment;
-        this.treeView.description = `${this.ccloudEnvironment!.name} | ${this.schemaRegistry.id}`;
+        // update the tree view title to show the currently focused Schema Registry and repopulate the tree
+        if (this.schemaRegistry.isLocal) {
+          // just show "Local" since we don't have a name for the local SR instance
+          this.treeView.description = "Local";
+        } else {
+          const environment: CCloudEnvironment | null =
+            await getResourceManager().getCCloudEnvironment(
+              (this.schemaRegistry as CCloudSchemaRegistry).environmentId,
+            );
+          this.ccloudEnvironment = environment;
+          this.treeView.description = `${this.ccloudEnvironment!.name} | ${this.schemaRegistry.id}`;
+        }
         this.refresh();
       }
     });

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -72,12 +72,14 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
     this.treeView = vscode.window.createTreeView("confluent-schemas", { treeDataProvider: this });
 
     ccloudConnected.event((connected: boolean) => {
-      // TODO(shoup): check this for CCloud vs local once we start supporting local SR; check the
-      // TopicViewProvider for a similar check
-      logger.debug("ccloudConnected event fired, resetting", { connected });
-      // any transition of CCloud connection state should reset the tree view
-      this.reset();
+      if (this.schemaRegistry?.isCCloud) {
+        logger.debug("ccloudConnected event fired, resetting", { connected });
+        // any transition of CCloud connection state should reset the tree view
+        this.reset();
+      }
     });
+
+    // TODO(shoup): check localKafkaConnected and reset this view if local SR availability changes
 
     currentSchemaRegistryChanged.event(async (schemaRegistry: SchemaRegistry | null) => {
       if (!schemaRegistry) {

--- a/tests/unit/testResources/schema.ts
+++ b/tests/unit/testResources/schema.ts
@@ -1,11 +1,11 @@
 import { Schema, SchemaType } from "../../../src/models/schema";
-import { TEST_SCHEMA_REGISTRY } from "./schemaRegistry";
+import { TEST_CCLOUD_SCHEMA_REGISTRY } from "./schemaRegistry";
 
-export const TEST_SCHEMA = Schema.create({
+export const TEST_CCLOUD_SCHEMA = Schema.create({
   id: "100001",
   subject: "test-topic-value",
   version: 1,
   type: SchemaType.Avro,
-  schemaRegistryId: TEST_SCHEMA_REGISTRY.id,
-  environmentId: TEST_SCHEMA_REGISTRY.environmentId,
+  schemaRegistryId: TEST_CCLOUD_SCHEMA_REGISTRY.id,
+  environmentId: TEST_CCLOUD_SCHEMA_REGISTRY.environmentId,
 });

--- a/tests/unit/testResources/schemaRegistry.ts
+++ b/tests/unit/testResources/schemaRegistry.ts
@@ -1,7 +1,12 @@
-import { CCloudSchemaRegistry } from "../../../src/models/schemaRegistry";
+import { CCloudSchemaRegistry, LocalSchemaRegistry } from "../../../src/models/schemaRegistry";
 import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_PROVIDER, TEST_CCLOUD_REGION } from "./environments";
 
-export const TEST_SCHEMA_REGISTRY: CCloudSchemaRegistry = CCloudSchemaRegistry.create({
+export const TEST_LOCAL_SCHEMA_REGISTRY: LocalSchemaRegistry = LocalSchemaRegistry.create({
+  id: "local-abc123",
+  uri: "http://localhost:8081",
+});
+
+export const TEST_CCLOUD_SCHEMA_REGISTRY: CCloudSchemaRegistry = CCloudSchemaRegistry.create({
   id: "lsrc-abc123",
   provider: TEST_CCLOUD_PROVIDER.toUpperCase(),
   region: TEST_CCLOUD_REGION,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This is largely a compatibility update/fix to expand our SR usage beyond CCloud connections/environments as a follow-up to https://github.com/confluentinc/vscode/pull/348.
- renames previous SR/schema references with a CCloud prefix for clarity
- adds a `LocalSchemaRegistry` class (and updates the `SchemaRegistry` union type to use it)
- adds a new event emitter for when local SR is connected, used by the Docker event listener for updating the Resources view
- updates the local GraphQL query to pull in any locally-discoverable SR instance based on the [ide-sidecar SchemaRegistryConfig uri](https://github.com/confluentinc/ide-sidecar/blob/main/src/generated/resources/openapi.yaml#L865-L879)
  - (this is updated in https://github.com/confluentinc/vscode/pull/401 based on dynamically-assigned ports during SR container creation)
- updates commands to check whether a referenced SR is local vs CCloud
- updates the SR quickpick to break out local vs CCloud instances
- updates the SR tooltip to support local instances

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/0af8f020-1ee4-47bc-8796-2bf3a07f3ac0">
(Screenshot taken using https://github.com/confluentinc/vscode/pull/401 to start the local SR instance.)


### Associated PRs

- https://github.com/confluentinc/vscode/pull/396 
  - https://github.com/confluentinc/vscode/pull/399
    - https://github.com/confluentinc/vscode/pull/446
      - https://github.com/confluentinc/vscode/pull/400 👈
        - https://github.com/confluentinc/vscode/pull/401

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
