### PR TITLE
fix: reset Topics view when focused on a local cluster and `localKafkaConnected` fires

### DIFF
--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { toKafkaTopicOperations } from "../authz/types";
 import { ResponseError, TopicDataList, TopicV3Api } from "../clients/kafkaRest";
 import { ContextValues, getExtensionContext, setContextValue } from "../context";
-import { ccloudConnected, currentKafkaClusterChanged } from "../emitters";
+import { ccloudConnected, currentKafkaClusterChanged, localKafkaConnected } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
@@ -66,6 +66,17 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
         // a CCloud Kafka Cluster
         logger.debug(
           "Resetting topics view due to ccloudConnected event and currently focused on a CCloud cluster",
+          { connected },
+        );
+        this.reset();
+      }
+    });
+    localKafkaConnected.event((connected: boolean) => {
+      if (this.kafkaCluster?.isLocal) {
+        // any transition of local resource availability should reset the tree view if we're focused
+        // on a local Kafka cluster
+        logger.debug(
+          "Resetting topics view due to localKafkaConnected event and currently focused on a local cluster",
           { connected },
         );
         this.reset();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes https://github.com/confluentinc/vscode/issues/397.

We were previously only clearing the locally stored topics and _**not**_ clearing the "focused" (local) Kafka cluster whenever there was a change in local Kafka cluster availability:
<img width="392" alt="image" src="https://github.com/user-attachments/assets/a69d1569-53a4-4a28-be01-9e66d4e105ec">

Now we properly reset everything in the view (if it was previously focused on a local Kafka cluster):

https://github.com/user-attachments/assets/115e5355-6ae1-4dc1-9398-ba5aceb16b3c


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
