### PR TITLE
MINOR fix: set `id` on Local container to fix collapsibleState changes

### DIFF
--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -110,6 +110,7 @@ describe("ResourceViewProvider loading functions", () => {
 
     assert.ok(result instanceof ContainerTreeItem);
     assert.equal(result.label, "Local");
+    assert.equal(result.id, "local-container-connected");
     assert.equal(result.collapsibleState, vscode.TreeItemCollapsibleState.Expanded);
     assert.equal(result.description, TEST_LOCAL_KAFKA_CLUSTER.uri);
     assert.deepStrictEqual(result.children, [TEST_LOCAL_KAFKA_CLUSTER]);
@@ -122,6 +123,7 @@ describe("ResourceViewProvider loading functions", () => {
 
     assert.ok(result instanceof ContainerTreeItem);
     assert.equal(result.label, "Local");
+    assert.equal(result.id, "local-container");
     assert.equal(result.collapsibleState, vscode.TreeItemCollapsibleState.None);
     assert.equal(result.description, "(Not running)");
     assert.deepStrictEqual(result.children, []);

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -218,9 +218,13 @@ export async function loadLocalResources(): Promise<ContainerTreeItem<LocalKafka
   localContainerItem.tooltip = new vscode.MarkdownString(
     "Local Kafka clusters discoverable at port `8082` are shown here.",
   );
+  // XXX: if we don't adjust the ID, we'll see weird collapsibleState behavior
+  localContainerItem.id = "local-container";
 
   const localClusters: LocalKafkaCluster[] = await getLocalKafkaClusters();
   if (localClusters.length > 0) {
+    // XXX: if we don't adjust the ID, we'll see weird collapsibleState behavior
+    localContainerItem.id = "local-container-connected";
     localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     // override the default "child item count" description
     localContainerItem.description = localClusters.map((cluster) => cluster.uri).join(", ");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We saw this behavior before with the persistent CCloud container: if we create the tree item with a `None` collapsible state, then attempt to transition it to `Expanded`, it won't automatically expand:
<img width="883" alt="image" src="https://github.com/user-attachments/assets/f8dfa205-49b8-41bb-ac25-d6c17398f35b">

The fix here is to make sure the `id` changes so VS Code doesn't cache any UI state between those changes so it will actually show up as expanded.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
