### PR TITLE
add support for running extension tests with VS Code debugger

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "@vscode/test-cli";
+
+export default defineConfig([
+  {
+    files: "out/**/*.test.js",
+    mocha: {
+      ui: "bdd",
+    },
+  },
+]);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -33,7 +33,7 @@ const IS_CI = process.env.CI != null;
 const IS_WINDOWS = process.platform === "win32";
 
 export const ci = parallel(check, build, lint);
-export const test = series(clean, parallel(build, testBuild), testRun);
+export const test = series(clean, build, testBuild, testRun);
 
 export const bundle = series(clean, build, pack);
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -33,6 +33,7 @@ const IS_CI = process.env.CI != null;
 const IS_WINDOWS = process.platform === "win32";
 
 export const ci = parallel(check, build, lint);
+export const test = series(clean, parallel(build, testBuild), testRun);
 
 export const bundle = series(clean, build, pack);
 
@@ -515,11 +516,10 @@ export async function lint() {
   if (warnCount > 50) throw new Error("ESLint found too many warnings (maximum: 50).");
 }
 
-test.description = "Run tests using @vscode/test-cli. Use --coverage for coverage report.";
-export async function test() {
+testBuild.description =
+  "Build test files for running tests via `gulp testRun` or through the VS Code test runner. Use --coverage to enable coverage reporting.";
+export async function testBuild() {
   const reportCoverage = IS_CI || process.argv.indexOf("--coverage", 2) >= 0;
-  // argv array is something like ['gulp', 'test', '-t', 'something'], we look for the one after -t
-  const testFilter = process.argv.find((v, i, a) => i > 0 && a[i - 1] === "-t");
   const testFiles = globSync(["src/**/*.test.ts", "src/testing.ts"]);
   const entryMap = Object.fromEntries(
     testFiles.map((filename) => [filename.slice(0, -extname(filename).length), filename]),
@@ -557,6 +557,14 @@ export async function test() {
   };
   const bundle = await rollup(testInput);
   await bundle.write(testOutput);
+  return 0;
+}
+
+testRun.description = "Run tests using @vscode/test-cli. Use --coverage for coverage report.";
+export async function testRun() {
+  const reportCoverage = IS_CI || process.argv.indexOf("--coverage", 2) >= 0;
+  // argv array is something like ['gulp', 'test', '-t', 'something'], we look for the one after -t
+  const testFilter = process.argv.find((v, i, a) => i > 0 && a[i - 1] === "-t");
   await runTests({
     extensionDevelopmentPath: resolve(DESTINATION),
     extensionTestsPath: resolve(DESTINATION + "/src/testing.js"),


### PR DESCRIPTION
Separates our `test` task into `testBuild` and `testRun` to allow running tests with the VS Code debugger. Also adds a `.vscode-test.js` file so the [Extension Test Runner extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.extension-test-runner) can discover tests in `out/` after a `testBuild`.
https://code.visualstudio.com/api/working-with-extensions/testing-extension#quick-setup-the-test-cli

<img width="896" alt="image" src="https://github.com/user-attachments/assets/6bb03bb7-42cd-4bdd-8cf8-eb45998b92fa">

Closes #510.

> [!NOTE]  
> To use this locally, you'll need to install+enable the above extension, as well as make sure the `gulp testBuild` process runs so the `*.test.js` files show up in our `out/` directory.  