### PR TITLE
Make webview cache render templates and track multiple panels per id

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -368,7 +368,17 @@ function template(options = {}) {
     transform(code, id) {
       if (filter(id)) {
         return {
-          code: `const template = ${JSON.stringify(code)}; export default (variables) => template.replace(/\\$\\{([^}]+)\\}/g, (_, v) => variables[v]);`,
+          code: `
+          const template = ${JSON.stringify(code)}; 
+          export default (variables) => {
+            const keys = Object.keys(variables);
+            const values = Object.values(variables);
+            return template.replace(/\\$\\{([^}]+)\\}/g, (_, expr) => {
+              // evaluate expression in { } in the context of variables
+              const fn = new Function(...keys, 'return (' + expr + ');');
+              return fn(...values);
+            });
+          }`,
           map: { mappings: "" },
         };
       }
@@ -677,6 +687,7 @@ export async function format() {
       "src/**/*.ts",
       "src/**/*.css",
       "src/**/*.html",
+      "src/**/*.json",
       "src/**/*.graphql",
       "*.md",
       "*.js",

--- a/src/webview-cache.ts
+++ b/src/webview-cache.ts
@@ -1,4 +1,12 @@
 import * as vscode from "vscode";
+import { randomBytes } from "crypto";
+import { getExtensionContext } from "./context";
+
+type TemplateFunction = (ctx: {
+  cspSource: string;
+  nonce: string;
+  path: (src: string) => vscode.Uri;
+}) => string;
 
 /**
  * Cache for webview panels that are already open. Prevents opening multiple instances of the same
@@ -6,45 +14,63 @@ import * as vscode from "vscode";
  */
 export class WebviewPanelCache {
   // Map of webview specific unique id to an open the webview panel instance.
-  openWebviews: Map<string, vscode.WebviewPanel>;
-
-  constructor() {
-    this.openWebviews = new Map();
-  }
+  openWebviews = new Map<string, vscode.WebviewPanel[]>();
 
   /**
    * Find or create a webview panel with the given id. If a webview with this id exists, return it, else create a new one.
    *
-   * @param id Unique identifier for the webview. If a webview with this id is already open, it will be returned.
+   * @param config Contains unique id for the webview. If a webview with this id is already open, it will be returned, unless `multiple` flag is enabled.
+   *   Also contains `template` function that generates string template for the new webview.
    * @param viewType createWebviewPanel() viewType parameter, if needing to create a new webview.
    * @param title  createWebviewPanel() title parameter, if needing to create a new webview.
    * @param viewColumn createWebviewPanel() viewColumn parameter, if needing to create a new webview.
    * @param options createWebviewPanel() options parameter, if needing to create a new webview.
    * @returns [vscode.WebviewPanel, boolean] The webview panel and a boolean indicating if it was already open.
    */
-  public findOrCreate(
-    id: string,
+  findOrCreate(
+    config: { id: string; multiple?: boolean; template: TemplateFunction },
     viewType: string,
     title: string,
     viewColumn: vscode.ViewColumn,
     options: vscode.WebviewOptions,
   ): [vscode.WebviewPanel, boolean] {
-    // If one cached already by this id, return it.
-    const existing = this.openWebviews.get(id);
-    if (existing) {
-      // existing.reveal();
-      return [existing, true];
+    const { id, multiple = false, template } = config;
+
+    // Check if any panels for the id exist in the cache.
+    const cached = this.openWebviews.get(id);
+    // Only return a cached panel if `multiple` flag is `false`, otherwise create more panels.
+    if (cached != null && cached.length > 0 && !multiple) {
+      const panel = cached[0];
+      return [panel, true];
     }
 
-    // Create a new webview and add it to the cache.
-    const webview = vscode.window.createWebviewPanel(viewType, title, viewColumn, options);
-    this.openWebviews.set(id, webview);
+    const context = getExtensionContext();
+    const staticRoot = vscode.Uri.joinPath(context.extensionUri, "webview");
 
-    // Remove the webview from this cache when it is disposed.
-    webview.onDidDispose(() => {
-      this.openWebviews.delete(id);
+    // Create a new webview panel…
+    const panel = vscode.window.createWebviewPanel(viewType, title, viewColumn, {
+      ...options,
+      localResourceRoots: [staticRoot, ...(options.localResourceRoots ?? [])],
     });
 
-    return [webview, false];
+    // …initialize its template…
+    panel.webview.html = template({
+      cspSource: panel.webview.cspSource,
+      nonce: randomBytes(16).toString("base64"),
+      path: (src: string) => panel.webview.asWebviewUri(vscode.Uri.joinPath(staticRoot, src)),
+    });
+
+    // …and add it to the cache.
+    if (!this.openWebviews.has(id)) this.openWebviews.set(id, []);
+    const list = this.openWebviews.get(id)!;
+    list.push(panel);
+
+    // Remove the webview from this cache when it is disposed.
+    panel.onDidDispose(() => {
+      const index = list.indexOf(panel);
+      if (index >= 0) list.splice(index, 1);
+      if (list.length === 0) this.openWebviews.delete(id);
+    });
+    return [panel, false];
   }
 }

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -7,7 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; font-src ${cspSource}; style-src 'nonce-${nonce}'; style-src-attr 'unsafe-inline'; script-src 'nonce-${nonce}' 'unsafe-eval';"
     />
-    <link rel="stylesheet" type="text/css" nonce="${nonce}" href="${webviewStylesheet}" />
+    <link rel="stylesheet" type="text/css" nonce="${nonce}" href="${path('main.css')}" />
   </head>
   <body>
     <main class="wrapper">
@@ -627,7 +627,7 @@
         opacity: 0.5;
       }
     </style>
-    <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
-    <script type="module" nonce="${nonce}" src="${messageViewerUri}"></script>
+    <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>
+    <script type="module" nonce="${nonce}" src="${path('message-viewer.js')}"></script>
   </body>
 </html>

--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -7,7 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; font-src ${cspSource}; style-src 'nonce-${nonce}'; style-src-attr 'unsafe-inline'; script-src 'nonce-${nonce}' 'unsafe-eval';"
     />
-    <link rel="stylesheet" type="text/css" nonce="${nonce}" href="${webviewStylesheet}" />
+    <link rel="stylesheet" type="text/css" nonce="${nonce}" href="${path('main.css')}" />
   </head>
   <body>
     <main class="container">
@@ -75,8 +75,8 @@
       </form>
     </main>
 
-    <script type="module" nonce="${nonce}" src="${webviewUri}"></script>
-    <script nonce="${nonce}" src="${submitScriptUri}" type="module"></script>
+    <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>
+    <script type="module" nonce="${nonce}" src="${path('scaffold-form.js')}"></script>
     <style nonce="${nonce}">
       body {
         max-width: 1000px;

--- a/src/webview/uikit/uikit.css
+++ b/src/webview/uikit/uikit.css
@@ -139,7 +139,7 @@
   color: var(--vscode-input-foreground);
   background: var(--vscode-input-background);
   border-radius: 3px;
-  border: 2px solid var(--vscode-input-border);
+  border: 1px solid var(--vscode-dropdown-border);
   height: var(--cflt-input-height);
   min-width: var(--cflt-input-min-width);
   padding: 2px 5px;


### PR DESCRIPTION
Follow up for #427. In the original implementation I tracked duplicate tabs with unique IDs, so if the original tab was closed, clicking on Play button in the sidebar would not be able to switch to other existing tabs of the same topic. Fixing it here by moving this responsibility to webview cache. The cache now tracks lists of panels per ID, and if `multiple` flag is enabled, it can create a new panel for the id that already has other panels. This resolves the mentioned issue and makes it possible to follow similar pattern in the future for other type of webviews.

Another thing I'm addressing here is the bootstrap code we need to deal with when instantiating a webview. Primarily the part about rendering the template and link static assets to the webview. This now happens inside the webview cache. When instantiating a webview, you need to provide the template function (which is generated in build time) and the template itself should use `${path('file.css')}` expressions in places where the static link is needed. Just like before, you need to make sure this file is prebuilt.

@noeldevelops while testing, I found a style issue in default light theme where text inputs in scaffold forms didn't have any border. Updated in `uikit.css` the missing color.