### PR TITLE
remove all commands that resulted in "COMING SOON" notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,6 +419,14 @@
           "when": "false"
         },
         {
+          "command": "confluent.kafka-clusters.item.rename",
+          "when": "false"
+        },
+        {
+          "command": "confluent.resources.item.rename",
+          "when": "false"
+        },
+        {
           "command": "confluent.schemaViewer.refresh",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -471,17 +471,17 @@
         {
           "command": "confluent.schemaViewer.refresh",
           "group": "navigation@1",
-          "when": "resourceFilename =~ /.*\\.confluent\\.(avsc|json|proto)/"
+          "when": "false"
         },
         {
           "command": "confluent.schemaViewer.validate",
           "group": "navigation@2",
-          "when": "resourceFilename =~ /.*\\.confluent\\.(avsc|json|proto)/"
+          "when": "false"
         },
         {
           "command": "confluent.schemaViewer.uploadVersion",
           "group": "navigation@3",
-          "when": "resourceFilename =~ /.*\\.confluent\\.(avsc|json|proto)/"
+          "when": "false"
         }
       ],
       "view/title": [
@@ -564,7 +564,7 @@
         },
         {
           "command": "confluent.kafka-clusters.item.rename",
-          "when": "view == confluent-resources && viewItem == ccloud-kafka-cluster",
+          "when": "false",
           "group": "inline@2"
         },
         {
@@ -584,7 +584,7 @@
         },
         {
           "command": "confluent.resources.item.rename",
-          "when": "view == confluent-resources && viewItem == ccloud-environment",
+          "when": "false",
           "group": "inline@2"
         },
         {

--- a/src/commands/environments.ts
+++ b/src/commands/environments.ts
@@ -12,8 +12,8 @@ async function renameEnvironmentCommand(item?: CCloudEnvironment | undefined) {
     return;
   }
 
-  // TODO: fix this once we can update CCloud environments via the sidecar
-  vscode.window.showInformationMessage("COMING SOON: Renaming environments is not yet supported.");
+  // TODO: implement this once we can update CCloud environments via the sidecar
+  // refer to https://github.com/confluentinc/vscode/pull/420 for reverting changes to package.json
 }
 
 export function registerEnvironmentCommands(): vscode.Disposable[] {

--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -15,13 +15,9 @@ const logger = new Logger("commands.kafkaClusters");
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function renameKafkaClusterCommand(item?: CCloudKafkaCluster | undefined) {
-  // TEMPORARY: remove this info message and un-comment the lines below once the sidecar supports
-  // mutations via GraphQL to update the KafkaCluster name
-  vscode.window.showInformationMessage(
-    "COMING SOON: Renaming Kafka clusters is not yet supported.",
-  );
-  return;
-
+  // TODO: un-comment the lines below once the sidecar supports mutations via GraphQL
+  // refer to https://github.com/confluentinc/vscode/pull/420 for reverting changes to package.json
+  // ---
   // // If the command was triggered through the command palette, `item` will be undefined, so we
   // // need to prompt the user for the CCloud Kafka cluster.
   // const kafkaCluster: CCloudKafkaCluster | undefined =
@@ -29,10 +25,8 @@ async function renameKafkaClusterCommand(item?: CCloudKafkaCluster | undefined) 
   // if (!kafkaCluster) {
   //   return;
   // }
-
   // // LocalKafkaClusters aren't returned above, so we can safely assume it's a CCloudKafkaCluster
   // const cloudKafkaCluster = kafkaCluster as CCloudKafkaCluster;
-
   // const newName: string | undefined = await vscode.window.showInputBox({
   //   prompt: "Enter new name",
   //   ignoreFocusOut: true,
@@ -41,7 +35,6 @@ async function renameKafkaClusterCommand(item?: CCloudKafkaCluster | undefined) 
   // if (!newName) {
   //   return;
   // }
-
   // await vscode.window.withProgress(
   //   {
   //     location: vscode.ProgressLocation.Notification,

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -2,12 +2,12 @@ import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { SchemaDocumentProvider } from "../documentProviders/schema";
 import { Logger } from "../logging";
+import { ContainerTreeItem } from "../models/main";
 import { Schema } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
 import { ResourceManager } from "../storage/resourceManager";
 import { getSchemasViewProvider } from "../viewProviders/schemas";
-import { ContainerTreeItem } from "../models/main";
 
 const logger = new Logger("commands.schemas");
 
@@ -37,25 +37,21 @@ async function copySchemaRegistryId() {
   vscode.window.showInformationMessage(`Copied "${schemaRegistry.id}" to clipboard.`);
 }
 
+// refer to https://github.com/confluentinc/vscode/pull/420 for reverting changes to package.json for
+// the following three commands:
 function refreshCommand(item: any) {
   logger.info("item", item);
-  vscode.window.showInformationMessage(
-    "COMING SOON: Refreshing schema content is not yet supported.",
-  );
+  // TODO: implement this
 }
 
 function validateCommand(item: any) {
   logger.info("item", item);
-  vscode.window.showInformationMessage(
-    "COMING SOON: Validating schema content is not yet supported.",
-  );
+  // TODO: implement this
 }
 
 function uploadVersionCommand(item: any) {
   logger.info("item", item);
-  vscode.window.showInformationMessage(
-    "COMING SOON: Uploading new version to Schema Registry is not yet supported.",
-  );
+  // TODO: implement this
 }
 
 /** Diff the most recent two versions of schemas bound to a subject. */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes https://github.com/confluentinc/vscode/issues/283.

Instead of showing actions that we intend to include (but are blocked by sidecar updates or other dependencies), we're hiding them from the UI entirely. The comments around the associated code now also link to this PR so it should be easy to revert the `when` clauses in package.json once we get around to implementing the associated functionality.

The following were also blocked from showing up in the command palette and may need to be reverted once we implement them:
- `confluent.kafka-clusters.item.rename`
- `confluent.resources.item.rename`

The three `confluent.schemaViewer.*` commands already had a `when: false` section in the command palette.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
