### PR TITLE
MINOR: drop Schema Registry authz error log to `debug`

### DIFF
--- a/src/authz/schemaRegistry.ts
+++ b/src/authz/schemaRegistry.ts
@@ -69,7 +69,7 @@ export async function canAccessSchemaTypeForTopic(
   } catch (error) {
     if (error instanceof ResponseError) {
       const decision = await determineAccessFromResponseError(error.response);
-      logger.debug("determined access from response error:", { decision, type });
+      logger.debug("determined access from response error:", { canAccessSchemas: decision, type });
       return decision;
     } else {
       logger.error("error making lookupSchemaUnderSubject request:", error);
@@ -88,8 +88,7 @@ export async function determineAccessFromResponseError(response: Response): Prom
     return false;
   }
 
-  logger.error("error response looking up subject:", body);
-
+  logger.debug("error response looking up subject:", body);
   // "Schema not found" = schema exists but this endpoint can't get it (???)
   const schema404 = body.error_code === 40403;
   // "Subject '...' not found" = no schema(s) for the topic


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Drops one portion of logging from `error` to `debug` when determining, from the SR API error response, whether or not a user can access the Schema Registry subjects.

Before:
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/d2622765-1353-4bf1-b74c-bc7f6f17f964">

After:
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/6b4ef4da-e9d1-416f-8684-0bb3dbd6f1b1">

Will likely need one more small follow-on branch to update our middlewares to specifically look for this kind of request without masking/silencing any error responses for actions dealing with schema uploads.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
