### PR TITLE
fix+cleanup sidecar handle methods

### DIFF
--- a/src/sidecar/constants.ts
+++ b/src/sidecar/constants.ts
@@ -7,14 +7,17 @@ export const SIDECAR_PORT: number = 26636;
 export const SIDECAR_BASE_URL: string =
   process.env.SIDECAR_BASE_URL || `http://127.0.0.1:${SIDECAR_PORT}`;
 
-export const SIDECAR_CURRENT_CONNECTION_ID_HEADER: string = "x-connection-id"; // Header name for the sidecar's current connection ID in the request headers.
-export const WORKSPACE_PROCESS_ID_HEADER: string = "x-workspace-process-id"; // Header name for the workspace's PID in the request headers.
+/** Header used to tell the sidecar which connection ID to use in the request, if applicable. */
+export const SIDECAR_CONNECTION_ID_HEADER: string = "x-connection-id";
 
+/** Header used to specify a given (Kafka, Schema Registry, etc) cluster ID, if applicable */
+export const CLUSTER_ID_HEADER: string = "x-cluster-id";
+
+/** Enable the middleware that emits debug logs for every request to / response from the sidecar. */
 export const ENABLE_REQUEST_RESPONSE_LOGGING: boolean =
   process.env.ENABLE_REQUEST_RESPONSE_LOGGING === "true";
-
-// Header name for the sidecar's PID in the response headers.
+/** Header name for the sidecar's PID in the response headers. */
 export const SIDECAR_PROCESS_ID_HEADER = "x-sidecar-pid";
 
-// OS-independent path to the log file for the sidecar process.
+/** OS-independent path to the log file for the sidecar process. */
 export const SIDECAR_LOGFILE_PATH = join(tmpdir(), "vscode-confluent-sidecar.log");

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -273,9 +273,6 @@ export class SidecarHandle {
       ...this.defaultClientConfigParams.headers,
       [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
     });
