### PR TITLE
Update/docker convenience cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
         "category": "Confluent: Debug Tools"
       },
       {
+        "command": "confluent.docker.setSocketPath",
+        "icon": "$(key)",
+        "title": "Set Docker Socket Path",
+        "category": "Confluent: Docker"
+      },
+      {
         "command": "confluent.docker.startLocalResources",
         "icon": "$(debug-start)",
         "title": "Start Local Resources",
@@ -347,7 +353,7 @@
         "confluent.localDocker.socketPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the Docker socket file."
+          "markdownDescription": "Path to the Docker socket file.  (You can also use the [\"Set Docker Socket Path\" command](command:confluent.docker.setSocketPath).)"
         },
         "confluent.localDocker.kafkaImageRepo": {
           "type": "string",

--- a/src/commands/docker.test.ts
+++ b/src/commands/docker.test.ts
@@ -195,7 +195,7 @@ describe("commands/docker.ts orderWorkflows()", () => {
   });
 });
 
-describe.only("commands/docker.ts addDockerPath()", () => {
+describe("commands/docker.ts addDockerPath()", () => {
   let sandbox: sinon.SinonSandbox;
   let showOpenDialogStub: sinon.SinonStub;
   let getConfigurationStub: sinon.SinonStub;

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -10,7 +10,7 @@ import {
 } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ResponseError } from "../clients/docker";
-import { isDockerAvailable } from "../docker/configs";
+import { isDockerAvailable, getSocketPath } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { getKafkaWorkflow, getSchemaRegistryWorkflow } from "../docker/workflows";
 import { LocalResourceWorkflow } from "../docker/workflows/base";
@@ -159,13 +159,15 @@ export async function addDockerPath() {
     canSelectFolders: false,
     canSelectMany: false,
     filters: {
+      // is this the right filter? openDialogOptions are not fully listed https://code.visualstudio.com/api/references/vscode-api#OpenDialogOptions
       Dockerfile: ["Dockerfile"],
     },
   });
 
   const configs: WorkspaceConfiguration = workspace.getConfiguration();
 
-  const paths: string[] = configs.get<string[]>("docker.paths", []);
+  //getting the paths instead of searching their env for it
+  const paths: string[] = getDockerPaths();
 
   if (newDockerUris && newDockerUris.length > 0) {
     const newDockerPath: string = newDockerUris[0].fsPath;


### PR DESCRIPTION
## Summary of Changes

Addresses #488. Changes made to:
- docker.test.ts
- docker.ts
- package.json

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
Yes, now a convenience command, 'Set Docker Path' is available to add the docker socket path: 
<img width="713" alt="Screenshot 2024-11-15 at 3 03 55 PM" src="https://github.com/user-attachments/assets/6ffc256a-f6a3-4cd6-96fe-bcb0ec4c7aa1">


- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
