### PR TITLE
MINOR: direct connections follow-ups

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -18,7 +18,6 @@ import {
 } from "./clients/sidecar";
 import { getExtensionContext } from "./context/extension";
 import { ContextValues, setContextValue } from "./context/values";
-import { directConnectionDeleted } from "./emitters";
 import { ExtensionContextNotSetError } from "./errors";
 import { Logger } from "./logging";
 import { ConnectionId, isDirect } from "./models/resource";
@@ -188,7 +187,6 @@ export class DirectConnectionManager {
       action: "deleted",
     });
 
-    directConnectionDeleted.fire(id);
     ResourceLoader.deregisterInstance(id);
   }
 

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -99,6 +99,10 @@ export class DirectConnectionManager {
         // watch for any cross-workspace direct connection additions/removals
         if (key === SecretStorageKeys.DIRECT_CONNECTIONS) {
           const connections = await getResourceManager().getDirectConnections();
+          // ensure all DirectResourceLoader instances are up to date
+          for (const [id] of connections.entries()) {
+            this.initResourceLoader(id as ConnectionId);
+          }
           // refresh the Resources view to stay in sync with the secret storage
           getResourceViewProvider().refresh();
           // if the Topics/Schemas views were focused on a resource whose direct connection was removed,

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -99,9 +99,15 @@ export class DirectConnectionManager {
         // watch for any cross-workspace direct connection additions/removals
         if (key === SecretStorageKeys.DIRECT_CONNECTIONS) {
           const connections = await getResourceManager().getDirectConnections();
-          // ensure all DirectResourceLoader instances are up to date
+          // ensure all DirectResourceLoader instances are up to date -- if this isn't done, hopping
+          // workspaces and attempting to focus on a direct connection-based resource will fail with
+          // the `Unknown connection ID` error
+          const existingLoaderIds = ResourceLoader.loaders().map((loader) => loader.connectionId);
           for (const [id] of connections.entries()) {
-            this.initResourceLoader(id as ConnectionId);
+            const connId = id as ConnectionId;
+            if (!existingLoaderIds.includes(connId)) {
+              this.initResourceLoader(connId);
+            }
           }
           // refresh the Resources view to stay in sync with the secret storage
           getResourceViewProvider().refresh();

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -100,6 +100,8 @@ export class DirectConnectionManager {
         // watch for any cross-workspace direct connection additions/removals
         if (key === SecretStorageKeys.DIRECT_CONNECTIONS) {
           const connections = await getResourceManager().getDirectConnections();
+          // refresh the Resources view to stay in sync with the secret storage
+          getResourceViewProvider().refresh();
           // if the Topics/Schemas views were focused on a resource whose direct connection was removed,
           // reset the view(s) to prevent orphaned resources from being used for requests
           const topicsView = getTopicViewProvider();
@@ -173,8 +175,6 @@ export class DirectConnectionManager {
     await getResourceManager().addDirectConnection(spec);
     // create a new ResourceLoader instance for managing the new connection's resources
     this.initResourceLoader(connectionId);
-    // refresh the Resources view to load the new connection
-    getResourceViewProvider().refresh();
 
     // `message` is hard-coded in the webview, so we don't actually use the connection object yet
     return { success, message: JSON.stringify(connection) };
@@ -188,8 +188,6 @@ export class DirectConnectionManager {
       action: "deleted",
     });
 
-    // refresh the Resources view to remove the deleted connection
-    getResourceViewProvider().refresh();
     directConnectionDeleted.fire(id);
     ResourceLoader.deregisterInstance(id);
   }

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -250,7 +250,7 @@ export class DirectConnectionManager {
         newConnectionPromises.push(tryToCreateConnection(connectionSpec));
       }
       // create a new ResourceLoader instance for managing the new connection's resources
-      this.initResourceLoader(id as ConnectionId);
+      this.initResourceLoader(id);
     }
 
     if (newConnectionPromises.length > 0) {

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { KafkaCluster } from "./models/kafkaCluster";
-import { ConnectionId } from "./models/resource";
 import { SchemaRegistry } from "./models/schemaRegistry";
 
 // NOTE: these are kept at the global level to allow for easy access from any file and track where
@@ -17,9 +16,6 @@ export const ccloudOrganizationChanged = new vscode.EventEmitter<void>();
 
 export const localKafkaConnected = new vscode.EventEmitter<boolean>();
 export const localSchemaRegistryConnected = new vscode.EventEmitter<boolean>();
-
-/** Indicate that a direct connection was removed, by its connection ID. */
-export const directConnectionDeleted = new vscode.EventEmitter<ConnectionId>();
 
 /**
  * Fired whenever a Kafka cluster is selected from the Resources view, chosen from the "Select Kafka

--- a/src/storage/resourceLoader.ts
+++ b/src/storage/resourceLoader.ts
@@ -36,7 +36,7 @@ export abstract class ResourceLoader implements IResourceBase {
   }
 
   // Map of connectionId to ResourceLoader instance.
-  private static registry: Map<string, ResourceLoader> = new Map();
+  private static registry: Map<ConnectionId, ResourceLoader> = new Map();
 
   public static registerInstance(connectionId: ConnectionId, loader: ResourceLoader): void {
     ResourceLoader.registry.set(connectionId, loader);

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -4,14 +4,13 @@ import { ContextValues, setContextValue } from "../context/values";
 import {
   ccloudConnected,
   currentSchemaRegistryChanged,
-  directConnectionDeleted,
   localSchemaRegistryConnected,
 } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
 import { ContainerTreeItem } from "../models/main";
-import { ConnectionId, isCCloud, isLocal } from "../models/resource";
+import { isCCloud, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, generateSchemaSubjectGroups } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { ResourceLoader } from "../storage/resourceLoader";
@@ -140,16 +139,6 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
       }
     });
 
-    const directDisconnectedSub: vscode.Disposable = directConnectionDeleted.event(
-      (connectionId: ConnectionId) => {
-        if (this.schemaRegistry && this.schemaRegistry.connectionId === connectionId) {
-          logger.debug("directConnectionDeleted event fired, resetting", { connectionId });
-          // any deletion of the focused direct connection should reset the tree view
-          this.reset();
-        }
-      },
-    );
-
     const localSchemaRegistryConnectedSub: vscode.Disposable = localSchemaRegistryConnected.event(
       (connected: boolean) => {
         if (this.schemaRegistry && isLocal(this.schemaRegistry)) {
@@ -183,12 +172,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
       },
     );
 
-    return [
-      ccloudConnectedSub,
-      directDisconnectedSub,
-      localSchemaRegistryConnectedSub,
-      currentSchemaRegistryChangedSub,
-    ];
+    return [ccloudConnectedSub, localSchemaRegistryConnectedSub, currentSchemaRegistryChangedSub];
   }
 
   /** Try to reveal this particular schema, if present */

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -1,18 +1,13 @@
 import * as vscode from "vscode";
 import { getExtensionContext } from "../context/extension";
 import { ContextValues, setContextValue } from "../context/values";
-import {
-  ccloudConnected,
-  currentKafkaClusterChanged,
-  directConnectionDeleted,
-  localKafkaConnected,
-} from "../emitters";
+import { ccloudConnected, currentKafkaClusterChanged, localKafkaConnected } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
 import { KafkaCluster } from "../models/kafkaCluster";
 import { ContainerTreeItem } from "../models/main";
-import { ConnectionId, isCCloud, isLocal } from "../models/resource";
+import { isCCloud, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, generateSchemaSubjectGroups } from "../models/schema";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
 import { ResourceLoader, TopicFetchError } from "../storage/resourceLoader";
@@ -144,16 +139,6 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
       }
     });
 
-    const directDisconnectedSub: vscode.Disposable = directConnectionDeleted.event(
-      (connectionId: ConnectionId) => {
-        if (this.kafkaCluster && this.kafkaCluster.connectionId === connectionId) {
-          logger.debug("directConnectionDeleted event fired, resetting", { connectionId });
-          // any deletion of the focused direct connection should reset the tree view
-          this.reset();
-        }
-      },
-    );
-
     const localKafkaConnectedSub: vscode.Disposable = localKafkaConnected.event(
       (connected: boolean) => {
         if (this.kafkaCluster && isLocal(this.kafkaCluster)) {
@@ -195,12 +180,7 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
       },
     );
 
-    return [
-      ccloudConnectedSub,
-      directDisconnectedSub,
-      localKafkaConnectedSub,
-      currentKafkaClusterChangedSub,
-    ];
+    return [ccloudConnectedSub, localKafkaConnectedSub, currentKafkaClusterChangedSub];
   }
 }
 

--- a/tests/unit/testResources/kafkaCluster.ts
+++ b/tests/unit/testResources/kafkaCluster.ts
@@ -1,10 +1,9 @@
-import { randomUUID } from "crypto";
 import {
   CCloudKafkaCluster,
   DirectKafkaCluster,
   LocalKafkaCluster,
 } from "../../../src/models/kafkaCluster";
-import { ConnectionId } from "../../../src/models/resource";
+import { TEST_DIRECT_CONNECTION_ID } from "./connection";
 import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_PROVIDER, TEST_CCLOUD_REGION } from "./environments";
 
 export const TEST_LOCAL_KAFKA_CLUSTER: LocalKafkaCluster = LocalKafkaCluster.create({
@@ -25,7 +24,7 @@ export const TEST_CCLOUD_KAFKA_CLUSTER: CCloudKafkaCluster = CCloudKafkaCluster.
 });
 
 export const TEST_DIRECT_KAFKA_CLUSTER = DirectKafkaCluster.create({
-  connectionId: randomUUID() as ConnectionId,
+  connectionId: TEST_DIRECT_CONNECTION_ID,
   // connectionType set by default
   id: "direct-abc123",
   name: "Kafka Cluster",

--- a/tests/unit/testResources/topic.ts
+++ b/tests/unit/testResources/topic.ts
@@ -1,9 +1,13 @@
 import { KAFKA_TOPIC_OPERATIONS } from "../../../src/authz/constants";
 import { ConnectionType } from "../../../src/clients/sidecar";
 import { CCLOUD_CONNECTION_ID, LOCAL_CONNECTION_ID } from "../../../src/constants";
-import { ConnectionId } from "../../../src/models/resource";
 import { KafkaTopic } from "../../../src/models/topic";
-import { TEST_CCLOUD_KAFKA_CLUSTER, TEST_LOCAL_KAFKA_CLUSTER } from "./kafkaCluster";
+import { TEST_DIRECT_CONNECTION_ID } from "./connection";
+import {
+  TEST_CCLOUD_KAFKA_CLUSTER,
+  TEST_DIRECT_KAFKA_CLUSTER,
+  TEST_LOCAL_KAFKA_CLUSTER,
+} from "./kafkaCluster";
 
 const TEST_KAFKA_TOPIC_BODY = {
   // connectionId: configured below
@@ -42,10 +46,10 @@ export const TEST_CCLOUD_KAFKA_TOPIC: KafkaTopic = KafkaTopic.create({
 
 export const TEST_DIRECT_KAFKA_TOPIC: KafkaTopic = KafkaTopic.create({
   ...TEST_KAFKA_TOPIC_BODY,
-  connectionId: "test-direct-connection" as ConnectionId,
+  connectionId: TEST_DIRECT_CONNECTION_ID,
   connectionType: ConnectionType.Direct,
   name: "test-direct-topic",
   partition_count: 1,
-  clusterId: "test-direct-cluster",
-  environmentId: "test-direct-connection",
+  clusterId: TEST_DIRECT_KAFKA_CLUSTER.id,
+  environmentId: TEST_DIRECT_KAFKA_CLUSTER.environmentId,
 });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Resources view now updates across workspaces whenever a connection is added/deleted (instead of only one workspace calling `getResourceViewProvider().refresh()` during create/delete)
- The `DirectConnectionManager`'s secrets listener reinitializes any missing `DirectResourceLoader` instances upon adding/removing connections (cross-workspace)
- Removed the`directConnectionDeleted` emitter since the `DirectConnectionManager`'s secrets listener was already handling that same behavior: https://github.com/confluentinc/vscode/blob/48999081ae62d4a45875667426293e312ab49ad3/src/directConnectManager.ts#L103-L115
- Cleanup for `Direct*` test resources to use other `Direct*` resources' properties instead of randomly generated strings

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