-    // headers.append("Content-Type", "application/json");
-    // headers.append("Authorization", `Bearer ${this.auth_secret}`);
-    // headers.append(SIDECAR_CONNECTION_ID_HEADER, connectionId);
 
     const response = await fetch(`${SIDECAR_BASE_URL}/gateway/v1/graphql`, {
       method: "POST",

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -14,7 +14,6 @@ import {
   SubjectsV1Api,
 } from "../clients/schemaRegistryRest";
 import {
-  Configuration,
   ConfigurationParameters,
   ConnectionsResourceApi,
   KafkaConsumeResourceApi,
@@ -22,14 +21,16 @@ import {
   Middleware,
   PreferencesResourceApi,
   ResponseError,
+  Configuration as SidecarRestConfiguration,
   TemplatesApi,
   VersionResourceApi,
 } from "../clients/sidecar";
 import { Logger } from "../logging";
 import {
+  CLUSTER_ID_HEADER,
   ENABLE_REQUEST_RESPONSE_LOGGING,
   SIDECAR_BASE_URL,
-  SIDECAR_CURRENT_CONNECTION_ID_HEADER,
+  SIDECAR_CONNECTION_ID_HEADER,
   SIDECAR_PROCESS_ID_HEADER,
 } from "./constants";
 import {
@@ -40,9 +41,10 @@ import {
 
 const logger = new Logger("sidecarHandle");
 
-// sidecar handle module
-// Represents a short-term handle to a running, handshaken sidecar process.
-// Should be used for a single code block and then discarded.
+/**
+ * A short-term handle to a running, handshaken sidecar process.
+ * Should be used for a single code block and then discarded.
+ */
 export class SidecarHandle {
   authToken: string;
   myPid: string;
@@ -64,9 +66,9 @@ export class SidecarHandle {
     // used for client creation for individual service (class) methods, merged with any custom
     // config parameters provided by the caller
     this.defaultHeaders = {
-      // Intercept requests to set the Accept header to `application/*` to handle non-JSON responses
-      // For example, the sidecar returns a ZIP file for the `POST /gateway/v1/templates/{name}/apply` endpoint
-      Accept: "application/*",
+      // Expect JSON request and response bodies unless otherwise overridden (e.g. TemplatesApi).
+      Accept: "application/json",
+      "Content-Type": "application/json",
       // Set the Authorization header to the current auth token.
       Authorization: `Bearer ${this.auth_secret}`,
     };
@@ -85,82 +87,59 @@ export class SidecarHandle {
     };
   }
 
-  /* Convenience methods to return the pre-configured OpenAPI-spec generated sidecar client
-    services for making REST requests to the sidecar. Obtaining from a SidecarHandle
-    obtained from getSidecar() ensures that the sidecar has been started, handshook with,
-    and that OpenAPI request filter has been installed which will inject the necessary
-    auth and process id headers.
-  */
+  // === OPENAPI CLIENT METHODS ===
 
-  createCustomHeaders(headers: Record<string, string>): Record<string, string> {
-    return { ...this.defaultHeaders, ...headers };
+  // --- SIDECAR OPENAPI CLIENT METHODS ---
+
+  /**
+   * Creates and returns a (Sidecar REST OpenAPI spec) {@link ConnectionsResourceApi} client instance with a preconfigured
+   * {@link SidecarRestConfiguration}.
+   */
+  public getConnectionsResourceApi(): ConnectionsResourceApi {
+    const config = new SidecarRestConfiguration(this.defaultClientConfigParams);
+    return new ConnectionsResourceApi(config);
   }
 
-  createClientConfig(params?: ConfigurationParameters): Configuration {
-    if (params == null) {
-      return new Configuration(this.defaultClientConfigParams);
-    }
-    // if any headers are passed, make sure we don't replace the default headers
-    if (params.headers != null) {
-      params.headers = this.createCustomHeaders(params.headers);
-    }
-    return new Configuration({ ...this.defaultClientConfigParams, ...params });
-  }
-
-  // Return a client instance for making REST requests to the sidecar.
-  private getClient<T>(
-    clientServiceClass: new (config: Configuration) => T,
-    configParams?: ConfigurationParameters,
-  ): T {
-    const config: Configuration = this.createClientConfig(configParams);
-    return new clientServiceClass(config);
-  }
-
-  // Return the ConnectionsResourceApi client instance for making REST requests to the sidecar.
-  public getConnectionsResourceApi(configParams?: ConfigurationParameters): ConnectionsResourceApi {
-    return this.getClient(ConnectionsResourceApi, configParams);
-  }
-
-  // Return the TemplatesApi client instance for making REST requests to the sidecar.
-  public getTemplatesApi(configParams?: ConfigurationParameters): TemplatesApi {
-    return this.getClient(TemplatesApi, configParams);
-  }
-
-  public VersionResourceApi(configParams?: ConfigurationParameters): VersionResourceApi {
-    return this.getClient(VersionResourceApi, configParams);
-  }
-
-  public getTopicV3Api(clusterId: string, connectionId: string): TopicV3Api {
-    const config: unknown = this.createClientConfig({
-      headers: { "x-cluster-id": clusterId, "x-connection-id": connectionId },
+  /**
+   * Creates and returns a (Sidecar REST OpenAPI spec) {@link TemplatesApi} client instance with a
+   * preconfigured {@link SidecarRestConfiguration}.
+   */
+  public getTemplatesApi(): TemplatesApi {
+    const config = new SidecarRestConfiguration({
+      ...this.defaultClientConfigParams,
+      headers: {
+        ...this.defaultClientConfigParams.headers,
+        // Intercept requests to set the Accept header to `application/*` to handle non-JSON responses
+        // For example, the sidecar returns a ZIP file for the `POST /gateway/v1/templates/{name}/apply` endpoint
+        Accept: "application/*",
+      },
     });
-    return new TopicV3Api(config as KafkaRestConfiguration);
+    return new TemplatesApi(config);
   }
 
-  public getPartitionV3Api(clusterId: string, connectionId: string): PartitionV3Api {
-    const config: unknown = this.createClientConfig({
-      headers: { "x-cluster-id": clusterId, "x-connection-id": connectionId },
+  /**
+   * Creates and returns a (Sidecar REST OpenAPI spec) {@link VersionResourceApi} client instance
+   * with a preconfigured {@link SidecarRestConfiguration}.
+   */
+  public getVersionResourceApi(configParams?: ConfigurationParameters): VersionResourceApi {
+    const config = new SidecarRestConfiguration({
+      ...this.defaultClientConfigParams,
+      ...configParams,
     });
-    return new PartitionV3Api(config as KafkaRestConfiguration);
+    return new VersionResourceApi(config);
   }
 
-  public getSchemasV1Api(clusterId: string, connectionId: string): SchemasV1Api {
-    const config: unknown = this.createClientConfig({
-      headers: { "x-cluster-id": clusterId, "x-connection-id": connectionId },
-    });
-    return new SchemasV1Api(config as SchemaRegistryRestConfiguration);
-  }
-
-  public getSubjectsV1Api(clusterId: string, connectionId: string): SubjectsV1Api {
-    const config: unknown = this.createClientConfig({
-      headers: { "x-cluster-id": clusterId, "x-connection-id": connectionId },
-    });
-    return new SubjectsV1Api(config as SchemaRegistryRestConfiguration);
-  }
-
+  /**
+   * Creates and returns a (Sidecar REST OpenAPI spec) {@link KafkaConsumeResourceApi} client instance
+   * with a preconfigured {@link SidecarRestConfiguration}.
+   */
   public getKafkaConsumeApi(connectionId: string) {
-    const configuration = this.createClientConfig({
-      headers: { "x-connection-id": connectionId },
+    const configuration = new SidecarRestConfiguration({
+      ...this.defaultClientConfigParams,
+      headers: {
+        ...this.defaultClientConfigParams.headers,
+        [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
+      },
       middleware: [
         {
           async onError(context) {
@@ -187,11 +166,102 @@ export class SidecarHandle {
     return new KafkaConsumeResourceApi(configuration);
   }
 
-  public getPreferencesApi() {
-    return new PreferencesResourceApi(this.createClientConfig());
+  /**
+   * Creates and returns a (Sidecar REST OpenAPI spec) {@link PreferencesResourceApi} client instance
+   * with a preconfigured {@link SidecarRestConfiguration}.
+   */
+  public getPreferencesApi(): PreferencesResourceApi {
+    const config = new SidecarRestConfiguration({
+      ...this.defaultClientConfigParams,
+    });
+    return new PreferencesResourceApi(config);
   }
 
-  // Make a GraphQL request to the sidecar.
+  /**
+   * Creates and returns a (Sidecar REST OpenAPI spec) {@link MicroProfileHealthApi} client instance
+   * with the provided {@link SidecarRestConfiguration}.
+   */
+  public getMicroProfileHealthApi(config: SidecarRestConfiguration): MicroProfileHealthApi {
+    // Factored out of getSidecarPid() to allow for test mocking.
+    return new MicroProfileHealthApi(config);
+  }
+
+  // --- KAFKA REST OPENAPI CLIENT METHODS ---
+
+  /**
+   * Creates and returns a (Kafka v3 REST OpenAPI spec) {@link TopicV3Api} client instance with a
+   * preconfigured {@link KafkaRestConfiguration}.
+   */
+  public getTopicV3Api(clusterId: string, connectionId: string): TopicV3Api {
+    const config = new KafkaRestConfiguration({
+      ...this.defaultClientConfigParams,
+      headers: {
+        ...this.defaultClientConfigParams.headers,
+        [CLUSTER_ID_HEADER]: clusterId,
+        [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
+      },
+    });
+    return new TopicV3Api(config);
+  }
+
+  /**
+   * Creates and returns a (Kafka v3 REST OpenAPI spec) {@link PartitionV3Api} client instance with a
+   * preconfigured {@link KafkaRestConfiguration}.
+   */
+  public getPartitionV3Api(clusterId: string, connectionId: string): PartitionV3Api {
+    const config = new KafkaRestConfiguration({
+      ...this.defaultClientConfigParams,
+      headers: {
+        ...this.defaultClientConfigParams.headers,
+        [CLUSTER_ID_HEADER]: clusterId,
+        [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
+      },
+    });
+    return new PartitionV3Api(config);
+  }
+
+  // --- SCHEMA REGISTRY REST OPENAPI CLIENT METHODS ---
+
+  /**
+   * Creates and returns a (Schema Registry REST OpenAPI spec) {@link SchemasV1Api} client instance
+   * with a preconfigured {@link SchemaRegistryRestConfiguration}.
+   */
+  public getSchemasV1Api(clusterId: string, connectionId: string): SchemasV1Api {
+    const config = new SchemaRegistryRestConfiguration({
+      ...this.defaultClientConfigParams,
+      headers: {
+        ...this.defaultClientConfigParams.headers,
+        [CLUSTER_ID_HEADER]: clusterId,
+        [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
+      },
+    });
+    return new SchemasV1Api(config);
+  }
+
+  /**
+   * Creates and returns a (Schema Registry REST OpenAPI spec) {@link SubjectsV1Api} client instance
+   * with a preconfigured {@link SchemaRegistryRestConfiguration}.
+   */
+  public getSubjectsV1Api(clusterId: string, connectionId: string): SubjectsV1Api {
+    const config = new SchemaRegistryRestConfiguration({
+      ...this.defaultClientConfigParams,
+      headers: {
+        ...this.defaultClientConfigParams.headers,
+        [CLUSTER_ID_HEADER]: clusterId,
+        [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
+      },
+    });
+    return new SubjectsV1Api(config);
+  }
+
+  // === END OF OPENAPI CLIENT METHODS ===
+
+  /**
+   * Make a GraphQL request to the sidecar via fetch.
+   *
+   * NOTE: This uses the GraphQL schema in `src/graphql/sidecar.graphql` to generate the types for
+   * the query and variables via the `gql.tada` package.
+   */
   public async query<Result, Variables>(
     query: TadaDocumentNode<Result, Variables>,
     connectionId: string,
@@ -199,10 +269,13 @@ export class SidecarHandle {
     // The signature looks odd, but it's the only way to make optional param by condition
     ...[variables]: Variables extends Record<any, never> ? [never?] : [Variables]
   ): Promise<Result> {
-    const headers = new Headers();
-    headers.append("Content-Type", "application/json");
-    headers.append("Authorization", `Bearer ${this.auth_secret}`);
-    headers.append(SIDECAR_CURRENT_CONNECTION_ID_HEADER, connectionId);
+    const headers = new Headers({
+      ...this.defaultClientConfigParams.headers,
+      [SIDECAR_CONNECTION_ID_HEADER]: connectionId,
+    });
+    // headers.append("Content-Type", "application/json");
+    // headers.append("Authorization", `Bearer ${this.auth_secret}`);
+    // headers.append(SIDECAR_CONNECTION_ID_HEADER, connectionId);
 
     const response = await fetch(`${SIDECAR_BASE_URL}/gateway/v1/graphql`, {
       method: "POST",
@@ -235,19 +308,14 @@ export class SidecarHandle {
     return payload.data;
   }
 
-  public getMicroProfileHealthApi(config: Configuration): MicroProfileHealthApi {
-    // Factored out of getSidecarPid() to allow for test mocking.
-    return new MicroProfileHealthApi(config);
-  }
-
   /** Return the PID of the sidecar process by provoking it to raise a 401 Unauthorized error.
    * with the PID in the response header.
    * */
   public async getSidecarPid(): Promise<number> {
     // coax the sidecar to yield its pid by sending a bad auth token request to the
     // healthcheck route.
-
-    const config = this.createClientConfig({
+    const config = new SidecarRestConfiguration({
+      ...this.defaultClientConfigParams,
       headers: { Authorization: "Bearer bad-token" },
       // Need to prevent the default ErrorResponseMiddleware from catching the error we expect.
       middleware: [],

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -15,7 +15,6 @@ import {
   SIDECAR_LOGFILE_PATH,
   SIDECAR_PORT,
   SIDECAR_PROCESS_ID_HEADER,
-  WORKSPACE_PROCESS_ID_HEADER,
 } from "./constants";
 import { ErrorResponseMiddleware } from "./middlewares";
 import { SidecarHandle } from "./sidecarHandle";
@@ -29,6 +28,9 @@ import { Tail } from "tail";
  */
 export const sidecarOutputChannel: vscode.OutputChannel =
   vscode.window.createOutputChannel("Confluent (Sidecar)");
+
+/** Header name for the workspace's PID in the request headers. */
+const WORKSPACE_PROCESS_ID_HEADER: string = "x-workspace-process-id";
 
 const SIDECAR_AUTH_TOKEN_SECRET_KEY = "CONFLUENT_SIDECAR_AUTH_SECRET";
 const MOMENTARY_PAUSE_MS = 500; // half a second.
@@ -184,7 +186,7 @@ export class SidecarManager {
     // outside of this function.
     var version_result: SidecarVersionResponse | undefined = undefined;
     try {
-      version_result = await handle.VersionResourceApi().gatewayV1VersionGet();
+      version_result = await handle.getVersionResourceApi().gatewayV1VersionGet();
       logger.info(`Sidecar version: ${version_result.version}`);
     } catch (e) {
       // Some devs may have sidecars running that don't have the version endpoint (Pinnipeds especially)


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Sets the `SidecarHandle` default headers to accept `application/json` by default, only overridden by the `getTemplatesApi` method so it can accept .zip files.

Fixes the issue where we were seeing non-JSON response bodies returned.

+ more comment updates +JSdoc formatting since some of these areas haven't been touched in months

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
