### PR TITLE
Reintroduce schema registry progress view QP, fix naming.

### DIFF
--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -6,7 +6,10 @@ import { currentKafkaClusterChanged } from "../emitters";
 import { Logger } from "../logging";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
 import { KafkaTopic } from "../models/topic";
-import { kafkaClusterQuickPick } from "../quickpicks/kafkaClusters";
+import {
+  kafkaClusterQuickPick,
+  kafkaClusterQuickPickWithViewProgress,
+} from "../quickpicks/kafkaClusters";
 import { getSidecar } from "../sidecar";
 import { getResourceManager } from "../storage/resourceManager";
 import { getTopicViewProvider } from "../viewProviders/topics";
@@ -52,7 +55,7 @@ async function selectKafkaClusterCommand(cluster?: KafkaCluster) {
   const kafkaCluster: KafkaCluster | undefined =
     cluster instanceof CCloudKafkaCluster || cluster instanceof LocalKafkaCluster
       ? cluster
-      : await kafkaClusterQuickPick();
+      : await kafkaClusterQuickPickWithViewProgress();
   if (!kafkaCluster) {
     return;
   }

--- a/src/commands/schemaRegistry.ts
+++ b/src/commands/schemaRegistry.ts
@@ -2,13 +2,15 @@ import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { currentSchemaRegistryChanged } from "../emitters";
 import { CCloudSchemaRegistry, SchemaRegistry } from "../models/schemaRegistry";
-import { schemaRegistryQuickPick } from "../quickpicks/schemaRegistries";
+import { schemaRegistryQuickPickWithViewProgress } from "../quickpicks/schemaRegistries";
 
 async function selectSchemaRegistryCommand(cluster?: SchemaRegistry) {
   // ensure whatever was passed in is a SchemaRegistry instance; if not, prompt the user to pick one
   // TODO(shoup): update to support LocalSchemaRegistry
   const schemaRegistry =
-    cluster instanceof CCloudSchemaRegistry ? cluster : await schemaRegistryQuickPick();
+    cluster instanceof CCloudSchemaRegistry
+      ? cluster
+      : await schemaRegistryQuickPickWithViewProgress();
   if (!schemaRegistry) {
     return;
   }

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -9,8 +9,10 @@ import { hasCCloudAuthSession } from "../sidecar/connections";
 
 const logger = new Logger("quickpicks.kafkaClusters");
 
-/** Progress wrapper for the Kafka Cluster quickpick to accomodate data-fetching time. */
-export async function kafkaClusterQuickPick(
+/** Progress wrapper for the Kafka Cluster quickpick to accomodate data-fetching time.
+ * Highlights the topics view while the quickpick is awaited.
+ */
+export async function kafkaClusterQuickPickWithViewProgress(
   includeLocal: boolean = true,
   includeCCloud: boolean = true,
 ): Promise<KafkaCluster | undefined> {
@@ -20,17 +22,17 @@ export async function kafkaClusterQuickPick(
       title: "Loading Kafka clusters...",
     },
     async () => {
-      return await generateKafkaClusterQuickPick(includeLocal, includeCCloud);
+      return await kafkaClusterQuickPick(includeLocal, includeCCloud);
     },
   );
 }
 
 /**
- * Create a quickpick to let the user choose a Kafka cluster (listed by CCloud environment / "Local"
+ * Create and await a quickpick to let the user choose a Kafka cluster (listed by CCloud environment / "Local"
  * separators). Mainly used in the event a command was triggered through the command palette instead
  * of through the view->item->context menu.
  */
-async function generateKafkaClusterQuickPick(
+export async function kafkaClusterQuickPick(
   includeLocal: boolean = true,
   includeCCloud: boolean = true,
 ): Promise<KafkaCluster | undefined> {

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -11,6 +11,24 @@ import { getSchemasViewProvider } from "../viewProviders/schemas";
 const logger = new Logger("quickpicks.schemaRegistry");
 
 /**
+ * Runs the schemaRegistryQuickPick with a view progress indicator
+ * on the schemas view.
+ */
+export async function schemaRegistryQuickPickWithViewProgress(): Promise<
+  SchemaRegistry | undefined
+> {
+  return await vscode.window.withProgress(
+    {
+      location: { viewId: "confluent-schemas" },
+      title: "Loading Schema Registries...",
+    },
+    async () => {
+      return await schemaRegistryQuickPick();
+    },
+  );
+}
+
+/**
  * Create a quickpick to let the user choose a Schema Registry (listed by CCloud environment
  * separators). Mainly used in the event a command was triggered through the command palette instead
  * of through the view->item->context menu.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Reinstate the schema registry quickpick + progress on the schemas view variant, now named `schemaRegistryQuickPickWithViewProgress()`.

Respell the peer one for kafka clusters `kafkaClusterQuickPickWithViewProgress()`.

Basically, keep the plain `...QuickPick()` named function view/progress free like other quickpics, but still have the variants that mark the progress against a specific view.

From https://github.com/confluentinc/vscode/pull/442/files#r1825107775