### PR TITLE
auth notification followup

### DIFF
--- a/src/sidecar/authStatusPolling.ts
+++ b/src/sidecar/authStatusPolling.ts
@@ -106,7 +106,7 @@ export async function watchCCloudConnectionStatus(): Promise<void> {
     // the sidecar is handling a transient error, so exit this polling iteration early and check
     // the status again on the next iteration
     logger.warn("current CCloud connection has an invalid token; waiting for updated status");
-    // only notify if there are pending requests to Confluent Cloud and we haven't shown the notification yet
+    // only notify if CCloud requests have happened recently and we haven't shown the notification yet
     if (numRecentCCloudRequests > 0 && !invalidTokenNotificationOpen) {
       invalidTokenNotificationOpen = true;
       vscode.window.withProgress(

--- a/src/sidecar/middlewares.test.ts
+++ b/src/sidecar/middlewares.test.ts
@@ -1,0 +1,104 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import { RequestContext, ResponseContext } from "../clients/sidecar";
+import { CCLOUD_CONNECTION_ID, LOCAL_CONNECTION_ID } from "../constants";
+import * as middlewares from "./middlewares";
+
+function fakeRequestWithHeader(key: string, value: string): RequestContext {
+  return {
+    fetch: () => Promise.resolve(new Response()),
+    url: "test",
+    init: {
+      headers: {
+        [key]: value,
+      },
+    },
+  };
+}
+
+function fakeResponseWithHeader(key: string, value: string): ResponseContext {
+  const request = fakeRequestWithHeader(key, value);
+  return {
+    fetch: () => Promise.resolve(new Response()),
+    url: "test",
+    response: new Response(),
+    init: request.init,
+  };
+}
+
+describe("CCloudRequestsPendingMiddleware methods", () => {
+  let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
+  let middleware: middlewares.CCloudRequestsPendingMiddleware;
+  let numRecentCCloudRequestsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers();
+    middleware = new middlewares.CCloudRequestsPendingMiddleware();
+    // can't edit this as a read-only import, so we use a stub to set the value, but then
+    // assert against `middlewares.numRecentCCloudRequests` directly
+    numRecentCCloudRequestsStub = sandbox.stub(middlewares, "numRecentCCloudRequests").value(0);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("pre() should increment numRecentCCloudRequests only if the x-connection-id header is set to the static CCloud connection ID", async () => {
+    const requestContext = fakeRequestWithHeader("x-connection-id", CCLOUD_CONNECTION_ID);
+
+    await middleware.pre(requestContext);
+
+    assert.equal(middlewares.numRecentCCloudRequests, 1);
+  });
+
+  it("pre() should NOT increment numRecentCCloudRequests for non-'x-connection-id' headers", async () => {
+    const requestContext = fakeRequestWithHeader("foo", CCLOUD_CONNECTION_ID);
+
+    await middleware.pre(requestContext);
+
+    assert.equal(middlewares.numRecentCCloudRequests, 0);
+  });
+
+  it("pre() should NOT increment numRecentCCloudRequests for 'x-connection-id' headers that don't match the static CCloud connection ID", async () => {
+    const requestContext = fakeRequestWithHeader("x-connection-id", LOCAL_CONNECTION_ID);
+
+    await middleware.pre(requestContext);
+
+    assert.equal(middlewares.numRecentCCloudRequests, 0);
+  });
+
+  it("post() should decrement numRecentCCloudRequests after a delay if headers contain 'x-connection-id'", async () => {
+    const numRequests = 1;
+    const responseContext = fakeResponseWithHeader("x-connection-id", CCLOUD_CONNECTION_ID);
+    numRecentCCloudRequestsStub.value(numRequests);
+
+    await middleware.post(responseContext);
+    clock.tick(15000);
+
+    assert.equal(middlewares.numRecentCCloudRequests, numRequests - 1);
+  });
+
+  it("post() should NOT decrement numRecentCCloudRequests if headers don't contain 'x-connection-id'", async () => {
+    const numRequests = 1;
+    const responseContext = fakeResponseWithHeader("foo", CCLOUD_CONNECTION_ID);
+    numRecentCCloudRequestsStub.value(numRequests);
+
+    await middleware.post(responseContext);
+    clock.tick(15000);
+
+    assert.equal(middlewares.numRecentCCloudRequests, numRequests);
+  });
+
+  it("post() should NOT decrement numRecentCCloudRequests for 'x-connection-id' headers that don't match the static CCloud connection ID", async () => {
+    const numRequests = 1;
+    const responseContext = fakeResponseWithHeader("foo", CCLOUD_CONNECTION_ID);
+    numRecentCCloudRequestsStub.value(numRequests);
+
+    await middleware.post(responseContext);
+    clock.tick(15000);
+
+    assert.equal(middlewares.numRecentCCloudRequests, numRequests);
+  });
+});

--- a/src/sidecar/middlewares.ts
+++ b/src/sidecar/middlewares.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 import { Middleware, RequestContext, ResponseContext } from "../clients/sidecar";
-
+import { CCLOUD_CONNECTION_ID } from "../constants";
 import { Logger } from "../logging";
+
 const logger = new Logger("sidecar.middlewares");
 
 // only create this if enabled in SidecarHandle setup
@@ -112,4 +113,47 @@ export class ErrorResponseMiddleware implements Middleware {
       // default if status >= 400
     }
   }
+}
+
+/** Track the number of requests to Confluent Cloud that have happened recently, controlled by
+ * {@link CCloudRequestsPendingMiddleware}. */
+export let numRecentCCloudRequests: number = 0;
+/** Middleware to track the number of requests to Confluent Cloud that are currently pending. */
+export class CCloudRequestsPendingMiddleware implements Middleware {
+  async pre(context: RequestContext): Promise<void> {
+    // increment the count of pending requests to Confluent Cloud
+    if (hasCCloudConnectionIdHeader(context.init.headers)) {
+      const origValue: number = numRecentCCloudRequests;
+      numRecentCCloudRequests++;
+      logger.debug(`CCloud requests pending: ${origValue} -> ${numRecentCCloudRequests}`);
+    }
+  }
+  async post(context: ResponseContext): Promise<void> {
+    // decrement the count of pending requests to Confluent Cloud after a delay so we get a feeling
+    // for "recent activity" instead of the exact current state of pending requests (which will
+    // likely be 0 unless someone get the timing just right)
+    if (hasCCloudConnectionIdHeader(context.init.headers)) {
+      const origValue: number = numRecentCCloudRequests;
+      setTimeout(() => {
+        numRecentCCloudRequests--;
+        logger.debug(
+          `CCloud requests pending (delayed): ${origValue} -> ${numRecentCCloudRequests}`,
+        );
+      }, 15_000);
+    }
+  }
+}
+
+/** Check if headers include the CCloud connection ID, indicating that the request is going to be
+ * sent to CCloud via the sidecar. */
+function hasCCloudConnectionIdHeader(headers: HeadersInit | Headers | undefined): boolean {
+  if (!headers) {
+    return false;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "x-connection-id" && value === CCLOUD_CONNECTION_ID) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -33,6 +33,7 @@ import {
   SIDECAR_PROCESS_ID_HEADER,
 } from "./constants";
 import {
+  CCloudRequestsPendingMiddleware,
   DebugRequestResponseMiddleware,
   ErrorResponseMiddleware,
   setDebugOutputChannel,
@@ -71,7 +72,10 @@ export class SidecarHandle {
       Authorization: `Bearer ${this.auth_secret}`,
     };
 
-    let middleware: Middleware[] = [new ErrorResponseMiddleware()];
+    let middleware: Middleware[] = [
+      new ErrorResponseMiddleware(),
+      new CCloudRequestsPendingMiddleware(),
+    ];
     if (ENABLE_REQUEST_RESPONSE_LOGGING) {
       // Add middleware to log request and response details; disabled by default
       setDebugOutputChannel();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to https://github.com/confluentinc/vscode/pull/450 to only show the progress notification if CCloud requests happened "recently" (in this case, over the past 15sec). This will prevent the notification from popping up if the user hasn't been doing anything CCloud-related for "a while" after the extension has been activated.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
