### PR TITLE
bug fix - prevent non-direct connections deregistering when adding a new direct connect

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -110,16 +110,16 @@ export class DirectConnectionManager {
           // part 1: ensure any new connections have registered loaders; if this isn't done, hopping
           // workspaces and attempting to focus on a direct connection-based resource will fail with
           // the `Unknown connection ID` error
-          const existingLoaderIds: ConnectionId[] = ResourceLoader.loaders().map(
-            (loader) => loader.connectionId,
-          );
+          const existingLoaderIds: ConnectionId[] = ResourceLoader.loaders()
+            .filter((loader) => loader.connectionType === "DIRECT")
+            .map((loader) => loader.connectionId);
           for (const id of connections.keys()) {
             if (!existingLoaderIds.includes(id)) {
               this.initResourceLoader(id);
             }
           }
-          // part 2: remove any removed connections was removed from the secret storage to prevent
-          // any requests to orphaned resources/connections
+          // part 2: remove any direct connections not in the secret storage to prevent
+          // requests to orphaned resources/connections
           for (const id of existingLoaderIds) {
             if (!connections.has(id)) {
               ResourceLoader.deregisterInstance(id);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Make sure we're not accidentally deleting the CCloud & Local connections when we create a new Direct Connection

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Noticed an issue where you wouldn't be able to interact with Topics and Schemas from CCloud after adding a new Direct Connection. It looks like we were accidentally de-registering those connections' ResourceLoaders when that new connection came in. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
