### PR TITLE
[v0.21.x] remove Start/Restart notification for existing Docker containers

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -82,7 +82,6 @@ export async function runWorkflowWithProgress(
         token.onCancellationRequested(() => {
           logger.debug("cancellation requested, exiting workflow early", {
             start,
-            workflow: workflow.constructor.name,
             resourceKind: workflow.resourceKind,
           });
           workflow.sendTelemetryEvent("Notification Button Clicked", {
@@ -93,7 +92,7 @@ export async function runWorkflowWithProgress(
           // early returns handled within each workflow depending on how far it got
         });
 
-        logger.debug(`running ${workflow.constructor.name} workflow`, { start });
+        logger.debug(`running ${workflow.resourceKind} workflow`, { start });
         workflow.sendTelemetryEvent("Workflow Initiated", {
           start,
         });
@@ -103,12 +102,12 @@ export async function runWorkflowWithProgress(
           } else {
             await workflow.stop(token, progress);
           }
-          logger.debug(`finished ${workflow.constructor.name} workflow`, { start });
+          logger.debug(`finished ${workflow.resourceKind} workflow`, { start });
           workflow.sendTelemetryEvent("Workflow Finished", {
             start,
           });
         } catch (error) {
-          logger.error(`error running ${workflow.constructor.name} workflow`, error);
+          logger.error(`error running ${workflow.resourceKind} workflow`, error);
           if (error instanceof Error) {
             workflow.sendTelemetryEvent("Workflow Errored", {
               start,
@@ -118,7 +117,6 @@ export async function runWorkflowWithProgress(
                 dockerImage: workflow.imageRepoTag,
                 extensionUserFlow: "Local Resource Management",
                 localResourceKind: workflow.resourceKind,
-                localResourceWorkflow: workflow.constructor.name,
               },
             });
             let errorMsg: string = "";

--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -236,7 +236,15 @@ export class EventListener {
         break;
       }
 
-      yield valueString;
+      // we may get multiple events in a single string, so split them up and handle each one
+      const valueStrings = valueString.trim().split("\n");
+      for (const smallerValueString of valueStrings) {
+        if (!smallerValueString) {
+          // skip empty strings
+          continue;
+        }
+        yield smallerValueString;
+      }
     }
   }
 

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, commands, Progress, window } from "vscode";
+import { CancellationToken, commands, Progress, ProgressLocation, window } from "vscode";
 import { ContainerInspectResponse, ContainerSummary, ResponseError } from "../../clients/docker";
 import { Logger } from "../../logging";
 import { getTelemetryLogger } from "../../telemetry/telemetryLogger";
@@ -181,35 +181,69 @@ export abstract class LocalResourceWorkflow {
 
   /**
    * Handle when a workflow detects existing containers based on its image repo+tag by checking the
-   * container states and prompting the user to take action.
+   * container states and auto-(re)starting them. This acts as a mini-workflow within the main one
+   * by showing a progress notification while the containers are started/restarted.
    */
   async handleExistingContainers(containers: ContainerSummary[]) {
+    const plural = containers.length > 1 ? "s" : "";
     const containerNames: string[] = containers.map(
       (container) => container.Names?.join(", ") || "unknown",
     );
     const containerImages: string[] = containers.map((container) => container.Image || "unknown");
     const containerStates: string[] = containers.map((container) => container.State || "unknown");
-    this.logger.debug(`found ${containers.length} existing container(s)`, {
+    this.logger.debug(`found ${containers.length} existing container${plural}`, {
       states: containerStates,
       names: containerNames,
       images: containerImages,
     });
-    for (const container of containers) {
-      if (!(container.Id && container.Names)) {
-        // ID & Names not required by the OpenAPI spec, but very unlikely to be missing if we have the container
-        // https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerList
-        this.logger.warn("missing container ID or name; can't start/restart container", {
-          container,
+
+    const anyRunning: boolean = containers.some((container) => container.State === "running");
+    window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Local",
+        cancellable: true,
+      },
+      async (progress, token: CancellationToken) => {
+        token.onCancellationRequested(() => {
+          this.logger.debug("cancellation requested, exiting workflow early");
+          this.sendTelemetryEvent("Notification Button Clicked", {
+            buttonLabel: "Cancel",
+            notificationType: "progress",
+            purpose: `Existing ${this.resourceKind} Containers Detected`,
+          });
         });
-        continue;
-      }
-      // if any are in RUNNING state, auto-restart, otherwise auto-start
-      if (container.State === "running") {
-        await restartContainer(container.Id);
-      } else {
-        await this.startContainer({ id: container.Id, name: container.Names[0] });
-      }
-    }
+
+        this.progress = progress;
+        const actionLabel = anyRunning ? "Restarting..." : "Starting...";
+        this.logAndUpdateProgress(
+          `Found ${containers.length} existing ${this.resourceKind} container${plural}. ${actionLabel}`,
+        );
+
+        for (const container of containers) {
+          if (!(container.Id && container.Names)) {
+            // ID & Names not required by the OpenAPI spec, but very unlikely to be missing if we have the container
+            // https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerList
+            this.logger.warn("missing container ID or name; can't start/restart container", {
+              container,
+            });
+            continue;
+          }
+          // if any are in RUNNING state, auto-restart, otherwise auto-start
+          if (container.State === "running") {
+            await restartContainer(container.Id);
+          } else {
+            await this.startContainer({ id: container.Id, name: container.Names[0] });
+          }
+        }
+
+        this.logAndUpdateProgress(
+          `Waiting for ${this.resourceKind} container${plural} to be ready...`,
+        );
+        // resolve and close this progress notification once the workflow gives the all-clear
+        await this.waitForLocalResourceEventChange();
+      },
+    );
   }
 
   /** Log a message and display it in the user-facing progress notification for this workflow. */

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -251,7 +251,6 @@ export abstract class LocalResourceWorkflow {
       dockerImage: this.imageRepoTag,
       extensionUserFlow: "Local Resource Management",
       localResourceKind: this.resourceKind,
-      localResourceWorkflow: this.constructor.name,
       ...properties,
     });
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR smooths out the UX when attempting to start local resources and existing containers (matching the configured image repo+tag) are found. This previously showed an error notification to the effect of `Existing [Kafka|Schema Registry] container(s) found. Please (re)start or remove it/them and try again`, and only afforded the user a button the Start/Restart them or leave VS Code to handle the existing containers.

Now, we automatically start the container(s) (or restart if any are already showing a `running` state) and bypass the notification(s) and need for user interaction at all.


https://github.com/user-attachments/assets/f1f83088-b5bd-47c8-9a2e-d4e6fbb9c304



## Any additional details or context that should be provided?

One lingering complaint I had with this start/restart flow was it was hard to know what exactly was happening since the tree view progress indicator didn't provide additional text -- ("what's loading? are we waiting on Kafka, or Schema Registry, or both? something else?") -- so I decided to wrap this in a progress notification to take over the main workflow's progress-notification updating, which then resolves the same way the main workflows do (by waiting for the associated resource's event emitter(s) to fire).

Once that was done, it became more apparent that some events being handled by the system event listener [were not JSON parseable](https://github.com/confluentinc/vscode/blob/main/src/docker/eventListener.ts#L167-L174) -- turns out that was because we were getting multiple events at once and we weren't splitting them out properly:
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/8a83e9dc-4cab-44bd-a7cb-922dbb75ca2a">

This is now fixed in https://github.com/confluentinc/vscode/pull/586/commits/fd9e18f6e3a8fdabab636d6e924c885e8144a13c

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
