### PR TITLE
[0.20.x] another `INVALID_TOKEN` handling follow-up

### DIFF
--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -7,6 +7,9 @@ import { SchemaRegistry } from "./models/schemaRegistry";
 
 /** Indicate whether or not we have a CCloud connection (controlled by our auth provider). */
 export const ccloudConnected = new vscode.EventEmitter<boolean>();
+/** Fires whenever we see a non-`INVALID_TOKEN` authentication status from the sidecar for the
+ * current CCloud connection, and is only used to resolve any open progress notification(s). */
+export const nonInvalidTokenStatus = new vscode.EventEmitter<void>();
 /** Signal to the auth provider that we no longer have a valid auth status for the current CCloud connection. */
 export const ccloudAuthSessionInvalidated = new vscode.EventEmitter<void>();
 export const ccloudOrganizationChanged = new vscode.EventEmitter<void>();

--- a/src/sidecar/authStatusPolling.ts
+++ b/src/sidecar/authStatusPolling.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { AuthErrors, Connection, Status } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
-import { ccloudAuthSessionInvalidated } from "../emitters";
+import { ccloudAuthSessionInvalidated, nonInvalidTokenStatus } from "../emitters";
 import { Logger } from "../logging";
 import { getResourceManager } from "../storage/resourceManager";
 import { IntervalPoller } from "../utils/timing";
@@ -84,6 +84,10 @@ export async function watchCCloudConnectionStatus(): Promise<void> {
     // poll faster to try and get to a non-transient status as quickly as possible since it's going
     // to affect how our CCloudAuthStatusMiddleware behaves
     pollCCloudConnectionAuth.useFastFrequency();
+    // ensure any open progress notifications are closed even if no requests are going through the middleware
+    nonInvalidTokenStatus.fire();
+    // ...and don't bother checking for expiration or errors until we get another status back
+    return;
   } else {
     pollCCloudConnectionAuth.useSlowFrequency();
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Saw during some more clicktesting that we weren't properly returning from the auth status poller from an `INVALID_TOKEN` status, so we would still get the error notification prompting for users to reauthenticate.

I also noticed that, with careful timing, we could end up in a stuck-progress state after kicking off a request during the `INVALID_TOKEN` status because each middleware was keeping track of its own event emitter and is-notification-open boolean. This moves those up to a global level and ensures the auth poller can fire the event emitter even if no requests are going through the middleware so it can close a progress notification on its own.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
