### PR TITLE
fix: reset `LOCAL` connection on managed container "start" events

### DIFF
--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -32,7 +32,7 @@ export function getSocketPath(): string {
   } else {
     path = path ? path : DEFAULT_UNIX_SOCKET_PATH;
   }
-  logger.debug("using docker socket path:", { socketPath: path });
+  logger.trace("using docker socket path:", { socketPath: path });
 
   return path;
 }

--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -11,6 +11,7 @@ import {
 import { ContextValues, setContextValue } from "../context";
 import { localKafkaConnected, localSchemaRegistryConnected } from "../emitters";
 import { Logger } from "../logging";
+import { updateLocalConnection } from "../sidecar/connections";
 import { IntervalPoller } from "../utils/timing";
 import {
   defaultRequestInit,
@@ -331,6 +332,8 @@ export class EventListener {
       await setContextValue(ContextValues.localSchemaRegistryAvailable, started);
       localSchemaRegistryConnected.fire(started);
     }
+    // delete+recreate the local connection to purge any previous clusters from the sidecar cache
+    await updateLocalConnection();
   }
 
   /** Handling for an event that describes when a container is stopped. */

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -60,7 +60,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
   let stopContainerStub: sinon.SinonStub;
   let waitForLocalResourceEventChangeStub: sinon.SinonStub;
 
-  let updateLocalSchemaRegistryURI: sinon.SinonStub;
+  let updateLocalConnectionStub: sinon.SinonStub;
 
   before(async () => {
     await getExtensionContext();
@@ -116,7 +116,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
       .stub(workflow, "waitForLocalResourceEventChange")
       .resolves();
 
-    updateLocalSchemaRegistryURI = sandbox.stub(connections, "updateLocalSchemaRegistryURI");
+    updateLocalConnectionStub = sandbox.stub(connections, "updateLocalConnection");
   });
 
   afterEach(() => {
@@ -146,7 +146,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     assert.ok(startContainerStub.calledOnce);
     assert.ok(workflowShowErrorNotificationStub.notCalled);
 
-    assert.ok(updateLocalSchemaRegistryURI.calledOnce);
+    assert.ok(updateLocalConnectionStub.calledOnce);
 
     assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
   });

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -11,7 +11,7 @@ import {
 import { localSchemaRegistryConnected } from "../../emitters";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
-import { updateLocalSchemaRegistryURI } from "../../sidecar/connections";
+import { updateLocalConnection } from "../../sidecar/connections";
 import {
   getLocalKafkaImageName,
   getLocalKafkaImageTag,
@@ -338,7 +338,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
 
     // inform the sidecar that it needs to look for the Schema Registry container at the dynamically
     // assigned REST proxy port
-    await updateLocalSchemaRegistryURI(`http://localhost:${restProxyPort}`);
+    await updateLocalConnection(`http://localhost:${restProxyPort}`);
 
     return { id: container.Id, name: CONTAINER_NAME };
   }

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -12,7 +12,11 @@ import { localSchemaRegistryConnected } from "../../emitters";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
 import { updateLocalSchemaRegistryURI } from "../../sidecar/connections";
-import { getLocalKafkaImageName, getLocalSchemaRegistryImageTag } from "../configs";
+import {
+  getLocalKafkaImageName,
+  getLocalKafkaImageTag,
+  getLocalSchemaRegistryImageTag,
+} from "../configs";
 import { LocalResourceKind, MANAGED_CONTAINER_LABEL } from "../constants";
 import {
   createContainer,
@@ -218,7 +222,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
     }
 
     const kafkaImageRepo: string = getLocalKafkaImageName();
-    const kafkaImageTag: string = kafkaWorkflow.imageTag;
+    const kafkaImageTag: string = getLocalKafkaImageTag();
 
     // TODO(shoup): update this for direct connections
     // TEMPORARY: this will go away once we start working with direct connections

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -1,5 +1,6 @@
 import { AuthenticationSession, authentication } from "vscode";
 import { getSidecar } from ".";
+import { ContainerListRequest, ContainerSummary, Port } from "../clients/docker";
 import {
   Connection,
   ConnectionSpec,
@@ -14,9 +15,15 @@ import {
   LOCAL_CONNECTION_SPEC,
 } from "../constants";
 import { ContextValues, getContextValue } from "../context";
+import {
+  getLocalSchemaRegistryImageName,
+  getLocalSchemaRegistryImageTag,
+  isDockerAvailable,
+} from "../docker/configs";
+import { MANAGED_CONTAINER_LABEL } from "../docker/constants";
+import { getContainersForImage } from "../docker/containers";
 import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
 import { Logger } from "../logging";
-import { getStorageManager } from "../storage";
 import { getResourceManager } from "../storage/resourceManager";
 
 const logger = new Logger("sidecar.connections");
@@ -146,30 +153,75 @@ export function hasCCloudAuthSession(): boolean {
   return !!isCcloudConnected;
 }
 
-// TODO(shoup): update for direct connections
-/** Delete and recreate the local connection, pulling the latest schema_registry_uri from secret storage. */
-export async function updateLocalConnection(): Promise<Connection> {
+/**
+ * Discover any supported locally-running resources and update the local connection with the
+ * relevant resource configs (for now, just Schema Registry containers, but in the future will
+ * include Kafka and other resources).
+ */
+export async function updateLocalConnection(schemaRegistryUri?: string): Promise<void> {
   let spec: ConnectionSpec = LOCAL_CONNECTION_SPEC;
 
-  // update the schema registry URI if we know it and it's available
-  const schemaRegistryUri: string | undefined =
-    await getStorageManager().getSecret("schema_registry_uri");
+  // TODO(shoup): look up Kafka containers here once direct connections are used
+
+  schemaRegistryUri = schemaRegistryUri ?? (await discoverSchemaRegistry());
   if (schemaRegistryUri) {
     spec = {
       ...LOCAL_CONNECTION_SPEC,
       local_config: {
+        ...LOCAL_CONNECTION_SPEC.local_config,
         schema_registry_uri: schemaRegistryUri,
       },
     };
   }
 
-  await deleteLocalConnection();
-  return await tryToCreateConnection(spec);
+  const currentLocalConnection: Connection | null = await getLocalConnection();
+  // inform sidecar if the spec has changed (whether this is a new spec or if we're changing configs)
+  if (JSON.stringify(spec) !== JSON.stringify(currentLocalConnection?.spec)) {
+    await deleteLocalConnection();
+    await tryToCreateConnection(spec);
+  }
 }
 
-/** Store the newest Schema Registry URI in secret storage and refresh the local connection. */
-export async function updateLocalSchemaRegistryURI(uri: string): Promise<void> {
-  await getStorageManager().setSecret("schema_registry_uri", uri);
-  const resp: Connection = await updateLocalConnection();
-  logger.debug("Updated local connection with Schema Registry URI:", resp);
+// TODO(shoup): this may need to move into a different file for general resource discovery
+/** Discover any running Schema Registry containers and return the URI to include the REST proxy port. */
+async function discoverSchemaRegistry(): Promise<string | undefined> {
+  const dockerAvailable = await isDockerAvailable();
+  if (!dockerAvailable) {
+    return;
+  }
+
+  const imageRepo = getLocalSchemaRegistryImageName();
+  const imageTag = getLocalSchemaRegistryImageTag();
+  const repoTag = `${imageRepo}:${imageTag}`;
+  const containerListRequest: ContainerListRequest = {
+    all: true,
+    filters: JSON.stringify({
+      ancestor: [repoTag],
+      label: [MANAGED_CONTAINER_LABEL],
+      status: ["running"],
+    }),
+  };
+  const containers: ContainerSummary[] = await getContainersForImage(containerListRequest);
+  if (containers.length === 0) {
+    return;
+  }
+  // we only care about the first container
+  const container: ContainerSummary = containers.filter((c) => !!c.Ports)[0];
+  const ports: Port[] = container.Ports?.filter((p) => !!p.PublicPort) || [];
+  if (!ports || ports.length === 0) {
+    logger.debug("No ports found on Schema Registry container", { container });
+    return;
+  }
+  const schemaRegistryPort: Port | undefined = ports.find((p) => !!p.PublicPort);
+  if (!schemaRegistryPort) {
+    logger.debug("No PublicPort found on Schema Registry container", { container });
+    return;
+  }
+  const restProxyPort = schemaRegistryPort.PublicPort;
+  if (!restProxyPort) {
+    logger.debug("No REST proxy port found on Schema Registry container", { container });
+    return;
+  }
+  logger.debug("Discovered Schema Registry REST proxy port", { schemaRegistryPort });
+  return `http://localhost:${restProxyPort}`;
 }

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,15 +1,7 @@
 import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
-import { ContainerListRequest, ContainerSummary, Port } from "../clients/docker";
 import { IconNames } from "../constants";
 import { ContextValues, getExtensionContext, setContextValue } from "../context";
-import {
-  getLocalSchemaRegistryImageName,
-  getLocalSchemaRegistryImageTag,
-  isDockerAvailable,
-} from "../docker/configs";
-import { MANAGED_CONTAINER_LABEL } from "../docker/constants";
-import { getContainersForImage } from "../docker/containers";
 import {
   ccloudConnected,
   ccloudOrganizationChanged,
@@ -32,7 +24,7 @@ import {
   LocalSchemaRegistry,
   SchemaRegistryTreeItem,
 } from "../models/schemaRegistry";
-import { hasCCloudAuthSession, updateLocalSchemaRegistryURI } from "../sidecar/connections";
+import { hasCCloudAuthSession, updateLocalConnection } from "../sidecar/connections";
 import { CCloudResourcePreloader } from "../storage/ccloudPreloader";
 import { getResourceManager } from "../storage/resourceManager";
 
@@ -252,7 +244,7 @@ export async function loadLocalResources(): Promise<
   // before we try listing any resources (for possibly the first time), we need to check if any
   // supported Schema Registry containers are running, then grab their REST proxy port to send to
   // the sidecar for discovery before the GraphQL query kicks off
-  await discoverSchemaRegistry();
+  await updateLocalConnection();
 
   const localResources: LocalResourceGroup[] = await getLocalResources();
   if (localResources.length > 0) {
@@ -317,50 +309,4 @@ async function getCCloudEnvironmentChildren(environment: CCloudEnvironment) {
 
   // TODO: add flink compute pools here ?
   return subItems;
-}
-
-/**
- * Discover any running Schema Registry containers and send the REST proxy port to the sidecar for
- * discovery.
- */
-async function discoverSchemaRegistry() {
-  const dockerAvailable = await isDockerAvailable();
-  if (!dockerAvailable) {
-    return;
-  }
-
-  const imageRepo = getLocalSchemaRegistryImageName();
-  const imageTag = getLocalSchemaRegistryImageTag();
-  const repoTag = `${imageRepo}:${imageTag}`;
-  const containerListRequest: ContainerListRequest = {
-    all: true,
-    filters: JSON.stringify({
-      ancestor: [repoTag],
-      label: [MANAGED_CONTAINER_LABEL],
-      status: ["running"],
-    }),
-  };
-  const containers: ContainerSummary[] = await getContainersForImage(containerListRequest);
-  if (containers.length === 0) {
-    return;
-  }
-  // we only care about the first container
-  const container: ContainerSummary = containers.filter((c) => !!c.Ports)[0];
-  const ports: Port[] = container.Ports?.filter((p) => !!p.PublicPort) || [];
-  if (!ports || ports.length === 0) {
-    logger.debug("No ports found on Schema Registry container", { container });
-    return;
-  }
-  const schemaRegistryPort: Port | undefined = ports.find((p) => !!p.PublicPort);
-  if (!schemaRegistryPort) {
-    logger.debug("No PublicPort found on Schema Registry container", { container });
-    return;
-  }
-  const restProxyPort = schemaRegistryPort.PublicPort;
-  if (!restProxyPort) {
-    logger.debug("No REST proxy port found on Schema Registry container", { container });
-    return;
-  }
-  logger.debug("Discovered Schema Registry REST proxy port", { schemaRegistryPort });
-  await updateLocalSchemaRegistryURI(`http://localhost:${restProxyPort}`);
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #525.

To avoid the sidecar caching the local Kafka cluster / SR configuration during any resource changes after the extension activates, we need to delete and recreate the connection with the new configuration.

If we don't do this, we see error responses (after local resources successfully start) when other extension actions are attempting to make requests to the (new) configuration. -- (e.g. listing topics/schemas, consuming messages, creating topics/schemas) -- but the sidecar is referencing the old configuration. This appears in a couple different ways:
- Kafka: an error 408 response with `Timed out waiting for node assignment` (only for Kafka
- Schema Registry: an error 500 response to the effect of `Connection refused: localhost/127.0.0.1:<old port>`

Now, we look discover local SR after extension activation or from a container "start" event, then we check if the new local connection `ConnectionSpec` is different from what the sidecar is already tracking, and update it if there are any changes the sidecar should be informed of.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
