### PR TITLE
improve notifications when Docker is unreachable

### DIFF
--- a/src/commands/docker.test.ts
+++ b/src/commands/docker.test.ts
@@ -1,6 +1,5 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import { window } from "vscode";
 import * as dockerConfigs from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import * as dockerWorkflows from "../docker/workflows";
@@ -11,9 +10,6 @@ import { runWorkflowWithProgress } from "./docker";
 
 describe("commands/docker.ts runWorkflowWithProgress()", () => {
   let sandbox: sinon.SinonSandbox;
-
-  // vscode stubs
-  let showErrorMessageStub: sinon.SinonStub;
 
   // Docker+workflow stubs
   let isDockerAvailableStub: sinon.SinonStub;
@@ -27,8 +23,6 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-
-    showErrorMessageStub = sandbox.stub(window, "showErrorMessage").resolves();
 
     // default to Docker being available for majority of tests
     isDockerAvailableStub = sandbox.stub(dockerConfigs, "isDockerAvailable").resolves(true);
@@ -55,12 +49,11 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
     sandbox.restore();
   });
 
-  it("should show a basic error notification if Docker is not available", async () => {
+  it("should exit early if Docker is not available", async () => {
     isDockerAvailableStub.resolves(false);
 
     await runWorkflowWithProgress();
 
-    assert.ok(showErrorMessageStub.calledOnce);
     assert.ok(localResourcesQuickPickStub.notCalled);
     assert.ok(getKafkaWorkflowStub.notCalled);
     assert.ok(getSchemaRegistryWorkflowStub.notCalled);

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -1,13 +1,5 @@
 import * as Sentry from "@sentry/node";
-import {
-  CancellationToken,
-  commands,
-  Disposable,
-  env,
-  ProgressLocation,
-  Uri,
-  window,
-} from "vscode";
+import { CancellationToken, Disposable, ProgressLocation, window } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ResponseError } from "../clients/docker";
 import { isDockerAvailable } from "../docker/configs";
@@ -39,24 +31,8 @@ export async function runWorkflowWithProgress(
   start: boolean = true,
   resourceKinds: LocalResourceKind[] = [],
 ) {
-  const dockerAvailable = await isDockerAvailable();
+  const dockerAvailable = await isDockerAvailable(true);
   if (!dockerAvailable) {
-    const installLinkButton = "Install Docker";
-    const openLogsButton = "Open Logs";
-    window
-      .showErrorMessage(
-        "Unable to launch local resources because Docker is not available. Please install Docker and try again once it's running.",
-        installLinkButton,
-        openLogsButton,
-      )
-      .then((selection) => {
-        if (selection === installLinkButton) {
-          const uri = Uri.parse("https://docs.docker.com/engine/install/");
-          env.openExternal(uri);
-        } else if (selection === openLogsButton) {
-          commands.executeCommand("confluent.showOutputChannel");
-        }
-      });
     return;
   }
 

--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -2,16 +2,21 @@ import * as assert from "assert";
 import { normalize } from "path";
 import sinon from "sinon";
 import { Agent, RequestInit as UndiciRequestInit } from "undici";
-import { workspace } from "vscode";
-import { SystemApi } from "../clients/docker";
+import { window, workspace } from "vscode";
+import { ResponseError, SystemApi } from "../clients/docker";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
 import * as configs from "./configs";
 
 describe("docker/configs functions", function () {
   let sandbox: sinon.SinonSandbox;
 
+  // vscode stubs
+  let showErrorMessageStub: sinon.SinonStub;
+
   beforeEach(function () {
     sandbox = sinon.createSandbox();
+
+    showErrorMessageStub = sandbox.stub(window, "showErrorMessage").resolves();
   });
 
   afterEach(function () {
@@ -64,6 +69,7 @@ describe("docker/configs functions", function () {
 
     assert.strictEqual(result, true);
     assert.ok(systemPingStub.calledOnce);
+    assert.ok(showErrorMessageStub.notCalled);
   });
 
   it("isDockerAvailable() should return false when Docker is not available", async function () {
@@ -75,5 +81,44 @@ describe("docker/configs functions", function () {
 
     assert.strictEqual(result, false);
     assert.ok(systemPingStub.calledOnce);
+  });
+
+  it("isDockerAvailable() should show a notification if `showNotification` is set to true and Docker is not available", async function () {
+    const systemPingStub = sandbox
+      .stub(SystemApi.prototype, "systemPing")
+      .rejects(new Error("Docker not available"));
+
+    await configs.isDockerAvailable(true);
+
+    assert.ok(systemPingStub.calledOnce);
+    assert.ok(showErrorMessageStub.calledOnce);
+  });
+
+  it("showDockerUnavailableErrorNotification() should show ResponseError content in the error notification", async () => {
+    const error = new ResponseError(new Response("uh oh", { status: 400 }));
+
+    await configs.showDockerUnavailableErrorNotification(error);
+
+    assert.ok(
+      showErrorMessageStub.calledOnceWith(
+        "Docker is not available: Error 400: uh oh",
+        "Show Logs",
+        "File Issue",
+      ),
+    );
+  });
+
+  it("showDockerUnavailableErrorNotification() should show a canned response when dealing with non-ResponseErrors", async () => {
+    const error = new Error("connect ENOENT /var/run/docker.sock");
+
+    await configs.showDockerUnavailableErrorNotification(error);
+
+    assert.ok(
+      showErrorMessageStub.calledOnceWith(
+        "Docker is not available: Please install Docker and try again once it's running.",
+        "Install Docker",
+        "Show Logs",
+      ),
+    );
   });
 });

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -89,6 +89,10 @@ export function defaultRequestInit(): RequestInit {
 /**
  * Check if Docker is available by attempting to ping the API.
  * @see https://docs.docker.com/reference/api/engine/version/v1.47/#tag/System/operation/SystemPing
+ *
+ * If `showNotification` is true, a notification will be shown to the user with hints on how to
+ * resolve the issue. Callers should **not** set this to `true` if the function is called from a
+ * background process or a non-interactive command.
  */
 export async function isDockerAvailable(showNotification: boolean = false): Promise<boolean> {
   const client = new SystemApi();
@@ -98,7 +102,7 @@ export async function isDockerAvailable(showNotification: boolean = false): Prom
     logger.debug("docker ping response:", resp);
     return true;
   } catch (error) {
-    logResponseError(error, "docker ping", {});
+    logResponseError(error, "docker ping");
     if (showNotification) {
       await showDockerUnavailableErrorNotification(error);
     }

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -1,7 +1,8 @@
 import { normalize } from "path";
 import { Agent, RequestInit as UndiciRequestInit } from "undici";
-import { workspace, WorkspaceConfiguration } from "vscode";
+import { commands, env, Uri, window, workspace, WorkspaceConfiguration } from "vscode";
 import { ResponseError, SystemApi } from "../clients/docker";
+import { logResponseError } from "../errors";
 import { Logger } from "../logging";
 import {
   LOCAL_DOCKER_SOCKET_PATH,
@@ -89,25 +90,67 @@ export function defaultRequestInit(): RequestInit {
  * Check if Docker is available by attempting to ping the API.
  * @see https://docs.docker.com/reference/api/engine/version/v1.47/#tag/System/operation/SystemPing
  */
-export async function isDockerAvailable(): Promise<boolean> {
+export async function isDockerAvailable(showNotification: boolean = false): Promise<boolean> {
   const client = new SystemApi();
   const init: RequestInit = defaultRequestInit();
   try {
-    const resp = await client.systemPing(init);
+    const resp: string = await client.systemPing(init);
     logger.debug("docker ping response:", resp);
     return true;
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("docker ping error response:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        data: await error.response.clone().text(),
-      });
-    } else if (error instanceof Error) {
-      logger.debug("can't ping docker:", {
-        error: error.message,
-      });
+    logResponseError(error, "docker ping", {});
+    if (showNotification) {
+      await showDockerUnavailableErrorNotification(error);
     }
   }
   return false;
+}
+
+/** Show a notification after getting an error while attempting to ping the Docker engine API. */
+export async function showDockerUnavailableErrorNotification(error: unknown): Promise<void> {
+  let notificationMessage: string = "";
+
+  // buttons to show in the notification; if left as empty strings, they won't appear at all
+  let primaryButton: string = "";
+  let secondaryButton: string = "";
+
+  if (error instanceof ResponseError) {
+    let errorMessage: string;
+    try {
+      // e.g. {"message":"client version 1.47 is too new. Maximum supported API version is 1.43"}
+      errorMessage = (await error.response.clone().json()).message;
+    } catch {
+      errorMessage = await error.response.clone().text();
+    }
+    primaryButton = "Show Logs";
+    secondaryButton = "File Issue";
+    notificationMessage = `Error ${error.response.status}: ${errorMessage}`;
+  } else {
+    // likely FetchError->TypeError: connect ENOENT <socket path> but not a lot else we can do here
+    primaryButton = "Install Docker";
+    secondaryButton = "Show Logs";
+    notificationMessage = "Please install Docker and try again once it's running.";
+  }
+
+  window
+    .showErrorMessage(
+      "Docker is not available: " + notificationMessage,
+      primaryButton,
+      secondaryButton,
+    )
+    .then((selection) => {
+      switch (selection) {
+        case "Install Docker": {
+          const uri = Uri.parse("https://docs.docker.com/engine/install/");
+          env.openExternal(uri);
+          break;
+        }
+        case "Show Logs":
+          commands.executeCommand("confluent.showOutputChannel");
+          break;
+        case "File Issue":
+          commands.executeCommand("confluent.support.issue");
+          break;
+      }
+    });
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,7 +26,7 @@ type ResponseError =
 export async function logResponseError(
   e: unknown,
   message: string,
-  extra: Record<string, string>,
+  extra: Record<string, string> = {},
   sendTelemetry: boolean = false,
 ): Promise<void> {
   let errorMessage: string = "";


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #546.

Mainly adjusts where we show the error notification so it can be invoked from `isDockerAvailable()` instead of as a follow-on call, so we can choose whether or not to inform the user about a specific response error (e.g. not meeting the minimum Docker engine API version) or a non-`ResponseError` type.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
