### PR TITLE
MINOR: logging updates for Docker ping / image pull

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -1,5 +1,13 @@
 import * as Sentry from "@sentry/node";
-import { CancellationToken, Disposable, env, ProgressLocation, Uri, window } from "vscode";
+import {
+  CancellationToken,
+  commands,
+  Disposable,
+  env,
+  ProgressLocation,
+  Uri,
+  window,
+} from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ResponseError } from "../clients/docker";
 import { isDockerAvailable } from "../docker/configs";
@@ -33,15 +41,20 @@ export async function runWorkflowWithProgress(
 ) {
   const dockerAvailable = await isDockerAvailable();
   if (!dockerAvailable) {
+    const installLinkButton = "Install Docker";
+    const openLogsButton = "Open Logs";
     window
       .showErrorMessage(
         "Unable to launch local resources because Docker is not available. Please install Docker and try again once it's running.",
-        "Install Docker",
+        installLinkButton,
+        openLogsButton,
       )
       .then((selection) => {
-        if (selection) {
+        if (selection === installLinkButton) {
           const uri = Uri.parse("https://docs.docker.com/engine/install/");
           env.openExternal(uri);
+        } else if (selection === openLogsButton) {
+          commands.executeCommand("confluent.showOutputChannel");
         }
       });
     return;

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -1,7 +1,7 @@
 import { normalize } from "path";
 import { Agent, RequestInit as UndiciRequestInit } from "undici";
 import { workspace, WorkspaceConfiguration } from "vscode";
-import { SystemApi } from "../clients/docker";
+import { ResponseError, SystemApi } from "../clients/docker";
 import { Logger } from "../logging";
 import {
   LOCAL_DOCKER_SOCKET_PATH,
@@ -97,7 +97,13 @@ export async function isDockerAvailable(): Promise<boolean> {
     logger.debug("docker ping response:", resp);
     return true;
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof ResponseError) {
+      logger.debug("docker ping error response:", {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        data: await error.response.clone().text(),
+      });
+    } else if (error instanceof Error) {
       logger.debug("can't ping docker:", {
         error: error.message,
       });

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -98,7 +98,7 @@ export async function isDockerAvailable(): Promise<boolean> {
     return true;
   } catch (error) {
     if (error instanceof ResponseError) {
-      logger.debug("docker ping error response:", {
+      logger.error("docker ping error response:", {
         status: error.response.status,
         statusText: error.response.statusText,
         data: await error.response.clone().text(),

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -51,11 +51,10 @@ export async function pullImage(repo: string, tag: string): Promise<void> {
     // use the `imageCreateRaw` method to get the raw response text, because otherwise we get a void response
     const resp = await client.imageCreateRaw({ fromImage: repoTag }, init);
     // wait for all the "Pulling..."/"Already exists" type messages to be finished
-    const body = await resp.raw.clone().text();
+    await resp.raw.clone().text();
     logger.debug(`Pulled "${repoTag}" image:`, {
       status: resp.raw.status,
       statusText: resp.raw.statusText,
-      body,
     });
     getTelemetryLogger().logUsage("Docker Image Pulled", {
       dockerImage: repoTag,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- promote response errors from the `/_ping` endpoint to `error` level (Docker version incompatibility or otherwise) -- this won't be the case if docker isn't running at all; that will still show up under the `can't ping docker` debug log and avoid getting spammy
- add another "Open Logs" button for quickly seeing the above error responses
- remove the image pull response body since it can be hundreds of lines of text with all the ANSI escape codes and related progress updates
 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
