### PR TITLE
feat(Docker): implement multi-select quickpick and new workflow to allow starting and stopping local Schema Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,9 @@ All notable changes to this extension will be documented in this file.
   upload" icon button drives the process given a file with extension ".avsc" (Avro Schema), ".proto"
   (Protobuf), or ".json" (JSON schema),
   [issue #388](https://github.com/confluentinc/vscode/issues/388).
-- "Start Local Resources" functionality to run `confluentinc/confluent-local` Kafka locally as a
-  Docker container (or up to four containers). Available from the Resources view's "Local" item, as
-  well as the command palette.
-- "Stop Local Resources" functionality to stop running `confluentinc/confluent-local` Kafka Docker
-  containers. Available from the Resources view's "Local" item, as well as the command palette.
+- "Start Local Resources" / "Stop Local Resources" functionality to start and stop Confluent's Kafka
+  and Schema Registry containers via Docker engine API integration, available as actions on the
+  "Local" item in the Resources view, as well as the command palette.
 
 ## 0.20.1
 

--- a/package.json
+++ b/package.json
@@ -620,7 +620,7 @@
         },
         {
           "command": "confluent.docker.startLocalResources",
-          "when": "view == confluent-resources && viewItem =~ /local-container.*/ && !confluent.localKafkaClusterAvailable",
+          "when": "view == confluent-resources && viewItem =~ /local-container.*/ && !(confluent.localKafkaClusterAvailable && confluent.localSchemaRegistryAvailable)",
           "group": "inline"
         },
         {

--- a/package.json
+++ b/package.json
@@ -393,7 +393,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.create)",
+        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.create)\nOr start Schema Registry locally through Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -352,7 +352,18 @@
           "type": "string",
           "default": "localhost",
           "description": "Host to use for the Kafka REST Proxy when starting a local Kafka cluster"
-        }
+        },
+        "confluent.localDocker.schemaRegistryImageRepo": {
+          "type": "string",
+          "default": "confluentinc/cp-schema-registry",
+          "description": "Docker image repo to use when starting a local Schema Registry container",
+          "readOnly": true
+        },
+        "confluent.localDocker.schemaRegistryImageTag": {
+          "type": "string",
+          "default": "latest",
+          "description": "Docker image tag to use when starting a local Schema Registry container"
+        },
       }
     },
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -352,17 +352,6 @@
           "type": "string",
           "default": "localhost",
           "description": "Host to use for the Kafka REST Proxy when starting a local Kafka cluster"
