### PR TITLE
Migrate all storage manager keys to a single enum.

### DIFF
--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -6,7 +6,7 @@ import { SchemaDocumentProvider } from "../documentProviders/schema";
 import { Logger } from "../logging";
 import { Schema } from "../models/schema";
 import { getStorageManager } from "../storage";
-import { StateDiffs } from "../storage/constants";
+import { WorkspaceStorageKeys } from "../storage/constants";
 
 const logger = new Logger("commands.diffs");
 
@@ -16,7 +16,7 @@ async function selectForCompareCommand(item: any) {
   }
   const uri: vscode.Uri = convertItemToUri(item);
   logger.debug("Selected item for compare", uri);
-  await getStorageManager().setWorkspaceState(StateDiffs.SELECTED_RESOURCE, uri);
+  await getStorageManager().setWorkspaceState(WorkspaceStorageKeys.DIFF_BASE_URI, uri);
   // allows the "Compare with Selected" command to be used
   await setContextValue(ContextValues.resourceSelectedForCompare, true);
 }
@@ -29,7 +29,7 @@ async function compareWithSelectedCommand(item: any) {
   logger.debug("Comparing with selected item", uri2);
 
   const uri1: vscode.Uri | undefined = await getStorageManager().getWorkspaceState(
-    StateDiffs.SELECTED_RESOURCE,
+    WorkspaceStorageKeys.DIFF_BASE_URI,
   );
   if (!uri1) {
     logger.error("No resource selected for compare; this shouldn't happen", uri2);

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -1,35 +1,27 @@
-// Global/Workspace state keys
-export enum StateEnvironments {
-  CCLOUD = "environments.ccloud",
-}
-
-export enum StateKafkaClusters {
-  LOCAL = "kafkaClusters.local",
-  CCLOUD = "kafkaClusters.ccloud",
-}
-
-export enum StateKafkaTopics {
-  LOCAL = "kafkaTopics.local",
-  CCLOUD = "kafkaTopics.ccloud",
-}
-
-export enum StateSchemaRegistry {
-  CCLOUD = "schemaRegistries.ccloud",
-}
-
-export enum StateSchemas {
-  CCLOUD = "schemas.ccloud",
-}
-
-export enum StateDiffs {
-  SELECTED_RESOURCE = "diffs.selectedResource",
-}
-
-/** Single enum to hold all of the keys the extension uses
- * within the workspace storage. */
+/** Workspace state keys. A single enum to hold all of the keys the extension uses
+ * to cache data within the workspace storage via ResourceManager + StorageManager. */
 export enum WorkspaceStorageKeys {
-  // Eventually migrate all of these to the State* enums above
-  // into this enum here for consistency.
+  /** Environments found in ccloud */
+  CCLOUD_ENVIRONMENTS = "ccloudEnvironments",
+
+  /** Kafka clusters found in CCLoud */
+  CCLOUD_KAFKA_CLUSTERS = "ccloudKafkaClusters",
+  /** Kafka clusters found from local, should be removed in #637 */
+  LOCAL_KAFKA_CLUSTERS = "localKafkaClusters",
+
+  /** CCloud Kafka topics */
+  CCLOUD_KAFKA_TOPICS = "ccloudKafkaTopics",
+  /** Local Kafka topics, should be removed in #638 */
+  LOCAL_KAFKA_TOPICS = "localKafkaTopics",
+
+  /** CCloud schema registries */
+  CCLOUD_SCHEMA_REGISTRIES = "ccloudSchemaRegistries",
+
+  /** CCLoud schema bindings (not the schema documents themselves) */
+  CCLOUD_SCHEMAS = "ccloudSchemas",
+
+  /** What (Schema) URI was chosen first to diff against? */
+  DIFF_BASE_URI = "diffs.selectedResource",
 
   /** URI annotation facility, setURIMetadata() and the like.*/
   URI_METADATA = "uriMetadata",

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -16,13 +16,7 @@ import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/k
 import { Schema } from "../models/schema";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
-import {
-  StateEnvironments,
-  StateKafkaClusters,
-  StateKafkaTopics,
-  StateSchemaRegistry,
-  UriMetadataKeys,
-} from "./constants";
+import { UriMetadataKeys, WorkspaceStorageKeys } from "./constants";
 import {
   CCloudKafkaClustersByEnv,
   CCloudSchemaRegistryByEnv,
@@ -58,7 +52,7 @@ describe("ResourceManager (CCloud) environment methods", function () {
     await getResourceManager().setCCloudEnvironments(environments);
     // verify the environments were stored correctly by checking through the StorageManager instead of the ResourceManager
     let storedEnvironments: CCloudEnvironment[] | undefined =
-      await storageManager.getWorkspaceState(StateEnvironments.CCLOUD);
+      await storageManager.getWorkspaceState(WorkspaceStorageKeys.CCLOUD_ENVIRONMENTS);
     assert.ok(storedEnvironments);
     assert.deepStrictEqual(storedEnvironments, environments);
   });
@@ -99,7 +93,9 @@ describe("ResourceManager (CCloud) environment methods", function () {
     await resourceManager.setCCloudEnvironments(environments);
     await resourceManager.deleteCCloudEnvironments();
     // verify the environments were deleted correctly
-    const missingEnvironments = await storageManager.getWorkspaceState(StateEnvironments.CCLOUD);
+    const missingEnvironments = await storageManager.getWorkspaceState(
+      WorkspaceStorageKeys.CCLOUD_ENVIRONMENTS,
+    );
     assert.deepStrictEqual(missingEnvironments, undefined);
   });
 });
@@ -135,7 +131,7 @@ describe("ResourceManager Kafka cluster methods", function () {
     await getResourceManager().setCCloudKafkaClusters(ccloudClusters);
     // verify the clusters were stored correctly by checking through the StorageManager instead of the ResourceManager
     let storedClustersByEnv: CCloudKafkaClustersByEnv | undefined =
-      await storageManager.getWorkspaceState(StateKafkaClusters.CCLOUD);
+      await storageManager.getWorkspaceState(WorkspaceStorageKeys.CCLOUD_KAFKA_CLUSTERS);
     assert.ok(storedClustersByEnv);
     assert.ok(storedClustersByEnv instanceof Map);
     assert.ok(storedClustersByEnv.has(TEST_CCLOUD_ENVIRONMENT.id));
@@ -156,7 +152,7 @@ describe("ResourceManager Kafka cluster methods", function () {
     await getResourceManager().setCCloudKafkaClusters(newClusters);
     // verify the clusters were stored correctly by checking through the StorageManager instead of the ResourceManager
     let storedClustersByEnv: CCloudKafkaClustersByEnv | undefined =
-      await storageManager.getWorkspaceState(StateKafkaClusters.CCLOUD);
+      await storageManager.getWorkspaceState(WorkspaceStorageKeys.CCLOUD_KAFKA_CLUSTERS);
     assert.ok(storedClustersByEnv);
     // make sure both environments exist and the first wasn't overwritten
     assert.deepStrictEqual(storedClustersByEnv.get(newEnvironmentId), newClusters);
@@ -170,7 +166,7 @@ describe("ResourceManager Kafka cluster methods", function () {
     await getResourceManager().setCCloudKafkaClusters(ccloudClusters);
     // verify the clusters were not duplicated
     let storedClustersByEnv: CCloudKafkaClustersByEnv | undefined =
-      await storageManager.getWorkspaceState(StateKafkaClusters.CCLOUD);
+      await storageManager.getWorkspaceState(WorkspaceStorageKeys.CCLOUD_KAFKA_CLUSTERS);
     assert.ok(storedClustersByEnv);
     assert.ok(storedClustersByEnv instanceof Map);
     assert.ok(storedClustersByEnv.has(TEST_CCLOUD_ENVIRONMENT.id));
@@ -253,7 +249,9 @@ describe("ResourceManager Kafka cluster methods", function () {
     await resourceManager.setCCloudKafkaClusters(ccloudClusters);
     await resourceManager.deleteCCloudKafkaClusters();
     // verify the clusters were deleted correctly
-    const missingClusters = await storageManager.getWorkspaceState(StateKafkaClusters.CCLOUD);
+    const missingClusters = await storageManager.getWorkspaceState(
+      WorkspaceStorageKeys.CCLOUD_KAFKA_CLUSTERS,
+    );
     assert.deepStrictEqual(missingClusters, undefined);
   });
 
@@ -261,7 +259,7 @@ describe("ResourceManager Kafka cluster methods", function () {
     await getResourceManager().setLocalKafkaClusters(localClusters);
     // verify the clusters were stored correctly by checking through the StorageManager instead of the ResourceManager
     let storedClusters: LocalKafkaCluster[] | undefined = await storageManager.getWorkspaceState(
-      StateKafkaClusters.LOCAL,
+      WorkspaceStorageKeys.LOCAL_KAFKA_CLUSTERS,
     );
     assert.ok(storedClusters);
     assert.deepStrictEqual(storedClusters, localClusters);
@@ -308,7 +306,9 @@ describe("ResourceManager Kafka cluster methods", function () {
     await resourceManager.setLocalKafkaClusters(localClusters);
     await resourceManager.deleteLocalKafkaClusters();
     // verify the clusters were deleted correctly
-    const missingClusters = await storageManager.getWorkspaceState(StateKafkaClusters.LOCAL);
+    const missingClusters = await storageManager.getWorkspaceState(
+      WorkspaceStorageKeys.LOCAL_KAFKA_CLUSTERS,
+    );
     assert.deepStrictEqual(missingClusters, undefined);
   });
 });
@@ -424,7 +424,9 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
     await resourceManager.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
     await resourceManager.deleteCCloudSchemaRegistries();
     // verify the Schema Registry was deleted correctly
-    const missingClusters = await storageManager.getWorkspaceState(StateSchemaRegistry.CCLOUD);
+    const missingClusters = await storageManager.getWorkspaceState(
+      WorkspaceStorageKeys.CCLOUD_SCHEMA_REGISTRIES,
+    );
     assert.deepStrictEqual(missingClusters, undefined);
   });
 });
@@ -635,13 +637,13 @@ describe("ResourceManager Kafka topic methods", function () {
 
     assert.equal(
       manager.topicKeyForCluster(TEST_CCLOUD_KAFKA_CLUSTER),
-      StateKafkaTopics.CCLOUD,
+      WorkspaceStorageKeys.CCLOUD_KAFKA_TOPICS,
       "Expected cloud cluster to map to StateKafkaTopics.CCLOUD",
     );
 
     assert.equal(
       manager.topicKeyForCluster(TEST_LOCAL_KAFKA_CLUSTER),
-      StateKafkaTopics.LOCAL,
+      WorkspaceStorageKeys.LOCAL_KAFKA_TOPICS,
       "Expected local cluster to map to StateKafkaTopics.LOCAL",
     );
   });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Convert individual enums with one or two values which are as keys into the single workspace storage namespace into a single enum. Helps ensure they're all unique. Revisiting them all also helped identify those which should no longer exist (issues #637, #638).
- Have clicktested around and things continue to work well.
- Closes #535.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
