### PR TITLE
expose setting for `confluentinc/cp-schema-registry` image tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
 - Ability to update basic topic configuration fields via webform
+- Local Resources: the Docker image tag used to start a Schema Registry container is now
+  configurable via the extension settings.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -386,6 +386,11 @@
           "type": "string",
           "default": "latest",
           "description": "Docker image tag to use when starting a local Kafka container"
+        },
+        "confluent.localDocker.schemaRegistryImageTag": {
+          "type": "string",
+          "default": "latest",
+          "markdownDescription": "Docker image tag to use when starting a local Schema Registry container. (By default, this will use the [`confluentinc/cp-schema-registry`](https://hub.docker.com/r/confluentinc/cp-schema-registry/tags) image.)"
         }
       }
     },

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -60,7 +60,6 @@ export function getLocalSchemaRegistryImageName(): string {
 /** Get the local Schema Registry image tag based on user settings. */
 export function getLocalSchemaRegistryImageTag(): string {
   const configs: WorkspaceConfiguration = workspace.getConfiguration();
-  // we are not currently exposing these settings, so we'll always use the default value
   return configs.get(LOCAL_SCHEMA_REGISTRY_IMAGE_TAG, DEFAULT_SCHEMA_REGISTRY_TAG);
 }
 

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -8,7 +8,12 @@ import {
 } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { Logger } from "../logging";
-import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../preferences/constants";
+import {
+  LOCAL_KAFKA_IMAGE,
+  LOCAL_KAFKA_IMAGE_TAG,
+  LOCAL_SCHEMA_REGISTRY_IMAGE,
+  LOCAL_SCHEMA_REGISTRY_IMAGE_TAG,
+} from "../preferences/constants";
 
 const logger = new Logger("quickpicks.localResources");
 
@@ -37,7 +42,9 @@ export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
       description: schemaRegistryRepoTag,
       detail:
         "A local Schema Registry instance that can be used to manage schemas for Kafka topics",
-      // no button to change SR image until we have other candidate images
+      buttons: [
+        { iconPath: new ThemeIcon("gear"), tooltip: `Select Schema Registry Docker Image Tag` },
+      ],
     },
   ];
   quickpick.show();
@@ -58,6 +65,12 @@ export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
         commands.executeCommand(
           "workbench.action.openSettings",
           `@id:${LOCAL_KAFKA_IMAGE} @id:${LOCAL_KAFKA_IMAGE_TAG}`,
+        );
+      } else if (event.button.tooltip?.includes(LocalResourceKind.SchemaRegistry)) {
+        // open Settings and filter to the Schema Registry image repo+tag settings
+        commands.executeCommand(
+          "workbench.action.openSettings",
+          `@id:${LOCAL_SCHEMA_REGISTRY_IMAGE} @id:${LOCAL_SCHEMA_REGISTRY_IMAGE_TAG}`,
         );
       }
     },


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes https://github.com/confluentinc/vscode/issues/664.

Exposes the `confluent.localDocker.schemaRegistryImageTag` setting in package.json and adds a quickpick button for the SR image tag config to allow users to define an image tag other than `latest`:
<img width="1416" alt="image" src="https://github.com/user-attachments/assets/a90f5551-2a21-428f-99b2-22682a48e089">

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
