### PR TITLE
MINOR fix: don't switch windows when dismissing project-created notification

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
 import * as Sentry from "@sentry/node";
+import * as vscode from "vscode";
 
 import { posix } from "path";
 import { unzip } from "unzipit";
@@ -7,7 +7,7 @@ import { Template, TemplateList, TemplateManifest, TemplatesApi } from "./client
 import { Logger } from "./logging";
 import { getSidecar } from "./sidecar";
 
-import { ExtensionContext, Uri, ViewColumn } from "vscode";
+import { ExtensionContext, ViewColumn } from "vscode";
 import { registerCommandWithLogging } from "./commands";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { WebviewPanelCache } from "./webview-cache";
@@ -151,7 +151,7 @@ async function applyTemplate(
       { title: "Open in Current Window" },
       { title: "Dismiss", isCloseAffordance: true },
     );
-    if (selection !== undefined) {
+    if (selection !== undefined && selection.title !== "Dismiss") {
       // if "true" is set in the `vscode.openFolder` command, it will open a new window instead of
       // reusing the current one
       const keepsExistingWindow = selection.title === "Open in New Window";


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Since the hitting `ESC` is the same as clicking the "Dismiss" button (due to [`isCloseAffordance=true`](https://github.com/confluentinc/vscode/blob/431c9a977360dea9d7d5e7e088b0316cfe6c0754/src/scaffold.ts#L152)), we should never get `undefined` in the user selection after a `🎉 Project Generated` notification pops up, so we can safely check against the `Dismiss` item being selected to prevent the workspace changing to the new project directory.

Closes #512. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
