### PR TITLE
fix: auth expiration and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this extension will be documented in this file.
   not be visible when updating from <0.20.x to this release, but will be visible in future updates.)
   [#476](https://github.com/confluentinc/vscode/issues/476)
   [#520](https://github.com/confluentinc/vscode/issues/520)
+- When a CCloud connection expires, the extension will now properly clear the views in the sidebar,
+  and the associated error notification's "Log in to Confluent Cloud" button will now work as
+  expected. [#565](https://github.com/confluentinc/vscode/issues/565)
 
 ## 0.20.2
 

--- a/src/authn/ccloudPolling.test.ts
+++ b/src/authn/ccloudPolling.test.ts
@@ -7,10 +7,12 @@ import { getExtensionContext } from "../../tests/unit/testUtils";
 import { Connection, Status } from "../clients/sidecar";
 import { nonInvalidTokenStatus } from "../emitters";
 import * as connections from "../sidecar/connections";
+import { ResourceManager } from "../storage/resourceManager";
 import {
-  AUTH_PROMPT_TRACKER,
+  AuthPromptTracker,
   checkAuthExpiration,
   MINUTES_UNTIL_REAUTH_WARNING,
+  pollCCloudConnectionAuth,
   REAUTH_BUTTON_TEXT,
   REMIND_BUTTON_TEXT,
   watchCCloudConnectionStatus,
@@ -29,31 +31,24 @@ function createFakeConnection(expiresInMinutes: number | undefined): Connection 
   return connection;
 }
 
-describe("CCloud auth expiration checks", () => {
+describe("authn/ccloudPolling.ts checkAuthExpiration()", () => {
   let sandbox: sinon.SinonSandbox;
+
   let showWarningMessageStub: sinon.SinonStub;
   let showErrorMessageStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    // REAUTH_BUTTON_TEXT is the only option that doesn't adjust the AuthPromptTracker's
-    // `reauthWarningPromptOpen`, so if we don't use that, we'll see weird state changes
-    const warningMessageThenable = Promise.resolve(REAUTH_BUTTON_TEXT);
-    showWarningMessageStub = sandbox.stub(vscode.window, "showWarningMessage");
-    showWarningMessageStub.returns(warningMessageThenable);
-
-    // we don't need to handle any specific return value for this stub
-    const errorMessageThenable = Promise.resolve("test");
-    showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
-    showErrorMessageStub.returns(errorMessageThenable);
-
-    // reset the auth prompt tracker state
-    AUTH_PROMPT_TRACKER.authErrorPromptOpen = false;
-    AUTH_PROMPT_TRACKER.reauthWarningPromptOpen = false;
-    AUTH_PROMPT_TRACKER.earliestReauthWarning = new Date(0);
+    // assume the user doesn't click any notification buttons by default for most tests
+    showWarningMessageStub = sandbox.stub(vscode.window, "showWarningMessage").resolves();
+    showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage").resolves();
+    // prevent attempting to open a browser window for these tests
+    sandbox.stub(vscode.env, "openExternal");
   });
 
   afterEach(() => {
+    // reset the AuthPromptTracker singleton instance so it can be recreated fresh for each test
+    AuthPromptTracker["instance"] = null;
     sandbox.restore();
   });
 
@@ -67,17 +62,7 @@ describe("CCloud auth expiration checks", () => {
       ),
       `showWarningMessage called ${showWarningMessageStub.callCount}/1 time(s) with args [${showWarningMessageStub.args}]`,
     );
-    assert.ok(AUTH_PROMPT_TRACKER.reauthWarningPromptOpen);
-  }
-
-  /** Reusable helper function to check that our "reauth warning" notification was NOT called. */
-  function assertReauthWarningPromptNotOpened() {
-    assert.ok(
-      showWarningMessageStub.notCalled,
-      `showWarningMessage called ${showWarningMessageStub.callCount}/0 time(s) with args [${showWarningMessageStub.args}]`,
-    );
-    // not checking .reauthWarningPromptOpen here because it may be opened from a previous call,
-    // just want to make sure the notification isn't trying to be opened again
+    assert.ok(AuthPromptTracker.getInstance().reauthWarningPromptOpen);
   }
 
   /** Reusable helper function to check that our "auth expired" notification was called as expected. */
@@ -91,43 +76,45 @@ describe("CCloud auth expiration checks", () => {
     );
   }
 
-  /** Reusable helper function to check that our "auth expired" notification was NOT called. */
-  function assertAuthExpiredPromptNotOpened() {
-    assert.ok(
-      showErrorMessageStub.notCalled,
-      `showErrorMessage called ${showErrorMessageStub.callCount}/0 time(s) with args [${showErrorMessageStub.args}]`,
-    );
-  }
-
-  it("should not show any notifications if auth doesn't expire soon", async () => {
+  it("should not show any notifications if auth doesn't expire soon and there are no errors", async () => {
     // check against a connection that expires in 120min
-    await checkAuthExpiration(createFakeConnection(120));
+    const connection = createFakeConnection(120);
+
+    await checkAuthExpiration(connection);
+
     // warning notification should not show up
-    assertReauthWarningPromptNotOpened();
-    assert.ok(!AUTH_PROMPT_TRACKER.reauthWarningPromptOpen);
+    assert.ok(showWarningMessageStub.notCalled);
+    assert.ok(!AuthPromptTracker.getInstance().reauthWarningPromptOpen);
     // error notification should not show up
-    assertAuthExpiredPromptNotOpened();
+    assert.ok(showErrorMessageStub.notCalled);
   });
 
   it("should show a warning notification if auth expires soon", async () => {
     // check against a connection that expires "soon"
-    await checkAuthExpiration(createFakeConnection(MINUTES_UNTIL_REAUTH_WARNING - 1));
+    const expiringSoonConnection = createFakeConnection(MINUTES_UNTIL_REAUTH_WARNING - 1);
+    // simulate a user clicking "Reauthenticate" so we don't reset `.reauthWarningPromptOpen`
+    showWarningMessageStub.resolves(REAUTH_BUTTON_TEXT);
+
+    await checkAuthExpiration(expiringSoonConnection);
+
     // warning notification should show up
     assertReauthWarningPromptOpened();
     // error notification should not show up
-    assertAuthExpiredPromptNotOpened();
+    assert.ok(showErrorMessageStub.notCalled);
   });
 
   it("should show an error notification if auth has expired", async () => {
     // expired auth will cycle the CCloud connection, which requires the auth provider to be set up,
     // which requires the extension context to be available
     await getExtensionContext();
-
     // check against a connection that expired already (5min ago)
-    await checkAuthExpiration(createFakeConnection(-5));
+    const expiredConnection = createFakeConnection(-5);
+
+    await checkAuthExpiration(expiredConnection);
+
     // warning notification should not show up
-    assertReauthWarningPromptNotOpened();
-    assert.ok(!AUTH_PROMPT_TRACKER.reauthWarningPromptOpen);
+    assert.ok(showWarningMessageStub.notCalled);
+    assert.ok(!AuthPromptTracker.getInstance().reauthWarningPromptOpen);
     // error notification should show up
     assertAuthExpiredPromptOpened();
   });
@@ -136,29 +123,32 @@ describe("CCloud auth expiration checks", () => {
     // expired auth will cycle the CCloud connection, which requires the auth provider to be set up,
     // which requires the extension context to be available
     await getExtensionContext();
+    // simulate a user clicking "Reauthenticate" so we don't reset `.reauthWarningPromptOpen`
+    showWarningMessageStub.resolves(REAUTH_BUTTON_TEXT);
 
     // PART 1) check against a connection that expires "soon"
-    await checkAuthExpiration(createFakeConnection(MINUTES_UNTIL_REAUTH_WARNING - 1));
+    const expiringConnection = createFakeConnection(MINUTES_UNTIL_REAUTH_WARNING - 1);
+    await checkAuthExpiration(expiringConnection);
     // warning notification should show up
     assertReauthWarningPromptOpened();
     // error notification should not show up
-    assertAuthExpiredPromptNotOpened();
+    assert.ok(showErrorMessageStub.notCalled);
 
     // reset the stubs so we can check the next notification
     showWarningMessageStub.resetHistory();
     showErrorMessageStub.resetHistory();
 
     // PART 2) check again once we're past the auth expiration time
-    await checkAuthExpiration(createFakeConnection(-5));
+    const expiredConnection = createFakeConnection(-5);
+    await checkAuthExpiration(expiredConnection);
     // warning notification should not show up again, but should still be open
-    assertReauthWarningPromptNotOpened();
-    assert.ok(AUTH_PROMPT_TRACKER.reauthWarningPromptOpen);
+    assert.ok(showWarningMessageStub.notCalled);
+    assert.ok(AuthPromptTracker.getInstance().reauthWarningPromptOpen);
     // error notification should show up
-    console.error("part 2: error notification");
     assertAuthExpiredPromptOpened();
   });
 
-  it("should handle undefined `requires_authentication_at`", async () => {
+  it("checkAuthExpiration() should handle undefined `requires_authentication_at`", async () => {
     // no expiration time available, e.g. auth flow hasn't completed yet
     try {
       await checkAuthExpiration(createFakeConnection(undefined));
@@ -166,17 +156,21 @@ describe("CCloud auth expiration checks", () => {
       assert.fail("checkAuthExpiration threw an error with undefined expiration");
     }
     // warning notification should not show up
-    assertReauthWarningPromptNotOpened();
-    assert.ok(!AUTH_PROMPT_TRACKER.reauthWarningPromptOpen);
+    assert.ok(showWarningMessageStub.notCalled);
+    assert.ok(!AuthPromptTracker.getInstance().reauthWarningPromptOpen);
     // error notification should not show up
-    assertAuthExpiredPromptNotOpened();
+    assert.ok(showErrorMessageStub.notCalled);
   });
 });
 
-describe("CCloud connection status polling", () => {
+describe("authn/ccloudPolling.ts watchCCloudConnectionStatus()", () => {
   let sandbox: sinon.SinonSandbox;
+
   let getCCloudConnectionStub: sinon.SinonStub;
   let nonInvalidTokenStatusFireStub: sinon.SinonStub;
+  let stubResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
+  let pollFastStub: sinon.SinonStub;
+  let pollSlowStub: sinon.SinonStub;
 
   before(async () => {
     await getExtensionContext();
@@ -184,12 +178,30 @@ describe("CCloud connection status polling", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
     getCCloudConnectionStub = sandbox.stub(connections, "getCCloudConnection");
     nonInvalidTokenStatusFireStub = sandbox.stub(nonInvalidTokenStatus, "fire");
+
+    stubResourceManager = sinon.createStubInstance(ResourceManager);
+    sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
+
+    pollFastStub = sandbox.stub(pollCCloudConnectionAuth, "useFastFrequency");
+    pollSlowStub = sandbox.stub(pollCCloudConnectionAuth, "useSlowFrequency");
   });
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  it("should take no action when no connection is fetched from the sidecar", async () => {
+    getCCloudConnectionStub.resolves(undefined);
+
+    await watchCCloudConnectionStatus();
+
+    assert.ok(stubResourceManager.setCCloudAuthStatus.notCalled);
+    assert.ok(pollFastStub.notCalled);
+    assert.ok(nonInvalidTokenStatusFireStub.notCalled);
+    assert.ok(pollSlowStub.notCalled);
   });
 
   const nonTransientStatuses: Status[] = ["FAILED", "NO_TOKEN", "VALID_TOKEN"];
@@ -201,17 +213,46 @@ describe("CCloud connection status polling", () => {
 
       await watchCCloudConnectionStatus();
 
+      assert.ok(stubResourceManager.setCCloudAuthStatus.calledOnceWith(status));
+      assert.ok(pollFastStub.notCalled);
       assert.ok(nonInvalidTokenStatusFireStub.called);
+      assert.ok(pollSlowStub.called);
     });
   });
 
   it("should NOT fire the nonInvalidTokenStatus event emitter when the CCloud auth status is INVALID_TOKEN", async () => {
+    const status = "INVALID_TOKEN";
     const connection = createFakeConnection(120);
-    connection.status.authentication.status = "INVALID_TOKEN";
+    connection.status.authentication.status = status;
     getCCloudConnectionStub.resolves(connection);
 
     await watchCCloudConnectionStatus();
 
+    assert.ok(stubResourceManager.setCCloudAuthStatus.calledOnceWith(status));
+    assert.ok(pollFastStub.called);
     assert.ok(nonInvalidTokenStatusFireStub.notCalled);
+    assert.ok(pollSlowStub.notCalled);
   });
+
+  // TODO(shoup): ccloudPolling.ts will need to be refactored to allow stubbing across the entire module
+  // it("should call checkAuthErrors() when the connection hasn't passed its requires_authentication_at time", async () => {
+  //   const connection = createFakeConnection(120);
+  //   getCCloudConnectionStub.resolves(connection);
+
+  //   await watchCCloudConnectionStatus();
+
+  //   assert.ok(
+  //     checkAuthErrorsStub.calledOnceWith(connection),
+  //     `checkAuthErrors(): ${checkAuthErrorsStub.callCount} -> ${JSON.stringify(checkAuthErrorsStub.args)}`,
+  //   );
+  // });
+
+  // it("should not call checkAuthErrors() when the connection has passed its requires_authentication_at time", async () => {
+  //   const connection = createFakeConnection(-5);
+  //   getCCloudConnectionStub.resolves(connection);
+
+  //   await watchCCloudConnectionStatus();
+
+  //   assert.ok(checkAuthErrorsStub.notCalled);
+  // });
 });

--- a/src/authn/ccloudPolling.test.ts
+++ b/src/authn/ccloudPolling.test.ts
@@ -148,7 +148,7 @@ describe("authn/ccloudPolling.ts checkAuthExpiration()", () => {
     assertAuthExpiredPromptOpened();
   });
 
-  it("checkAuthExpiration() should handle undefined `requires_authentication_at`", async () => {
+  it("should handle undefined `requires_authentication_at`", async () => {
     // no expiration time available, e.g. auth flow hasn't completed yet
     try {
       await checkAuthExpiration(createFakeConnection(undefined));

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -133,6 +133,20 @@ describe("ConfluentCloudAuthProvider", () => {
     getCCloudConnectionStub.resolves(null);
     const deleteConnectionStub = sandbox.stub(connections, "deleteCCloudConnection").resolves();
 
+    authProvider["_session"] = null;
+    await authProvider.removeSession("sessionId");
+
+    assert.ok(deleteConnectionStub.notCalled);
+    assert.ok(handleSessionRemovedStub.notCalled);
+  });
+
+  it("removeSession() should only update the provider's internal state when no connection exists but the provider is still tracking a session internally", async () => {
+    const handleSessionRemovedStub = sandbox.stub().resolves();
+    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+    getCCloudConnectionStub.resolves(null);
+    const deleteConnectionStub = sandbox.stub(connections, "deleteCCloudConnection").resolves();
+
+    authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
     await authProvider.removeSession("sessionId");
 
     assert.ok(deleteConnectionStub.notCalled);

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -1,25 +1,216 @@
 import { chromium } from "@playwright/test";
 import * as assert from "assert";
+import * as sinon from "sinon";
 import * as vscode from "vscode";
+import {
+  TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+  TEST_CCLOUD_CONNECTION,
+  TEST_CCLOUD_USER,
+} from "../../tests/unit/testResources/connection";
 import { getExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
 import { Connection } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { getSidecar } from "../sidecar";
-import { createCCloudConnection, deleteCCloudConnection } from "../sidecar/connections";
-import { StorageManager } from "../storage";
+import * as connections from "../sidecar/connections";
+import { getStorageManager, StorageManager } from "../storage";
+import { AUTH_COMPLETED_KEY, AUTH_SESSION_EXISTS_KEY } from "../storage/constants";
 import { getUriHandler, UriEventHandler } from "../uriHandler";
+import { pollCCloudConnectionAuth } from "./ccloudPolling";
 import { ConfluentCloudAuthProvider, getAuthProvider } from "./ccloudProvider";
 
 const AUTH_CALLBACK_URI = vscode.Uri.parse("vscode://confluentinc.vscode-confluent/authCallback");
+
+const TEST_CCLOUD_AUTH_SESSION: vscode.AuthenticationSession = {
+  id: TEST_CCLOUD_CONNECTION.id!,
+  accessToken: TEST_CCLOUD_CONNECTION.id!,
+  account: {
+    id: TEST_CCLOUD_USER.id!,
+    label: TEST_CCLOUD_USER.username!,
+  },
+  scopes: [],
+};
 
 describe("ConfluentCloudAuthProvider", () => {
   let authProvider: ConfluentCloudAuthProvider;
   let uriHandler: UriEventHandler;
 
+  let sandbox: sinon.SinonSandbox;
+  // helper function stubs
+  let getCCloudConnectionStub: sinon.SinonStub;
+  let createCCloudConnectionStub: sinon.SinonStub;
+  // auth provider stubs
+  let browserAuthFlowStub: sinon.SinonStub;
+  let stubOnDidChangeSessions: sinon.SinonStubbedInstance<
+    vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>
+  >;
+
   before(async () => {
     await getExtensionContext();
-    authProvider = getAuthProvider();
+
     uriHandler = getUriHandler();
+  });
+
+  beforeEach(() => {
+    authProvider = getAuthProvider();
+
+    sandbox = sinon.createSandbox();
+    getCCloudConnectionStub = sandbox.stub(connections, "getCCloudConnection");
+    createCCloudConnectionStub = sandbox.stub(connections, "createCCloudConnection");
+
+    // don't handle the progress notification, openExternal, etc in this test suite
+    browserAuthFlowStub = sandbox.stub(authProvider, "browserAuthFlow").resolves();
+    stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);
+    authProvider["_onDidChangeSessions"] = stubOnDidChangeSessions;
+  });
+
+  afterEach(() => {
+    // reset the singleton instance between tests
+    ConfluentCloudAuthProvider["instance"] = null;
+    sandbox.restore();
+  });
+
+  it("createSession() should create a new CCloud connection when one doesn't exist", async () => {
+    // first call doesn't return a Connection, second call returns the connection from createCCloudConnection()
+    getCCloudConnectionStub.onFirstCall().resolves(null);
+    createCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+    getCCloudConnectionStub.onSecondCall().resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+
+    await authProvider.createSession();
+
+    assert.ok(createCCloudConnectionStub.called);
+    assert.ok(browserAuthFlowStub.called);
+  });
+
+  it("createSession() should reuse an existing CCloud connection", async () => {
+    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+
+    await authProvider.createSession();
+
+    assert.ok(createCCloudConnectionStub.notCalled);
+    assert.ok(browserAuthFlowStub.called);
+  });
+
+  it("getSessions() should treat connections with a NO_TOKEN/FAILED auth status as nonexistent", async () => {
+    getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+
+    const sessions = await authProvider.getSessions();
+
+    assert.deepStrictEqual(sessions, []);
+  });
+
+  it("getSessions() should return an empty array when no connection exists", async () => {
+    getCCloudConnectionStub.resolves(null);
+
+    const sessions = await authProvider.getSessions();
+
+    assert.deepStrictEqual(sessions, []);
+  });
+
+  it("getSessions() should return an AuthenticationSession when a valid connection exists", async () => {
+    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+
+    const sessions = await authProvider.getSessions();
+
+    assert.strictEqual(sessions.length, 1);
+    assert.deepStrictEqual(sessions[0], TEST_CCLOUD_AUTH_SESSION);
+  });
+
+  it("removeSession() should delete an existing connection", async () => {
+    const handleSessionRemovedStub = sandbox.stub().resolves();
+    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+    const deleteConnectionStub = sandbox.stub(connections, "deleteCCloudConnection").resolves();
+
+    await authProvider.removeSession("sessionId");
+
+    assert.ok(deleteConnectionStub.called);
+    assert.ok(handleSessionRemovedStub.calledWith(true));
+  });
+
+  it("removeSession() should only update the provider's internal state when no connection exists", async () => {
+    const handleSessionRemovedStub = sandbox.stub().resolves();
+    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+    getCCloudConnectionStub.resolves(null);
+    const deleteConnectionStub = sandbox.stub(connections, "deleteCCloudConnection").resolves();
+
+    await authProvider.removeSession("sessionId");
+
+    assert.ok(deleteConnectionStub.notCalled);
+    assert.ok(handleSessionRemovedStub.calledWith(true));
+  });
+
+  it("handleSessionCreated() should update the provider's internal state, fire the _onDidChangeSessions event, and adjust polling", async () => {
+    const storageManager = getStorageManager();
+    const setSecretStub = sandbox.stub(storageManager, "setSecret").resolves();
+    const pollStartStub = sandbox.stub(pollCCloudConnectionAuth, "start").resolves();
+    const pollStopStub = sandbox.stub(pollCCloudConnectionAuth, "stop").resolves();
+
+    await authProvider["handleSessionCreated"](TEST_CCLOUD_AUTH_SESSION, true);
+
+    assert.strictEqual(authProvider["_session"], TEST_CCLOUD_AUTH_SESSION);
+    assert.ok(setSecretStub.calledWith(AUTH_SESSION_EXISTS_KEY, "true"));
+    assert.ok(stubOnDidChangeSessions.fire.called);
+    assert.ok(
+      stubOnDidChangeSessions.fire.calledWith({
+        added: [TEST_CCLOUD_AUTH_SESSION],
+        removed: [],
+        changed: [],
+      }),
+    );
+    assert.ok(pollStartStub.called);
+    assert.ok(pollStopStub.notCalled);
+  });
+
+  it("handleSessionRemoved() should update the provider's internal state, fire the _onDidChangeSessions event, and adjust polling", async () => {
+    const storageManager = getStorageManager();
+    const deleteSecretStub = sandbox.stub(storageManager, "deleteSecret").resolves();
+    const pollStartStub = sandbox.stub(pollCCloudConnectionAuth, "start").resolves();
+    const pollStopStub = sandbox.stub(pollCCloudConnectionAuth, "stop").resolves();
+
+    authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
+    await authProvider["handleSessionRemoved"](true);
+
+    assert.strictEqual(authProvider["_session"], null);
+    assert.ok(deleteSecretStub.calledWith(AUTH_SESSION_EXISTS_KEY));
+    assert.ok(deleteSecretStub.calledWith(AUTH_COMPLETED_KEY));
+    assert.ok(stubOnDidChangeSessions.fire.called);
+    assert.ok(
+      stubOnDidChangeSessions.fire.calledWith({
+        added: [],
+        removed: [TEST_CCLOUD_AUTH_SESSION],
+        changed: [],
+      }),
+    );
+    assert.ok(pollStartStub.notCalled);
+    assert.ok(pollStopStub.called);
+  });
+
+  it("handleSessionSecretChange() should call handleSessionCreated() when a session is available", async () => {
+    const handleSessionCreatedStub = sandbox.stub().resolves();
+    authProvider["handleSessionCreated"] = handleSessionCreatedStub;
+    const handleSessionRemovedStub = sandbox.stub().resolves();
+    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+    sandbox.stub(vscode.authentication, "getSession").resolves(TEST_CCLOUD_AUTH_SESSION);
+
+    await authProvider["handleSessionSecretChange"]();
+
+    assert.ok(handleSessionCreatedStub.calledOnceWith(TEST_CCLOUD_AUTH_SESSION));
+    assert.ok(handleSessionRemovedStub.notCalled);
+  });
+
+  it("handleSessionSecretChange() should call handleSessionRemoved() when no session is available", async () => {
+    const handleSessionCreatedStub = sandbox.stub().resolves();
+    authProvider["handleSessionCreated"] = handleSessionCreatedStub;
+    const handleSessionRemovedStub = sandbox.stub().resolves();
+    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+
+    sandbox.stub(vscode.authentication, "getSession").resolves(undefined);
+
+    authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
+    await authProvider["handleSessionSecretChange"]();
+
+    assert.ok(handleSessionCreatedStub.notCalled);
+    assert.ok(handleSessionRemovedStub.called);
   });
 
   it("should reject the waitForUriHandling promise when the URI query contains 'success=false'", async () => {
@@ -55,7 +246,7 @@ describe("CCloud auth flow", () => {
   beforeEach(async () => {
     await storageManager.clearWorkspaceState();
     // make sure we don't have a lingering CCloud connection from other tests
-    await deleteCCloudConnection();
+    await connections.deleteCCloudConnection();
   });
 
   it("should successfully authenticate via CCloud with the sign_in_uri", async function () {
@@ -68,7 +259,7 @@ describe("CCloud auth flow", () => {
     // NOTE: can't be used with an arrow-function because it needs to be able to access `this`
     this.slow(10000); // mark this test as slow if it takes longer than 10s
     this.retries(2); // retry this test up to 2 times if it fails
-    const newConnection: Connection = await createCCloudConnection();
+    const newConnection: Connection = await connections.createCCloudConnection();
     await testAuthFlow(newConnection.metadata.sign_in_uri!);
     // make sure the newly-created connection is available via the sidecar
     const client = (await getSidecar()).getConnectionsResourceApi();

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -364,6 +364,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       async () => {
         logger.debug("ccloudAuthSessionInvalidated event fired");
         // don't delete the actual CCloud connection, just remove it from the authentication provider
+        // so we can continue to use the same sign_in_uri until the user explicitly signs out
         await this.handleSessionRemoved(true);
         ccloudConnected.fire(false);
       },

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -462,7 +462,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     await clearCurrentCCloudResources();
     pollCCloudConnectionAuth.stop();
     if (!this._session) {
-      logger.error("handleSessionRemoved(): no cached `_session` to remove; this shouldn't happen");
+      logger.debug("handleSessionRemoved(): no cached `_session` to remove; this shouldn't happen");
     } else {
       this._onDidChangeSessions.fire({
         added: [],

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -378,9 +378,6 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
   private waitForCancellationRequest(token: vscode.CancellationToken): Promise<void> {
     return new Promise<void>((_, reject) =>
       token.onCancellationRequested(async () => {
-        // TODO(shoup): remove this once we're managing a persistent connection and transitioning
-        // between NO_TOKEN->VALID_TOKEN->NO_TOKEN instead of creating/deleting connections
-        await deleteCCloudConnection();
         reject();
       }),
     );

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,60 @@
+import * as Sentry from "@sentry/node";
+
+import { ResponseError as DockerResponseError } from "./clients/docker";
+import { ResponseError as KafkaResponseError } from "./clients/kafkaRest";
+import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRegistryRest";
+import { ResponseError as SidecarResponseError } from "./clients/sidecar";
+import { Logger } from "./logging";
+
+const logger = new Logger("errors");
+
 /** Thrown when attempting to get the ExtensionContext before extension activation. */
 export class ExtensionContextNotSetError extends Error {
   constructor(source: string, message: string = "ExtensionContext not set yet") {
     super(`${source}: ${message}`);
+  }
+}
+
+/** Combined ResponseError type from our OpenAPI spec generated client code. */
+type ResponseError =
+  | SidecarResponseError
+  | KafkaResponseError
+  | SchemaRegistryResponseError
+  | DockerResponseError;
+
+/** Log the possibly-ResponseError and any additional information, and optionally send to Sentry. */
+export async function logResponseError(
+  e: unknown,
+  message: string,
+  extra: Record<string, string>,
+  sendTelemetry: boolean = false,
+): Promise<void> {
+  let errorMessage: string = "";
+  let errorContext: Record<string, string | number | boolean | null | undefined> = {};
+  let responseStatusCode: number | undefined;
+
+  if ((e as any).response) {
+    // one of our ResponseError types, attempt to extract more information before logging
+    const error = e as ResponseError;
+    const errorBody = await error.response.clone().text();
+    errorMessage = `[${message}] error response:`;
+    errorContext = {
+      status: error.response.status,
+      statusText: error.response.statusText,
+      body: errorBody.slice(0, 5000), // limit to 5000 characters
+      errorType: error.constructor.name,
+    };
+    responseStatusCode = error.response.status;
+  } else {
+    // something we caught that wasn't actually a ResponseError type but was passed in here anyway
+    errorMessage = `[${message}] error:`;
+  }
+
+  logger.error(errorMessage, { ...errorContext, ...extra });
+  if (sendTelemetry) {
+    Sentry.captureException(e, {
+      contexts: { response: { status_code: responseStatusCode } },
+      extra: { ...errorContext, ...extra },
+    });
   }
 }

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -23,6 +23,7 @@ import {
 import { MANAGED_CONTAINER_LABEL } from "../docker/constants";
 import { getContainersForImage } from "../docker/containers";
 import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
+import { logResponseError } from "../errors";
 import { Logger } from "../logging";
 import { getResourceManager } from "../storage/resourceManager";
 
@@ -35,20 +36,11 @@ export async function tryToGetConnection(id: string): Promise<Connection | null>
   try {
     connection = await client.gatewayV1ConnectionsIdGet({ id: id });
   } catch (error) {
-    if (error instanceof ResponseError) {
-      if (error.response.status === 404) {
-        logger.debug("No connection found", { connectionId: id });
-      } else {
-        logger.error("Error response fetching existing connection:", {
-          status: error.response.status,
-          statusText: error.response.statusText,
-          body: JSON.stringify(error.response.body),
-          connectionId: id,
-        });
-      }
+    if (error instanceof ResponseError && error.response.status === 404) {
+      logger.debug("No connection found", { connectionId: id });
     } else {
       // only log the non-404 errors, since we expect a 404 if the connection doesn't exist
-      logger.error("Error fetching connection", { error, connectionId: id });
+      logResponseError(error, "fetching connection", { connectionId: id }, true);
     }
   }
   return connection;
@@ -75,7 +67,7 @@ export async function tryToCreateConnection(spec: ConnectionSpec): Promise<Conne
     logger.debug("created new connection:", { type: spec.type });
     return connection;
   } catch (error) {
-    logger.error("create connection error:", error);
+    logResponseError(error, "creating connection", { connectionId: spec.id! }, true);
     throw error;
   }
 }
@@ -101,7 +93,7 @@ export async function tryToDeleteConnection(id: string): Promise<void> {
       logger.debug("no connection found to delete:", { id });
       return;
     }
-    logger.error("delete connection error:", error);
+    logResponseError(error, "deleting connection", { connectionId: id }, true);
     throw error;
   }
 }

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -102,7 +102,7 @@ export class IntervalPoller {
    * Will not take any action if the poller is already running at the fast frequency.
    */
   public useFastFrequency() {
-    logger.debug(`${this.name}: using fast frequency polling interval`, {
+    logger.trace(`${this.name}: using fast frequency polling interval`, {
       fastFrequency: `${this.fastFrequency}ms`,
       slowFrequency: `${this.slowFrequency}ms`,
     });
@@ -116,7 +116,7 @@ export class IntervalPoller {
    * Will not take any action if the poller is already running at the slow frequency.
    */
   public useSlowFrequency() {
-    logger.debug(`${this.name}: using slow frequency polling interval`, {
+    logger.trace(`${this.name}: using slow frequency polling interval`, {
       fastFrequency: `${this.fastFrequency}ms`,
       slowFrequency: `${this.slowFrequency}ms`,
     });

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -8,7 +8,7 @@ import {
 import { SIDECAR_PORT } from "../../../src/sidecar/constants";
 import { TEST_CCLOUD_ORGANIZATION } from "./organization";
 
-const TEST_CCLOUD_USER: UserInfo = {
+export const TEST_CCLOUD_USER: UserInfo = {
   id: "test-user-id",
   username: "test-user",
   first_name: "Test",
@@ -18,12 +18,14 @@ const TEST_CCLOUD_USER: UserInfo = {
 };
 const TEST_AUTH_EXPIRATION = new Date(Date.now() + 4 * 60 * 60 * 1000);
 
+/** A basic CCloud {@link Connection} with `NO_TOKEN` auth status. */
 export const TEST_CCLOUD_CONNECTION: Connection = {
   api_version: "gateway/v1",
   kind: "Connection",
   id: CCLOUD_CONNECTION_ID,
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${CCLOUD_CONNECTION_ID}`,
+    sign_in_uri: `http://login.confluent.io/login?...`,
   },
   spec: {
     ...CCLOUD_CONNECTION_SPEC,
@@ -39,6 +41,7 @@ export const TEST_CCLOUD_CONNECTION: Connection = {
   },
 };
 
+/** A CCloud {@link Connection} with `VALID_TOKEN` auth status and user info. */
 export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = {
   ...TEST_CCLOUD_CONNECTION,
   status: {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #565 and #500.

This PR fixes two fairly big issues with CCloud authentication/connection management:
- When we get `errors` from a non-`INVALID_TOKEN` status, we weren't invalidating the (VS Code) auth session. This meant all of the sidebar content would persist and appear to the user that they could still interact with their CCloud resources, when that really wasn't the case. ([see fix](https://github.com/confluentinc/vscode/pull/566#discussion_r1835184182))
- The error notification that appeared from an auth-errors scenario would show a "Log in to Confluent Cloud" button that made a call to our auth provider, but it wouldn't actually open the browser due to a flaw in the provider's `getSessions()` logic:
  - When the button is clicked (and `authentication.getSession(AUTH_PROVIDER_ID, [], { createIfNone: true })` is called), it goes through the provider's `getSessions()` method, where the sidecar says we have a connection (no matter what auth status). Our auth provider considered it usable as a VS Code authentication session and therefore never made it to `createSession()` and never opened the browser tab. ([see fix](https://github.com/confluentinc/vscode/pull/566#discussion_r1835184269))
    - Due to connections with `NO_TOKEN`/`FAILED` auth status being accepted, when we converted the connection to a VS Code auth session, we would fall back to using the `unk username` values.

Also fixes a few minor issues:
- We no longer save the auth status (`VALID_TOKEN`, `FAILED`, etc) as the VS Code authentication session's `accessToken`, which means we should no longer see the "Grant access to _____" notifications in the Accounts menu anymore. This is because the session will either exist, or it won't; there will be no same-session-different-token mismatching to confuse VS Code.
- `ccloudAuthSessionInvalidated` no longer tells the auth provider to delete the CCloud connection entirely; that was leftover from before we had the `FAILED` auth status as a means of "resetting" the connection. Instead, it just removes the session from the auth provider's internal tracking, which primarily just prompts the user to sign in again.
- The ordering of the auth poller's check for expiration and errors is now flipped, so expired CCloud auth will float the notification and exit earlier and not show double "Confluent Cloud authentication expired at ____" + "Error authenticating with Confluent Cloud." notifications

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

I've introduced a new `logResponseError()` helper function to capture a lot of the `if (error instanceof ResponseError)` logging dance we've done in a number of other places, because we were seeing response errors during connection creation/deletion while debugging the primary issues mentioned above earlier today. I plan on making some follow-on PRs to use it more and reduce some boilerplate code while increasing our visibility in error cases (if the user has telemetry enabled).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
