### PR TITLE
fix: only export ExtensionContext for extension test mode

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,9 @@ const logger = new Logger("extension");
 // This method is called when your extension is activated based on the activation events
 // defined in package.json
 // ref: https://code.visualstudio.com/api/references/activation-events
-export async function activate(context: vscode.ExtensionContext): Promise<vscode.ExtensionContext> {
+export async function activate(
+  context: vscode.ExtensionContext,
+): Promise<vscode.ExtensionContext | undefined> {
   observabilityContext.extensionVersion = context.extension.packageJSON.version;
   observabilityContext.extensionActivated = false;
 
@@ -102,8 +104,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<vscode
     Sentry.captureException(e);
     throw e;
   }
-  // XXX: used for testing; do not remove
-  return context;
+
+  // XXX: used to provide the ExtensionContext for tests; do not remove
+  if (context.extensionMode === vscode.ExtensionMode.Test) {
+    return context;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Currently, another extension can access that info (if the Confluent extension is activated) via:
```ts
const cfltExt = vscode.extensions.getExtension("confluentinc.vscode-confluent");
const cfltContext: vscode.ExtensionContext | undefined = cfltExt?.exports;
const status = await cfltContext?.secrets.get(<secret name>); // or .globalState / .workspaceState calls
```

This currently isn't a big problem considering we don't store any sensitive user info or CCloud auth information, but we need this to be tightened up before we start storing direct connection information in secret storage.

For the short term, we need to make sure we don't expose the extension context (global/workspace state, secret storage) to other extensions and only expose it for the "test" extension mode since our tests rely on it. Maybe longer-term we can decide if there are any bits of the extension we _do_ want to be visible to other extensions.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
