### PR TITLE
create telemetry event enum and `logUsage()` wrapper

### DIFF
--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -17,6 +17,7 @@ import {
 import { getStorageManager } from "../storage";
 import { SecretStorageKeys } from "../storage/constants";
 import { getResourceManager } from "../storage/resourceManager";
+import { UserEvent } from "../telemetry/events";
 import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
 import { getUriHandler } from "../uriHandler";
 import { openExternal, pollCCloudConnectionAuth } from "./ccloudPolling";
@@ -158,7 +159,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     // User logged in successfully so we send an identify event to Segment
     if (authenticatedConnection.status.authentication.user) {
       sendTelemetryIdentifyEvent({
-        eventName: "Signed In",
+        eventName: UserEvent.SignedIn,
         userInfo: authenticatedConnection.status.authentication.user,
         session: undefined,
       });

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -18,6 +18,7 @@ import { Logger } from "../logging";
 import { ConnectionLabel } from "../models/resource";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
 import { localResourcesQuickPick } from "../quickpicks/localResources";
+import { UserEvent } from "../telemetry/events";
 
 const logger = new Logger("commands.docker");
 
@@ -103,7 +104,7 @@ export async function runWorkflowWithProgress(
             start,
             resourceKind: workflow.resourceKind,
           });
-          workflow.sendTelemetryEvent("Notification Button Clicked", {
+          workflow.sendTelemetryEvent(UserEvent.NotificationButtonClicked, {
             buttonLabel: "Cancel",
             notificationType: "progress",
             start,
@@ -112,7 +113,7 @@ export async function runWorkflowWithProgress(
         });
 
         logger.debug(`running ${workflow.resourceKind} workflow`, { start });
-        workflow.sendTelemetryEvent("Workflow Initiated", {
+        workflow.sendTelemetryEvent(UserEvent.WorkflowInitiated, {
           start,
         });
         try {
@@ -122,13 +123,13 @@ export async function runWorkflowWithProgress(
             await workflow.stop(token, progress);
           }
           logger.debug(`finished ${workflow.resourceKind} workflow`, { start });
-          workflow.sendTelemetryEvent("Workflow Finished", {
+          workflow.sendTelemetryEvent(UserEvent.WorkflowFinished, {
             start,
           });
         } catch (error) {
           logger.error(`error running ${workflow.resourceKind} workflow`, error);
           if (error instanceof Error) {
-            workflow.sendTelemetryEvent("Workflow Errored", {
+            workflow.sendTelemetryEvent(UserEvent.WorkflowErrored, {
               start,
             });
             Sentry.captureException(error, {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
 import { Logger } from "../logging";
-import { getTelemetryLogger } from "../telemetry/telemetryLogger";
+import { UserEvent, logUsage } from "../telemetry/events";
 
 const logger = new Logger("commands");
 
@@ -10,7 +10,7 @@ export function registerCommandWithLogging(
   command: (...args: any[]) => void,
 ): vscode.Disposable {
   const wrappedCommand = async (...args: any[]) => {
-    getTelemetryLogger().logUsage("Command Invoked", { command: commandName });
+    logUsage(UserEvent.CommandInvoked, { command: commandName });
     try {
       await command(...args);
     } catch (e) {

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -38,7 +38,7 @@ import { DirectResourceLoader } from "./storage/directResourceLoader";
 import { LocalResourceLoader } from "./storage/localResourceLoader";
 import { ResourceLoader } from "./storage/resourceLoader";
 import { BitSet, includesSubstring, Stream } from "./stream/stream";
-import { getTelemetryLogger } from "./telemetry/telemetryLogger";
+import { logUsage, UserEvent } from "./telemetry/events";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { type post } from "./webview/message-viewer";
@@ -1010,7 +1010,7 @@ class Timer extends Data {
 }
 
 function track(details: object) {
-  getTelemetryLogger().logUsage("Message Viewer Action", details);
+  logUsage(UserEvent.MessageViewerAction, details);
 }
 
 let timer: ReturnType<typeof setTimeout>;

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -33,7 +33,7 @@ import { SecretStorageKeys } from "./storage/constants";
 import { DirectResourceLoader } from "./storage/directResourceLoader";
 import { ResourceLoader } from "./storage/resourceLoader";
 import { DirectConnectionsById, getResourceManager } from "./storage/resourceManager";
-import { getTelemetryLogger } from "./telemetry/telemetryLogger";
+import { logUsage, UserEvent } from "./telemetry/events";
 import { getResourceViewProvider } from "./viewProviders/resources";
 import { getSchemasViewProvider } from "./viewProviders/schemas";
 import { getTopicViewProvider } from "./viewProviders/topics";
@@ -179,7 +179,7 @@ export class DirectConnectionManager {
       return { success: false, message: errorMessage };
     }
 
-    getTelemetryLogger().logUsage("Connection", {
+    logUsage(UserEvent.DirectConnectionAction, {
       type: platform,
       action: "created",
       withKafka: !!kafkaClusterConfig,
@@ -199,7 +199,7 @@ export class DirectConnectionManager {
     await Promise.all([getResourceManager().deleteDirectConnection(id), tryToDeleteConnection(id)]);
 
     // TODO(shoup): look up connection platform once we begin storing it alongside the spec
-    getTelemetryLogger().logUsage("Connection", {
+    logUsage(UserEvent.DirectConnectionAction, {
       action: "deleted",
     });
 

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -1,6 +1,6 @@
 import { ImageApi, ImageInspect, ResponseError } from "../clients/docker";
 import { Logger } from "../logging";
-import { getTelemetryLogger } from "../telemetry/telemetryLogger";
+import { UserEvent, logUsage } from "../telemetry/events";
 import { defaultRequestInit } from "./configs";
 
 const logger = new Logger("docker.images");
@@ -56,7 +56,7 @@ export async function pullImage(repo: string, tag: string): Promise<void> {
       status: resp.raw.status,
       statusText: resp.raw.statusText,
     });
-    getTelemetryLogger().logUsage("Docker Image Pulled", {
+    logUsage(UserEvent.DockerImagePulled, {
       dockerImage: repoTag,
     });
   } catch (error) {

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -19,6 +19,7 @@ import { localKafkaConnected } from "../../emitters";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
 import { ResourceManager } from "../../storage/resourceManager";
+import { UserEvent } from "../../telemetry/events";
 import { getLocalKafkaImageTag } from "../configs";
 import { MANAGED_CONTAINER_LABEL } from "../constants";
 import { createContainer, getContainersForImage } from "../containers";
@@ -101,7 +102,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     }
     count = parseInt(numContainersString, 10);
     const plural = count > 1 ? "s" : "";
-    this.sendTelemetryEvent("Input Box Filled", {
+    this.sendTelemetryEvent(UserEvent.InputBoxFilled, {
       numContainers: count,
       purpose: "Kafka Broker/Container Count",
     });
@@ -136,7 +137,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
         success = false;
         break;
       }
-      this.sendTelemetryEvent("Docker Container Created", {
+      this.sendTelemetryEvent(UserEvent.DockerContainerCreated, {
         dockerContainerName: container.name,
       });
       // then start the container

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -12,6 +12,7 @@ import { localSchemaRegistryConnected } from "../../emitters";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
 import { updateLocalConnection } from "../../sidecar/connections";
+import { UserEvent } from "../../telemetry/events";
 import {
   getLocalKafkaImageName,
   getLocalKafkaImageTag,
@@ -102,7 +103,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
             commands.executeCommand("confluent.docker.startLocalResources", [
               LocalResourceKind.Kafka,
             ]);
-            this.sendTelemetryEvent("Notification Button Clicked", {
+            this.sendTelemetryEvent(UserEvent.NotificationButtonClicked, {
               buttonLabel: START_KAFKA_BUTTON,
               notificationType: "error",
               purpose: "No Kafka Containers Found",
@@ -112,7 +113,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
               "workbench.action.openSettings",
               `@id:${LOCAL_KAFKA_IMAGE} @id:${LOCAL_KAFKA_IMAGE_TAG}`,
             );
-            this.sendTelemetryEvent("Notification Button Clicked", {
+            this.sendTelemetryEvent(UserEvent.NotificationButtonClicked, {
               buttonLabel: IMAGE_SETTINGS_BUTTON,
               notificationType: "error",
               purpose: "No Kafka Containers Found",
@@ -140,7 +141,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       this.showErrorNotification(`Failed to create ${this.resourceKind} container.`);
       return;
     }
-    this.sendTelemetryEvent("Docker Container Created", {
+    this.sendTelemetryEvent(UserEvent.DockerContainerCreated, {
       dockerContainerName: container.name,
     });
     if (token.isCancellationRequested) return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,6 +74,7 @@ import { getCCloudAuthSession } from "./sidecar/connections";
 import { StorageManager } from "./storage";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
 import { constructResourceLoaderSingletons } from "./storage/resourceLoaderInitialization";
+import { UserEvent, logUsage } from "./telemetry/events";
 import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { getUriHandler } from "./uriHandler";
@@ -119,7 +120,7 @@ export async function activate(
 async function _activateExtension(
   context: vscode.ExtensionContext,
 ): Promise<vscode.ExtensionContext> {
-  getTelemetryLogger().logUsage("Extension Activated");
+  logUsage(UserEvent.ExtensionActivated);
 
   // must be done first to allow any other downstream callers to call `getExtensionContext()`
   // (e.g. StorageManager for secrets/states, webviews for extension root path, etc)
@@ -341,7 +342,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
   // Send an Identify event to Segment with the session info if available
   if (cloudSession) {
     sendTelemetryIdentifyEvent({
-      eventName: "Activated With Session",
+      eventName: UserEvent.ActivatedWithSession,
       userInfo: undefined,
       session: cloudSession,
     });

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -9,7 +9,7 @@ import { getSidecar } from "./sidecar";
 
 import { ExtensionContext, ViewColumn } from "vscode";
 import { registerCommandWithLogging } from "./commands";
-import { getTelemetryLogger } from "./telemetry/telemetryLogger";
+import { UserEvent, logUsage } from "./telemetry/events";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { type post } from "./webview/scaffold-form";
@@ -45,7 +45,7 @@ export const scaffoldProjectRequest = async () => {
   }
 
   if (pickedTemplate !== undefined) {
-    getTelemetryLogger().logUsage("Scaffold Template Picked", {
+    logUsage(UserEvent.ScaffoldTemplatePicked, {
       templateName: pickedTemplate.spec.display_name,
     });
   } else {
@@ -91,7 +91,7 @@ export const scaffoldProjectRequest = async () => {
         return null satisfies MessageResponse<"SetOptionValue">;
       }
       case "Submit":
-        getTelemetryLogger().logUsage("Scaffold Form Submitted", {
+        logUsage(UserEvent.ScaffoldFormSubmitted, {
           templateName: pickedTemplate?.spec.display_name,
         });
         if (pickedTemplate) applyTemplate(pickedTemplate, body.data);
@@ -130,7 +130,7 @@ async function applyTemplate(
 
     if (!fileUris || fileUris.length !== 1) {
       // This means the user cancelled @ save dialog. Show a message and return
-      getTelemetryLogger().logUsage("Scaffold Cancelled", {
+      logUsage(UserEvent.ScaffoldCancelled, {
         templateName: pickedTemplate.spec.display_name,
       });
       vscode.window.showInformationMessage("Project generation cancelled");
@@ -140,7 +140,7 @@ async function applyTemplate(
     const destination = await getNonConflictingDirPath(fileUris[0], pickedTemplate);
 
     await extractZipContents(arrayBuffer, destination);
-    getTelemetryLogger().logUsage("Scaffold Completed", {
+    logUsage(UserEvent.ScaffoldCompleted, {
       templateName: pickedTemplate.spec.display_name,
     });
     // Notify the user that the project was generated successfully
@@ -155,7 +155,7 @@ async function applyTemplate(
       // if "true" is set in the `vscode.openFolder` command, it will open a new window instead of
       // reusing the current one
       const keepsExistingWindow = selection.title === "Open in New Window";
-      getTelemetryLogger().logUsage("Scaffold Folder Opened", {
+      logUsage(UserEvent.ScaffoldFolderOpened, {
         templateName: pickedTemplate.spec.display_name,
         keepsExistingWindow,
       });

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -9,11 +9,14 @@ export enum UserEvent {
 
   DirectConnectionAction = "Direct Connection Action",
 
+  DockerContainerCreated = "Docker Container Created",
   DockerContainerStarted = "Docker Container Started",
   DockerContainerStopped = "Docker Container Stopped",
   DockerImagePulled = "Docker Image Pulled",
 
   ExtensionActivated = "Extension Activated",
+
+  InputBoxFilled = "Input Box Filled",
 
   MessageViewerAction = "Message Viewer Action",
 
@@ -26,6 +29,10 @@ export enum UserEvent {
   ScaffoldFolderOpened = "Scaffold Folder Opened",
 
   SignedIn = "Signed In",
+
+  WorkflowInitiated = "Workflow Initiated",
+  WorkflowFinished = "Workflow Finished",
+  WorkflowErrored = "Workflow Errored",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -1,0 +1,34 @@
+import { TelemetryTrustedValue } from "vscode";
+import { getTelemetryLogger } from "./telemetryLogger";
+
+/** The names of user events that can be logged when telemetry is enabled. */
+export enum UserEvent {
+  ActivatedWithSession = "Activated With Session",
+
+  CommandInvoked = "Command Invoked",
+
+  DirectConnectionAction = "Direct Connection Action",
+
+  DockerContainerStarted = "Docker Container Started",
+  DockerContainerStopped = "Docker Container Stopped",
+  DockerImagePulled = "Docker Image Pulled",
+
+  ExtensionActivated = "Extension Activated",
+
+  MessageViewerAction = "Message Viewer Action",
+
+  NotificationButtonClicked = "Notification Button Clicked",
+
+  ScaffoldTemplatePicked = "Scaffold Template Picked",
+  ScaffoldFormSubmitted = "Scaffold Form Submitted",
+  ScaffoldCancelled = "Scaffold Cancelled",
+  ScaffoldCompleted = "Scaffold Completed",
+  ScaffoldFolderOpened = "Scaffold Folder Opened",
+
+  SignedIn = "Signed In",
+}
+
+/** Log a {@link UserEvent} with optional extra data. */
+export function logUsage(event: UserEvent, data?: Record<string, any | TelemetryTrustedValue>) {
+  getTelemetryLogger().logUsage(event, data);
+}

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { UserInfo } from "../clients/sidecar/models/UserInfo";
-import { getTelemetryLogger } from "./telemetryLogger";
+import { logUsage, UserEvent } from "./events";
 
 /** Given authenticated session and/or userInfo, clean the data & send an Identify event to Segment via TelemetryLogger
  * @param eventName - The event name to be sent to Segment as a follow up per docs: "follow the Identify call with a Track event that records what caused the user to be identified"
@@ -15,7 +15,7 @@ export function sendTelemetryIdentifyEvent({
   userInfo,
   session,
 }: {
-  eventName: string;
+  eventName: UserEvent;
   userInfo: UserInfo | undefined;
   session: vscode.AuthenticationSession | undefined;
 }) {
@@ -32,7 +32,7 @@ export function sendTelemetryIdentifyEvent({
     }
   }
   if (id) {
-    getTelemetryLogger().logUsage(eventName, {
+    logUsage(eventName, {
       identify: true,
       user: { id, domain, social_connection },
     });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #489.

Migrates our use of `getTelemetryLogger().logUsage(<string>, data)` to use an enum, which should help us more quickly determine what events are being sent, where we might want/need to clean up or standardize event names, etc. Majority of the changes are in here: https://github.com/confluentinc/vscode/blob/6905985c65970621d59271ffc40174f7f962eb2b/src/telemetry/events.ts#L5-L36

And the rest of the changes are updating imports and previous `getTelemetryLogger().logUsage(<string> ...)` calls.

Same general pattern used in [`setContextValue()`](https://github.com/confluentinc/vscode/blob/main/src/context/values.ts#L12).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
