### PR TITLE
🍒 Persist consume mode and timestamp

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -496,6 +496,12 @@ function messageViewerStartPollingCommand(
       case "GetFilteredPartitions": {
         return partitionFilter() satisfies MessageResponse<"GetFilteredPartitions">;
       }
+      case "GetConsumeMode": {
+        return mode() satisfies MessageResponse<"GetConsumeMode">;
+      }
+      case "GetConsumeModeTimestamp": {
+        return (params().timestamp ?? null) satisfies MessageResponse<"GetConsumeModeTimestamp">;
+      }
       case "GetMaxSize": {
         return String(stream().capacity) satisfies MessageResponse<"GetMaxSize">;
       }

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -177,16 +177,17 @@ function messageViewerStartPollingCommand(
   /** Most recent failure info */
   const latestError = os.signal<{ message: string } | null>(null);
 
+  /** Wrapper for `panel.visible` that gracefully switches to `false` when panel is disposed. */
+  const panelActive = os.produce(true, (value, signal) => {
+    const disposed = panel.onDidDispose(() => value(false));
+    const changedState = panel.onDidChangeViewState(() => value(panel.visible));
+    signal.onabort = () => (disposed.dispose(), changedState.dispose());
+  });
+
   /** Notify an active webview only after flushing the rest of updates. */
   const notifyUI = () => {
     queueMicrotask(() => {
-      try {
-        if (panel.visible) {
-          panel.webview.postMessage(["Timestamp", "Success", Date.now()]);
-        }
-      } catch {
-        // panel might be disposed which causes `panel.visible` getter to throw
-      }
+      if (panelActive()) panel.webview.postMessage(["Timestamp", "Success", Date.now()]);
     });
   };
 

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -469,8 +469,12 @@ class MessageViewerViewModel extends ViewModel {
   }
 
   /** Consume mode affects parameters used for consuming messages. */
-  consumeMode = this.signal<ConsumeMode>("beginning");
-  consumeModeTimestamp = this.signal(Date.now());
+  consumeMode = this.resolve(() => {
+    return post("GetConsumeMode", { timestamp: this.timestamp() });
+  }, "beginning" as ConsumeMode);
+  consumeModeTimestamp = this.resolve(() => {
+    return post("GetConsumeModeTimestamp", { timestamp: this.timestamp() });
+  }, Date.now());
 
   async handleConsumeModeChange(value: ConsumeMode) {
     const timestamp = Date.now();
@@ -625,6 +629,8 @@ export function post(
 ): Promise<keyof typeof messageLimitLabel>;
 export function post(type: "GetConsumedPartitions", body: object): Promise<number[] | null>;
 export function post(type: "GetFilteredPartitions", body: object): Promise<number[] | null>;
+export function post(type: "GetConsumeMode", body: object): Promise<ConsumeMode>;
+export function post(type: "GetConsumeModeTimestamp", body: object): Promise<number | null>;
 export function post(
   type: "PartitionConsumeChange",
   body: { partitions: number[] | null },


### PR DESCRIPTION
Cherry-pick https://github.com/confluentinc/vscode/pull/478 to `v0.20.x`.
