### PR TITLE
Frack ResourceLoader into a partially abstract base class and a CCLoud-centric subclass.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ import { sidecarOutputChannel } from "./sidecar";
 import { getCCloudAuthSession } from "./sidecar/connections";
 import { StorageManager } from "./storage";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
-import { ResourceLoader } from "./storage/resourceLoader";
+import { constructResourceLoaderSingletons } from "./storage/resourceLoader";
 import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { getUriHandler } from "./uriHandler";
@@ -123,8 +123,8 @@ async function _activateExtension(
   activateMessageViewer(context);
   registerProjectGenerationCommand(context);
 
-  // Construct the singleton, let it register its event listener.
-  ResourceLoader.getInstance();
+  // Construct the singletons, let it register its event listener.
+  constructResourceLoaderSingletons();
 
   // set up the local Docker event listener singleton and start watching for system events
   EventListener.getInstance().start();

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { IconNames } from "../constants";
+import { CCLOUD_CONNECTION_ID, IconNames } from "../constants";
 import { getLocalResources, LocalResourceGroup } from "../graphql/local";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
@@ -41,8 +41,8 @@ export async function schemaRegistryQuickPick(): Promise<SchemaRegistry | undefi
   let cloudSchemaRegistries: CCloudSchemaRegistry[] = [];
 
   // schema registries are a coarse resource, so ensure they are loaded before proceeding
-  const preloader = ResourceLoader.getInstance();
-  await preloader.ensureCoarseResourcesLoaded();
+  const ccloudLoader = ResourceLoader.getInstance(CCLOUD_CONNECTION_ID);
+  await ccloudLoader.ensureCoarseResourcesLoaded();
 
   // first we grab all available (local+CCloud) Schema Registries
   let localGroups: LocalResourceGroup[] = [];

--- a/src/quickpicks/schemas.ts
+++ b/src/quickpicks/schemas.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { getSubjectIcon, Schema, SchemaType } from "../models/schema";
+import { SchemaRegistry } from "../models/schemaRegistry";
 import { ResourceLoader } from "../storage/resourceLoader";
 import { getResourceManager } from "../storage/resourceManager";
 
@@ -10,15 +11,15 @@ import { getResourceManager } from "../storage/resourceManager";
  *
  */
 export async function schemaSubjectQuickPick(
-  schemaRegistryId: string,
+  schemaRegistry: SchemaRegistry,
   onlyType: SchemaType | undefined = undefined,
 ): Promise<string | undefined> {
   // ensure that the resources are loaded before trying to access them
-  const preloader = ResourceLoader.getInstance();
-  await preloader.ensureCoarseResourcesLoaded();
-  await preloader.ensureSchemasLoaded(schemaRegistryId);
+  const loader = ResourceLoader.getInstance(schemaRegistry.connectionId);
+  await loader.ensureCoarseResourcesLoaded();
+  await loader.ensureSchemasLoaded(schemaRegistry.id);
 
-  const schemas = await getResourceManager().getSchemasForRegistry(schemaRegistryId);
+  const schemas = await getResourceManager().getSchemasForRegistry(schemaRegistry.id);
 
   let schemaSubjects: string[] | undefined;
 

--- a/src/storage/resourceLoader.ts
+++ b/src/storage/resourceLoader.ts
@@ -1,5 +1,6 @@
 import { Require } from "dataclass";
 import { Schema as ResponseSchema, SchemasV1Api } from "../clients/schemaRegistryRest";
+import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudConnected } from "../emitters";
 import { getEnvironments } from "../graphql/environments";
 import { Logger } from "../logging";
@@ -9,29 +10,21 @@ import { getSidecar } from "../sidecar";
 import { getResourceManager } from "./resourceManager";
 
 const logger = new Logger("storage.resourceLoader");
-/**
- * Singleton class responsible for loading / caching resources into the resource manager.
- * View providers and/or other consumers of resources stored in the resource manager should
- * call {@link ensureCoarseResourcesLoaded} to ensure that the resources are cached before attempting to
- * access them from the resource manager.
- *
- * The preloader handles loading the following "coarse" resources via ${link ensureCoarseResourcesLoaded}:
- *  - CCloud Environments (ResourceManager.getCCloudEnvironments())
- *  - CCloud Kafka Clusters (ResourceManager.getCCloudKafkaClusters())
- *  - CCloud Schema Registries (ResourceManager.getCCloudSchemaRegistries())
- *
- * Also handles loading the schemas for a single Schema Registry via {@link ensureSchemasLoaded}, but
- * only after when the coarse resources have been loaded. Because there may be "many" schemas in a schema registry,
- * this is considered a 'fine grained resource' and is not loaded until requested.
- */
-export class ResourceLoader {
-  private static instance: ResourceLoader | null = null;
+
+/** Construct the singleton resource loaders so they may register their event listeners. */
+export function constructResourceLoaderSingletons(): void {
+  CCLoudResourceLoader.getInstance();
+}
+
+export abstract class ResourceLoader {
+  /** What kind of resources does this loader manage? Human readable string. */
+  public abstract kind: string;
 
   /** Have the course resources been cached already? */
-  private coarseLoadingComplete: boolean = false;
+  protected coarseLoadingComplete: boolean = false;
 
   /** If in progress of loading the coarse resources, the promise doing so. */
-  private currentlyCoarseLoadingPromise: Promise<void> | null = null;
+  protected currentlyCoarseLoadingPromise: Promise<void> | null = null;
 
   /**
    * Known state of resource manager cache for each schema registry's schemas by schema registry id:
@@ -40,63 +33,58 @@ export class ResourceLoader {
    *  * True: Fully cached. Go ahead and make use of resourceManager.getCCloudSchemasForCluster(id)
    *  * Promise<void>: in progress of fetching, join awaiting this promise to know when it's safe to use resourceManager.getCCloudSchemasForCluster(id).
    */
-  private schemaRegistryCacheStates: Map<string, boolean | Promise<void>> = new Map();
+  protected schemaRegistryCacheStates: Map<string, boolean | Promise<void>> = new Map();
 
-  public static getInstance(): ResourceLoader {
-    if (!ResourceLoader.instance) {
-      ResourceLoader.instance = new ResourceLoader();
+  /** Get the ResourceLoader subclass instance corresponding to the given connectionId */
+  public static getInstance(connectionId: string): ResourceLoader {
+    if (connectionId === CCLOUD_CONNECTION_ID) {
+      return CCLoudResourceLoader.getInstance();
     }
-    return ResourceLoader.instance;
+
+    throw new Error(`Unknown connectionId ${connectionId}`);
   }
 
-  private constructor() {
-    // When the ccloud connection state changes, reset the preloader's state.
-    ccloudConnected.event(async (connected: boolean) => {
-      this.coarseLoadingComplete = false;
-      this.currentlyCoarseLoadingPromise = null;
-      this.schemaRegistryCacheStates.clear();
-
-      if (connected) {
-        // Start the coarse preloading process if we think we have a ccloud connection.
-        await this.ensureCoarseResourcesLoaded();
-      }
-    });
-
-    // TODO: something similar for docker events re/local resources?
-    // TODO: discuss with @shoup over 'coarse' resources vs localness -- this was all originally ccloud.
+  /** Go back to initial state, not having cached anything. */
+  protected reset(): void {
+    this.coarseLoadingComplete = false;
+    this.currentlyCoarseLoadingPromise = null;
+    this.schemaRegistryCacheStates.clear();
   }
+
+  // Coarse resource-related methods.
+
+  protected abstract deleteStaticResources(): void;
+
+  protected abstract doLoadCoarseResources(): Promise<void>;
 
   /**
    * Promise ensuring that the "coarse" ccloud resources are cached into the resource manager.
    *
-   * Fired off when CCloud edges to connected, and/or when any view controller needs to get at
-   * any of the following CCloud resources stored in ResourceManager. Is safe to call multiple times
-   * in a ccloud session, as it will only fetch the resources once. Concurrent calls while the resources
+   * Fired off when the connection edges to connected, and/or when any view controller needs to get at
+   * any of the following resources stored in ResourceManager. Is safe to call multiple times
+   * in a connected session, as it will only fetch the resources once. Concurrent calls while the resources
    * are being fetched will await the same promise. Subsequent calls after completion will return
    * immediately.
    *
-   * Currently, when the CCloud connection / authentication session is closed/ended, the resources
-   * are left in the resource manager, however the preloader will reset its state to not having fetched
+   * Currently, when the connection / authentication session is closed/ended, the resources
+   * are left in the resource manager, however the loader will reset its state to not having fetched
    * the resources, so that the next call to ensureResourcesLoaded() will re-fetch the resources.
    *
    * Coarse resources are:
-   *   - CCloud Environments (ResourceManager.getCCloudEnvironments())
-   *   - CCloud Kafka Clusters (ResourceManager.getCCloudKafkaClusters())
-   *   - CCloud Schema Registries (ResourceManager.getCCloudSchemaRegistries())
+   *   - Environments
+   *   - Kafka Clusters
+   *   - Schema Registries
    *
    * They do not include topics within a cluster or schemas within a schema registry, which are fetched
    * and cached more closely to when they are needed.
    */
   public async ensureCoarseResourcesLoaded(forceDeepRefresh: boolean = false): Promise<void> {
-    // If caller requested a deep refresh, reset the preloader's state so that we fall through to
+    // If caller requested a deep refresh, reset the loader's state so that we fall through to
     // re-fetching the coarse resources.
     if (forceDeepRefresh) {
-      logger.info("Deep refreshing CCloud resources, forgetting all ccloud cached resources.");
-      this.coarseLoadingComplete = false;
-      this.currentlyCoarseLoadingPromise = null;
-      // Also implies forgetting any cached schemas so that they will be re-fetched upon demand.
-      this.schemaRegistryCacheStates.clear();
-      getResourceManager().deleteCCloudResources();
+      logger.info(`Deep refreshing ${this.kind} resources.`);
+      this.reset();
+      this.deleteStaticResources();
     }
 
     // If the resources are already loaded, nothing to wait on.
@@ -115,11 +103,111 @@ export class ResourceLoader {
     await this.currentlyCoarseLoadingPromise;
   }
 
+  // Schema registry related 'fine grained' methods.
+
+  /**
+   * Mark this schema registry cache as stale, such as when known that a schema has been added or removed,
+   * but the registry isn't currently being displayed
+   */
+  public purgeSchemas(schemaRegistryId: string): void {
+    this.schemaRegistryCacheStates.set(schemaRegistryId, false);
+  }
+
+  /** Ensure that this single Schema Registry's schemas have been loaded. */
+  public async ensureSchemasLoaded(
+    schemaRegistryId: string,
+    forceDeepRefresh: boolean = false,
+  ): Promise<void> {
+    if (forceDeepRefresh) {
+      // If the caller wants to force a deep refresh, then reset this Schema Registry's state to not having
+      // fetched the schemas yet, so that we'll ignore any prior cached schemas and fetch them anew.
+      this.schemaRegistryCacheStates.set(schemaRegistryId, false);
+    }
+
+    const schemaRegistryCacheState = this.schemaRegistryCacheStates.get(schemaRegistryId);
+
+    // Ensure is a valid Schema Registry id. See doLoadResources() for initial setting
+    // of these keys.
+    if (schemaRegistryCacheState === undefined) {
+      throw new Error(`Schema registry with id ${schemaRegistryId} is unknown to the loader.`);
+    }
+
+    // If schemas for this Schema Registry are already loaded, nothing to wait on.
+    if (schemaRegistryCacheState === true) {
+      return;
+    }
+
+    // If in progress of loading, have the caller await the promise that is currently loading the schemas.
+    if (schemaRegistryCacheState instanceof Promise) {
+      return schemaRegistryCacheState;
+    }
+
+    // This caller is the first to request the preload of the schemas in this registry,
+    // so do the work in the foreground, but also store the promise so that any other
+    // concurrent callers can await it.
+    const schemaLoadingPromise = this.doLoadSchemas(schemaRegistryId);
+    this.schemaRegistryCacheStates.set(schemaRegistryId, schemaLoadingPromise);
+    await schemaLoadingPromise;
+  }
+
+  /** Load the schemas for this single Schema Registry into the resource manager. */
+  protected abstract doLoadSchemas(schemaRegistryId: string): Promise<void>;
+}
+
+/**
+ * Singleton class responsible for loading / caching CCLoud resources into the resource manager.
+ * View providers and/or other consumers of resources stored in the resource manager should
+ * call {@link ensureCoarseResourcesLoaded} to ensure that the resources are cached before attempting to
+ * access them from the resource manager.
+ *
+ * Handles loading the following "coarse" resources via ${link ensureCoarseResourcesLoaded}:
+ *  - CCloud Environments (ResourceManager.getCCloudEnvironments())
+ *  - CCloud Kafka Clusters (ResourceManager.getCCloudKafkaClusters())
+ *  - CCloud Schema Registries (ResourceManager.getCCloudSchemaRegistries())
+ *
+ * Also handles loading the schemas for a single Schema Registry via {@link ensureSchemasLoaded}, but
+ * only after when the coarse resources have been loaded. Because there may be "many" schemas in a schema registry,
+ * this is considered a 'fine grained resource' and is not loaded until requested.
+ */
+export class CCLoudResourceLoader extends ResourceLoader {
+  kind = "CCloud";
+
+  private static instance: CCLoudResourceLoader | null = null;
+
+  public static getInstance(): ResourceLoader {
+    if (!CCLoudResourceLoader.instance) {
+      CCLoudResourceLoader.instance = new CCLoudResourceLoader();
+    }
+    return CCLoudResourceLoader.instance;
+  }
+
+  private constructor() {
+    super();
+    // When the ccloud connection state changes, reset the loader's state.
+    ccloudConnected.event(async (connected: boolean) => {
+      this.reset();
+
+      if (connected) {
+        // Start the coarse preloading process if we think we have a ccloud connection.
+        await this.ensureCoarseResourcesLoaded();
+      }
+    });
+  }
+
+  protected deleteStaticResources(): void {
+    getResourceManager().deleteCCloudResources();
+  }
+
   /**
    * Load the {@link CCloudEnvironment}s and their direct children (Kafka clusters, schema registry) into
    * the resource manager.
+   *
+   * Worker function that does the actual loading of the coarse resources:
+   *   - Environments (ResourceManager.getCCloudEnvironments())
+   *   - Kafka Clusters (ResourceManager.getCCloudKafkaClusters())
+   *   - Schema Registries (ResourceManager.getCCloudSchemaRegistries())
    */
-  private async doLoadCoarseResources(): Promise<void> {
+  protected async doLoadCoarseResources(): Promise<void> {
     // Start loading the ccloud-related resources from sidecar API into the resource manager for local caching.
     // If the loading fails at any time (including, say, the user logs out of CCloud while in progress), then
     // an exception will be thrown and the loadingComplete flag will remain false.
@@ -166,52 +254,7 @@ export class ResourceLoader {
     }
   }
 
-  /** Mark this schema registry cache as stale, such as when known that a schema has been added or removed,
-   * but the registry isn't currently being displayed
-   */
-  public purgeSchemas(schemaRegistryId: string): void {
-    this.schemaRegistryCacheStates.set(schemaRegistryId, false);
-  }
-
-  /** Ensure that this single Schema Registry's schemas have been loaded. */
-  public async ensureSchemasLoaded(
-    schemaRegistryId: string,
-    forceDeepRefresh: boolean = false,
-  ): Promise<void> {
-    if (forceDeepRefresh) {
-      // If the caller wants to force a deep refresh, then reset this Schema Registry's state to not having
-      // fetched the schemas yet, so that we'll ignore any prior cached schemas and fetch them anew.
-      this.schemaRegistryCacheStates.set(schemaRegistryId, false);
-    }
-
-    const schemaRegistryCacheState = this.schemaRegistryCacheStates.get(schemaRegistryId);
-
-    // Ensure is a valid Schema Registry id. See doLoadResources() for initial setting
-    // of these keys.
-    if (schemaRegistryCacheState === undefined) {
-      throw new Error(`Schema registry with id ${schemaRegistryId} is unknown to the preloader.`);
-    }
-
-    // If schemas for this Schema Registry are already loaded, nothing to wait on.
-    if (schemaRegistryCacheState === true) {
-      return;
-    }
-
-    // If in progress of loading, have the caller await the promise that is currently loading the schemas.
-    if (schemaRegistryCacheState instanceof Promise) {
-      return schemaRegistryCacheState;
-    }
-
-    // This caller is the first to request the preload of the schemas in this registry,
-    // so do the work in the foreground, but also store the promise so that any other
-    // concurrent callers can await it.
-    const schemaLoadingPromise = this.doLoadSchemas(schemaRegistryId);
-    this.schemaRegistryCacheStates.set(schemaRegistryId, schemaLoadingPromise);
-    await schemaLoadingPromise;
-  }
-
-  /** Load the schemas for this single Schema Registry into the resource manager. */
-  private async doLoadSchemas(schemaRegistryId: string): Promise<void> {
+  protected async doLoadSchemas(schemaRegistryId: string): Promise<void> {
     try {
       logger.info("Deep loading schemas for Schema Registry", {
         schemaRegistryId,

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
-import { IconNames } from "../constants";
+import { CCLOUD_CONNECTION_ID, IconNames } from "../constants";
 import { ContextValues, getExtensionContext, setContextValue } from "../context";
 import {
   ccloudConnected,
@@ -73,7 +73,7 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
     ccloudConnected.event((connected: boolean) => {
       logger.debug("ccloudConnected event fired", { connected });
       // No need to force a deep refresh when the connection status changes because the
-      // preloader will have already begun loading resources due to also observing this event.
+      // loader will have already begun loading resources due to also observing this event.
       this.refresh();
     });
 
@@ -169,14 +169,14 @@ export async function loadCCloudResources(
   cloudContainerItem.iconPath = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);
 
   if (hasCCloudAuthSession()) {
-    const preloader = ResourceLoader.getInstance();
-    // TODO: have this cached in the resource manager via the preloader
+    const loader = ResourceLoader.getInstance(CCLOUD_CONNECTION_ID);
+    // TODO: have this cached in the resource manager via the loader
     const currentOrg = await getCurrentOrganization();
 
     let ccloudEnvironments: CCloudEnvironment[] = [];
     try {
-      // Ensure all of the preloading is complete before referencing resource manager CCloud resources.
-      await preloader.ensureCoarseResourcesLoaded(forceDeepRefresh);
+      // Ensure all of the loading is complete before referencing resource manager CCloud resources.
+      await loader.ensureCoarseResourcesLoaded(forceDeepRefresh);
       const resourceManager = getResourceManager();
       ccloudEnvironments = await resourceManager.getCCloudEnvironments();
     } catch (e) {
@@ -270,7 +270,7 @@ export async function loadLocalResources(): Promise<
     localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     // override the default "child item count" description
     localContainerItem.description = localKafkaClusters.map((cluster) => cluster.uri).join(", ");
-    // TODO: this should be handled in the preloader once it (and ResourceManager) start handling
+    // TODO: this should be handled in the loader once it (and ResourceManager) start handling
     // local resources
     getResourceManager().setLocalKafkaClusters(localKafkaClusters);
     localContainerItem.children = [...localKafkaClusters, ...localSchemaRegistries];
@@ -291,8 +291,8 @@ export async function loadLocalResources(): Promise<
 async function getCCloudEnvironmentChildren(environment: CCloudEnvironment) {
   const subItems: (CCloudKafkaCluster | CCloudSchemaRegistry)[] = [];
 
-  // Ensure all of the preloading is complete before referencing resource manager ccloud resources.
-  await ResourceLoader.getInstance().ensureCoarseResourcesLoaded();
+  // Ensure all of the loading is complete before referencing resource manager ccloud resources.
+  await ResourceLoader.getInstance(CCLOUD_CONNECTION_ID).ensureCoarseResourcesLoaded();
 
   const rm = getResourceManager();
   // Get the Kafka clusters for this environment. Will at worst be an empty array.

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -40,18 +40,18 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
   }
 
   /** Deep refesh + repaint the view if it is showing the given registry id. Otherwise, hint
-   * the preloader to purge the cache for this schema registry (if currently cached), so that next
+   * the resource loader to purge the cache for this schema registry (if currently cached), so that next
    * time it is shown, it will be deep-fetched.
    */
-  refreshIfShowingRegistry(schemaRegistryId: string): void {
+  refreshIfShowingRegistry(schemaRegistry: SchemaRegistry): void {
     // if the schema registry is the one being shown, deep refresh the view
-    if (this.schemaRegistry?.id === schemaRegistryId) {
+    if (this.schemaRegistry?.id === schemaRegistry.id) {
       this.refresh(true);
     } else {
-      // Otherwise at least inform the preloader to purge the cache for this schema registry
+      // Otherwise at least inform the resource loader to purge the cache for this schema registry
       // (if currently cached).
-      const preloader = ResourceLoader.getInstance();
-      preloader.purgeSchemas(schemaRegistryId);
+      const loader = ResourceLoader.getInstance(schemaRegistry.connectionId);
+      loader.purgeSchemas(schemaRegistry.id);
     }
   }
 
@@ -163,15 +163,16 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
       }
       // Schema items are leaf nodes, so we don't need to handle them here
     } else {
-      // TODO(james): integrate local schema caching into the preloader
+      // TODO(james): integrate local schema caching into the loader.
+      // (James: Easier said that done, but is gonna happen.)
       if (this.schemaRegistry != null) {
         let schemas: Schema[] = [];
 
         if (this.ccloudEnvironment != null) {
-          const preloader = ResourceLoader.getInstance();
+          const loader = ResourceLoader.getInstance(this.schemaRegistry.connectionId);
           // ensure that the resources are loaded before trying to access them
-          await preloader.ensureCoarseResourcesLoaded();
-          await preloader.ensureSchemasLoaded(this.schemaRegistry.id, this.forceDeepRefresh);
+          await loader.ensureCoarseResourcesLoaded();
+          await loader.ensureSchemasLoaded(this.schemaRegistry.id, this.forceDeepRefresh);
           if (this.forceDeepRefresh) {
             // Just honored the user's request for a deep refresh.
             this.forceDeepRefresh = false;

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -179,20 +179,20 @@ export async function getTopicsForCluster(
   const resourceManager = getResourceManager();
 
   if (cluster instanceof CCloudKafkaCluster) {
-    // Ensure all of the needed ccloud preloading is complete before referencing
+    // Ensure all of the needed ccloud loading is complete before referencing
     // resource manager ccloud resources, namely the schema registry and its schemas.
 
-    const preloader = ResourceLoader.getInstance();
+    const loader = ResourceLoader.getInstance(cluster.connectionId);
 
     // Honor forceRefresh, in case they, say, _just_ created the schema registry.
-    await preloader.ensureCoarseResourcesLoaded(forceRefresh);
+    await loader.ensureCoarseResourcesLoaded(forceRefresh);
 
     // Get the schema registry id for the cluster's environment
     const schemaRegistry = await resourceManager.getCCloudSchemaRegistry(cluster.environmentId);
 
     if (schemaRegistry) {
       // Ensure the schemas are loaded for the schema registry, honoring the forceRefresh flag.
-      await preloader.ensureSchemasLoaded(schemaRegistry.id, forceRefresh);
+      await loader.ensureSchemasLoaded(schemaRegistry.id, forceRefresh);
     }
   }
 


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Frack ResourceLoader into a partially abstract base class and a CCLoud-centric subclass.
- Plan is to have subclasses for each major connection type (ccloud, local, direct), each distinguishable by their connectionId values. `ResourceLoader.getInstance()` now takes a connectionId to pivot off of.
- Right now is just one subclass, CCLoudResourceLoader, but `LocalResourceLoader` is now one step closer to being created.
- Updated all of the existing callpoints to ResourceLoader.getInstance(), and some are currently ccloud-centric, but others look like they'll smoothly work when `LocalResourceLoader` comes online.
- Renamed all `preloader` mentions as either varnames or comments to just `loader`.
- Close #551.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
