### PR TITLE
Make hasCCloudAuthSession() fast and not async.

### DIFF
--- a/src/commands/organizations.ts
+++ b/src/commands/organizations.ts
@@ -10,7 +10,7 @@ import { getSidecar } from "../sidecar";
 import { clearCurrentCCloudResources, hasCCloudAuthSession } from "../sidecar/connections";
 
 async function useOrganizationCommand() {
-  if (!(await hasCCloudAuthSession())) {
+  if (!hasCCloudAuthSession()) {
     return;
   }
   const organization: CCloudOrganization | undefined = await organizationQuickPick();

--- a/src/quickpicks/environments.ts
+++ b/src/quickpicks/environments.ts
@@ -9,7 +9,7 @@ export async function environmentQuickPick(): Promise<CCloudEnvironment | undefi
   // the command palette instead of through the view->item->context menu
   let cloudEnvironments: CCloudEnvironment[] = [];
 
-  if (!(await hasCCloudAuthSession())) {
+  if (!hasCCloudAuthSession()) {
     vscode.window.showInformationMessage("No Confluent Cloud connection found.");
     return undefined;
   }

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -44,7 +44,7 @@ async function generateKafkaClusterQuickPick(
   if (includeCCloud) {
     // list all Kafka clusters for all CCloud environments for the given connection; to be separated
     // further by environment in the quickpick menu below
-    if (await hasCCloudAuthSession()) {
+    if (hasCCloudAuthSession()) {
       const envGroups = await getEnvironments();
       cloudEnvironments = envGroups.map((group) => group.environment);
       cloudKafkaClusters = envGroups.map((group) => group.kafkaClusters).flat();
@@ -58,7 +58,7 @@ async function generateKafkaClusterQuickPick(
   availableKafkaClusters.push(...localKafkaClusters, ...cloudKafkaClusters);
   if (availableKafkaClusters.length === 0) {
     vscode.window.showInformationMessage("No local Apache Kafka clusters available.");
-    if (includeCCloud && !(await hasCCloudAuthSession())) {
+    if (includeCCloud && !hasCCloudAuthSession()) {
       const login = "Log in to Confluent Cloud";
       vscode.window
         .showInformationMessage("Connect to Confluent Cloud to access remote clusters.", login)

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -29,7 +29,7 @@ export async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefi
  */
 async function generateSchemaRegistryQuickPick(): Promise<SchemaRegistry | undefined> {
   // TODO(shoup): update to support LocalSchemaRegistry
-  if (!(await hasCCloudAuthSession())) {
+  if (!hasCCloudAuthSession()) {
     return undefined;
   }
   // list all Schema Registries for all CCloud environments for the given connection; to be

--- a/src/sidecar/connections.test.ts
+++ b/src/sidecar/connections.test.ts
@@ -1,0 +1,21 @@
+import * as assert from "assert";
+import { ContextValues, setContextValue } from "../context";
+import { hasCCloudAuthSession } from "./connections";
+
+describe("hasCCloudAuthSession() tests", () => {
+  afterEach(() => {
+    setContextValue(ContextValues.ccloudConnectionAvailable, false);
+  });
+
+  it("hasCCloudAuthSession() should return false when the context value is false or undefined", () => {
+    for (const value of [false, undefined]) {
+      setContextValue(ContextValues.ccloudConnectionAvailable, value);
+      assert.strictEqual(hasCCloudAuthSession(), false, `Expected ${value} to return false`);
+    }
+  });
+
+  it("hasCCloudAuthSession() should return true when the context value is true", () => {
+    setContextValue(ContextValues.ccloudConnectionAvailable, true);
+    assert.strictEqual(hasCCloudAuthSession(), true);
+  });
+});

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -2,6 +2,7 @@ import { AuthenticationSession, authentication } from "vscode";
 import { getSidecar } from ".";
 import { Connection, ConnectionsResourceApi, ResponseError } from "../clients/sidecar";
 import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../constants";
+import { ContextValues, getContextValue } from "../context";
 import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
 import { Logger } from "../logging";
 import { getResourceManager } from "../storage/resourceManager";
@@ -79,6 +80,12 @@ export async function getCCloudAuthSession(
   return await authentication.getSession(AUTH_PROVIDER_ID, [], { createIfNone: createIfNone });
 }
 
-export async function hasCCloudAuthSession(): Promise<boolean> {
-  return !!(await getCCloudAuthSession());
+/** Do we currently have a ccloud connection? */
+export function hasCCloudAuthSession(): boolean {
+  // Fastest way to check if the user is connected to Confluent Cloud, no round trips to sidecar. At extension startup
+  // we set the initial context value to false, and any changes via ccloud auth provider will update this value.
+  const isCcloudConnected: boolean | undefined = getContextValue(
+    ContextValues.ccloudConnectionAvailable,
+  );
+  return !!isCcloudConnected;
 }

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -141,7 +141,7 @@ async function loadResources(
   // - an unexpandable item with a "No connection" description where the user can connect to CCloud
   // - a "connected" expandable item with a description of the current connection name and the ability
   //   to add a new connection or switch connections
-  if (await hasCCloudAuthSession()) {
+  if (hasCCloudAuthSession()) {
     const preloader = CCloudResourcePreloader.getInstance();
     // TODO: have this cached in the resource manager  via the preloader
     const currentOrg = await getCurrentOrganization();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Reimplement `hasCCloudAuthSession()` atop the `ccloudConnectionAvailable` context value, managed faithfully by the auth provider, freeing need to interact with the auth provider directly.
- No longer need to be async.
- Fix up callers, now instantaneous instead of ~200ms best case.
- Write testlets.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
