### PR TITLE
cleanup: refactor connections management for local

### DIFF
--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -1,10 +1,10 @@
 import { graphql } from "gql.tada";
-import { Connection, ConnectionsResourceApi, ResponseError } from "../clients/sidecar";
-import { LOCAL_CONNECTION_ID, LOCAL_CONNECTION_SPEC } from "../constants";
+import { LOCAL_CONNECTION_ID } from "../constants";
 import { ContextValues, setContextValue } from "../context";
 import { Logger } from "../logging";
 import { LocalKafkaCluster } from "../models/kafkaCluster";
 import { getSidecar } from "../sidecar";
+import { createLocalConnection, getLocalConnection } from "../sidecar/connections";
 
 const logger = new Logger("graphql.local");
 
@@ -13,7 +13,15 @@ export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
 
   // this is a bit odd, but we need to have a local "connection" to the sidecar before we can query
   // it for local Kafka clusters, so check if we have a connection first
-  await ensureLocalConnection();
+  if (!(await getLocalConnection())) {
+    try {
+      await createLocalConnection();
+    } catch {
+      // error should be caught+logged in createLocalConnection
+      // TODO: window.showErrorMessage here? might get noisy since this is triggered from refreshes
+      return localKafkaClusters;
+    }
+  }
 
   const query = graphql(`
     query localConnections {
@@ -58,36 +66,4 @@ export async function getLocalKafkaClusters(): Promise<LocalKafkaCluster[]> {
   // indicate to the UI that we have at least one local Kafka cluster available
   await setContextValue(ContextValues.localKafkaClusterAvailable, localKafkaClusters.length > 0);
   return localKafkaClusters;
-}
-
-async function ensureLocalConnection(): Promise<void> {
-  const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
-
-  let localConnection: Connection | null = null;
-  try {
-    localConnection = await client.gatewayV1ConnectionsIdGet({
-      id: LOCAL_CONNECTION_ID,
-    });
-  } catch (e) {
-    if (e instanceof ResponseError) {
-      if (e.response.status === 404) {
-        logger.debug("No local connection");
-      } else {
-        logger.error("Error response from fetching existing local connection:", {
-          status: e.response.status,
-          statusText: e.response.statusText,
-          body: JSON.stringify(e.response.body),
-        });
-      }
-    } else {
-      logger.error("Error while fetching local connection:", e);
-    }
-  }
-
-  if (!localConnection) {
-    await client.gatewayV1ConnectionsPost({
-      ConnectionSpec: LOCAL_CONNECTION_SPEC,
-    });
-  }
-  return;
 }

--- a/src/sidecar/connections.test.ts
+++ b/src/sidecar/connections.test.ts
@@ -31,8 +31,6 @@ describe("sidecar/connections.ts", () => {
   });
 
   afterEach(() => {
-    // setContextValue(ContextValues.ccloudConnectionAvailable, false);
-
     sandbox.restore();
   });
 

--- a/src/sidecar/connections.test.ts
+++ b/src/sidecar/connections.test.ts
@@ -1,6 +1,10 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as sidecar from ".";
+import {
+  TEST_CCLOUD_CONNECTION,
+  TEST_LOCAL_CONNECTION,
+} from "../../tests/unit/testResources/connection";
 import { getExtensionContext } from "../../tests/unit/testUtils";
 import { Connection, ConnectionsResourceApi } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_SPEC, LOCAL_CONNECTION_SPEC } from "../constants";
@@ -35,6 +39,8 @@ describe("sidecar/connections.ts", () => {
   });
 
   for (const connectionSpec of [LOCAL_CONNECTION_SPEC, CCLOUD_CONNECTION_SPEC]) {
+    const fakeConnection: Connection =
+      connectionSpec.type === "LOCAL" ? TEST_LOCAL_CONNECTION : TEST_CCLOUD_CONNECTION;
     it(`${connectionSpec.type}: tryToGetConnection() should return null if no connection exists / we get a 404 response`, async () => {
       stubConnectionsResourceApi.gatewayV1ConnectionsIdGet.rejects({ response: { status: 404 } });
 
@@ -44,21 +50,19 @@ describe("sidecar/connections.ts", () => {
     });
 
     it(`${connectionSpec.type}: tryToGetConnection() should return a connection if it exists`, async () => {
-      const expectedConnection: Connection = { id: "test-id" } as Connection;
-      stubConnectionsResourceApi.gatewayV1ConnectionsIdGet.resolves(expectedConnection);
+      stubConnectionsResourceApi.gatewayV1ConnectionsIdGet.resolves(fakeConnection);
 
       const connection = await getLocalConnection();
 
-      assert.strictEqual(connection, expectedConnection);
+      assert.strictEqual(connection, fakeConnection);
     });
 
     it(`${connectionSpec.type}: tryToCreateConnection() should create and return a new connection`, async () => {
-      const expectedConnection: Connection = { id: "test-id" } as Connection;
-      stubConnectionsResourceApi.gatewayV1ConnectionsPost.resolves(expectedConnection);
+      stubConnectionsResourceApi.gatewayV1ConnectionsPost.resolves(fakeConnection);
 
       const connection = await tryToCreateConnection(connectionSpec);
 
-      assert.strictEqual(connection, expectedConnection);
+      assert.strictEqual(connection, fakeConnection);
     });
   }
 

--- a/src/sidecar/connections.test.ts
+++ b/src/sidecar/connections.test.ts
@@ -1,10 +1,89 @@
 import * as assert from "assert";
+import * as sinon from "sinon";
+import * as sidecar from ".";
+import { getExtensionContext } from "../../tests/unit/testUtils";
+import { Connection, ConnectionsResourceApi } from "../clients/sidecar";
+import { CCLOUD_CONNECTION_SPEC, LOCAL_CONNECTION_SPEC } from "../constants";
 import { ContextValues, setContextValue } from "../context";
-import { hasCCloudAuthSession } from "./connections";
+import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
+import { getResourceManager } from "../storage/resourceManager";
+import {
+  clearCurrentCCloudResources,
+  deleteCCloudConnection,
+  getLocalConnection,
+  hasCCloudAuthSession,
+  tryToCreateConnection,
+} from "./connections";
 
-describe("hasCCloudAuthSession() tests", () => {
+describe("sidecar/connections.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let stubConnectionsResourceApi: sinon.SinonStubbedInstance<ConnectionsResourceApi>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    // create the stubs for the sidecar + service client
+    const stubSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
+      sandbox.createStubInstance(sidecar.SidecarHandle);
+    stubConnectionsResourceApi = sandbox.createStubInstance(ConnectionsResourceApi);
+    stubSidecarHandle.getConnectionsResourceApi.returns(stubConnectionsResourceApi);
+    // stub the getSidecar function to return the stub sidecar handle
+    sandbox.stub(sidecar, "getSidecar").resolves(stubSidecarHandle);
+  });
+
   afterEach(() => {
-    setContextValue(ContextValues.ccloudConnectionAvailable, false);
+    // setContextValue(ContextValues.ccloudConnectionAvailable, false);
+
+    sandbox.restore();
+  });
+
+  for (const connectionSpec of [LOCAL_CONNECTION_SPEC, CCLOUD_CONNECTION_SPEC]) {
+    it(`${connectionSpec.type}: tryToGetConnection() should return null if no connection exists / we get a 404 response`, async () => {
+      stubConnectionsResourceApi.gatewayV1ConnectionsIdGet.rejects({ response: { status: 404 } });
+
+      const connection = await getLocalConnection();
+
+      assert.strictEqual(connection, null);
+    });
+
+    it(`${connectionSpec.type}: tryToGetConnection() should return a connection if it exists`, async () => {
+      const expectedConnection: Connection = { id: "test-id" } as Connection;
+      stubConnectionsResourceApi.gatewayV1ConnectionsIdGet.resolves(expectedConnection);
+
+      const connection = await getLocalConnection();
+
+      assert.strictEqual(connection, expectedConnection);
+    });
+
+    it(`${connectionSpec.type}: tryToCreateConnection() should create and return a new connection`, async () => {
+      const expectedConnection: Connection = { id: "test-id" } as Connection;
+      stubConnectionsResourceApi.gatewayV1ConnectionsPost.resolves(expectedConnection);
+
+      const connection = await tryToCreateConnection(connectionSpec);
+
+      assert.strictEqual(connection, expectedConnection);
+    });
+  }
+
+  it("deleteCCloudConnection() should delete the connection without error", async () => {
+    stubConnectionsResourceApi.gatewayV1ConnectionsIdDelete.resolves();
+
+    await assert.doesNotReject(deleteCCloudConnection());
+  });
+
+  it("clearCurrentCCloudResources() should clear resources and fire events", async () => {
+    // just needed for this test, otherwise we'd put this in the before() block
+    await getExtensionContext();
+
+    const resourceManager = getResourceManager();
+    const deleteCCloudResourcesStub = sandbox.stub(resourceManager, "deleteCCloudResources");
+    const currentKafkaClusterChangedFireStub = sandbox.stub(currentKafkaClusterChanged, "fire");
+    const currentSchemaRegistryChangedFireStub = sandbox.stub(currentSchemaRegistryChanged, "fire");
+
+    await clearCurrentCCloudResources();
+
+    assert.ok(deleteCCloudResourcesStub.calledOnce);
+    assert.ok(currentKafkaClusterChangedFireStub.calledOnceWith(null));
+    assert.ok(currentSchemaRegistryChangedFireStub.calledOnceWith(null));
   });
 
   it("hasCCloudAuthSession() should return false when the context value is false or undefined", () => {

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -21,7 +21,7 @@ import { getResourceManager } from "../storage/resourceManager";
 const logger = new Logger("sidecar.connections");
 
 /** Get the existing {@link Connection} (if it exists). */
-async function tryToGetConnection(id: string): Promise<Connection | null> {
+export async function tryToGetConnection(id: string): Promise<Connection | null> {
   let connection: Connection | null = null;
   const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
   try {
@@ -57,7 +57,7 @@ export async function getLocalConnection(): Promise<Connection | null> {
 }
 
 /** Create a new {@link Connection} with the given {@link ConnectionSpec}. */
-async function tryToCreateConnection(spec: ConnectionSpec): Promise<Connection> {
+export async function tryToCreateConnection(spec: ConnectionSpec): Promise<Connection> {
   let connection: Connection;
   const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
   try {

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -23,7 +23,7 @@ const logger = new Logger("sidecar.connections");
 /** Get the existing {@link Connection} (if it exists). */
 async function tryToGetConnection(id: string): Promise<Connection | null> {
   let connection: Connection | null = null;
-  const client = (await getSidecar()).getConnectionsResourceApi();
+  const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
   try {
     connection = await client.gatewayV1ConnectionsIdGet({ id: id });
   } catch (error) {
@@ -31,7 +31,7 @@ async function tryToGetConnection(id: string): Promise<Connection | null> {
       if (error.response.status === 404) {
         logger.debug("No connection found", { connectionId: id });
       } else {
-        logger.error("Error response from fetching existing local connection:", {
+        logger.error("Error response fetching existing connection:", {
           status: error.response.status,
           statusText: error.response.statusText,
           body: JSON.stringify(error.response.body),
@@ -40,7 +40,7 @@ async function tryToGetConnection(id: string): Promise<Connection | null> {
       }
     } else {
       // only log the non-404 errors, since we expect a 404 if the connection doesn't exist
-      logger.error("Error getting existing connection", { error, connectionId: id });
+      logger.error("Error fetching connection", { error, connectionId: id });
     }
   }
   return connection;
@@ -64,11 +64,11 @@ async function tryToCreateConnection(spec: ConnectionSpec): Promise<Connection> 
     connection = await client.gatewayV1ConnectionsPost({
       ConnectionSpec: spec,
     });
-    logger.debug("created new connection", { type: spec.type });
+    logger.debug("created new connection:", { type: spec.type });
     return connection;
   } catch (error) {
-    logger.error("create connection error", error);
-    throw new Error("Error while trying to create new connection. Please try again.");
+    logger.error("create connection error:", error);
+    throw error;
   }
 }
 
@@ -84,7 +84,7 @@ export async function createLocalConnection(): Promise<Connection> {
 
 /** Delete the existing Confluent Cloud {@link Connection} (if it exists). */
 export async function deleteCCloudConnection(): Promise<void> {
-  const client = (await getSidecar()).getConnectionsResourceApi();
+  const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
   try {
     await client.gatewayV1ConnectionsIdDelete({ id: CCLOUD_CONNECTION_ID });
     logger.debug("deleted existing CCloud connection");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Mainly moving the get/create local connection functionality to `src/sidecar/connections.ts` instead of where it previously lived (`src/graphql/local.ts`), to be more generally-usable.

Also added some new tests since `src/sidecar/connections.ts` was largely uncovered, and we have a couple new core functions for getting/creating connections for a spec. We could stand to break some of these out into not-mocked/-stubbed tests, but with the direct connect updates coming, I'd like to hold off for a bit.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
