### PR TITLE
[v0.21.x] adjust Sentry filter behavior and add rollup output source map base

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -143,7 +143,13 @@ export function build(done) {
     context: "globalThis",
   };
   /** @type {import("rollup").OutputOptions} */
-  const extOutput = { dir: DESTINATION, format: "cjs", sourcemap: true, exports: "named" };
+  const extOutput = {
+    dir: DESTINATION,
+    format: "cjs",
+    sourcemap: true,
+    sourcemapBaseUrl: `file://${process.cwd()}/${DESTINATION}/`,
+    exports: "named",
+  };
 
   /** @type {import("rollup").RollupOptions} */
   const webInput = {
@@ -209,7 +215,7 @@ function getSentryReleaseVersion() {
     // add "dirty" to the revision instead of sha if there are uncommmited changes
     const isDirty =
       spawnSync("git", ["diff", "--quiet"], { stdio: "pipe", shell: IS_WINDOWS }).status !== 0;
-    if (isDirty) revision = "dirty";
+    if (isDirty) revision = "shouptest10";
     else {
       revision = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
         stdio: "pipe",

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -215,7 +215,7 @@ function getSentryReleaseVersion() {
     // add "dirty" to the revision instead of sha if there are uncommmited changes
     const isDirty =
       spawnSync("git", ["diff", "--quiet"], { stdio: "pipe", shell: IS_WINDOWS }).status !== 0;
-    if (isDirty) revision = "shouptest10";
+    if (isDirty) revision = "dirty";
     else {
       revision = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
         stdio: "pipe",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import * as Sentry from "@sentry/node";
  */
 if (process.env.SENTRY_DSN) {
   Sentry.init({
+    // debug: true, // enable for local "prod" debugging with dev console
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
     release: process.env.SENTRY_RELEASE,
@@ -19,7 +20,7 @@ if (process.env.SENTRY_DSN) {
       // https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
       SentryCore.thirdPartyErrorFilterIntegration({
         filterKeys: ["confluent-vscode-extension-sentry-do-not-use"],
-        behaviour: "apply-tag-if-contains-third-party-frames",
+        behaviour: "drop-error-if-exclusively-contains-third-party-frames",
       }),
       Sentry.rewriteFramesIntegration(),
     ],


### PR DESCRIPTION
Something was wrong with our build output where all our sourcemap info was being flagged as third party, which meant even when we explicitly called `Sentry.captureException()`, it would mark everything as `third_party_code: true` (https://github.com/confluentinc/vscode/pull/603). 

After doing some digging and enabling Sentry debug mode and viewing logs in the dev tools console, it seemed to be using the wrong paths:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/f9ad510e-d1c1-483a-8cdc-02b7053eaf67">

The most minimal fix I could find was ensuring `sourcemapBaseUrl` was set in our build `extOutput`, which then properly associated our extension code in Sentry. We're then able to see the unminified code as expected.