-        },
-        "confluent.localDocker.schemaRegistryImageRepo": {
-          "type": "string",
-          "default": "confluentinc/cp-schema-registry",
-          "description": "Docker image repo to use when starting a local Schema Registry container",
-          "readOnly": true
-        },
-        "confluent.localDocker.schemaRegistryImageTag": {
-          "type": "string",
-          "default": "latest",
-          "description": "Docker image tag to use when starting a local Schema Registry container"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
           "type": "string",
           "default": "latest",
           "description": "Docker image tag to use when starting a local Schema Registry container"
-        },
+        }
       }
     },
     "viewsContainers": {

--- a/src/commands/docker.test.ts
+++ b/src/commands/docker.test.ts
@@ -2,8 +2,10 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { window } from "vscode";
 import * as dockerConfigs from "../docker/configs";
+import { LocalResourceKind } from "../docker/constants";
 import * as dockerWorkflows from "../docker/workflows";
 import { ConfluentLocalWorkflow } from "../docker/workflows/confluent-local";
+import * as quickpicks from "../quickpicks/localResources";
 import { runWorkflowWithProgress } from "./docker";
 
 describe("commands/docker.ts runWorkflowWithProgress()", () => {
@@ -16,6 +18,7 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
   let getKafkaWorkflowStub: sinon.SinonStub;
   let isDockerAvailableStub: sinon.SinonStub;
   let stubbedKafkaWorkflow: sinon.SinonStubbedInstance<ConfluentLocalWorkflow>;
+  let localResourcesQuickPickStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -28,6 +31,10 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
     getKafkaWorkflowStub = sandbox
       .stub(dockerWorkflows, "getKafkaWorkflow")
       .returns(stubbedKafkaWorkflow);
+    // set default quickpick as Kafka for majority of tests
+    localResourcesQuickPickStub = sandbox
+      .stub(quickpicks, "localResourcesQuickPick")
+      .resolves([LocalResourceKind.Kafka]);
   });
 
   afterEach(() => {

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -11,16 +11,22 @@ import { localResourcesQuickPick } from "../quickpicks/localResources";
 
 const logger = new Logger("commands.docker");
 
+/** Run the .start() workflow(s) from an array of resource kinds. If none are provided, the user
+ * will be shown a multi-select quickpick. */
 async function startLocalResourcesWithProgress(resourceKinds: LocalResourceKind[] = []) {
   await runWorkflowWithProgress(true, resourceKinds);
 }
 
+/** Run the .stop() workflow(s) from an array of resource kinds. If none are provided, the user
+ * will be shown a multi-select quickpick. */
 async function stopLocalResourcesWithProgress(resourceKinds: LocalResourceKind[] = []) {
   await runWorkflowWithProgress(false, resourceKinds);
 }
 
-/** Prompt the user with a multi-select quickpick, allowing them to choose which resource types to
- * start. Then run the local resource workflow(s) with a progress notification. */
+/**
+ * Run the local resource workflow(s) with a progress notification. If no `resourceKinds` are
+ * provided, the user will be shown a multi-select quickpick to choose which resources to start/stop.
+ */
 export async function runWorkflowWithProgress(
   start: boolean = true,
   resourceKinds: LocalResourceKind[] = [],

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -58,8 +58,7 @@ async function runWorkflowWithProgress(
     }
   }
   if (resources.includes(LocalResourceKind.SchemaRegistry)) {
-    const schemaRegistryWorkflow = getSchemaRegistryWorkflow();
-    if (schemaRegistryWorkflow) subworkflows.push(schemaRegistryWorkflow);
+    subworkflows.push(getSchemaRegistryWorkflow());
   }
   // add logic for looking up other resources' workflows here
 
@@ -161,8 +160,7 @@ function getSchemaRegistryWorkflow(): LocalResourceWorkflow | undefined {
       workflow = ConfluentPlatformSchemaRegistryWorkflow.getInstance();
       break;
     default:
-      window.showErrorMessage(`Unsupported image repo: ${imageRepo}`);
-      return;
+      throw new Error(`Unsupported Schema Registry image repo: ${imageRepo}`);
   }
   return workflow;
 }

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -46,6 +46,10 @@ async function runWorkflowWithProgress(
   // how the workflow should be run
   const resources: LocalResourceKind[] =
     resourceKinds.length > 0 ? resourceKinds : await localResourcesQuickPick();
+  if (resources.length === 0) {
+    // nothing selected, or user clicked a quickpick button to adjust settings
+    return;
+  }
 
   // based on the imageRepo chosen by the user, select the appropriate workflow before running them
   const subworkflows: LocalResourceWorkflow[] = [];

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -2,10 +2,11 @@ import * as Sentry from "@sentry/node";
 import { CancellationToken, Disposable, env, ProgressLocation, Uri, window } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ResponseError } from "../clients/docker";
-import { isDockerAvailable } from "../docker/configs";
+import { getLocalSchemaRegistryImageName, isDockerAvailable } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { getKafkaWorkflow } from "../docker/workflows";
 import { LocalResourceWorkflow } from "../docker/workflows/base";
+import { ConfluentPlatformSchemaRegistryWorkflow } from "../docker/workflows/cp-schema-registry";
 import { Logger } from "../logging";
 import { localResourcesQuickPick } from "../quickpicks/localResources";
 
@@ -153,6 +154,15 @@ export function registerDockerCommands(): Disposable[] {
 }
 
 function getSchemaRegistryWorkflow(): LocalResourceWorkflow | undefined {
-  // TODO: implement this once the ConfluentPlatformSchemaRegistryWorkflow is available
-  return;
+  const imageRepo: string = getLocalSchemaRegistryImageName();
+  let workflow: LocalResourceWorkflow;
+  switch (imageRepo) {
+    case ConfluentPlatformSchemaRegistryWorkflow.imageRepo:
+      workflow = ConfluentPlatformSchemaRegistryWorkflow.getInstance();
+      break;
+    default:
+      window.showErrorMessage(`Unsupported image repo: ${imageRepo}`);
+      return;
+  }
+  return workflow;
 }

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -12,12 +12,12 @@ import { localResourcesQuickPick } from "../quickpicks/localResources";
 
 const logger = new Logger("commands.docker");
 
-async function startLocalResourcesWithProgress() {
-  await runWorkflowWithProgress();
+async function startLocalResourcesWithProgress(resourceKinds: LocalResourceKind[] = []) {
+  await runWorkflowWithProgress(true, resourceKinds);
 }
 
-async function stopLocalResourcesWithProgress() {
-  await runWorkflowWithProgress(false);
+async function stopLocalResourcesWithProgress(resourceKinds: LocalResourceKind[] = []) {
+  await runWorkflowWithProgress(false, resourceKinds);
 }
 
 /** Prompt the user with a multi-select quickpick, allowing them to choose which resource types to

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -21,7 +21,7 @@ async function stopLocalResourcesWithProgress(resourceKinds: LocalResourceKind[]
 
 /** Prompt the user with a multi-select quickpick, allowing them to choose which resource types to
  * start. Then run the local resource workflow(s) with a progress notification. */
-async function runWorkflowWithProgress(
+export async function runWorkflowWithProgress(
   start: boolean = true,
   resourceKinds: LocalResourceKind[] = [],
 ) {

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -52,12 +52,14 @@ export function getLocalKafkaImageTag(): string {
 /** Get the local Schema Registry image name based on user settings. */
 export function getLocalSchemaRegistryImageName(): string {
   const configs: WorkspaceConfiguration = workspace.getConfiguration();
+  // we are not currently exposing these settings, so we'll always use the default value
   return configs.get(LOCAL_SCHEMA_REGISTRY_IMAGE, DEFAULT_SCHEMA_REGISTRY_REPO);
 }
 
 /** Get the local Schema Registry image tag based on user settings. */
 export function getLocalSchemaRegistryImageTag(): string {
   const configs: WorkspaceConfiguration = workspace.getConfiguration();
+  // we are not currently exposing these settings, so we'll always use the default value
   return configs.get(LOCAL_SCHEMA_REGISTRY_IMAGE_TAG, DEFAULT_SCHEMA_REGISTRY_TAG);
 }
 

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -7,8 +7,15 @@ import {
   LOCAL_DOCKER_SOCKET_PATH,
   LOCAL_KAFKA_IMAGE,
   LOCAL_KAFKA_IMAGE_TAG,
+  LOCAL_SCHEMA_REGISTRY_IMAGE,
+  LOCAL_SCHEMA_REGISTRY_IMAGE_TAG,
 } from "../preferences/constants";
-import { DEFAULT_KAFKA_IMAGE_REPO, DEFAULT_KAFKA_IMAGE_TAG } from "./constants";
+import {
+  DEFAULT_KAFKA_IMAGE_REPO,
+  DEFAULT_KAFKA_IMAGE_TAG,
+  DEFAULT_SCHEMA_REGISTRY_REPO,
+  DEFAULT_SCHEMA_REGISTRY_TAG,
+} from "./constants";
 
 const logger = new Logger("docker.configs");
 
@@ -40,6 +47,18 @@ export function getLocalKafkaImageName(): string {
 export function getLocalKafkaImageTag(): string {
   const configs: WorkspaceConfiguration = workspace.getConfiguration();
   return configs.get(LOCAL_KAFKA_IMAGE_TAG, DEFAULT_KAFKA_IMAGE_TAG);
+}
+
+/** Get the local Schema Registry image name based on user settings. */
+export function getLocalSchemaRegistryImageName(): string {
+  const configs: WorkspaceConfiguration = workspace.getConfiguration();
+  return configs.get(LOCAL_SCHEMA_REGISTRY_IMAGE, DEFAULT_SCHEMA_REGISTRY_REPO);
+}
+
+/** Get the local Schema Registry image tag based on user settings. */
+export function getLocalSchemaRegistryImageTag(): string {
+  const configs: WorkspaceConfiguration = workspace.getConfiguration();
+  return configs.get(LOCAL_SCHEMA_REGISTRY_IMAGE_TAG, DEFAULT_SCHEMA_REGISTRY_TAG);
 }
 
 /** Default request options for Docker API requests, to be used with service class methods from `src/clients/docker/*`. */

--- a/src/docker/constants.ts
+++ b/src/docker/constants.ts
@@ -18,4 +18,5 @@ export const MANAGED_CONTAINER_LABEL = "io.confluent.vscode.managed";
 /** Types of resources that can be locally managed by this extension through the Docker engine API. */
 export enum LocalResourceKind {
   Kafka = "Kafka",
+  SchemaRegistry = "Schema Registry",
 }

--- a/src/docker/constants.ts
+++ b/src/docker/constants.ts
@@ -26,6 +26,9 @@ export const DEFAULT_KAFKA_IMAGE_TAG = "latest";
  */
 export const DEFAULT_SCHEMA_REGISTRY_TAG = "latest";
 
+/** Network name to use when creating new Docker containers from the extension workflows. */
+export const DEFAULT_DOCKER_NETWORK = "vscode-confluent-local-network";
+
 /** Label to use when creating containers, to allow for easier identification later. */
 export const MANAGED_CONTAINER_LABEL = "io.confluent.vscode.managed";
 

--- a/src/docker/constants.ts
+++ b/src/docker/constants.ts
@@ -6,11 +6,25 @@
 export const DEFAULT_KAFKA_IMAGE_REPO = "confluentinc/confluent-local";
 
 /**
+ * Default image to use for the local Schema Registry container.
+ *
+ * Must match the default value in the "confluent.docker.localSchemaRegistryImage" configuration in package.json.
+ */
+export const DEFAULT_SCHEMA_REGISTRY_REPO = "confluentinc/cp-schema-registry";
+
+/**
  * Default image tag to use for local Kafka (broker) container(s).
  *
  * Must match the default value in the "confluent.docker.localKafkaImageTag" configuration in package.json.
  */
 export const DEFAULT_KAFKA_IMAGE_TAG = "latest";
+
+/**
+ * Default image tag to use for the local Schema Registry container.
+ *
+ * Must match the default value in the "confluent.docker.localSchemaRegistryImageTag" configuration in package.json.
+ */
+export const DEFAULT_SCHEMA_REGISTRY_TAG = "latest";
 
 /** Label to use when creating containers, to allow for easier identification later. */
 export const MANAGED_CONTAINER_LABEL = "io.confluent.vscode.managed";

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -149,3 +149,17 @@ export function getContainerEnvVars(container: ContainerInspectResponse): Record
   });
   return envVars;
 }
+
+export function getContainerPorts(container: ContainerInspectResponse): Record<string, string> {
+  const ports: Record<string, string> = {};
+  const portBindings = container.HostConfig?.PortBindings;
+  if (portBindings) {
+    Object.keys(portBindings).forEach((containerPort) => {
+      const hostPort = portBindings[containerPort]?.[0]?.HostPort;
+      if (hostPort) {
+        ports[containerPort] = hostPort;
+      }
+    });
+  }
+  return ports;
+}

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -140,3 +140,12 @@ export async function getContainer(id: string): Promise<ContainerInspectResponse
     throw error;
   }
 }
+
+export function getContainerEnvVars(container: ContainerInspectResponse): Record<string, string> {
+  const envVars: Record<string, string> = {};
+  container.Config?.Env?.forEach((envVar) => {
+    const [key, value] = envVar.split("=");
+    envVars[key] = value;
+  });
+  return envVars;
+}

--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -328,6 +328,7 @@ export class EventListener {
       await setContextValue(ContextValues.localKafkaClusterAvailable, started);
       localKafkaConnected.fire(started);
     } else if (imageName.startsWith(schemaRegistryImage)) {
+      await setContextValue(ContextValues.localSchemaRegistryAvailable, started);
       localSchemaRegistryConnected.fire(started);
     }
   }
@@ -341,11 +342,15 @@ export class EventListener {
     logger.debug(`container 'die' event for image: ${imageName}`);
 
     const kafkaImage = getLocalKafkaImageName();
+    const schemaRegistryImage = getLocalSchemaRegistryImageName();
+
     if (imageName.startsWith(kafkaImage)) {
       await setContextValue(ContextValues.localKafkaClusterAvailable, false);
       localKafkaConnected.fire(false);
+    } else if (imageName.startsWith(schemaRegistryImage)) {
+      await setContextValue(ContextValues.localSchemaRegistryAvailable, false);
+      localSchemaRegistryConnected.fire(false);
     }
-    // TODO(shoup): update for Schema Registry image
   }
 
   /** Wait for the container to show a specific {@link ContainerStateStatusEnum} status. */

--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -9,7 +9,7 @@ import {
   SystemEventsRequest,
 } from "../clients/docker";
 import { ContextValues, setContextValue } from "../context";
-import { localKafkaConnected } from "../emitters";
+import { localKafkaConnected, localSchemaRegistryConnected } from "../emitters";
 import { Logger } from "../logging";
 import { IntervalPoller } from "../utils/timing";
 import {
@@ -327,8 +327,9 @@ export class EventListener {
     if (imageName.startsWith(kafkaImage)) {
       await setContextValue(ContextValues.localKafkaClusterAvailable, started);
       localKafkaConnected.fire(started);
+    } else if (imageName.startsWith(schemaRegistryImage)) {
+      localSchemaRegistryConnected.fire(started);
     }
-    // TODO(shoup): update for Schema Registry image
   }
 
   /** Handling for an event that describes when a container is stopped. */

--- a/src/docker/ports.ts
+++ b/src/docker/ports.ts
@@ -1,0 +1,14 @@
+import * as net from "net";
+
+/** Look for an available port on the host machine and return it. */
+export async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, () => {
+      const port = (server.address() as net.AddressInfo).port;
+      server.close(() => resolve(port));
+    });
+  });
+}

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -46,6 +46,7 @@ export abstract class LocalResourceWorkflow {
   abstract start(
     token: CancellationToken,
     progress?: Progress<{ message?: string; increment?: number }>,
+    ...args: any[]
   ): Promise<void>;
 
   /**

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -2,6 +2,7 @@ import { CancellationToken, commands, Progress, window } from "vscode";
 import { ContainerInspectResponse, ContainerSummary, ResponseError } from "../../clients/docker";
 import { Logger } from "../../logging";
 import { getTelemetryLogger } from "../../telemetry/telemetryLogger";
+import { DEFAULT_DOCKER_NETWORK } from "../constants";
 import { getContainer, restartContainer, startContainer, stopContainer } from "../containers";
 import { imageExists, pullImage } from "../images";
 
@@ -26,7 +27,7 @@ export abstract class LocalResourceWorkflow {
   protected progress?: Progress<{ message?: string; increment?: number }>;
 
   /** Default Docker network name to use for all workflows' `.start()` logic. */
-  networkName: string = "vscode-confluent-local-network";
+  networkName: string = DEFAULT_DOCKER_NETWORK;
 
   /** Basic label for notifications and logs to tell the user what kind of resource is being started
    * or stopped for the given workflow. */

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -64,7 +64,6 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
   async start(
     token: CancellationToken,
     progress?: Progress<{ message?: string; increment?: number }>,
-    withSchemaRegistry: boolean = false,
   ): Promise<void> {
     this.progress = progress;
     this.imageTag = getLocalKafkaImageTag();

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -8,7 +8,6 @@ import {
   workspace,
   WorkspaceConfiguration,
 } from "vscode";
-import { findFreePort } from ".";
 import {
   ContainerCreateRequest,
   ContainerCreateResponse,
@@ -30,6 +29,7 @@ import { getLocalKafkaImageTag } from "../configs";
 import { MANAGED_CONTAINER_LABEL } from "../constants";
 import { createContainer, getContainersForImage } from "../containers";
 import { createNetwork } from "../networks";
+import { findFreePort } from "../ports";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
 export const CONTAINER_NAME_PREFIX = "vscode-confluent-local-broker";

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -64,6 +64,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
   async start(
     token: CancellationToken,
     progress?: Progress<{ message?: string; increment?: number }>,
+    withSchemaRegistry: boolean = false,
   ): Promise<void> {
     this.progress = progress;
     this.imageTag = getLocalKafkaImageTag();

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -2,20 +2,40 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { commands, window, workspace } from "vscode";
 import {
+  TEST_BROKER_CONFIGS,
   TEST_CANCELLATION_TOKEN,
   TEST_KAFKA_CONTAINERS,
 } from "../../../tests/unit/testResources/docker";
 import { getExtensionContext } from "../../../tests/unit/testUtils";
-import { ContainerCreateResponse, ContainerInspectResponse } from "../../clients/docker";
+import {
+  ContainerCreateOperationRequest,
+  ContainerCreateResponse,
+  ContainerInspectResponse,
+} from "../../clients/docker";
 import {
   LOCAL_DOCKER_SOCKET_PATH,
   LOCAL_KAFKA_IMAGE,
   LOCAL_KAFKA_IMAGE_TAG,
 } from "../../preferences/constants";
+import * as connections from "../../sidecar/connections";
 import { DEFAULT_UNIX_SOCKET_PATH } from "../configs";
-import { DEFAULT_KAFKA_IMAGE_REPO, DEFAULT_KAFKA_IMAGE_TAG } from "../constants";
+import {
+  DEFAULT_DOCKER_NETWORK,
+  DEFAULT_KAFKA_IMAGE_REPO,
+  DEFAULT_KAFKA_IMAGE_TAG,
+  LocalResourceKind,
+} from "../constants";
 import * as dockerContainers from "../containers";
-import { ConfluentPlatformSchemaRegistryWorkflow } from "./cp-schema-registry";
+import * as ports from "../ports";
+import { brokerConfigsToRestBootstrapServers } from "./confluent-local";
+import {
+  ConfluentPlatformSchemaRegistryWorkflow,
+  CONTAINER_NAME,
+  determineKafkaBootstrapServers,
+  determineKafkaDockerNetworks,
+  IMAGE_SETTINGS_BUTTON,
+  START_KAFKA_BUTTON,
+} from "./cp-schema-registry";
 
 describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistryWorkflow", () => {
   let sandbox: sinon.SinonSandbox;
@@ -34,7 +54,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
   // base class stubs
   let checkForImageStub: sinon.SinonStub;
   let handleExistingContainersStub: sinon.SinonStub;
-  let showErrorNotificationStub: sinon.SinonStub;
+  let workflowShowErrorNotificationStub: sinon.SinonStub;
   let fetchAndFilterKafkaContainersStub: sinon.SinonStub;
   let startContainerStub: sinon.SinonStub;
   let stopContainerStub: sinon.SinonStub;
@@ -76,7 +96,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     checkForImageStub = sandbox.stub(workflow, "checkForImage").resolves();
     handleExistingContainersStub = sandbox.stub(workflow, "handleExistingContainers").resolves();
-    showErrorNotificationStub = sandbox.stub(workflow, "showErrorNotification").resolves();
+    workflowShowErrorNotificationStub = sandbox.stub(workflow, "showErrorNotification").resolves();
     // assume we have Kafka containers to work off of for most tests
     fetchAndFilterKafkaContainersStub = sandbox
       .stub(workflow, "fetchAndFilterKafkaContainers")
@@ -95,6 +115,8 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     waitForLocalResourceEventChangeStub = sandbox
       .stub(workflow, "waitForLocalResourceEventChange")
       .resolves();
+
+    updateLocalSchemaRegistryURI = sandbox.stub(connections, "updateLocalSchemaRegistryURI");
   });
 
   afterEach(() => {
@@ -122,6 +144,9 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     assert.ok(createContainerStub.calledOnce);
     assert.ok(startContainerStub.calledOnce);
+    assert.ok(workflowShowErrorNotificationStub.notCalled);
+
+    assert.ok(updateLocalSchemaRegistryURI.calledOnce);
 
     assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
   });
@@ -166,6 +191,73 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     assert.ok(waitForLocalResourceEventChangeStub.notCalled);
   });
 
