### PR TITLE
[v0.21.x] change Sentry error filter behavior

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,9 +16,10 @@ if (process.env.SENTRY_DSN) {
     tracesSampleRate: 0,
     profilesSampleRate: 0,
     integrations: [
+      // https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
       SentryCore.thirdPartyErrorFilterIntegration({
         filterKeys: ["confluent-vscode-extension-sentry-do-not-use"],
-        behaviour: "drop-error-if-contains-third-party-frames",
+        behaviour: "apply-tag-if-contains-third-party-frames",
       }),
       Sentry.rewriteFramesIntegration(),
     ],


### PR DESCRIPTION
Temporarily lifting this filter until we can figure out why all our frames are being marked as third party.