### PR TITLE
HTML closing tags fix 

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -12,19 +12,19 @@
   <body>
     <main class="container">
       <h1>Create a new connection (⚠️ experimental)</h1>
-      <p>Form currently <strong>only supports connections with no authentication required</strong>, but more auth types are coming soon. Close this tab to cancel changes.</p>
+      <p>
+        Form currently <strong>only supports connections with no authentication required</strong>,
+        but more auth types are coming soon. Close this tab to cancel changes.
+      </p>
       <form data-on-submit="this.handleSubmit(event)">
         <div class="input-container">
           <div>
             <label for="name" class="label">Connection Label (optional)</label>
-            <input
-              class="input"
-              id="name"
-              name="name"
-              type="text"
-            />
+            <input class="input" id="name" name="name" type="text" />
           </div>
-          <span class="description">An easy to remember name to reference this connection in the future</span>
+          <span class="description"
+            >An easy to remember name to reference this connection in the future</span
+          >
         </div>
         <fieldset>
           <legend>Kafka Broker</legend>
@@ -39,7 +39,10 @@
                 required
               />
             </div>
-            <span class="description">A comma-separated list of host/port pairs to use for establishing the initial connection to the Kafka cluster</span>
+            <span class="description"
+              >A comma-separated list of host/port pairs to use for establishing the initial
+              connection to the Kafka cluster</span
+            >
           </div>
         </fieldset>
         <fieldset>
@@ -47,36 +50,64 @@
           <div class="input-container">
             <div>
               <label for="uri" class="label">Schema Registry URL</label>
-              <input
-                class="input"
-                id="uri"
-                name="uri"
-                type="url"
-              />
+              <input class="input" id="uri" name="uri" type="url" />
             </div>
             <span class="description">The URL of the Schema Registry to use for serialization</span>
+          </div>
         </fieldset>
         <fieldset class="input-container">
           <legend>Which connection system or platform are you using?</legend>
           <div class="radio-container">
             <div>
-              <input type="radio" id="apache-kafka" name="platform" value="Apache Kafka" data-on-change="this.updateValue(event)" />
+              <input
+                type="radio"
+                id="apache-kafka"
+                name="platform"
+                value="Apache Kafka"
+                data-on-change="this.updateValue(event)"
+              />
               <label for="apache-kafka">Apache Kafka</label>
             </div>
             <div>
-              <input type="radio" id="confluent-cloud" name="platform" value="Confluent Cloud" data-on-change="this.updateValue(event)"/>
+              <input
+                type="radio"
+                id="confluent-cloud"
+                name="platform"
+                value="Confluent Cloud"
+                data-on-change="this.updateValue(event)"
+              />
               <label for="confluent-cloud">Confluent Cloud</label>
             </div>
             <div>
-              <input type="radio" id="confluent-platform" name="platform" value="Confluent Platform" data-on-change="this.updateValue(event)"/>
+              <input
+                type="radio"
+                id="confluent-platform"
+                name="platform"
+                value="Confluent Platform"
+                data-on-change="this.updateValue(event)"
+              />
               <label for="confluent-platform">Confluent Platform</label>
             </div>
             <div>
-              <input type="radio" id="local" name="platform" value="Local" data-on-change="this.updateValue(event)"/>
+              <input
+                type="radio"
+                id="local"
+                name="platform"
+                value="Local"
+                data-on-change="this.updateValue(event)"
+              />
               <label for="local">Local</label>
             </div>
             <div>
-              <input type="radio" id="other" name="platform" value="Other" checked required data-on-change="this.updateValue(event)"/>
+              <input
+                type="radio"
+                id="other"
+                name="platform"
+                value="Other"
+                checked
+                required
+                data-on-change="this.updateValue(event)"
+              />
               <label for="other">Other (specify)</label>
               <input
                 class="input"
@@ -88,14 +119,16 @@
             </div>
           </div>
         </fieldset>
-        </div>
         <!-- <input class="button" type="button" value="Test Connection" data-on-click="this.testConnection(event)" /> -->
-        <input class="button" type="submit" value="Save" data-attr-disabled="this.success()"/>
+        <input class="button" type="submit" value="Save" data-attr-disabled="this.success()" />
         <template data-if="this.errorMessage()">
           <div class="info error" data-text="this.errorMessage()"></div>
         </template>
         <template data-if="this.success() === true">
-          <div class="info success">Connection added. Close this tab and view & interact with your connection in the resources sidebar.</div>
+          <div class="info success">
+            Connection added. Close this tab and view & interact with your connection in the
+            resources sidebar.
+          </div>
         </template>
       </form>
     </main>

--- a/src/webview/topic-config-form.html
+++ b/src/webview/topic-config-form.html
@@ -12,16 +12,25 @@
   <body>
     <main class="container">
       <h1>Configure Topic: <span data-text="this.topicName()"></span></h1>
-        <template data-if="this.cCloudLink()">
-          <p>To configure advanced options, <a data-attr-href="this.settingsLink()">visit topic settings in Confluent Cloud.</a></p>
-        </template>
+      <template data-if="this.cCloudLink()">
+        <p>
+          To configure advanced options,
+          <a data-attr-href="this.settingsLink()">visit topic settings in Confluent Cloud.</a>
+        </p>
+      </template>
       <template data-if="this.errorOnSubmit()">
         <p class="error" data-text="this.errorOnSubmit()"></p>
       </template>
       <form data-on-submit="this.handleSubmit(event)">
         <div class="input-container">
           <label for="cleanup-policy" class="label">Cleanup Policy</label>
