### PR TITLE
remove `lstat` from sentry filter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ if (process.env.SENTRY_DSN) {
     ],
     ignoreErrors: [
       "The request failed and the interceptors did not return an alternative response",
-      "ENOENT: no such file or directory, lstat",
+      "ENOENT: no such file or directory",
     ],
   });
 }


### PR DESCRIPTION
So we don't (continue to) get `ENOENT: no such file or directory, stat` and others