+  it("start() should allow users to start Kafka resources via the notification buttons if no Kafka containers are available", async () => {
+    fetchAndFilterKafkaContainersStub.resolves([]);
+    // stub the user clicking the 'Start Kafka' button
+    showErrorMessageStub.resolves(START_KAFKA_BUTTON);
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(handleExistingContainersStub.notCalled);
+
+    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    assert.ok(
+      showErrorMessageStub.calledOnceWith(
+        `No running Kafka containers found for image "${DEFAULT_KAFKA_IMAGE_REPO}:${DEFAULT_KAFKA_IMAGE_TAG}". Please start Kafka and try again.`,
+        START_KAFKA_BUTTON,
+        IMAGE_SETTINGS_BUTTON,
+      ),
+    );
+    assert.ok(
+      executeCommandStub.calledOnceWith("confluent.docker.startLocalResources", [
+        LocalResourceKind.Kafka,
+      ]),
+    );
+    // bailing here
+
+    assert.ok(createContainerStub.notCalled);
+    assert.ok(startContainerStub.notCalled);
+
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
+  it("start() should allow users to access Docker image settings via the notification buttons if no Kafka containers are available", async () => {
+    fetchAndFilterKafkaContainersStub.resolves([]);
+    // stub the user clicking the 'Configure Image Settings' button
+    showErrorMessageStub.resolves(IMAGE_SETTINGS_BUTTON);
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(handleExistingContainersStub.notCalled);
+
+    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    assert.ok(
+      showErrorMessageStub.calledOnceWith(
+        `No running Kafka containers found for image "${DEFAULT_KAFKA_IMAGE_REPO}:${DEFAULT_KAFKA_IMAGE_TAG}". Please start Kafka and try again.`,
+        START_KAFKA_BUTTON,
+        IMAGE_SETTINGS_BUTTON,
+      ),
+    );
+    assert.ok(
+      executeCommandStub.calledOnceWith(
+        "workbench.action.openSettings",
+        `@id:${LOCAL_KAFKA_IMAGE} @id:${LOCAL_KAFKA_IMAGE_TAG}`,
+      ),
+    );
+    // bailing here
+
+    assert.ok(createContainerStub.notCalled);
+    assert.ok(startContainerStub.notCalled);
+
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
   it("start() should exit early and show an error notification if a container fails to be created", async () => {
     createContainerStub.rejects(new Error("uh oh"));
 
@@ -180,6 +272,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     assert.ok(showErrorMessageStub.notCalled);
 
     assert.ok(createContainerStub.calledOnce);
+    assert.ok(workflowShowErrorNotificationStub.calledOnce);
     // bailing here
     assert.ok(startContainerStub.notCalled);
 
@@ -226,18 +319,137 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     assert.ok(waitForLocalResourceEventChangeStub.notCalled);
   });
 
-  // TODO: ADD MORE HERE
-  // workflow.fetchAndFilterKafkaContainers()
-
   it("fetchAndFilterKafkaContainers() should return Kafka containers", async () => {
+    // restore normal functionality so we can actually test this method
+    fetchAndFilterKafkaContainersStub.restore();
     getContainersForImageStub.resolves(TEST_KAFKA_CONTAINERS);
+    // each time `getContainer()` is called, we should expect to get back our test container
+    TEST_KAFKA_CONTAINERS.forEach((container, index) => {
+      getContainerStub.onCall(index).resolves(container);
+    });
 
     const kafkaContainers = await workflow.fetchAndFilterKafkaContainers();
 
     assert.deepEqual(kafkaContainers, TEST_KAFKA_CONTAINERS);
   });
+
+  it("fetchAndFilterKafkaContainers() should return an empty array if no Kafka containers are found", async () => {
+    // restore normal functionality so we can actually test this method
+    fetchAndFilterKafkaContainersStub.restore();
+    getContainersForImageStub.resolves([]);
+
+    const kafkaContainers = await workflow.fetchAndFilterKafkaContainers();
+
+    assert.deepEqual(kafkaContainers, []);
+  });
+
+  it("createSchemaRegistryContainer() should create the correct container body", async () => {
+    const kafkaBootstrapServers = ["localhost:9092"];
+    const kafkaNetworks = [DEFAULT_DOCKER_NETWORK];
+
+    const restProxyPort = 8081;
+    sandbox.stub(ports, "findFreePort").resolves(restProxyPort);
+
+    const container = await workflow.createSchemaRegistryContainer(
+      kafkaBootstrapServers,
+      kafkaNetworks,
+    );
+
+    assert.ok(createContainerStub.calledOnce);
+    assert.ok(container);
+
+    const createBody: ContainerCreateOperationRequest = {
+      body: {
+        Image: workflow.imageRepoTag,
+        Hostname: CONTAINER_NAME,
+        ExposedPorts: { [`${restProxyPort}/tcp`]: {} },
+        HostConfig: {
+          NetworkMode: workflow.networkName,
+          PortBindings: {
+            [`${restProxyPort}/tcp`]: [{ HostIp: "0.0.0.0", HostPort: restProxyPort.toString() }],
+          },
+        },
+        Env: [
+          `SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://${kafkaBootstrapServers.join(",")}`,
+          `SCHEMA_REGISTRY_HOST_NAME=${CONTAINER_NAME}`,
+          `SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:${restProxyPort}`,
+          "SCHEMA_REGISTRY_DEBUG=true",
+        ],
+        Tty: false,
+      },
+      name: CONTAINER_NAME,
+    };
+    assert.ok(
+      createContainerStub.calledWith(workflow.imageRepo, workflow.imageTag, createBody),
+      `createContainerStub called with: ${JSON.stringify(createContainerStub.args, null, 2)}\n\nand not ${JSON.stringify([workflow.imageRepo, workflow.imageTag, createBody], null, 2)}`,
+    );
+  });
 });
 
-// TODO: ADD MORE HERE
-// determineKafkaDockerNetwork()
-// determineKafkaBootstrapServers()
+describe("docker/workflows/cp-schema-registry.ts helper functions", () => {
+  it("determineKafkaDockerNetworks() should return the expected Docker network from extension-managed Kafka containers", () => {
+    // should already have the DEFAULT_DOCKER_NETWORK set
+    const networks = determineKafkaDockerNetworks(TEST_KAFKA_CONTAINERS);
+
+    assert.deepEqual(networks, [DEFAULT_DOCKER_NETWORK]);
+  });
+
+  it("determineKafkaDockerNetworks() should return the array of unique Docker networks if available in ContainerInspectResponses", () => {
+    const kafkaContainers: ContainerInspectResponse[] = [
+      {
+        NetworkSettings: {
+          Networks: {
+            bridge: {},
+            host: {},
+          },
+        },
+      },
+      {
+        NetworkSettings: {
+          Networks: {
+            bridge: {},
+          },
+        },
+      },
+    ];
+
+    const networks = determineKafkaDockerNetworks(kafkaContainers);
+
+    assert.deepEqual(networks, ["bridge", "host"]);
+  });
+
+  it("determineKafkaDockerNetworks() should return an empty array if no networks are found in the ContainerInspectResponses", () => {
+    const kafkaContainers: ContainerInspectResponse[] = [
+      {
+        NetworkSettings: {
+          Networks: {},
+        },
+      },
+    ];
+
+    const networks = determineKafkaDockerNetworks(kafkaContainers);
+
+    assert.deepEqual(networks, []);
+  });
+
+  it("determineKafkaBootstrapServers() should return the correct bootstrap servers", () => {
+    const bootstrapServers = determineKafkaBootstrapServers(TEST_KAFKA_CONTAINERS);
+
+    // use the same function the Kafka workflow uses to determine bootstrap servers
+    assert.deepEqual(bootstrapServers, brokerConfigsToRestBootstrapServers(TEST_BROKER_CONFIGS));
+  });
+
+  it("determineKafkaBootstrapServers() should return an empty array if no bootstrap servers are found", () => {
+    const kafkaContainers: ContainerInspectResponse[] = [
+      {
+        Config: {
+          Env: [],
+        },
+      },
+    ];
+
+    const bootstrapServers = determineKafkaBootstrapServers(kafkaContainers);
+
+    assert.deepEqual(bootstrapServers, []);
+  });
+});

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -1,0 +1,243 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { commands, window, workspace } from "vscode";
+import {
+  TEST_CANCELLATION_TOKEN,
+  TEST_KAFKA_CONTAINERS,
+} from "../../../tests/unit/testResources/docker";
+import { getExtensionContext } from "../../../tests/unit/testUtils";
+import { ContainerCreateResponse, ContainerInspectResponse } from "../../clients/docker";
+import {
+  LOCAL_DOCKER_SOCKET_PATH,
+  LOCAL_KAFKA_IMAGE,
+  LOCAL_KAFKA_IMAGE_TAG,
+} from "../../preferences/constants";
+import { DEFAULT_UNIX_SOCKET_PATH } from "../configs";
+import { DEFAULT_KAFKA_IMAGE_REPO, DEFAULT_KAFKA_IMAGE_TAG } from "../constants";
+import * as dockerContainers from "../containers";
+import { ConfluentPlatformSchemaRegistryWorkflow } from "./cp-schema-registry";
+
+describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistryWorkflow", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  // vscode stubs
+  let showErrorMessageStub: sinon.SinonStub;
+  let executeCommandStub: sinon.SinonStub;
+  let getConfigurationStub: sinon.SinonStub;
+
+  // docker/containers.ts wrapper function stubs
+  let createContainerStub: sinon.SinonStub;
+  let getContainersForImageStub: sinon.SinonStub;
+  let getContainerStub: sinon.SinonStub;
+
+  let workflow: ConfluentPlatformSchemaRegistryWorkflow;
+  // base class stubs
+  let checkForImageStub: sinon.SinonStub;
+  let handleExistingContainersStub: sinon.SinonStub;
+  let showErrorNotificationStub: sinon.SinonStub;
+  let fetchAndFilterKafkaContainersStub: sinon.SinonStub;
+  let startContainerStub: sinon.SinonStub;
+  let stopContainerStub: sinon.SinonStub;
+  let waitForLocalResourceEventChangeStub: sinon.SinonStub;
+
+  let updateLocalSchemaRegistryURI: sinon.SinonStub;
+
+  before(async () => {
+    await getExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    showErrorMessageStub = sandbox.stub(window, "showErrorMessage").resolves();
+    executeCommandStub = sandbox.stub(commands, "executeCommand").resolves();
+    // this should probably live in a separate test helper file
+    getConfigurationStub = sandbox.stub(workspace, "getConfiguration");
+    getConfigurationStub.returns({
+      get: sandbox.stub().callsFake((key: string) => {
+        switch (key) {
+          case LOCAL_KAFKA_IMAGE:
+            return DEFAULT_KAFKA_IMAGE_REPO;
+          case LOCAL_KAFKA_IMAGE_TAG:
+            return DEFAULT_KAFKA_IMAGE_TAG;
+          case LOCAL_DOCKER_SOCKET_PATH:
+            return DEFAULT_UNIX_SOCKET_PATH;
+        }
+      }),
+    });
+
+    // assume no running containers matching this workflow image for most tests
+    getContainersForImageStub = sandbox
+      .stub(dockerContainers, "getContainersForImage")
+      .resolves([]);
+    getContainerStub = sandbox.stub(dockerContainers, "getContainer");
+
+    workflow = ConfluentPlatformSchemaRegistryWorkflow.getInstance();
+
+    checkForImageStub = sandbox.stub(workflow, "checkForImage").resolves();
+    handleExistingContainersStub = sandbox.stub(workflow, "handleExistingContainers").resolves();
+    showErrorNotificationStub = sandbox.stub(workflow, "showErrorNotification").resolves();
+    // assume we have Kafka containers to work off of for most tests
+    fetchAndFilterKafkaContainersStub = sandbox
+      .stub(workflow, "fetchAndFilterKafkaContainers")
+      .resolves(TEST_KAFKA_CONTAINERS);
+    // assume the container is created successfully for most tests
+    const fakeCreatedContainer: ContainerCreateResponse = { Id: "1", Warnings: [] };
+    createContainerStub = sandbox
+      .stub(dockerContainers, "createContainer")
+      .resolves(fakeCreatedContainer);
+    // assume the container starts successfully for most tests
+    const fakeStartedContainer: ContainerInspectResponse = { Id: "1" };
+    startContainerStub = sandbox.stub(workflow, "startContainer").resolves(fakeStartedContainer);
+    // assume the container stops successfully for most tests
+    stopContainerStub = sandbox.stub(workflow, "stopContainer").resolves();
+    // don't block on waiting for the event to resolve for most tests
+    waitForLocalResourceEventChangeStub = sandbox
+      .stub(workflow, "waitForLocalResourceEventChange")
+      .resolves();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it(".imageRepo should return the correct image repository for this workflow", () => {
+    // making sure the getter method is working as expected against the static property
+    assert.equal(workflow.imageRepo, ConfluentPlatformSchemaRegistryWorkflow.imageRepo);
+  });
+
+  it("start() should create and start Schema Registry container", async () => {
+    getContainersForImageStub.resolves([]);
+    createContainerStub.resolves({ Id: "1" });
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    // happy path: no existing containers, Kafka container(s) exist to work off of
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce); // twice if fetchAndFilterKafkaContainersStub is not stubbed
+    assert.ok(handleExistingContainersStub.notCalled);
+
+    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+
+    assert.ok(createContainerStub.calledOnce);
+    assert.ok(startContainerStub.calledOnce);
+
+    assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
+  });
+
+  it("start() should handle existing containers and not create new ones", async () => {
+    const fakeContainers = [{ Id: "1", Names: ["container1"] }];
+    getContainersForImageStub.resolves(fakeContainers);
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(handleExistingContainersStub.calledOnceWith(fakeContainers));
+    // bailing here
+
+    assert.ok(fetchAndFilterKafkaContainersStub.notCalled);
+
+    assert.ok(createContainerStub.notCalled);
+    assert.ok(startContainerStub.notCalled);
+
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
+  it("start() should exit early when no Kafka containers are found", async () => {
+    fetchAndFilterKafkaContainersStub.resolves([]);
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(handleExistingContainersStub.notCalled);
+
+    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    assert.ok(showErrorMessageStub.calledOnce);
+    // bailing here
+
+    assert.ok(createContainerStub.notCalled);
+    assert.ok(startContainerStub.notCalled);
+
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
+  it("start() should exit early and show an error notification if a container fails to be created", async () => {
+    createContainerStub.rejects(new Error("uh oh"));
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(handleExistingContainersStub.notCalled);
+
+    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    assert.ok(showErrorMessageStub.notCalled);
+
+    assert.ok(createContainerStub.calledOnce);
+    // bailing here
+    assert.ok(startContainerStub.notCalled);
+
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
+  it("start() should exit early and if a container fails to start", async () => {
+    startContainerStub.resolves(undefined);
+
+    await workflow.start(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(checkForImageStub.calledOnce);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(handleExistingContainersStub.notCalled);
+
+    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+
+    assert.ok(createContainerStub.calledOnce);
+    assert.ok(startContainerStub.calledOnce);
+    // notification tested in base.test.ts as part of .startContainer() tests
+
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
+  it("stop() should stop Schema Registry container", async () => {
+    const fakeContainers = [{ Id: "1", Names: ["container1"] }];
+    getContainersForImageStub.resolves(fakeContainers);
+
+    await workflow.stop(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(stopContainerStub.calledOnce);
+    assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
+  });
+
+  it("stop() should exit early if there are no running Schema Registry containers", async () => {
+    getContainersForImageStub.resolves([]);
+
+    await workflow.stop(TEST_CANCELLATION_TOKEN);
+
+    assert.ok(getContainersForImageStub.calledOnce);
+    assert.ok(stopContainerStub.notCalled);
+    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+  });
+
+  // TODO: ADD MORE HERE
+  // workflow.fetchAndFilterKafkaContainers()
+
+  it("fetchAndFilterKafkaContainers() should return Kafka containers", async () => {
+    getContainersForImageStub.resolves(TEST_KAFKA_CONTAINERS);
+
+    const kafkaContainers = await workflow.fetchAndFilterKafkaContainers();
+
+    assert.deepEqual(kafkaContainers, TEST_KAFKA_CONTAINERS);
+  });
+});
+
+// TODO: ADD MORE HERE
+// determineKafkaDockerNetwork()
+// determineKafkaBootstrapServers()

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -163,13 +163,13 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
     };
     const existingContainers: ContainerSummary[] =
       await getContainersForImage(containerListRequest);
-    if (existingContainers.length === 0) {
+    const count = existingContainers.length;
+    const plural = count > 1 ? "s" : "";
+    if (count === 0) {
       return;
     }
 
-    this.logAndUpdateProgress(
-      `Stopping ${existingContainers.length} ${this.resourceKind} container(s)...`,
-    );
+    this.logAndUpdateProgress(`Stopping ${count} ${this.resourceKind} container${plural}...`);
     const promises: Promise<void>[] = [];
     for (const container of existingContainers) {
       if (!container.Id || !container.Names) {
@@ -189,6 +189,9 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
     // there would introduce a delay
     if (token.isCancellationRequested) return;
 
+    this.logAndUpdateProgress(
+      `Waiting for ${count} ${this.resourceKind} container${plural} to stop...`,
+    );
     await this.waitForLocalResourceEventChange();
   }
 

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -1,5 +1,5 @@
 import { CancellationToken, commands, Progress, window } from "vscode";
-import { findFreePort, LocalResourceContainer, LocalResourceWorkflow } from ".";
+import { findFreePort, getKafkaWorkflow } from ".";
 import {
   ContainerCreateRequest,
   ContainerCreateResponse,
@@ -8,7 +8,6 @@ import {
   ContainerSummary,
   HostConfig,
 } from "../../clients/docker";
-import { getKafkaWorkflow } from "../../commands/docker";
 import { localSchemaRegistryConnected } from "../../emitters";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
@@ -22,6 +21,7 @@ import {
   getContainerPorts,
   getContainersForImage,
 } from "../containers";
+import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
 const CONTAINER_NAME = "vscode-confluent-schema-registry";
 

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -27,6 +27,7 @@ import {
 const CONTAINER_NAME = "vscode-confluent-schema-registry";
 
 export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkflow {
+  resourceKind: string = "Schema Registry";
   static imageRepo = "confluentinc/cp-schema-registry";
 
   logger = new Logger("docker.workflow.cp-schema-registry");
@@ -87,7 +88,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       return;
     }
 
-    const waitMsg = "Waiting for Schema Registry container to be ready...";
+    const waitMsg = `Waiting for ${this.resourceKind} container to be ready...`;
     this.logger.debug(waitMsg);
     this.progress?.report({ message: waitMsg });
     await this.waitForLocalResourceEventChange();
@@ -114,7 +115,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       return;
     }
 
-    const stopMsg = `Stopping ${existingContainers.length} container(s)...`;
+    const stopMsg = `Stopping ${existingContainers.length} ${this.resourceKind} container(s)...`;
     this.logger.debug(stopMsg);
     this.progress?.report({ message: stopMsg });
     const promises: Promise<void>[] = [];
@@ -165,7 +166,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       kafkaNetworks,
     );
     if (!container) {
-      window.showErrorMessage("Failed to create Schema Registry container.");
+      window.showErrorMessage(`Failed to create ${this.resourceKind} container.`);
       return;
     }
 
@@ -178,7 +179,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
     if (!startedContainer) {
       window
         .showErrorMessage(
-          `Failed to start Schema Registry container "${CONTAINER_NAME}".`,
+          `Failed to start ${this.resourceKind} container "${CONTAINER_NAME}".`,
           "Open Logs",
         )
         .then(this.handleOpenLogsButton);
@@ -345,7 +346,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       },
     );
     if (!container) {
-      window.showErrorMessage("Failed to create Schema Registry container.");
+      window.showErrorMessage(`Failed to create ${this.resourceKind} container.`);
       return;
     }
 

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -8,12 +8,10 @@ import {
   ContainerSummary,
   HostConfig,
 } from "../../clients/docker";
-import { Connection, ConnectionsResourceApi } from "../../clients/sidecar";
 import { getKafkaWorkflow } from "../../commands/docker";
-import { LOCAL_CONNECTION_ID, LOCAL_CONNECTION_SPEC } from "../../constants";
 import { localSchemaRegistryConnected } from "../../emitters";
 import { Logger } from "../../logging";
-import { getSidecar } from "../../sidecar";
+import { updateLocalSchemaRegistryURI } from "../../sidecar/connections";
 import { getLocalKafkaImageName, getLocalSchemaRegistryImageTag } from "../configs";
 import { MANAGED_CONTAINER_LABEL } from "../constants";
 import {
@@ -276,17 +274,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
 
     // inform the sidecar that it needs to look for the Schema Registry container at the dynamically
     // assigned REST proxy port
-    const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
-    const resp: Connection = await client.gatewayV1ConnectionsIdPut({
-      id: LOCAL_CONNECTION_ID,
-      ConnectionSpec: {
-        ...LOCAL_CONNECTION_SPEC,
-        local_config: {
-          schema_registry_uri: `http://localhost:${restProxyPort}`,
-        },
-      },
-    });
-    this.logger.debug("Updated local connection with Schema Registry URI:", resp);
+    await updateLocalSchemaRegistryURI(`http://localhost:${restProxyPort}`);
 
     return { id: container.Id, name: CONTAINER_NAME };
   }

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -14,7 +14,7 @@ import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
 import { updateLocalSchemaRegistryURI } from "../../sidecar/connections";
 import { getLocalKafkaImageName, getLocalSchemaRegistryImageTag } from "../configs";
-import { MANAGED_CONTAINER_LABEL } from "../constants";
+import { LocalResourceKind, MANAGED_CONTAINER_LABEL } from "../constants";
 import {
   createContainer,
   getContainer,
@@ -85,7 +85,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
     if (kafkaContainers.length === 0) {
       const kafkaWorkflow = getKafkaWorkflow();
       this.logger.error("no Kafka containers found, skipping creation");
-      const startKafkaButton = "Start Local Resources";
+      const startKafkaButton = "Start Kafka";
       const imageSettingsButton = "Configure Image Settings";
       window
         .showErrorMessage(
@@ -95,7 +95,9 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
         )
         .then((selection) => {
           if (selection === startKafkaButton) {
-            commands.executeCommand("confluent.docker.startLocalResources");
+            commands.executeCommand("confluent.docker.startLocalResources", [
+              LocalResourceKind.Kafka,
+            ]);
             this.sendTelemetryEvent("Notification Button Clicked", {
               buttonLabel: startKafkaButton,
               notificationType: "error",

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -1,5 +1,5 @@
 import { CancellationToken, commands, Progress, window } from "vscode";
-import { findFreePort, getKafkaWorkflow } from ".";
+import { getKafkaWorkflow } from ".";
 import {
   ContainerCreateRequest,
   ContainerCreateResponse,
@@ -21,6 +21,7 @@ import {
   getContainerPorts,
   getContainersForImage,
 } from "../containers";
+import { findFreePort } from "../ports";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
 const CONTAINER_NAME = "vscode-confluent-schema-registry";

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -87,7 +87,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       return;
     }
 
-    const waitMsg = "Waiting for container to be ready...";
+    const waitMsg = "Waiting for Schema Registry container to be ready...";
     this.logger.debug(waitMsg);
     this.progress?.report({ message: waitMsg });
     await this.waitForLocalResourceEventChange();

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -1,0 +1,235 @@
+import { CancellationToken, Progress, window } from "vscode";
+import { findFreePort, LocalResourceContainer, LocalResourceWorkflow } from ".";
+import {
+  ContainerCreateRequest,
+  ContainerCreateResponse,
+  ContainerInspectResponse,
+  ContainerListRequest,
+  ContainerSummary,
+  HostConfig,
+} from "../../clients/docker";
+import { getKafkaWorkflow } from "../../commands/docker";
+import { localKafkaConnected } from "../../emitters";
+import { Logger } from "../../logging";
+import { getLocalSchemaRegistryImageTag } from "../configs";
+import { MANAGED_CONTAINER_LABEL } from "../constants";
+import { createContainer, getContainer, getContainersForImage, stopContainer } from "../containers";
+
+const CONTAINER_NAME_PREFIX = "vscode-confluent-schema-registry";
+
+export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkflow {
+  static imageRepo = "confluentinc/cp-schema-registry";
+
+  logger = new Logger("docker.workflow.cp-schema-registry");
+
+  networkName: string = "vscode-confluent-local-network";
+
+  // ensure only one instance of this workflow can run at a time
+  private static instance: ConfluentPlatformSchemaRegistryWorkflow;
+  private constructor() {
+    super(); // must call super() in derived class constructor
+  }
+  static getInstance(): ConfluentPlatformSchemaRegistryWorkflow {
+    if (!ConfluentPlatformSchemaRegistryWorkflow.instance) {
+      ConfluentPlatformSchemaRegistryWorkflow.instance =
+        new ConfluentPlatformSchemaRegistryWorkflow();
+    }
+    return ConfluentPlatformSchemaRegistryWorkflow.instance;
+  }
+
+  /**
+   * Start a `cp-schema-registry` container locally:
+   * - Ensure the Docker image is available
+   * - List existing Kafka broker containers based on the user-configured image repo+tag
+   * - Look up the network and bootstrap server environment variables
+   * - Create and start the Schema Registry container
+   * - Wait for the container to be ready
+   */
+  async start(
+    token: CancellationToken,
+    progress?: Progress<{ message?: string; increment?: number }>,
+  ): Promise<void> {
+    this.progress = progress;
+    this.imageTag = getLocalSchemaRegistryImageTag();
+
+    // already handles logging + updating the progress notification
+    await this.checkForImage(ConfluentPlatformSchemaRegistryWorkflow.imageRepo, this.imageTag);
+
+    const repoTag = `${ConfluentPlatformSchemaRegistryWorkflow.imageRepo}:${this.imageTag}`;
+    const containerListRequest: ContainerListRequest = {
+      all: true,
+      filters: JSON.stringify({
+        ancestor: [repoTag],
+        label: [MANAGED_CONTAINER_LABEL],
+      }),
+    };
+    const existingContainers: ContainerSummary[] =
+      await getContainersForImage(containerListRequest);
+    if (existingContainers.length > 0) {
+      this.logger.warn("Container already exists, skipping creation.", {
+        imageRepo: ConfluentPlatformSchemaRegistryWorkflow.imageRepo,
+        imageTag: this.imageTag,
+      });
+      window.showWarningMessage(
+        "Existing Schema Registry container(s) found. Please stop and remove them before starting new ones.",
+      );
+      return;
+    }
+
+    // list existing Kafka containers based on the user-configured image repo+tag
+    const kafkaWorkflow: LocalResourceWorkflow | undefined = getKafkaWorkflow();
+    if (!kafkaWorkflow) {
+      this.logger.error("Unable to look up Kafka image from workflow.");
+      return;
+    }
+
+    const kafkaImageRepo: string = kafkaWorkflow.constructor().imageRepo;
+    const kafkaImageTag: string = kafkaWorkflow.constructor().imageTag;
+    const kafkaContainerListRequest: ContainerListRequest = {
+      all: true,
+      filters: JSON.stringify({
+        ancestor: [`${kafkaImageRepo}:${kafkaImageTag}`],
+        label: [MANAGED_CONTAINER_LABEL],
+      }),
+    };
+    const kafkaContainers: ContainerSummary[] =
+      await getContainersForImage(kafkaContainerListRequest);
+    if (kafkaContainers.length === 0) {
+      window.showErrorMessage(
+        "No Kafka containers found. Please start Kafka before Schema Registry.",
+      );
+      return;
+    }
+
+    // inspect the containers to get the boostrap server URLs and Docker network name
+    const kafkaBootstrapServers: string[] = [];
+
+    // create the SR container
+    const createdContainer: ContainerCreateResponse | undefined =
+      await this.createSchemaRegistryContainer(kafkaBootstrapServers);
+    if (!createdContainer) {
+      window.showErrorMessage("Failed to create Schema Registry container.");
+      return;
+    }
+    // start the SR container
+
+    const waitMsg = "Waiting for container to be ready...";
+    this.logger.debug(waitMsg);
+    this.progress?.report({ message: waitMsg });
+    await this.waitForLocalResourceEventChange();
+  }
+
+  /** Stop Schema Registry container. */
+  async stop(
+    token: CancellationToken,
+    progress?: Progress<{ message?: string; increment?: number }>,
+  ): Promise<void> {
+    this.progress = progress;
+
+    const repoTag = `${ConfluentPlatformSchemaRegistryWorkflow.imageRepo}:${this.imageTag}`;
+    const containerListRequest: ContainerListRequest = {
+      all: true,
+      filters: JSON.stringify({
+        ancestor: [repoTag],
+        label: [MANAGED_CONTAINER_LABEL],
+      }),
+    };
+    const existingContainers: ContainerSummary[] =
+      await getContainersForImage(containerListRequest);
+    if (existingContainers.length === 0) {
+      return;
+    }
+
+    const stopMsg = `Stopping ${existingContainers.length} container(s)...`;
+    this.logger.debug(stopMsg);
+    this.progress?.report({ message: stopMsg });
+    const promises: Promise<void>[] = [];
+    for (const container of existingContainers) {
+      if (!container.Id || !container.Names) {
+        this.logger.error("Container missing ID or name", {
+          id: container.Id,
+          names: container.Names,
+        });
+        continue;
+      }
+      promises.push(this.stopContainer({ id: container.Id, name: container.Names[0] }));
+    }
+    await Promise.all(promises);
+
+    await this.waitForLocalResourceEventChange();
+  }
+
+  /** Block until we see the {@link localKafkaConnected} event fire. (Controlled by the EventListener
+   * in `src/docker/eventListener.ts` whenever a supported container starts or dies.) */
+  async waitForLocalResourceEventChange(): Promise<void> {
+    await new Promise((resolve) => {
+      localKafkaConnected.event(() => {
+        resolve(void 0);
+      });
+    });
+  }
+
+  async createSchemaRegistryContainer(
+    bootstrapServers: string[],
+  ): Promise<ContainerCreateResponse | undefined> {
+    const restProxyPort: number = await findFreePort();
+
+    const hostConfig: HostConfig = {
+      NetworkMode: this.networkName,
+      PortBindings: {
+        [`${restProxyPort}/tcp`]: [{ HostIp: "0.0.0.0", HostPort: restProxyPort.toString() }],
+      },
+    };
+    const envVars: string[] = [
+      `SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://${bootstrapServers.join(",")}`,
+      `SCHEMA_REGISTRY_HOST_NAME=${CONTAINER_NAME_PREFIX}`,
+      `SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:${restProxyPort}`,
+      "SCHEMA_REGISTRY_DEBUG=true",
+    ];
+    const body: ContainerCreateRequest = {
+      Image: `${ConfluentPlatformSchemaRegistryWorkflow.imageRepo}:${this.imageTag}`,
+      Hostname: CONTAINER_NAME_PREFIX,
+      ExposedPorts: {
+        [`${restProxyPort}/tcp`]: {},
+      },
+      HostConfig: hostConfig,
+      Env: envVars,
+      Tty: false,
+    };
+
+    const container: ContainerCreateResponse | undefined = await createContainer(
+      ConfluentPlatformSchemaRegistryWorkflow.imageRepo,
+      this.imageTag,
+      {
+        body,
+        name: CONTAINER_NAME_PREFIX,
+      },
+    );
+    if (!container) {
+      window.showErrorMessage("Failed to create Schema Registry container.");
+      return;
+    }
+    return container;
+  }
+
+  private async stopContainer(container: LocalResourceContainer): Promise<void> {
+    // names may start with a leading slash, so try to remove it
+    const containerName = container.name.replace(/^\/+/, "");
+    // check container status before deleting
+    const existingContainer: ContainerInspectResponse | undefined = await getContainer(
+      container.id,
+    );
+    if (!existingContainer) {
+      // assume it was cleaned up some other way
+      this.logger.warn("Container not found, skipping stop and delete steps.", {
+        id: container.id,
+        name: containerName,
+      });
+      return;
+    }
+
+    if (existingContainer.State?.Status === "running") {
+      await stopContainer(container.id);
+    }
+  }
+}

--- a/src/docker/workflows/index.ts
+++ b/src/docker/workflows/index.ts
@@ -1,8 +1,9 @@
 import net from "net";
 import { window } from "vscode";
-import { getLocalKafkaImageName } from "../configs";
+import { getLocalKafkaImageName, getLocalSchemaRegistryImageName } from "../configs";
 import { LocalResourceWorkflow } from "./base";
 import { ConfluentLocalWorkflow } from "./confluent-local";
+import { ConfluentPlatformSchemaRegistryWorkflow } from "./cp-schema-registry";
 
 // maybe this can live somewhere else if we need it for more than just container creation:
 /** Look for an available port on the host machine and return it. */
@@ -32,6 +33,20 @@ export function getKafkaWorkflow(): LocalResourceWorkflow {
       window.showErrorMessage(errorMsg);
       throw new Error(errorMsg);
     }
+  }
+  return workflow;
+}
+
+/** Determine which Schema Registry workflow to use based on the user-selected configuration. */
+export function getSchemaRegistryWorkflow(): LocalResourceWorkflow {
+  const imageRepo: string = getLocalSchemaRegistryImageName();
+  let workflow: LocalResourceWorkflow;
+  switch (imageRepo) {
+    case ConfluentPlatformSchemaRegistryWorkflow.imageRepo:
+      workflow = ConfluentPlatformSchemaRegistryWorkflow.getInstance();
+      break;
+    default:
+      throw new Error(`Unsupported Schema Registry image repo: ${imageRepo}`);
   }
   return workflow;
 }

--- a/src/docker/workflows/index.ts
+++ b/src/docker/workflows/index.ts
@@ -1,23 +1,8 @@
-import net from "net";
 import { window } from "vscode";
 import { getLocalKafkaImageName, getLocalSchemaRegistryImageName } from "../configs";
 import { LocalResourceWorkflow } from "./base";
 import { ConfluentLocalWorkflow } from "./confluent-local";
 import { ConfluentPlatformSchemaRegistryWorkflow } from "./cp-schema-registry";
-
-// maybe this can live somewhere else if we need it for more than just container creation:
-/** Look for an available port on the host machine and return it. */
-export async function findFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.unref();
-    server.on("error", reject);
-    server.listen(0, () => {
-      const port = (server.address() as net.AddressInfo).port;
-      server.close(() => resolve(port));
-    });
-  });
-}
 
 /** Determine which Kafka workflow to use based on the user-selected configuration. */
 export function getKafkaWorkflow(): LocalResourceWorkflow {

--- a/src/docker/workflows/index.ts
+++ b/src/docker/workflows/index.ts
@@ -45,8 +45,11 @@ export function getSchemaRegistryWorkflow(): LocalResourceWorkflow {
     case ConfluentPlatformSchemaRegistryWorkflow.imageRepo:
       workflow = ConfluentPlatformSchemaRegistryWorkflow.getInstance();
       break;
-    default:
-      throw new Error(`Unsupported Schema Registry image repo: ${imageRepo}`);
+    default: {
+      const errorMsg = `Unsupported Schema Registry image repo: ${imageRepo}`;
+      window.showErrorMessage(errorMsg);
+      throw new Error(errorMsg);
+    }
   }
   return workflow;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,7 +193,7 @@ async function setupContextValues() {
   const resourcesWithURIs = setContextValue(ContextValues.RESOURCES_WITH_URIS, [
     "ccloud-schema-registry",
     "local-kafka-cluster",
-    // TODO(shoup): add local-schema-registry here when implemented
+    "local-schema-registry",
   ]);
   await Promise.all([
     kafkaClusterSelected,

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -22,5 +22,7 @@ export const LOCAL_DOCKER_SOCKET_PATH = prefix + "localDocker.socketPath";
 
 export const LOCAL_KAFKA_IMAGE = prefix + "localDocker.kafkaImageRepo";
 export const LOCAL_KAFKA_IMAGE_TAG = prefix + "localDocker.kafkaImageTag";
+export const LOCAL_SCHEMA_REGISTRY_IMAGE = prefix + "localDocker.schemaRegistryImageRepo";
+export const LOCAL_SCHEMA_REGISTRY_IMAGE_TAG = prefix + "localDocker.schemaRegistryImageTag";
 
 export const LOCAL_KAFKA_REST_HOST = prefix + "localDocker.kafkaRestHost";

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -1,0 +1,50 @@
+import { QuickPick, QuickPickItem, ThemeIcon, window } from "vscode";
+import { IconNames } from "../constants";
+import { LocalResourceKind } from "../docker/constants";
+import { Logger } from "../logging";
+
+const logger = new Logger("quickpicks.localResources");
+
+/** Create a multi-select quickpick to allow the user to choose which resources to launch. */
+export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
+  const quickpick: QuickPick<QuickPickItem> = window.createQuickPick();
+  quickpick.title = "Local Resources";
+  quickpick.ignoreFocusOut = true;
+  quickpick.placeholder = "Select resources to launch";
+  quickpick.canSelectMany = true;
+
+  quickpick.items = [
+    {
+      label: LocalResourceKind.Kafka,
+      iconPath: new ThemeIcon(IconNames.CCLOUD_KAFKA),
+      detail: "A local Kafka cluster with a user-specified number of broker containers",
+      picked: true,
+    },
+    {
+      label: LocalResourceKind.SchemaRegistry,
+      iconPath: new ThemeIcon(IconNames.SCHEMA_REGISTRY),
+      detail:
+        "A local Schema Registry instance that can be used to manage schemas for Kafka topics",
+    },
+  ];
+  quickpick.show();
+
+  const selectedItems: QuickPickItem[] = [];
+  quickpick.onDidAccept(() => {
+    logger.debug("selected items", { items: JSON.stringify(quickpick.selectedItems) });
+    selectedItems.push(...quickpick.selectedItems);
+    quickpick.hide();
+    return;
+  });
+
+  // block until the quickpick is hidden
+  await new Promise<void>((resolve) => {
+    quickpick.onDidHide(() => {
+      resolve();
+    });
+  });
+
+  return selectedItems.length > 0
+    ? selectedItems.map((item) => item.label as LocalResourceKind)
+    : [];
+}

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -8,7 +8,7 @@ import {
 } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { Logger } from "../logging";
-import { LOCAL_KAFKA_IMAGE } from "../preferences/constants";
+import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../preferences/constants";
 
 const logger = new Logger("quickpicks.localResources");
 
@@ -54,8 +54,11 @@ export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
     async (event: { button: QuickInputButton; item: QuickPickItem }) => {
       quickpick.hide();
       if (event.button.tooltip?.includes(LocalResourceKind.Kafka)) {
-        // open Settings and focus on specific setting ID
-        commands.executeCommand("workbench.action.openSettings", LOCAL_KAFKA_IMAGE);
+        // open Settings and filter to the Kafka image repo+tag settings
+        commands.executeCommand(
+          "workbench.action.openSettings",
+          `@id:${LOCAL_KAFKA_IMAGE} @id:${LOCAL_KAFKA_IMAGE_TAG}`,
+        );
       }
     },
   );

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -12,7 +12,7 @@ import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../preferences/constan
 
 const logger = new Logger("quickpicks.localResources");
 
-/** Create a multi-select quickpick to allow the user to choose which resources to launch. */
+/** Create a multi-select quickpick to allow the user to choose which resources to start/stop. */
 export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
   const quickpick: QuickPick<QuickPickItem> = window.createQuickPick();
   quickpick.title = "Local Resources";

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -10,13 +10,13 @@ export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
   const quickpick: QuickPick<QuickPickItem> = window.createQuickPick();
   quickpick.title = "Local Resources";
   quickpick.ignoreFocusOut = true;
-  quickpick.placeholder = "Select resources to launch";
+  quickpick.placeholder = "Select resource types";
   quickpick.canSelectMany = true;
 
   quickpick.items = [
     {
       label: LocalResourceKind.Kafka,
-      iconPath: new ThemeIcon(IconNames.CCLOUD_KAFKA),
+      iconPath: new ThemeIcon(IconNames.KAFKA_CLUSTER),
       detail: "A local Kafka cluster with a user-specified number of broker containers",
       picked: true,
     },

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -82,15 +82,26 @@ export async function createLocalConnection(): Promise<Connection> {
   return await tryToCreateConnection(LOCAL_CONNECTION_SPEC);
 }
 
-/** Delete the existing Confluent Cloud {@link Connection} (if it exists). */
-export async function deleteCCloudConnection(): Promise<void> {
+/** Delete the existing {@link Connection} with the given ID. */
+export async function tryToDeleteConnection(id: string): Promise<void> {
   const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
   try {
-    await client.gatewayV1ConnectionsIdDelete({ id: CCLOUD_CONNECTION_ID });
-    logger.debug("deleted existing CCloud connection");
-  } catch (e) {
-    logger.error("Error deleting connection", e);
+    await client.gatewayV1ConnectionsIdDelete({ id: id });
+    logger.debug("deleted connection:", { id });
+  } catch (error) {
+    logger.error("delete connection error:", error);
+    throw error;
   }
+}
+
+/** Delete the existing Confluent Cloud {@link Connection} (if it exists). */
+export async function deleteCCloudConnection(): Promise<void> {
+  await tryToDeleteConnection(CCLOUD_CONNECTION_ID);
+}
+
+/** Delete the existing local {@link Connection} (if it exists). */
+export async function deleteLocalConnection(): Promise<void> {
+  await tryToDeleteConnection(LOCAL_CONNECTION_ID);
 }
 
 export async function clearCurrentCCloudResources() {
@@ -130,23 +141,15 @@ export function hasCCloudAuthSession(): boolean {
   return !!isCcloudConnected;
 }
 
-/** Update the local connection's Schema Registry URI. */
+// TODO(shoup): update for direct connections
+/** Delete the existing local connection, then recreate it with the new Schema Registry URI to avoid
+ * caching issues. */
 export async function updateLocalSchemaRegistryURI(uri: string): Promise<void> {
-  if (!(await getLocalConnection())) {
-    try {
-      await createLocalConnection();
-    } catch {
-      // error should be caught+logged in createLocalConnection
-    }
-  }
-  const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
-  const resp: Connection = await client.gatewayV1ConnectionsIdPut({
-    id: LOCAL_CONNECTION_ID,
-    ConnectionSpec: {
-      ...LOCAL_CONNECTION_SPEC,
-      local_config: {
-        schema_registry_uri: uri,
-      },
+  await deleteLocalConnection();
+  const resp: Connection = await tryToCreateConnection({
+    ...LOCAL_CONNECTION_SPEC,
+    local_config: {
+      schema_registry_uri: uri,
     },
   });
   logger.debug("Updated local connection with Schema Registry URI:", resp);

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -129,3 +129,25 @@ export function hasCCloudAuthSession(): boolean {
   );
   return !!isCcloudConnected;
 }
+
+/** Update the local connection's Schema Registry URI. */
+export async function updateLocalSchemaRegistryURI(uri: string): Promise<void> {
+  if (!(await getLocalConnection())) {
+    try {
+      await createLocalConnection();
+    } catch {
+      // error should be caught+logged in createLocalConnection
+    }
+  }
+  const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
+  const resp: Connection = await client.gatewayV1ConnectionsIdPut({
+    id: LOCAL_CONNECTION_ID,
+    ConnectionSpec: {
+      ...LOCAL_CONNECTION_SPEC,
+      local_config: {
+        schema_registry_uri: uri,
+      },
+    },
+  });
+  logger.debug("Updated local connection with Schema Registry URI:", resp);
+}

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -89,6 +89,10 @@ export async function tryToDeleteConnection(id: string): Promise<void> {
     await client.gatewayV1ConnectionsIdDelete({ id: id });
     logger.debug("deleted connection:", { id });
   } catch (error) {
+    if (error instanceof ResponseError && error.response.status === 404) {
+      logger.debug("no connection found to delete:", { id });
+      return;
+    }
     logger.error("delete connection error:", error);
     throw error;
   }

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -3,7 +3,11 @@ import * as vscode from "vscode";
 import { ContainerListRequest, ContainerSummary, Port } from "../clients/docker";
 import { IconNames } from "../constants";
 import { ContextValues, getExtensionContext, setContextValue } from "../context";
-import { getLocalSchemaRegistryImageName, getLocalSchemaRegistryImageTag } from "../docker/configs";
+import {
+  getLocalSchemaRegistryImageName,
+  getLocalSchemaRegistryImageTag,
+  isDockerAvailable,
+} from "../docker/configs";
 import { MANAGED_CONTAINER_LABEL } from "../docker/constants";
 import { getContainersForImage } from "../docker/containers";
 import {
@@ -320,6 +324,11 @@ async function getCCloudEnvironmentChildren(environment: CCloudEnvironment) {
  * discovery.
  */
 async function discoverSchemaRegistry() {
+  const dockerAvailable = await isDockerAvailable();
+  if (!dockerAvailable) {
+    return;
+  }
+
   const imageRepo = getLocalSchemaRegistryImageName();
   const imageTag = getLocalSchemaRegistryImageTag();
   const repoTag = `${imageRepo}:${imageTag}`;

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,7 +1,11 @@
 import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
+import { ContainerListRequest, ContainerSummary, Port } from "../clients/docker";
 import { IconNames } from "../constants";
 import { ContextValues, getExtensionContext, setContextValue } from "../context";
+import { getLocalSchemaRegistryImageName, getLocalSchemaRegistryImageTag } from "../docker/configs";
+import { MANAGED_CONTAINER_LABEL } from "../docker/constants";
+import { getContainersForImage } from "../docker/containers";
 import {
   ccloudConnected,
   ccloudOrganizationChanged,
@@ -24,7 +28,7 @@ import {
   LocalSchemaRegistry,
   SchemaRegistryTreeItem,
 } from "../models/schemaRegistry";
-import { hasCCloudAuthSession } from "../sidecar/connections";
+import { hasCCloudAuthSession, updateLocalSchemaRegistryURI } from "../sidecar/connections";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 import { getResourceManager } from "../storage/resourceManager";
 
@@ -241,6 +245,11 @@ export async function loadLocalResources(): Promise<
     "Local Kafka clusters discoverable at port `8082` are shown here.",
   );
 
+  // before we try listing any resources (for possibly the first time), we need to check if any
+  // supported Schema Registry containers are running, then grab their REST proxy port to send to
+  // the sidecar for discovery before the GraphQL query kicks off
+  await discoverSchemaRegistry();
+
   const localResources: LocalResourceGroup[] = await getLocalResources();
   if (localResources.length > 0) {
     const connectedId = "local-container-connected";
@@ -304,4 +313,45 @@ async function getCCloudEnvironmentChildren(environment: CCloudEnvironment) {
 
   // TODO: add flink compute pools here ?
   return subItems;
+}
+
+/**
+ * Discover any running Schema Registry containers and send the REST proxy port to the sidecar for
+ * discovery.
+ */
+async function discoverSchemaRegistry() {
+  const imageRepo = getLocalSchemaRegistryImageName();
+  const imageTag = getLocalSchemaRegistryImageTag();
+  const repoTag = `${imageRepo}:${imageTag}`;
+  const containerListRequest: ContainerListRequest = {
+    all: true,
+    filters: JSON.stringify({
+      ancestor: [repoTag],
+      label: [MANAGED_CONTAINER_LABEL],
+      status: ["running"],
+    }),
+  };
+  const containers: ContainerSummary[] = await getContainersForImage(containerListRequest);
+  if (containers.length === 0) {
+    return;
+  }
+  // we only care about the first container
+  const container: ContainerSummary = containers.filter((c) => !!c.Ports)[0];
+  const ports: Port[] = container.Ports?.filter((p) => !!p.PublicPort) || [];
+  if (!ports || ports.length === 0) {
+    logger.debug("No ports found on Schema Registry container", { container });
+    return;
+  }
+  const schemaRegistryPort: Port | undefined = ports.find((p) => !!p.PublicPort);
+  if (!schemaRegistryPort) {
+    logger.debug("No PublicPort found on Schema Registry container", { container });
+    return;
+  }
+  const restProxyPort = schemaRegistryPort.PublicPort;
+  if (!restProxyPort) {
+    logger.debug("No REST proxy port found on Schema Registry container", { container });
+    return;
+  }
+  logger.debug("Discovered Schema Registry REST proxy port", { schemaRegistryPort });
+  await updateLocalSchemaRegistryURI(`http://localhost:${restProxyPort}`);
 }

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -11,7 +11,7 @@ import { CCloudEnvironment } from "../models/environment";
 import { ContainerTreeItem } from "../models/main";
 import { Schema, SchemaTreeItem, generateSchemaSubjectGroups } from "../models/schema";
 import { CCloudSchemaRegistry, SchemaRegistry } from "../models/schemaRegistry";
-import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
+import { CCloudResourcePreloader, fetchSchemas } from "../storage/ccloudPreloader";
 import { getResourceManager } from "../storage/resourceManager";
 
 const logger = new Logger("viewProviders.schemas");
@@ -149,14 +149,11 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
 
   async getChildren(element?: SchemasViewProviderData): Promise<SchemasViewProviderData[]> {
     // we should get the following hierarchy/structure of tree items from this method:
-    // Value Schemas (ContainerTreeItem)
     // - topic1-value (ContainerTreeItem)
     //   - schema1-V2 (Schema)
     //   - schema1-V1 (Schema)
     // - topic2-value (ContainerTreeItem)
     //   - schema2-V1 (Schema)
-    // Key Schemas (ContainerTreeItem)
-    //   ( same as above but with "-key" subject suffixes )
 
     let schemaList: SchemasViewProviderData[] = [];
 
@@ -166,29 +163,32 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
       }
       // Schema items are leaf nodes, so we don't need to handle them here
     } else {
-      if (this.ccloudEnvironment != null && this.schemaRegistry != null) {
-        const preloader = CCloudResourcePreloader.getInstance();
-        // ensure that the resources are loaded before trying to access them
-        await preloader.ensureCoarseResourcesLoaded();
-        await preloader.ensureSchemasLoaded(this.schemaRegistry.id, this.forceDeepRefresh);
+      // TODO(james): integrate local schema caching into the preloader
+      if (this.schemaRegistry != null) {
+        let schemas: Schema[] = [];
 
-        if (this.forceDeepRefresh) {
-          // Just honored the user's request for a deep refresh.
-          this.forceDeepRefresh = false;
+        if (this.ccloudEnvironment != null) {
+          const preloader = CCloudResourcePreloader.getInstance();
+          // ensure that the resources are loaded before trying to access them
+          await preloader.ensureCoarseResourcesLoaded();
+          await preloader.ensureSchemasLoaded(this.schemaRegistry.id, this.forceDeepRefresh);
+          if (this.forceDeepRefresh) {
+            // Just honored the user's request for a deep refresh.
+            this.forceDeepRefresh = false;
+          }
+          schemas =
+            (await getResourceManager().getSchemasForRegistry(this.schemaRegistry.id)) ?? [];
+        } else {
+          // fetching local Schema Registry schemas, so we don't have an environmentId to use
+          try {
+            schemas = await fetchSchemas(this.schemaRegistry.id, this.schemaRegistry.connectionId);
+            await getResourceManager().setSchemasForRegistry(this.schemaRegistry.id, schemas);
+          } catch (error) {
+            logger.error("Failed to get schemas:", { error });
+          }
         }
-
-        const schemas = await getResourceManager().getSchemasForRegistry(this.schemaRegistry.id);
-
-        // will be undefined if the schema registry's schemas aren't in the cache (deep refresh of this one TODO?)
-        // if (schemas === undefined) {
-        // deep-read the schemas, put into resource manager.
-
-        if (!schemas || schemas.length === 0) {
-          // no schemas to display
-          return [];
-        }
-        // create the hierarchy of "Key/Value Schemas -> Subject -> Version" items
-        return generateSchemaSubjectGroups(schemas);
+        // return the hierarchy of "Key/Value Schemas -> Subject -> Version" items or return empty array
+        return schemas.length > 0 ? generateSchemaSubjectGroups(schemas) : [];
       }
     }
 

--- a/tests/unit/testResources/docker.ts
+++ b/tests/unit/testResources/docker.ts
@@ -1,0 +1,42 @@
+import { CancellationToken } from "vscode";
+import { ContainerInspectResponse } from "../../../src/clients/docker";
+import { DEFAULT_DOCKER_NETWORK } from "../../../src/docker/constants";
+import { KafkaBrokerConfig } from "../../../src/docker/workflows/confluent-local";
+
+// this should be moved even further up if needed for more tests
+export const TEST_CANCELLATION_TOKEN: CancellationToken = {
+  isCancellationRequested: false,
+  onCancellationRequested: () => ({ dispose: () => {} }),
+};
+
+export const TEST_BROKER_CONFIGS: KafkaBrokerConfig[] = [
+  {
+    brokerNum: 1,
+    containerName: "test-vscode-confluent-broker-1",
+    ports: { plainText: 9092, broker: 9093, controller: 9094 },
+  },
+  {
+    brokerNum: 2,
+    containerName: "test-vscode-confluent-broker-2",
+    ports: { plainText: 9095, broker: 9096, controller: 9097 },
+  },
+];
+
+export const TEST_KAFKA_CONTAINERS: ContainerInspectResponse[] = TEST_BROKER_CONFIGS.map(
+  (config: KafkaBrokerConfig) => {
+    return {
+      Id: `${config.brokerNum}`,
+      Name: config.containerName,
+      Config: {
+        Env: [
+          `KAFKA_LISTENERS=PLAINTEXT://${config.containerName}:${config.ports.broker},CONTROLLER://${config.containerName}:${config.ports.controller},PLAINTEXT_HOST://${config.containerName}:${config.ports.plainText}`,
+        ],
+      },
+      NetworkSettings: {
+        Networks: {
+          [DEFAULT_DOCKER_NETWORK]: {},
+        },
+      },
+    };
+  },
+);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The next big feature-related follow-up to https://github.com/confluentinc/vscode/pull/396 and https://github.com/confluentinc/vscode/pull/399, this time expanding resource starting and stopping to multiple resource types that can be started and stopped independently of each other, or sequentially.


https://github.com/user-attachments/assets/601fb314-582f-4e26-813c-f137162da811



Instead of "Start Local Resources" / "Stop Local Resources" only affecting Kafka containers, they will prompt the user with a multi-select quickpick:
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/0df9ce4f-6719-43e1-ba9d-9faffa8c7985">

The `Kafka` resource type also adds a secondary button that will link directly to the associated Docker image settings exposed by the extension:
<img width="839" alt="image" src="https://github.com/user-attachments/assets/a3b2477e-896d-46cb-9f86-480655a4e7f0">

## Q&A

### Can I start Schema Registry by itself?
- If local Kafka containers are already running and discoverable by the extension, Schema Registry can be started by itself. It just needs to be able to join the same Docker network and inspect the running containers to look up the bootstrap server URLs. If you attempt to start it with no Kafka containers running, an error notification will appear with options to either launch Kafka or update the Docker image repo/tag to match currently-running Kafka container(s):
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/a2f4ed61-a405-4782-8c59-3906cfd58e3b">

### If I already had `confluentinc/confluent-local` containers running, can I still start Schema Registry?
- As long as the image repo+tag configured in the extension settings match the containers you have running, Schema Registry should be able to start up and work with them just fine. However, if the tag is different, you may need to update the extension settings to match your current image tag: 
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/d17660a0-74e7-4413-a5c0-39c8560a3b44">


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
