### PR TITLE
Allow sharing message viewer state via links

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,6 +268,13 @@
         "enablement": "activeWebviewPanelId == message-viewer"
       },
       {
+        "command": "confluent.topic.consume.fromUri",
+        "icon": "$(link)",
+        "title": "Open Message Viewer from Link",
+        "category": "Confluent: Topic",
+        "enablement": "false"
+      },
+      {
         "command": "confluent.topics.create",
         "icon": "$(plus)",
         "title": "Create Topic",

--- a/package.json
+++ b/package.json
@@ -261,6 +261,13 @@
         "enablement": "activeWebviewPanelId == message-viewer"
       },
       {
+        "command": "confluent.topic.consume.getUri",
+        "icon": "$(link)",
+        "title": "Copy Link to Message Viewer",
+        "category": "Confluent: Topic",
+        "enablement": "activeWebviewPanelId == message-viewer"
+      },
+      {
         "command": "confluent.topics.create",
         "icon": "$(plus)",
         "title": "Create Topic",
@@ -539,7 +546,12 @@
         },
         {
           "command": "confluent.topic.consume.duplicate",
-          "group": "navigation",
+          "group": "navigation@1",
+          "when": "activeWebviewPanelId == message-viewer"
+        },
+        {
+          "command": "confluent.topic.consume.getUri",
+          "group": "navigation@2",
           "when": "activeWebviewPanelId == message-viewer"
         }
       ],

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -31,6 +31,9 @@ export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements 
         logger.debug("Got authCallback URI, firing as Event", uri);
         this.fire(uri);
         break;
+      case "/consume":
+        vscode.commands.executeCommand("confluent.topic.consume.fromUri", uri);
+        break;
       default:
         logger.warn("Got unexpected URI, ignoring", uri);
     }


### PR DESCRIPTION
Closes #171 

This PR adds a command to message viewer view that generates a `vscode://` link that can be shared with other vscode/confluent extension users to access predefined message viewer setup.

To make this work, I implemented a data class that represents a snapshot of params, used by the viewer. The structure also implements serialization/deserialization methods for `URLSearchParams` that represent the query part of a URI.

https://github.com/user-attachments/assets/ea2ee01b-94ba-4688-9321-167a922ddc3c

