### PR TITLE
[v0.20.x] error notification for wrong platform/arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- An error notification is now shown if the wrong extension version is installed based on the
+  platform and/or architecture. [issue #317](https://github.com/confluentinc/vscode/issues/317)
+
 ## 0.20.0
 
 ### Added

--- a/src/sidecar/checkArchitecture.ts
+++ b/src/sidecar/checkArchitecture.ts
@@ -13,7 +13,7 @@ export function checkSidecarOsAndArch(sidecarPath: string): void {
   logger.debug("platform+arch check complete", { ourBuild, sidecarBuild });
 
   if (!ourBuild.equals(sidecarBuild)) {
-    const errorMsg = `This Confluent for VS Code component is built for a different platform (${sidecarBuild.platform}-${sidecarBuild.arch}), whereas your VS Code is on ${ourBuild.platform}-${ourBuild.arch}.`;
+    const errorMsg = `This Confluent extension is built for a different platform (${sidecarBuild.platform}-${sidecarBuild.arch}), whereas your VS Code is on ${ourBuild.platform}-${ourBuild.arch}.`;
     const button = "Open Marketplace";
     window.showErrorMessage(errorMsg, button).then((action) => {
       if (action === button) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #317.

We previously saw thrown errors floated as error notifications, but something seems to have changed where we only see them in logs. This PR explicitly adds an error notification when the sidecar platform/arch doesn't match the user's platform/arch, along with a button that links directly to the Marketplace to uninstall/install.


https://github.com/user-attachments/assets/fb8b84bc-d6b9-46cc-bcc0-e90d2b23294e


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
