### PR TITLE
Ensure curling sidecar executable fails on non-200 status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ else
 	mkdir -p bin && \
 	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION)"; \
 	export EXECUTABLE_PATH=ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH) && \
-		curl -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
+		curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
 		chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
 		echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH)";
 endif


### PR DESCRIPTION
From `man curl`:

```
-f, --fail

(HTTP) Fail with error code 22 and with no response body output at all for HTTP transfers returning HTTP response codes at 400 or greater.

In normal cases when an HTTP server fails to deliver a document, it returns a body of text stating so (which often also describes why and more) and a 4xx HTTP response code. This command line option prevents curl from outputting that data and instead returns error 22 early. By default, curl does not consider HTTP response codes to indicate failure.
```

Our CI would "successfully" fail to download the sidecar executable and store "Not Found" in the executable file. That's bad. The `--fail` will make sure curl exits with non-zero status code.