### PR TITLE
add `captureException()` wrapper

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import {
   CancellationToken,
   Disposable,
@@ -14,6 +13,7 @@ import { isDockerAvailable } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { getKafkaWorkflow, getSchemaRegistryWorkflow } from "../docker/workflows";
 import { LocalResourceWorkflow } from "../docker/workflows/base";
+import { captureException } from "../errors";
 import { Logger } from "../logging";
 import { ConnectionLabel } from "../models/resource";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
@@ -125,7 +125,7 @@ export async function runWorkflowWithProgress(
             workflow.sendTelemetryEvent("Workflow Errored", {
               start,
             });
-            Sentry.captureException(error, {
+            captureException(error, {
               tags: {
                 dockerImage: workflow.imageRepoTag,
                 extensionUserFlow: "Local Resource Management",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,5 @@
-import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
+import { captureException } from "../errors";
 import { Logger } from "../logging";
 import { getTelemetryLogger } from "../telemetry/telemetryLogger";
 
@@ -18,7 +18,7 @@ export function registerCommandWithLogging(
       logger.error(msg, e);
       if (e instanceof Error) {
         // capture error with Sentry (only enabled in production builds)
-        Sentry.captureException(e, { tags: { command: commandName } });
+        captureException(e, { tags: { command: commandName } });
         // also show error notification to the user
         vscode.window.showErrorMessage(`${msg} ${e.message}`, "Open Logs").then(async (action) => {
           if (action !== undefined) {

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import { utcTicks } from "d3-time";
 import { Data } from "dataclass";
 import { ObservableScope } from "inertial";
@@ -26,6 +25,7 @@ import {
 import { registerCommandWithLogging } from "./commands";
 import { LOCAL_CONNECTION_ID } from "./constants";
 import { getExtensionContext } from "./context/extension";
+import { captureException } from "./errors";
 import { Logger } from "./logging";
 import { ConnectionId } from "./models/resource";
 import { type KafkaTopic } from "./models/topic";
@@ -539,7 +539,7 @@ function messageViewerStartPollingCommand(
             }
             default: {
               reportable = { message: "Something went wrong." };
-              Sentry.captureException(error, { extra: { status, payload } });
+              captureException(error, { extra: { status, payload } });
               window
                 .showErrorMessage("Error response while consuming messages.", "Open Logs")
                 .then((action) => {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,63 @@
+import * as assert from "assert";
+import { TEST_CCLOUD_CONNECTION } from "../tests/unit/testResources/connection";
+import { ResponseError } from "./clients/sidecar";
+import { observabilityContext } from "./context/observability";
+import { enrichErrorContext } from "./errors";
+import { SIDECAR_CONNECTION_ID_HEADER } from "./sidecar/constants";
+
+describe("errors.ts enrichErrorContext()", function () {
+  it("should include observabilityContext by default", function () {
+    const error = new Error("Test error");
+
+    const context = enrichErrorContext(error);
+
+    assert.deepStrictEqual(context.extra, observabilityContext.toRecord());
+  });
+
+  it("should include caller-provided context", function () {
+    const error = new Error("Test error");
+    const extraContext = { tags: { foo: "bar" } };
+
+    const context = enrichErrorContext(error, extraContext);
+
+    assert.deepStrictEqual(context, { extra: observabilityContext.toRecord(), ...extraContext });
+  });
+
+  it("should include merge caller-provided 'extra' context with observability context", function () {
+    const error = new Error("Test error");
+    const extra = { foo: "bar" };
+
+    const context = enrichErrorContext(error, { extra });
+
+    assert.deepStrictEqual(context.extra, { ...observabilityContext.toRecord(), ...extra });
+  });
+
+  it(`should include response status code and "${SIDECAR_CONNECTION_ID_HEADER}" header if provided`, function () {
+    const error = new ResponseError(
+      new Response("uh oh", {
+        status: 404,
+        headers: { [SIDECAR_CONNECTION_ID_HEADER]: TEST_CCLOUD_CONNECTION.id },
+      }),
+    );
+
+    const context = enrichErrorContext(error, { extra: { foo: "bar" } });
+
+    assert.deepStrictEqual(context.contexts.response, {
+      status_code: 404,
+      headers: { [SIDECAR_CONNECTION_ID_HEADER]: TEST_CCLOUD_CONNECTION.id },
+    });
+    assert.deepStrictEqual(context.extra, { ...observabilityContext.toRecord(), foo: "bar" });
+  });
+
+  it(`should include response context even if ${SIDECAR_CONNECTION_ID_HEADER} header is missing`, function () {
+    const error = new ResponseError(new Response("uh oh", { status: 404 }));
+
+    const context = enrichErrorContext(error);
+
+    assert.deepStrictEqual(context.contexts.response, {
+      status_code: 404,
+      headers: { [SIDECAR_CONNECTION_ID_HEADER]: "" },
+    });
+    assert.deepStrictEqual(context.extra, observabilityContext.toRecord());
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,4 @@
 import * as Sentry from "@sentry/node";
-
-import { ExclusiveEventHintOrCaptureContext } from "@sentry/core/build/types/utils/prepareEvent";
 import { ResponseError as DockerResponseError } from "./clients/docker";
 import { ResponseError as KafkaResponseError } from "./clients/kafkaRest";
 import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRegistryRest";
@@ -69,12 +67,10 @@ export async function logResponseError(
  * If a {@link ResponseError} is provided as the `error`, the response status code and any associated
  * `x-connection-id` header will be included in the event context under `contexts.response`.
  *
- * See {@link ExclusiveEventHintOrCaptureContext} for more information on the `context` parameter.
+ * See {@link Sentry.captureException}'s `ExclusiveEventHintOrCaptureContext` for more information
+ * on the `context` parameter.
  */
-export function captureException(
-  e: unknown,
-  context: ExclusiveEventHintOrCaptureContext = {},
-): void {
+export function captureException(e: unknown, context: any = {}): void {
   // TODO: check telemetry settings here?
   const obsContext: Record<string, any> = observabilityContext.toRecord();
   let errorContext: Record<string, any> = { extra: { ...obsContext } };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -74,8 +74,13 @@ export function captureException(
   // TODO: check telemetry settings here?
   const obsContext: Record<string, any> = observabilityContext.toRecord();
   const extraContext = context ? context : {};
-  // merge our observability context first, then allow overrides with anything passed by the caller
-  const errorContext: Record<string, any> = { extra: { ...obsContext }, ...extraContext };
+  // ensure observability context keys always make it into the Sentry event under `extra`, even if
+  // the caller provided their own `extra` data in `context`
+  const { extra: extraFromContext = {}, ...restExtraContext } = extraContext as any;
+  const errorContext: Record<string, any> = {
+    extra: { ...obsContext, ...extraFromContext },
+    ...restExtraContext,
+  };
   logger.debug("capturing exception before sending to Sentry", errorContext);
   Sentry.captureException(error, errorContext);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -105,6 +105,5 @@ export function captureException(
     };
   }
 
-  logger.debug("capturing exception before sending to Sentry", errorContext);
   Sentry.captureException(e, errorContext);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -76,6 +76,6 @@ export function captureException(
   const extraContext = context ? context : {};
   // merge our observability context first, then allow overrides with anything passed by the caller
   const errorContext: Record<string, any> = { extra: { ...obsContext }, ...extraContext };
-  logger.error("capturing exception before sending to Sentry", errorContext);
+  logger.debug("capturing exception before sending to Sentry", errorContext);
   Sentry.captureException(error, errorContext);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,7 @@ import { ContextValues, setContextValue } from "./context/values";
 import { DirectConnectionManager } from "./directConnectManager";
 import { EventListener } from "./docker/eventListener";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
+import { captureException } from "./errors";
 import { Logger, outputChannel } from "./logging";
 import {
   ENABLE_DIRECT_CONNECTIONS,
@@ -100,7 +101,7 @@ export async function activate(
   } catch (e) {
     logger.error("Error activating extension:", e);
     // if the extension is failing to activate for whatever reason, we need to know about it to fix it
-    Sentry.captureException(e);
+    captureException(e);
     throw e;
   }
 

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
 
 import { posix } from "path";
@@ -9,6 +8,7 @@ import { getSidecar } from "./sidecar";
 
 import { ExtensionContext, ViewColumn } from "vscode";
 import { registerCommandWithLogging } from "./commands";
+import { captureException } from "./errors";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
@@ -167,7 +167,7 @@ async function applyTemplate(
     }
   } catch (e) {
     logger.error("Failed to apply template", e);
-    Sentry.captureException(e);
+    captureException(e, { extra: { templateName: pickedTemplate.spec.display_name } });
     const action = await vscode.window.showErrorMessage(
       "There was an error while generating the project. Try again or file an issue.",
       { title: "Try again" },

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import { randomUUID } from "crypto";
 import * as vscode from "vscode";
 import { IconNames } from "../constants";
@@ -10,7 +9,7 @@ import {
   localKafkaConnected,
   localSchemaRegistryConnected,
 } from "../emitters";
-import { ExtensionContextNotSetError } from "../errors";
+import { captureException, ExtensionContextNotSetError } from "../errors";
 import { getDirectResources } from "../graphql/direct";
 import { getLocalResources } from "../graphql/local";
 import { getCurrentOrganization } from "../graphql/organizations";
@@ -249,7 +248,7 @@ export async function loadCCloudResources(
       // what went wrong since the user is effectively locked out of the CCloud resources for this org
       const msg = `Failed to load Confluent Cloud environments for the "${currentOrg?.name}" organization.`;
       logger.error(msg, e);
-      Sentry.captureException(e);
+      captureException(e);
       vscode.window.showErrorMessage(msg, "Open Logs", "File Issue").then(async (action) => {
         if (action === "Open Logs") {
           vscode.commands.executeCommand("confluent.showOutputChannel");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Adds a wrapper around our `Sentry.captureException()` calls to automatically include the `ObservabilityContext` as part of the event `extra`, and also include convenience `ResponseContext` status if the passed error is one of our supported `ResponseError` types. This will also include the associated `x-connection-id` header so we can see if the captured response error came from a CCloud or local connection (and eventually UUIDs for direct connections).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
