### PR TITLE
cleanup: move storage enum constants

### DIFF
--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -1,12 +1,12 @@
 import { homedir } from "os";
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
-import { StateDiffs } from "../constants";
 import { ContextValues, setContextValue } from "../context";
 import { SchemaDocumentProvider } from "../documentProviders/schema";
 import { Logger } from "../logging";
 import { Schema } from "../models/schema";
 import { getStorageManager } from "../storage";
+import { StateDiffs } from "../storage/constants";
 
 const logger = new Logger("commands.diffs");
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,32 +1,5 @@
 import { ConnectionSpec } from "./clients/sidecar";
 
-// Global/Workspace state keys
-export enum StateEnvironments {
-  CCLOUD = "environments.ccloud",
-}
-
-export enum StateKafkaClusters {
-  LOCAL = "kafkaClusters.local",
-  CCLOUD = "kafkaClusters.ccloud",
-}
-
-export enum StateKafkaTopics {
-  LOCAL = "kafkaTopics.local",
-  CCLOUD = "kafkaTopics.ccloud",
-}
-
-export enum StateSchemaRegistry {
-  CCLOUD = "schemaRegistries.ccloud",
-}
-
-export enum StateSchemas {
-  CCLOUD = "schemas.ccloud",
-}
-
-export enum StateDiffs {
-  SELECTED_RESOURCE = "diffs.selectedResource",
-}
-
 /**
  * Ids to use with ThemeIcons for different Confluent/Kafka resources
  * @see https://code.visualstudio.com/api/references/icons-in-labels

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -1,3 +1,30 @@
+// Global/Workspace state keys
+export enum StateEnvironments {
+  CCLOUD = "environments.ccloud",
+}
+
+export enum StateKafkaClusters {
+  LOCAL = "kafkaClusters.local",
+  CCLOUD = "kafkaClusters.ccloud",
+}
+
+export enum StateKafkaTopics {
+  LOCAL = "kafkaTopics.local",
+  CCLOUD = "kafkaTopics.ccloud",
+}
+
+export enum StateSchemaRegistry {
+  CCLOUD = "schemaRegistries.ccloud",
+}
+
+export enum StateSchemas {
+  CCLOUD = "schemas.ccloud",
+}
+
+export enum StateDiffs {
+  SELECTED_RESOURCE = "diffs.selectedResource",
+}
+
 // SECRET STORAGE KEYS
 // NOTE: these aren't actually storing any secrets, just used for cross-workspace event handling
 

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -10,17 +10,17 @@ import {
   TEST_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import { getTestStorageManager } from "../../tests/unit/testUtils";
-import {
-  StateEnvironments,
-  StateKafkaClusters,
-  StateKafkaTopics,
-  StateSchemaRegistry,
-} from "../constants";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
 import { Schema } from "../models/schema";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
+import {
+  StateEnvironments,
+  StateKafkaClusters,
+  StateKafkaTopics,
+  StateSchemaRegistry,
+} from "./constants";
 import {
   CCloudKafkaClustersByEnv,
   CCloudSchemaRegistryByEnv,

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -1,18 +1,18 @@
 import { StorageManager, getStorageManager } from ".";
-import {
-  StateEnvironments,
-  StateKafkaClusters,
-  StateKafkaTopics,
-  StateSchemaRegistry,
-  StateSchemas,
-} from "../constants";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
 import { Schema } from "../models/schema";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
-import { AUTH_COMPLETED_KEY } from "./constants";
+import {
+  AUTH_COMPLETED_KEY,
+  StateEnvironments,
+  StateKafkaClusters,
+  StateKafkaTopics,
+  StateSchemaRegistry,
+  StateSchemas,
+} from "./constants";
 
 const logger = new Logger("storage.resourceManager");
 


### PR DESCRIPTION
They were previously in `src/constants.ts`, where nothing aside from the ResourceManager used them. It was bothering me that they didn't live in `src/storage/constants.ts`.