### PR TITLE
cleanup: add `authn/` subdir

### DIFF
--- a/src/authn/ccloudPolling.test.ts
+++ b/src/authn/ccloudPolling.test.ts
@@ -6,6 +6,7 @@ import { TEST_CCLOUD_CONNECTION } from "../../tests/unit/testResources/connectio
 import { getExtensionContext } from "../../tests/unit/testUtils";
 import { Connection, Status } from "../clients/sidecar";
 import { nonInvalidTokenStatus } from "../emitters";
+import * as connections from "../sidecar/connections";
 import {
   AUTH_PROMPT_TRACKER,
   checkAuthExpiration,
@@ -13,8 +14,7 @@ import {
   REAUTH_BUTTON_TEXT,
   REMIND_BUTTON_TEXT,
   watchCCloudConnectionStatus,
-} from "./authStatusPolling";
-import * as connections from "./connections";
+} from "./ccloudPolling";
 
 configDotenv();
 

--- a/src/authn/ccloudPolling.ts
+++ b/src/authn/ccloudPolling.ts
@@ -7,7 +7,7 @@ import { getCCloudAuthSession, getCCloudConnection } from "../sidecar/connection
 import { getResourceManager } from "../storage/resourceManager";
 import { IntervalPoller } from "../utils/timing";
 
-const logger = new Logger("sidecar.authStatusPolling");
+const logger = new Logger("authn.ccloudPolling");
 
 // TODO(shoup): the majority of this auth checking/prompting logic below should move into the auth provider
 

--- a/src/authn/ccloudPolling.ts
+++ b/src/authn/ccloudPolling.ts
@@ -3,9 +3,9 @@ import { AuthErrors, Connection, Status } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudAuthSessionInvalidated, nonInvalidTokenStatus } from "../emitters";
 import { Logger } from "../logging";
+import { getCCloudAuthSession, getCCloudConnection } from "../sidecar/connections";
 import { getResourceManager } from "../storage/resourceManager";
 import { IntervalPoller } from "../utils/timing";
-import { getCCloudAuthSession, getCCloudConnection } from "./connections";
 
 const logger = new Logger("sidecar.authStatusPolling");
 

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -1,14 +1,14 @@
 import { chromium } from "@playwright/test";
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getExtensionContext, getTestStorageManager } from "../tests/unit/testUtils";
-import { ConfluentCloudAuthProvider, getAuthProvider } from "./authProvider";
-import { Connection } from "./clients/sidecar";
-import { CCLOUD_CONNECTION_ID } from "./constants";
-import { getSidecar } from "./sidecar";
-import { createCCloudConnection, deleteCCloudConnection } from "./sidecar/connections";
-import { StorageManager } from "./storage";
-import { getUriHandler, UriEventHandler } from "./uriHandler";
+import { getExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
+import { Connection } from "../clients/sidecar";
+import { CCLOUD_CONNECTION_ID } from "../constants";
+import { getSidecar } from "../sidecar";
+import { createCCloudConnection, deleteCCloudConnection } from "../sidecar/connections";
+import { StorageManager } from "../storage";
+import { getUriHandler, UriEventHandler } from "../uriHandler";
+import { ConfluentCloudAuthProvider, getAuthProvider } from "./ccloudProvider";
 
 const AUTH_CALLBACK_URI = vscode.Uri.parse("vscode://confluentinc.vscode-confluent/authCallback");
 

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -23,7 +23,7 @@ import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
 import { getUriHandler } from "../uriHandler";
 import { openExternal, pollCCloudConnectionAuth } from "./ccloudPolling";
 
-const logger = new Logger("authProvider");
+const logger = new Logger("authn.ccloudProvider");
 
 export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider {
   /** Disposables belonging to this provider to be added to the extension context during activation,

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -1,27 +1,27 @@
 import * as vscode from "vscode";
-import { Connection } from "./clients/sidecar";
-import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID } from "./constants";
-import { ContextValues, getExtensionContext, setContextValue } from "./context";
-import { ccloudAuthSessionInvalidated, ccloudConnected } from "./emitters";
-import { ExtensionContextNotSetError } from "./errors";
-import { Logger } from "./logging";
-import { fetchPreferences } from "./preferences/updates";
-import { openExternal, pollCCloudConnectionAuth } from "./sidecar/authStatusPolling";
+import { Connection } from "../clients/sidecar";
+import { AUTH_PROVIDER_ID, CCLOUD_CONNECTION_ID } from "../constants";
+import { ContextValues, getExtensionContext, setContextValue } from "../context";
+import { ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
+import { ExtensionContextNotSetError } from "../errors";
+import { Logger } from "../logging";
+import { fetchPreferences } from "../preferences/updates";
 import {
   clearCurrentCCloudResources,
   createCCloudConnection,
   deleteCCloudConnection,
   getCCloudConnection,
-} from "./sidecar/connections";
-import { getStorageManager } from "./storage";
+} from "../sidecar/connections";
+import { getStorageManager } from "../storage";
 import {
   AUTH_COMPLETED_KEY,
   AUTH_SESSION_EXISTS_KEY,
   CCLOUD_AUTH_STATUS_KEY,
-} from "./storage/constants";
-import { getResourceManager } from "./storage/resourceManager";
-import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
-import { getUriHandler } from "./uriHandler";
+} from "../storage/constants";
+import { getResourceManager } from "../storage/resourceManager";
+import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
+import { getUriHandler } from "../uriHandler";
+import { openExternal, pollCCloudConnectionAuth } from "./ccloudPolling";
 
 const logger = new Logger("authProvider");
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { getAndActivateExtension, getExtensionContext } from "../tests/unit/testUtils";
-import { ConfluentCloudAuthProvider } from "./authProvider";
+import { ConfluentCloudAuthProvider } from "./authn/ccloudProvider";
 import { ExtensionContextNotSetError } from "./errors";
 import { StorageManager } from "./storage";
 import { ResourceManager } from "./storage/resourceManager";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ if (process.env.SENTRY_DSN) {
   Sentry.addEventProcessor(checkTelemetrySettings);
 }
 
-import { ConfluentCloudAuthProvider, getAuthProvider } from "./authProvider";
+import { ConfluentCloudAuthProvider, getAuthProvider } from "./authn/ccloudProvider";
 import { registerCommandWithLogging } from "./commands";
 import { registerConnectionCommands } from "./commands/connections";
 import { registerDebugCommands } from "./commands/debugtools";


### PR DESCRIPTION
Just renaming and reorganization, no functional changes.

Creates a new `authn/` subdir to house both the CCloud auth provider and the polling we use for checking errors and expiration. Once we start using direct connect auth, we'll add the auth provider in this same subdir.