### PR TITLE
[v0.21.x] fix(GQL): handle `null` CCloudEnvironment

### DIFF
--- a/src/graphql/environments.ts
+++ b/src/graphql/environments.ts
@@ -53,7 +53,10 @@ export async function getEnvironments(): Promise<CCloudEnvironmentGroup[]> {
     return envGroups;
   }
 
-  environments.forEach((env: any) => {
+  environments.forEach((env) => {
+    if (!env) {
+      return;
+    }
     const envGroup: CCloudEnvironmentGroup = {
       environment: CCloudEnvironment.create({
         id: env.id,


### PR DESCRIPTION
Closes #618.

Removing the `any` type lets the types generated from `gql.tada` using https://github.com/confluentinc/vscode/blob/main/src/graphql/sidecar.graphql do the work. Would be nice to get explicit named types eventually though.