### PR TITLE
Fix schema upload success message when was normalized to a not-most-recent version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Correct schema upload success message when the uploaded schema was normalized to a preexisting
+version which wasn't the most recent existing version for the subject, 
+[issue #642](https://github.com/confluentinc/vscode/issues/642).
+
 ## 0.21.2
 
 ### Fixed

--- a/src/commands/schemaUpload.test.ts
+++ b/src/commands/schemaUpload.test.ts
@@ -83,13 +83,24 @@ describe("commands/schemaUpload.ts schemaRegistrationMessage tests", function ()
     );
   });
 
-  it("normalized to existing version message is correct", () => {
+  it("normalized to existing version message is correct when normalized to most recent version", () => {
     const subject = "MyTopic-value";
     const version = 1;
     const message = schemaRegistrationMessage(subject, version, version);
     assert.strictEqual(
       message,
       `Normalized to existing version ${version} for subject "${subject}"`,
+    );
+  });
+
+  it("normalized to existing version message is correct when normalized to older version", () => {
+    const subject = "MyTopic-value";
+    const thisVersion = 1;
+    const maxVersion = 2;
+    const message = schemaRegistrationMessage(subject, maxVersion, thisVersion);
+    assert.strictEqual(
+      message,
+      `Normalized to existing version ${thisVersion} for subject "${subject}"`,
     );
   });
 });

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -297,20 +297,18 @@ export function extractDetail(message: string): string {
 /** Return the success message to show the user after having uploaded a new schema */
 export function schemaRegistrationMessage(
   subject: string,
-  existingVersion: number | undefined,
-  registeredVersion: number,
+  maxExistingVersion: number | undefined,
+  newlyRegisteredVersion: number,
 ): string {
-  // todo: make this return markdown and to not induce pain for the reader. Use a header
-  // that clearly delineates the different cases, then key / value rows for the details.
-
-  if (existingVersion === undefined) {
+  if (maxExistingVersion === undefined) {
     return `Schema registered to new subject "${subject}"`;
-  } else if (existingVersion === registeredVersion) {
+  } else if (maxExistingVersion >= newlyRegisteredVersion) {
     // was normalized and matched an existing schema version for this subject
-    return `Normalized to existing version ${registeredVersion} for subject "${subject}"`;
+    return `Normalized to existing version ${newlyRegisteredVersion} for subject "${subject}"`;
   } else {
-    // This was a new version of an existing subject.
-    return `New version ${registeredVersion} registered to existing subject "${subject}"`;
+    // This was a new version of an existing subject. The newly registered version is higher than
+    // the highest preexisting version.
+    return `New version ${newlyRegisteredVersion} registered to existing subject "${subject}"`;
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix the schema upload success message when the uploaded schema gets normalized to an old version for the subject. We handled when it was normalized to the most recent version, just not an older one.
- Closes #642


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
