### PR TITLE
Augment ce-kafka-rest spec to include schema parameters in Records API

### DIFF
--- a/src/clients/kafkaRest/apis/RecordsV3Api.ts
+++ b/src/clients/kafkaRest/apis/RecordsV3Api.ts
@@ -24,6 +24,7 @@ import {
 export interface ProduceRecordRequest {
   cluster_id: string;
   topic_name: string;
+  dry_run?: string;
   ProduceRequest?: ProduceRequest;
 }
 
@@ -54,6 +55,10 @@ export class RecordsV3Api extends runtime.BaseAPI {
     }
 
     const queryParameters: any = {};
+
+    if (requestParameters["dry_run"] != null) {
+      queryParameters["dry_run"] = requestParameters["dry_run"];
+    }
 
     const headerParameters: runtime.HTTPHeaders = {};
 

--- a/src/clients/kafkaRest/apis/RecordsV3Api.ts
+++ b/src/clients/kafkaRest/apis/RecordsV3Api.ts
@@ -24,7 +24,7 @@ import {
 export interface ProduceRecordRequest {
   cluster_id: string;
   topic_name: string;
-  dry_run?: string;
+  dry_run?: boolean;
   ProduceRequest?: ProduceRequest;
 }
 

--- a/src/clients/kafkaRest/models/ProduceRequestData.ts
+++ b/src/clients/kafkaRest/models/ProduceRequestData.ts
@@ -27,6 +27,24 @@ export interface ProduceRequestData {
   type?: string;
   /**
    *
+   * @type {string}
+   * @memberof ProduceRequestData
+   */
+  subject?: string | null;
+  /**
+   *
+   * @type {string}
+   * @memberof ProduceRequestData
+   */
+  subject_name_strategy?: string | null;
+  /**
+   *
+   * @type {number}
+   * @memberof ProduceRequestData
+   */
+  schema_version?: number | null;
+  /**
+   *
    * @type {any}
    * @memberof ProduceRequestData
    */
@@ -53,6 +71,10 @@ export function ProduceRequestDataFromJSONTyped(
   }
   return {
     type: json["type"] == null ? undefined : json["type"],
+    subject: json["subject"] == null ? undefined : json["subject"],
+    subject_name_strategy:
+      json["subject_name_strategy"] == null ? undefined : json["subject_name_strategy"],
+    schema_version: json["schema_version"] == null ? undefined : json["schema_version"],
     data: json["data"] == null ? undefined : json["data"],
   };
 }
@@ -63,6 +85,9 @@ export function ProduceRequestDataToJSON(value?: ProduceRequestData | null): any
   }
   return {
     type: value["type"],
+    subject: value["subject"],
+    subject_name_strategy: value["subject_name_strategy"],
+    schema_version: value["schema_version"],
     data: value["data"],
   };
 }

--- a/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
+++ b/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
@@ -1753,7 +1753,7 @@ components:
       in: query
       required: false
       schema:
-        type: string
+        type: boolean
 
     IncludeAuthorizedOperations:
       name: include_authorized_operations

--- a/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
+++ b/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
@@ -980,6 +980,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/ClusterId"
       - $ref: "#/components/parameters/TopicName"
+      - $ref: "#/components/parameters/DryRun"
 
     post:
       summary: Produce Records
@@ -1745,6 +1746,14 @@ components:
       schema:
         type: string
       example: consumer-1
+
+    DryRun:
+      name: dry_run
+      description: "To validate the action can be performed successfully or not. Default: false"
+      in: query
+      required: false
+      schema:
+        type: string
 
     IncludeAuthorizedOperations:
       name: include_authorized_operations
@@ -2650,6 +2659,19 @@ components:
             - BINARY
             - JSON
             - STRING
+        subject:
+          type: string
+          nullable: true
+        subject_name_strategy:
+          type: string
+          x-extensible-enum:
+            - TOPIC_NAME
+            - RECORD_NAME
+            - TOPIC_RECORD_NAME
+          nullable: true
+        schema_version:
+          type: integer
+          nullable: true
         data:
           $ref: "#/components/schemas/AnyValue"
       nullable: true


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Resolves #613 

- Adds `subject`, `subject_name_strategy` and `schema_version` parameters as specified in the (non-CE) [Kafka REST spec](https://github.com/confluentinc/ide-sidecar/blob/main/kafka-rest.openapi.yaml#L2475-L2508). Notice that we've excluded `schema` and `schema_id` -- this is because ide-sidecar currently does not support these fields being set in the Records API requests.
- Also adds the `dry_run` query parameter to the Records API. Support for this was added in https://github.com/confluentinc/ide-sidecar/pull/165. This will be used to implement #576.
- Generated API clients using `npx gulp apigen`

