### PR TITLE
minor: sort the template list in the UI

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -220,7 +220,14 @@ async function pathExists(path: string) {
 }
 
 async function pickTemplate(templateList: Template[]): Promise<vscode.QuickPickItem | undefined> {
-  const quickPickItems: vscode.QuickPickItem[] = templateList.map((templateItem: Template) => {
+  const sortedList = templateList.sort((a, b) => {
+    const nameA = a.spec.display_name.toLowerCase();
+    const nameB = b.spec.display_name.toLowerCase();
+    if (nameA < nameB) return -1;
+    if (nameA > nameB) return 1;
+    return 0;
+  });
+  const quickPickItems: vscode.QuickPickItem[] = sortedList.map((templateItem: Template) => {
     const tags = templateItem.spec?.tags ? `[${templateItem.spec.tags.join(", ")}]` : "";
     return {
       label: templateItem.spec.display_name,

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -221,11 +221,7 @@ async function pathExists(path: string) {
 
 async function pickTemplate(templateList: Template[]): Promise<vscode.QuickPickItem | undefined> {
   const sortedList = templateList.sort((a, b) => {
-    const nameA = a.spec.display_name.toLowerCase();
-    const nameB = b.spec.display_name.toLowerCase();
-    if (nameA < nameB) return -1;
-    if (nameA > nameB) return 1;
-    return 0;
+    return a.spec.display_name.toLowerCase().localeCompare(b.spec.display_name.toLowerCase());
   });
   const quickPickItems: vscode.QuickPickItem[] = sortedList.map((templateItem: Template) => {
     const tags = templateItem.spec?.tags ? `[${templateItem.spec.tags.join(", ")}]` : "";


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- @flippingbits brought this to my attention. Subtle difference but it's easier to read if the list is sorted alphabetically. 💡 

## Any additional details or context that should be provided?
| Before | After |
| -- | -- |
| <img width="611" alt="before" src="https://github.com/user-attachments/assets/c591b6a9-4664-4251-825c-b043ffd72aa9"> | <img width="613" alt="after" src="https://github.com/user-attachments/assets/a1c62dff-7656-4e6d-b2c1-a30c09b5b6f4"> |


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