-            <span class="description">The retention policy to use on old log segments. <a href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#cleanup-policy">More info.</a></span>
+          <span class="description"
+            >The retention policy to use on old log segments.
+            <a
+              href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#cleanup-policy"
+              >More info.</a
+            ></span
+          >
           <select
             id="cleanup-policy"
             class="input dropdown"
@@ -33,59 +42,76 @@
             <option value="compact">Compact</option>
             <option value="compact,delete">Compact, Delete</option>
           </select>
-            <span class="info error"></span>
-          </div>
-          <div class="input-container">
-            <label for="retention-size" class="label">Retention Size</label>
-              <span class="description">The maximum size a partition can grow to before it is discarded to free up space. <a href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#retention-bytes">More info.</a></span>
-            <select
-              class="input dropdown"
-              id="retention-size"
-              name="retention.bytes"
-              data-prop-value="this.retentionSize()"
-              data-on-change="this.handleChange(event)"
-            >
-              <option value="1048576">1 MB</option>
-              <option value="1073741824">1 GB</option>
-              <option value="1099511627776">1 TB</option>
-              <option value="-1">Infinite</option>
-            </select>
-              <span class="info error"></span>
-          </div>
-          <div class="input-container">
-            <label for="retention-ms" class="label">Retention Time</label>
-            <span class="description">The amount of time to retain data. <a href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#retention-ms">More info.</a></span>
-            <select
-              class="input dropdown"
-              id="retention-ms"
-              name="retention.ms"
-              data-prop-value="this.retentionMs()"
-              data-on-change="this.handleChange(event)"
-            >
-              <option value="3600000">1 Hour</option>
-              <option value="86400000">1 Day</option>
-              <option value="604800000">1 Week</option>
-              <option value="2592000000">1 Month</option>
-              <option value="31536000000">1 Year (365 days)</option>
-              <option value="-1">Infinite</option>
-            </select>
-            <span class="info error"></span>
-          </div>
-          <div class="input-container">
-            <label for="max-message-bytes" class="label">Max Message Size (Bytes)</label>
-              <span class="description">The maximum message size that can be appended to this topic, in bytes. <a href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#max-message-bytes">More info.</a></span>
-            <input
-              class="input"
-              id="max-message-bytes"
-              name="max.message.bytes"
-              type="number"
-              min="0"
-              max="20971520"
-              data-prop-value="this.maxMessageBytes()"
-              data-on-change="this.handleChange(event)"
-            />
-              <span class="info error"></span>
-          </div>
+          <span class="info error"></span>
+        </div>
+        <div class="input-container">
+          <label for="retention-size" class="label">Retention Size</label>
+          <span class="description"
+            >The maximum size a partition can grow to before it is discarded to free up space.
+            <a
+              href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#retention-bytes"
+              >More info.</a
+            ></span
+          >
+          <select
+            class="input dropdown"
+            id="retention-size"
+            name="retention.bytes"
+            data-prop-value="this.retentionSize()"
+            data-on-change="this.handleChange(event)"
+          >
+            <option value="1048576">1 MB</option>
+            <option value="1073741824">1 GB</option>
+            <option value="1099511627776">1 TB</option>
+            <option value="-1">Infinite</option>
+          </select>
+          <span class="info error"></span>
+        </div>
+        <div class="input-container">
+          <label for="retention-ms" class="label">Retention Time</label>
+          <span class="description"
+            >The amount of time to retain data.
+            <a
+              href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#retention-ms"
+              >More info.</a
+            ></span
+          >
+          <select
+            class="input dropdown"
+            id="retention-ms"
+            name="retention.ms"
+            data-prop-value="this.retentionMs()"
+            data-on-change="this.handleChange(event)"
+          >
+            <option value="3600000">1 Hour</option>
+            <option value="86400000">1 Day</option>
+            <option value="604800000">1 Week</option>
+            <option value="2592000000">1 Month</option>
+            <option value="31536000000">1 Year (365 days)</option>
+            <option value="-1">Infinite</option>
+          </select>
+          <span class="info error"></span>
+        </div>
+        <div class="input-container">
+          <label for="max-message-bytes" class="label">Max Message Size (Bytes)</label>
+          <span class="description"
+            >The maximum message size that can be appended to this topic, in bytes.
+            <a
+              href="https://docs.confluent.io/cloud/current/client-apps/topics/manage.html#max-message-bytes"
+              >More info.</a
+            ></span
+          >
+          <input
+            class="input"
+            id="max-message-bytes"
+            name="max.message.bytes"
+            type="number"
+            min="0"
+            max="20971520"
+            data-prop-value="this.maxMessageBytes()"
+            data-on-change="this.handleChange(event)"
+          />
+          <span class="info error"></span>
         </div>
         <div class="flex-row">
           <input
@@ -151,9 +177,9 @@
         body {
           max-width: unset;
         }
-         .container {
+        .container {
           padding: 20px 50px;
-         }
+        }
         .input-container {
           display: flex;
           flex-direction: column;
@@ -198,7 +224,7 @@
       .button.ghost {
         background-color: transparent;
         border: none;
-        color: var(--vscode-button-secondaryForeground);
+        color: var(--vscode-descriptionForeground);
         padding: 5px 0;
       }
       .button.ghost:hover:not(:disabled) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- A couple of HTML `</div>` tags got out of place in recent updates to the Topic Config and Direct Connection forms. While these don't cause any user-facing errors (HTML is so resilient!), a part of our tool chain was surfacing them as Syntax Errors. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- It looks like a lot of line changes, but it's just a cascade of line length format changes after removing the 2 extra closing tags. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
