### PR TITLE
Gulp task for assisting with live testing.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -34,6 +34,9 @@ const IS_WINDOWS = process.platform === "win32";
 
 export const ci = parallel(check, build, lint);
 export const test = series(clean, build, testBuild, testRun);
+export const liveTest = series(clean, build, testBuild);
+liveTest.description =
+  "Rebuild the out/ directory after codebase or test suite changes for live breakpoint debugging.";
 
 export const bundle = series(clean, build, pack);
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- New gulp target `liveTest` for preparing the `out/` directory for within-vscode debugging with breakpoints after having made either test suite or codebase changes.