### PR TITLE
add experimental direct connection setting and associated contextValue

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,28 +326,23 @@
           "default": false,
           "description": "Alert on sidecar process exceptions"
         },
-        "confluent.cloud.messageViewer.showSchemaWarningNotifications": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether or not warning notifications will appear when consuming messages without permission to access the associated Schema Registry."
-        },
-        "confluent.ssl.pemPaths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "Path(s) to `.pem` file(s) to use for SSL/TLS connections when making requests to Confluent/Kafka resources. (You can also use the [\"Add SSL/TLS PEM Path\" command](command:confluent.connections.addSSLPemPath).)"
-        },
         "confluent.debugging.sslTls.serverCertificateVerificationDisabled": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Disable SSL/TLS server certificate verification when making requests to Confluent/Kafka connections or resources.\n\n---\n\n⚠️ **WARNING**: This setting may allow a Man-in-the-Middle attack on the network connection between the Confluent extension and Confluent Cloud, which can lead to loss of sensitive data like credentials and PII. **_This should only be used for debugging purposes in non-production environments._**"
         },
-        "confluent.localDocker.socketPath": {
-          "type": "string",
-          "default": "",
-          "description": "Path to the Docker socket file."
+        "confluent.cloud.messageViewer.showSchemaWarningNotifications": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether or not warning notifications will appear when consuming messages without permission to access the associated Schema Registry."
+        },
+        "confluent.experimental.enableDirectConnections": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable direct connections to Kafka and Schema Registry resources.",
+          "tags": [
+            "experimental"
+          ]
         },
         "confluent.localDocker.kafkaImageRepo": {
           "type": "string",
@@ -366,6 +361,19 @@
           "type": "string",
           "default": "localhost",
           "description": "Host to use for the Kafka REST Proxy when starting a local Kafka cluster"
+        },
+        "confluent.localDocker.socketPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the Docker socket file."
+        },
+        "confluent.ssl.pemPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Path(s) to `.pem` file(s) to use for SSL/TLS connections when making requests to Confluent/Kafka resources. (You can also use the [\"Add SSL/TLS PEM Path\" command](command:confluent.connections.addSSLPemPath).)"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -326,23 +326,28 @@
           "default": false,
           "description": "Alert on sidecar process exceptions"
         },
-        "confluent.debugging.sslTls.serverCertificateVerificationDisabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Disable SSL/TLS server certificate verification when making requests to Confluent/Kafka connections or resources.\n\n---\n\n⚠️ **WARNING**: This setting may allow a Man-in-the-Middle attack on the network connection between the Confluent extension and Confluent Cloud, which can lead to loss of sensitive data like credentials and PII. **_This should only be used for debugging purposes in non-production environments._**"
-        },
         "confluent.cloud.messageViewer.showSchemaWarningNotifications": {
           "type": "boolean",
           "default": true,
           "description": "Whether or not warning notifications will appear when consuming messages without permission to access the associated Schema Registry."
         },
-        "confluent.experimental.enableDirectConnections": {
+        "confluent.ssl.pemPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Path(s) to `.pem` file(s) to use for SSL/TLS connections when making requests to Confluent/Kafka resources. (You can also use the [\"Add SSL/TLS PEM Path\" command](command:confluent.connections.addSSLPemPath).)"
+        },
+        "confluent.debugging.sslTls.serverCertificateVerificationDisabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable direct connections to Kafka and Schema Registry resources.",
-          "tags": [
-            "experimental"
-          ]
+          "markdownDescription": "Disable SSL/TLS server certificate verification when making requests to Confluent/Kafka connections or resources.\n\n---\n\n⚠️ **WARNING**: This setting may allow a Man-in-the-Middle attack on the network connection between the Confluent extension and Confluent Cloud, which can lead to loss of sensitive data like credentials and PII. **_This should only be used for debugging purposes in non-production environments._**"
+        },
+        "confluent.localDocker.socketPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the Docker socket file."
         },
         "confluent.localDocker.kafkaImageRepo": {
           "type": "string",
@@ -362,18 +367,13 @@
           "default": "localhost",
           "description": "Host to use for the Kafka REST Proxy when starting a local Kafka cluster"
         },
-        "confluent.localDocker.socketPath": {
-          "type": "string",
-          "default": "",
-          "description": "Path to the Docker socket file."
-        },
-        "confluent.ssl.pemPaths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [],
-          "markdownDescription": "Path(s) to `.pem` file(s) to use for SSL/TLS connections when making requests to Confluent/Kafka resources. (You can also use the [\"Add SSL/TLS PEM Path\" command](command:confluent.connections.addSSLPemPath).)"
+        "confluent.experimental.enableDirectConnections": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable direct connections to Kafka and Schema Registry resources.",
+          "tags": [
+            "experimental"
+          ]
         }
       }
     },

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -57,4 +57,9 @@ export enum ContextValues {
   kafkaClusterSelected = "confluent.kafkaClusterSelected",
   /** The user clicked a Schema Registry tree item. */
   schemaRegistrySelected = "confluent.schemaRegistrySelected",
+  /**
+   * EXPERIMENTAL: Are direct connections enabled at all?
+   * (This should go away once the `confluent.experimental.enableDirectConnections` setting is removed.)
+   */
+  directConnectionsEnabled = "confluent.directConnectionsEnabled",
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #624.

This just sets an initial experimental setting for us to use in follow-on branches as the direct connection + CP support is developed. It also adds a placeholder context value to be adjusted in a follow-on branch (as one of the responsibilities for https://github.com/confluentinc/vscode/issues/422).

<img width="756" alt="image" src="https://github.com/user-attachments/assets/c243e55e-e06c-4398-9f1e-5d8b4d700ab2">

Nothing is using this setting or context value yet.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
