### PR TITLE
[v0.21.x] fix: update CCloud auth status "secret" on reauthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Reauthenticating with CCloud and immediately clicking on items/actions in the sidebar will no
+  longer appear to (temporarily) invalidate the CCloud session.
+
 ## 0.21.1
 
 ### Added

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -470,8 +470,8 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     // the following calls are all workspace-scoped
     logger.debug("handleSessionRemoved()", { updateSecret });
     this.updateContextValue(false);
-    pollCCloudConnectionAuth.stop();
     await clearCurrentCCloudResources();
+    pollCCloudConnectionAuth.stop();
     if (!this._session) {
       logger.debug("handleSessionRemoved(): no cached `_session` to remove; this shouldn't happen");
     } else {

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -301,7 +301,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       return;
     }
 
-    // tell the sidecar to delete the connection, then update the auth state in the secret store
+    // tell the sidecar to delete the connection and update the auth status "secret" in storage
     // to prevent any last-minute requests from passing through the middleware
     await Promise.all([
       deleteCCloudConnection(),
@@ -450,7 +450,6 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       removed: [],
       changed: [],
     });
-    logger.debug("starting the poller for CCloud connection status");
     pollCCloudConnectionAuth.start();
     this.updateContextValue(true);
 
@@ -471,7 +470,6 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     // the following calls are all workspace-scoped
     logger.debug("handleSessionRemoved()", { updateSecret });
     this.updateContextValue(false);
-    logger.debug("stopping the poller for CCloud connection status");
     pollCCloudConnectionAuth.stop();
     await clearCurrentCCloudResources();
     if (!this._session) {

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -171,6 +171,11 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       `Successfully logged in to Confluent Cloud as ${authenticatedConnection.status.authentication.user?.username}`,
     );
     logger.debug("createSession() successfully authenticated with Confluent Cloud");
+    // update the auth status in the secret store so other workspaces can be notified of the change
+    // and the middleware doesn't get an outdated status before the poller can update it
+    await getResourceManager().setCCloudAuthStatus(
+      authenticatedConnection.status.authentication.status,
+    );
     const session = convertToAuthSession(authenticatedConnection);
     await this.handleSessionCreated(session, true);
     ccloudConnected.fire(true);
@@ -296,7 +301,12 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       return;
     }
 
-    await deleteCCloudConnection();
+    // tell the sidecar to delete the connection, then update the auth state in the secret store
+    // to prevent any last-minute requests from passing through the middleware
+    await Promise.all([
+      deleteCCloudConnection(),
+      getStorageManager().deleteSecret(CCLOUD_AUTH_STATUS_KEY),
+    ]);
     await this.handleSessionRemoved(true);
     ccloudConnected.fire(false);
   }
@@ -440,6 +450,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       removed: [],
       changed: [],
     });
+    logger.debug("starting the poller for CCloud connection status");
     pollCCloudConnectionAuth.start();
     this.updateContextValue(true);
 
@@ -460,8 +471,9 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     // the following calls are all workspace-scoped
     logger.debug("handleSessionRemoved()", { updateSecret });
     this.updateContextValue(false);
-    await clearCurrentCCloudResources();
+    logger.debug("stopping the poller for CCloud connection status");
     pollCCloudConnectionAuth.stop();
+    await clearCurrentCCloudResources();
     if (!this._session) {
       logger.debug("handleSessionRemoved(): no cached `_session` to remove; this shouldn't happen");
     } else {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to #566 where our middleware may be using a stale auth status "secret" set by the poller. 

After a user reauthenticates through CCloud, there is a short period of time (before the auth poller sets the correct `VALID_TOKEN` status) where a CCloud-related request can be made and our middleware will pick up the old (usually `FAILED`) status and invalidate the auth session, leading to a misleading state that flashes the sidebar between CCloud-connected/-disconnected.


https://github.com/user-attachments/assets/56ffaa56-e89f-42ef-94b1-7c68891550e0



Now, the CCloud auth provider will explicitly update the secret after a successful (re)authentication (and similarly explicitly delete the secret during a sign-out event), which will then prevent the middleware from incorrectly invalidating the CCloud auth session from the extension's perspective:


https://github.com/user-attachments/assets/913f0382-e9c7-4eaf-a819-a85423a3f552



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
