### PR TITLE
[v0.20.x] hotfix: move `nonInvalidTokenStatus` placement

### DIFF
--- a/src/sidecar/authStatusPolling.test.ts
+++ b/src/sidecar/authStatusPolling.test.ts
@@ -173,7 +173,7 @@ describe("CCloud auth expiration checks", () => {
   });
 });
 
-describe.only("CCloud connection status polling", () => {
+describe("CCloud connection status polling", () => {
   let sandbox: sinon.SinonSandbox;
   let getCCloudConnectionStub: sinon.SinonStub;
   let nonInvalidTokenStatusFireStub: sinon.SinonStub;

--- a/src/sidecar/authStatusPolling.test.ts
+++ b/src/sidecar/authStatusPolling.test.ts
@@ -4,14 +4,17 @@ import sinon from "sinon";
 import * as vscode from "vscode";
 import { TEST_CCLOUD_CONNECTION } from "../../tests/unit/testResources/connection";
 import { getExtensionContext } from "../../tests/unit/testUtils";
-import { Connection } from "../clients/sidecar";
+import { Connection, Status } from "../clients/sidecar";
+import { nonInvalidTokenStatus } from "../emitters";
 import {
   AUTH_PROMPT_TRACKER,
   checkAuthExpiration,
   MINUTES_UNTIL_REAUTH_WARNING,
   REAUTH_BUTTON_TEXT,
   REMIND_BUTTON_TEXT,
+  watchCCloudConnectionStatus,
 } from "./authStatusPolling";
+import * as connections from "./connections";
 
 configDotenv();
 
@@ -167,5 +170,48 @@ describe("CCloud auth expiration checks", () => {
     assert.ok(!AUTH_PROMPT_TRACKER.reauthWarningPromptOpen);
     // error notification should not show up
     assertAuthExpiredPromptNotOpened();
+  });
+});
+
+describe.only("CCloud connection status polling", () => {
+  let sandbox: sinon.SinonSandbox;
+  let getCCloudConnectionStub: sinon.SinonStub;
+  let nonInvalidTokenStatusFireStub: sinon.SinonStub;
+
+  before(async () => {
+    await getExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    getCCloudConnectionStub = sandbox.stub(connections, "getCCloudConnection");
+    nonInvalidTokenStatusFireStub = sandbox.stub(nonInvalidTokenStatus, "fire");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const nonTransientStatuses: Status[] = ["FAILED", "NO_TOKEN", "VALID_TOKEN"];
+  nonTransientStatuses.forEach((status) => {
+    it(`should fire the nonInvalidTokenStatus event emitter when the CCloud auth status is ${status}`, async () => {
+      const connection = createFakeConnection(120);
+      connection.status.authentication.status = status;
+      getCCloudConnectionStub.resolves(connection);
+
+      await watchCCloudConnectionStatus();
+
+      assert.ok(nonInvalidTokenStatusFireStub.called);
+    });
+  });
+
+  it("should NOT fire the nonInvalidTokenStatus event emitter when the CCloud auth status is INVALID_TOKEN", async () => {
+    const connection = createFakeConnection(120);
+    connection.status.authentication.status = "INVALID_TOKEN";
+    getCCloudConnectionStub.resolves(connection);
+
+    await watchCCloudConnectionStatus();
+
+    assert.ok(nonInvalidTokenStatusFireStub.notCalled);
   });
 });

--- a/src/sidecar/authStatusPolling.ts
+++ b/src/sidecar/authStatusPolling.ts
@@ -84,11 +84,11 @@ export async function watchCCloudConnectionStatus(): Promise<void> {
     // poll faster to try and get to a non-transient status as quickly as possible since it's going
     // to affect how our CCloudAuthStatusMiddleware behaves
     pollCCloudConnectionAuth.useFastFrequency();
-    // ensure any open progress notifications are closed even if no requests are going through the middleware
-    nonInvalidTokenStatus.fire();
     // ...and don't bother checking for expiration or errors until we get another status back
     return;
   } else {
+    // ensure any open progress notifications are closed even if no requests are going through the middleware
+    nonInvalidTokenStatus.fire();
     pollCCloudConnectionAuth.useSlowFrequency();
   }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This time we're actually firing `nonInvalidTokenStatus` for the right auth status. Also adding back some of the event emitter test behavior removed in https://github.com/confluentinc/vscode/pull/455.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added ~~new~~ previously existing with slight adjustments
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
