### PR TITLE
Fix encoding in idle-sidecar path

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -333,7 +333,7 @@ function sidecar() {
 
   return [
     virtual({
-      "ide-sidecar": `export const version = "${sidecarVersion}"; export default new URL("./${sidecarFilename}", import.meta.url).pathname;`,
+      "ide-sidecar": `export const version = "${sidecarVersion}"; export default decodeURIComponent(new URL("./${sidecarFilename}", import.meta.url).pathname);`,
     }),
     copy({
       copyOnce: true,


### PR DESCRIPTION
If the VS code extension is installed for a user that has a space in the path of the user's directory, the extension fails to load due to the URL encoding (% escaping) in the path

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
When you URL decode the calculated path for the idle-side car binary, the path is formatted in the original form which is understood by the OS path API. I tested this change with a manual update of the extension code (sidecar.js) and the extension worked on my machine again.

-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
