### PR TITLE
Repaint the schema view earlier and always if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this extension will be documented in this file.
   [issue #642](https://github.com/confluentinc/vscode/issues/642).
 - Fix possible race conditions in workspace state cache management when needing to read and mutate
   existing workspace state keys, [issue #534](https://github.com/confluentinc/vscode/issues/534).
+- Improve auto-refreshing the schema view controller when uploading a schema to the viewed registry, 
+  [issue #640](https://github.com/confluentinc/vscode/issues/640).
 
 ## 0.21.2
 

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -14,7 +14,7 @@ import { schemaRegistryQuickPick } from "../quickpicks/schemaRegistries";
 import { schemaSubjectQuickPick } from "../quickpicks/schemas";
 import { getSidecar } from "../sidecar";
 import { ResourceLoader } from "../storage/resourceLoader";
-import { getSchemasViewProvider } from "../viewProviders/schemas";
+import { getSchemasViewProvider, SchemasViewProvider } from "../viewProviders/schemas";
 
 const logger = new Logger("commands.schemaUpload");
 
@@ -125,15 +125,13 @@ export async function uploadNewSchema(item: vscode.Uri) {
 
   logger.info(successMessage);
 
-  // Refresh the schema registry cache while offering the user the option to view the schema in the schema registry.
-  const promises = [
-    vscode.window.showInformationMessage(successMessage, "View in Schema Registry"),
-    updateRegistryCacheAndFindNewSchema(registry, maybeNewId, subject),
-  ];
-
-  const results = await Promise.all(promises);
-
   const schemaViewProvider = getSchemasViewProvider();
+
+  // Refresh the schema registry cache while offering the user the option to view the schema in the schema registry.
+  const results: [string | undefined, Schema] = await Promise.all([
+    vscode.window.showInformationMessage(successMessage, "View in Schema Registry"),
+    updateRegistryCacheAndFindNewSchema(registry, maybeNewId, subject, schemaViewProvider),
+  ]);
 
   if (results[0]) {
     // User chose to view the schema in the schema registry.
@@ -145,11 +143,7 @@ export async function uploadNewSchema(item: vscode.Uri) {
 
     // get the new schema to pop in the view by getting the treeitem to reveal
     // the schema's item.
-    schemaViewProvider.revealSchema(results[1] as Schema);
-  } else {
-    // They didn't want to view the schema in the schema registry.
-    // But at least do a shallow refresh of the schema registry view.
-    schemaViewProvider.refresh();
+    schemaViewProvider.revealSchema(results[1]);
   }
 }
 
@@ -519,6 +513,7 @@ async function updateRegistryCacheAndFindNewSchema(
   registry: SchemaRegistry,
   newSchemaID: number,
   boundSubject: string,
+  schemaViewProvider: SchemasViewProvider,
 ): Promise<Schema> {
   const loader = ResourceLoader.getInstance(registry.connectionId);
 
@@ -527,6 +522,14 @@ async function updateRegistryCacheAndFindNewSchema(
   // Find the schema in the list of schemas for this registry. We know that
   // it should be present in the cache because we have just refreshed the cache.
   const schema = allSchemas!.find((s) => s.id === `${newSchemaID}` && s.subject === boundSubject);
+
+  // While here, if the schema view controller is focused on this registry, do a shallow refresh.
+  // (shallow is fine because we just updated the cache at the loader level).
+  // (This ensures that even if the user doesn't chose to highlight the new schema in the schema registry view,
+  //  they will still see the new schema in the view if they have it open w/o having to hit the 'refresh' button.)
+  if (schemaViewProvider.schemaRegistry?.id === registry.id) {
+    schemaViewProvider.refresh();
+  }
 
   return schema!;
 }

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -523,10 +523,13 @@ async function updateRegistryCacheAndFindNewSchema(
   // it should be present in the cache because we have just refreshed the cache.
   const schema = allSchemas!.find((s) => s.id === `${newSchemaID}` && s.subject === boundSubject);
 
-  // While here, if the schema view controller is focused on this registry, do a shallow refresh.
-  // (shallow is fine because we just updated the cache at the loader level).
-  // (This ensures that even if the user doesn't chose to highlight the new schema in the schema registry view,
-  //  they will still see the new schema in the view if they have it open w/o having to hit the 'refresh' button.)
+  // While here, if the schema view controller is focused on this registry, do a shallow refresh
+  //  (shallow is fine because we just updated any possible cache at the loader level).
+
+  // This ensures that even if the user doesn't chose to highlight the new schema in the schema registry view,
+  // they will still see the new schema in the view if they currently have its schema registry open
+  // w/o having to hit the 'refresh' button.
+
   if (schemaViewProvider.schemaRegistry?.id === registry.id) {
     schemaViewProvider.refresh();
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Push the refresh of the schemas view to happen earlier and independent of the user's info message choice to 
"reveal the schema" if we just uploaded a new schema into the being-viewed schema registry.
- We used to do this only after the user canceled the info box, but now we always do it, concurrently with the info box being displayed so as to be efficient time-wise from the user's perspective.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #640

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
