### PR TITLE
introduce `ObservabilityContext`

### DIFF
--- a/src/authn/ccloudPolling.ts
+++ b/src/authn/ccloudPolling.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { AuthErrors, Connection, Status } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
+import { observabilityContext } from "../context/observability";
 import { ccloudAuthSessionInvalidated, nonInvalidTokenStatus } from "../emitters";
 import { Logger } from "../logging";
 import { getCCloudAuthSession, getCCloudConnection } from "../sidecar/connections";
@@ -76,6 +77,8 @@ export async function watchCCloudConnectionStatus(): Promise<void> {
   });
 
   const authStatus: Status = connection.status.authentication.status;
+  observabilityContext.ccloudAuthLastSeenStatus = authStatus;
+
   await getResourceManager().setCCloudAuthStatus(authStatus);
   if (authStatus === "INVALID_TOKEN") {
     // poll faster to try and get to a non-transient status as quickly as possible since it's going

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
+import { observabilityContext } from "../context/observability";
 
 const FEEDBACK_URI = vscode.Uri.parse("https://www.surveymonkey.com/r/NYVKQD6");
 
@@ -14,8 +15,26 @@ function feedbackCommand() {
   vscode.env.openExternal(FEEDBACK_URI);
 }
 
+/**
+ * Wrapper function for the built-in `openIssueReporter` command, which pre-fills the extension ID
+ * and adds an expanded section for our extension data based on the current {@link observabilityContext}
+ */
 function issueCommand() {
-  vscode.commands.executeCommand("vscode.openIssueReporter", "confluentinc.vscode-confluent");
+  const extensionMarkdown = `
+<details open="true">
+<summary>Confluent Extension + Sidecar Data</summary>
+
+${observabilityContext.toMarkdownTable()}
+
+</details>
+`;
+
+  vscode.commands.executeCommand("vscode.openIssueReporter", {
+    extensionId: "confluentinc.vscode-confluent",
+    // issueTitle: "Issue title",
+    // issueBody: "Issue body",
+    extensionData: extensionMarkdown,
+  });
 }
 
 function openSettings() {

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -20,14 +20,20 @@ function feedbackCommand() {
  * and adds an expanded section for our extension data based on the current {@link observabilityContext}
  */
 function issueCommand() {
-  const extensionMarkdown = `
-<details open="true">
+  let extensionMarkdown = "";
+
+  const contextTable = observabilityContext.toMarkdownTable();
+  if (contextTable) {
+    // if we get a non-empty string, add it as a new collapsible section
+    extensionMarkdown = `
+<details>
 <summary>Confluent Extension + Sidecar Data</summary>
 
-${observabilityContext.toMarkdownTable()}
+${contextTable}
 
 </details>
 `;
+  }
 
   vscode.commands.executeCommand("vscode.openIssueReporter", {
     extensionId: "confluentinc.vscode-confluent",

--- a/src/context/observability.test.ts
+++ b/src/context/observability.test.ts
@@ -1,0 +1,16 @@
+import * as assert from "assert";
+import { version } from "ide-sidecar";
+import { observabilityContext } from "./observability";
+
+describe("ObservabilityContext", () => {
+  it("should convert to markdown table correctly", async () => {
+    const table = observabilityContext.toMarkdownTable();
+    // only check the first few rows of the table since the rest will be adjusted as needed
+    const expectedTableHead = `| Key | Value |
+| --- | --- |
+| extensionVersion | "" |
+| extensionActivated | false |
+| sidecarVersion | "${version}" |`;
+    assert.ok(table.startsWith(expectedTableHead));
+  });
+});

--- a/src/context/observability.ts
+++ b/src/context/observability.ts
@@ -1,8 +1,19 @@
 import { version } from "ide-sidecar";
+import { Status } from "../clients/sidecar";
 /**
  * Per-extension-instance singleton object for storing basic data to help debug issues, errors, etc.
  * This is created fresh each time the extension is activated, and will grow throughout the course
  * of the extension's lifecycle as actions are taken by the user.
+ *
+ * This class is intended to be used as a singleton, and should be created once and then updated
+ * as needed throughout the extension's lifecycle. Treat all properties as scoped to the lifetime of
+ * this extension instance.
+ *
+ * When dealing with "internal" properties, it is recommended to prefix them with an underscore to
+ * indicate that they are not intended to be exported to other formats (e.g. markdown table) but can
+ * still be accessed within the codebase as a `public` property. (Example: `_uniqueTopicNames` as an
+ * array of unique topic names that we _do not_ want to display in a markdown table, but may use
+ * to calculate a `topicCount` property based on `_uniqueTopicNames` that _is_ displayed in a table.)
  */
 class ObservabilityContext {
   constructor(
@@ -10,22 +21,38 @@ class ObservabilityContext {
     public extensionVersion: string = "",
     /** Whether or not the extension activated successfully. */
     public extensionActivated: boolean = false,
+
     /** The version of the sidecar process associated with this extension instance. */
     public sidecarVersion: string = version,
     /** How many times the extension started the sidecar. Anything over one will indicate restarts were required. */
     public sidecarStartCount: number = 0,
+
     /** Did the user successfully sign in to Confluent Cloud? */
     public ccloudAuthCompleted: boolean = false,
+    /** The expiration date of the Confluent Cloud auth session. */
+    public ccloudAuthExpiration: Date | undefined = undefined,
+    /** The last auth status seen for the Confluent Cloud auth session. */
+    public ccloudAuthLastSeenStatus: Status | undefined = undefined,
+    /** How many times the user signed in to Confluent Cloud. */
+    public ccloudSignInCount: number = 0,
+    /** How many times the user signed out of Confluent Cloud. */
+    public ccloudSignOutCount: number = 0,
   ) {}
 
   /** Converts the current state of the {@link ObservabilityContext} to a markdown table string. */
   toMarkdownTable(): string {
-    const keys = Object.keys(this);
+    // filter any "internal" properties from the keys
+    const keys = Object.keys(this).filter((key) => !key.startsWith("_"));
+
     // stringify all values so they can be displayed in the table
-    const values = Object.values(this).map((value) => JSON.stringify(value));
+    const values = keys.map((key) => {
+      return JSON.stringify((this as any)[key]);
+    });
+
     if (keys.length === 0) {
       return "";
     }
+
     const table = [
       "| Key | Value |",
       "| --- | --- |",

--- a/src/context/observability.ts
+++ b/src/context/observability.ts
@@ -1,0 +1,39 @@
+import { version } from "ide-sidecar";
+/**
+ * Per-extension-instance singleton object for storing basic data to help debug issues, errors, etc.
+ * This is created fresh each time the extension is activated, and will grow throughout the course
+ * of the extension's lifecycle as actions are taken by the user.
+ */
+class ObservabilityContext {
+  constructor(
+    /** The version of the activated extension instance, from `package.json`. */
+    public extensionVersion: string = "",
+    /** Whether or not the extension activated successfully. */
+    public extensionActivated: boolean = false,
+    /** The version of the sidecar process associated with this extension instance. */
+    public sidecarVersion: string = version,
+    /** How many times the extension started the sidecar. Anything over one will indicate restarts were required. */
+    public sidecarStartCount: number = 0,
+    /** Did the user successfully sign in to Confluent Cloud? */
+    public ccloudAuthCompleted: boolean = false,
+  ) {}
+
+  /** Converts the current state of the {@link ObservabilityContext} to a markdown table string. */
+  toMarkdownTable(): string {
+    const keys = Object.keys(this);
+    // stringify all values so they can be displayed in the table
+    const values = Object.values(this).map((value) => JSON.stringify(value));
+    if (keys.length === 0) {
+      return "";
+    }
+    const table = [
+      "| Key | Value |",
+      "| --- | --- |",
+      ...keys.map((key, index) => `| ${key} | ${values[index]} |`),
+    ];
+    return table.join("\n");
+  }
+}
+
+/** Singleton instance of the {@link ObservabilityContext} class. */
+export const observabilityContext: ObservabilityContext = new ObservabilityContext();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,7 @@ import { registerTopicCommands } from "./commands/topics";
 import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL } from "./constants";
 import { activateMessageViewer } from "./consume";
 import { setExtensionContext } from "./context/extension";
+import { observabilityContext } from "./context/observability";
 import { ContextValues, setContextValue } from "./context/values";
 import { EventListener } from "./docker/eventListener";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
@@ -81,10 +82,14 @@ const logger = new Logger("extension");
 // defined in package.json
 // ref: https://code.visualstudio.com/api/references/activation-events
 export async function activate(context: vscode.ExtensionContext): Promise<vscode.ExtensionContext> {
+  observabilityContext.extensionVersion = context.extension.packageJSON.version;
+  observabilityContext.extensionActivated = false;
+
   logger.info(`Extension ${context.extension.id}" activate() triggered.`);
   try {
     context = await _activateExtension(context);
     logger.info("Extension fully activated");
+    observabilityContext.extensionActivated = true;
   } catch (e) {
     logger.error("Error activating extension:", e);
     // if the extension is failing to activate for whatever reason, we need to know about it to fix it

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -21,6 +21,7 @@ import { SidecarHandle } from "./sidecarHandle";
 
 import { normalize } from "path";
 import { Tail } from "tail";
+import { observabilityContext } from "../context/observability";
 
 /**
  * Output channel for viewing sidecar logs.
@@ -314,6 +315,7 @@ export class SidecarManager {
    *  Actually spawn the sidecar process, handshake with it, return its auth token string.
    **/
   private async startSidecar(callnum: number): Promise<string> {
+    observabilityContext.sidecarStartCount++;
     return new Promise<string>((resolve, reject) => {
       (async () => {
         const logPrefix = `startSidecar(${callnum})`;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #449.

This PR adds a singleton class for the purpose of tracking basic extension+sidecar state information that will be used to make support faster and easier for the extension+sidecar teams. See below for the properties we're currently exposing:
https://github.com/confluentinc/vscode/blob/d470043161338dd0427f79d1dfa01fc96f594619/src/context/observability.ts#L18-L40



Test issue with the generated markdown: https://github.com/confluentinc/vscode/issues/600
<img width="467" alt="image" src="https://github.com/user-attachments/assets/9c7ff604-4a6a-46bb-88c9-408687c5095d">

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Follow-on branches:
- creating a wrapper for capturing exceptions to send to Sentry (#599): https://github.com/confluentinc/vscode/pull/616
- allowing the user to download this context along with extension+sidecar logs in a .zip file (#597) 


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
