### PR TITLE
MINOR: drop non-ResponseError docker logs to `debug`

### DIFF
--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -101,14 +101,17 @@ export async function isDockerAvailable(showNotification: boolean = false): Prom
     logger.debug("docker ping response:", resp);
     return true;
   } catch (error) {
-    if (error instanceof ResponseError) {
+    // either float this as an `error` log if it's a ResponseError or was an explicit action that
+    // warrants notifying the user that something is wrong
+    if (error instanceof ResponseError || showNotification) {
       logResponseError(error, "docker ping");
-      if (showNotification) {
-        await showDockerUnavailableErrorNotification(error);
-      }
     } else {
       // likely FetchError->TypeError: connect ENOENT <socket path> but not a lot else we can do here
       logger.debug("docker ping error:", error);
+    }
+    //...and then actually show the notification if it's requested
+    if (showNotification) {
+      await showDockerUnavailableErrorNotification(error);
     }
   }
   return false;

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -101,9 +101,14 @@ export async function isDockerAvailable(showNotification: boolean = false): Prom
     logger.debug("docker ping response:", resp);
     return true;
   } catch (error) {
-    logResponseError(error, "docker ping");
-    if (showNotification) {
-      await showDockerUnavailableErrorNotification(error);
+    if (error instanceof ResponseError) {
+      logResponseError(error, "docker ping");
+      if (showNotification) {
+        await showDockerUnavailableErrorNotification(error);
+      }
+    } else {
+      // likely FetchError->TypeError: connect ENOENT <socket path> but not a lot else we can do here
+      logger.debug("docker ping error:", error);
     }
   }
   return false;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

When we're polling the Docker engine API's `/_ping` endpoint and can't reach docker due to it not running (or similar non-ResponseError scenarios), we shouldn't bubble those up to the `error` log level, as it may mislead users into thinking something is wrong. This PR drops those passive `error` logs to `debug`:

Before:
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/ec0aa1e7-04f5-4550-a21c-fcd9912d76fa">


After:
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/6c37ea93-cd10-478d-b9b7-b9d0ffd1c401">


While still floating the error notification if the user attempts to launch a local resource and Docker is still unreachable:
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/803fa251-c4fe-4e95-8a1e-2763b9a402fa">




## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
