### PR TITLE
fix static container `id`s in Resources view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ All notable changes to this extension will be documented in this file.
   [issue #642](https://github.com/confluentinc/vscode/issues/642).
 - Fix possible race conditions in workspace state cache management when needing to read and mutate
   existing workspace state keys, [issue #534](https://github.com/confluentinc/vscode/issues/534).
-- Improve auto-refreshing the schema view controller when uploading a schema to the viewed registry, 
+- Improve auto-refreshing the schema view controller when uploading a schema to the viewed registry,
   [issue #640](https://github.com/confluentinc/vscode/issues/640).
+- Toggling the collapsible states of the top-level items in the Resources view and refreshing the
+  view will no longer reset those collapsible states.
+  [issue #681](https://github.com/confluentinc/vscode/issues/681)
 
 ## 0.21.2
 

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
+import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
 
 const FEEDBACK_URI = vscode.Uri.parse("https://www.surveymonkey.com/r/NYVKQD6");
@@ -36,7 +37,7 @@ ${contextTable}
   }
 
   vscode.commands.executeCommand("vscode.openIssueReporter", {
-    extensionId: "confluentinc.vscode-confluent",
+    extensionId: EXTENSION_ID,
     // issueTitle: "Issue title",
     // issueBody: "Issue body",
     extensionData: extensionMarkdown,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,10 @@
+import { extensions } from "vscode";
 import { ConnectionSpec } from "./clients/sidecar";
 import { ConnectionId } from "./models/resource";
+
+export const EXTENSION_ID = "confluentinc.vscode-confluent";
+/** The version of the extension, as defined in package.json. */
+export const EXTENSION_VERSION: string = extensions.getExtension(EXTENSION_ID)!.packageJSON.version;
 
 /**
  * Ids to use with ThemeIcons for different Confluent/Kafka resources

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,7 +1,6 @@
 import * as Sentry from "@sentry/node";
-import { randomUUID } from "crypto";
 import * as vscode from "vscode";
-import { IconNames } from "../constants";
+import { EXTENSION_VERSION, IconNames } from "../constants";
 import { getExtensionContext } from "../context/extension";
 import { ContextValues, setContextValue } from "../context/values";
 import {
@@ -233,8 +232,7 @@ export async function loadCCloudResources(
     [],
   );
   cloudContainerItem.iconPath = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);
-  // XXX: if we don't adjust the ID here, we'll see weird collapsibleState behavior
-  cloudContainerItem.id = randomUUID();
+  cloudContainerItem.id = `ccloud-${EXTENSION_VERSION}`;
 
   if (hasCCloudAuthSession()) {
     const loader = CCloudResourceLoader.getInstance();
@@ -267,6 +265,8 @@ export async function loadCCloudResources(
     cloudContainerItem.contextValue = "resources-ccloud-container-connected";
     cloudContainerItem.description = currentOrg?.name ?? "";
     cloudContainerItem.children = ccloudEnvironments;
+    // XXX: adjust the ID to ensure the collapsible state is correctly updated in the UI
+    cloudContainerItem.id = `ccloud-connected-${EXTENSION_VERSION}`;
   } else {
     // enables the "Add Connection" action to be displayed on hover
     cloudContainerItem.contextValue = "resources-ccloud-container";
@@ -293,8 +293,7 @@ export async function loadLocalResources(): Promise<
   localContainerItem.iconPath = new vscode.ThemeIcon(IconNames.LOCAL_RESOURCE_GROUP);
 
   const notConnectedId = "local-container";
-  // XXX: if we don't adjust the ID, we'll see weird collapsibleState behavior
-  localContainerItem.id = randomUUID();
+  localContainerItem.id = `local-${EXTENSION_VERSION}`;
   // enable the "Launch Local Resources" action
   localContainerItem.contextValue = notConnectedId;
 
@@ -327,6 +326,8 @@ export async function loadLocalResources(): Promise<
       setContextValue(ContextValues.localKafkaClusterAvailable, localEnvs.length > 0),
       setContextValue(ContextValues.localSchemaRegistryAvailable, localSchemaRegistries.length > 0),
     ]);
+    // XXX: adjust the ID to ensure the collapsible state is correctly updated in the UI
+    localContainerItem.id = `local-connected-${EXTENSION_VERSION}`;
     localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
     // override the default "child item count" description
     localContainerItem.description = localKafkaClusters.map((cluster) => cluster.uri).join(", ");
@@ -346,9 +347,7 @@ export async function loadDirectConnectResources(): Promise<ContainerTreeItem<Di
     [],
   );
   directContainerItem.iconPath = new vscode.ThemeIcon(IconNames.CONNECTION);
-
-  // XXX: if we don't adjust the ID, we'll see weird collapsibleState behavior
-  directContainerItem.id = randomUUID();
+  directContainerItem.id = `direct-${EXTENSION_VERSION}`;
 
   // top-level container before each direct "environment" (connection)
   directContainerItem.contextValue = "resources-direct-container";
@@ -358,8 +357,10 @@ export async function loadDirectConnectResources(): Promise<ContainerTreeItem<Di
   // CCloud environment (connection ID and environment ID are the same)
   directContainerItem.children = await getDirectResources();
   if (directContainerItem.children.length > 0) {
-    directContainerItem.description = `(${directContainerItem.children.length})`;
+    // XXX: adjust the ID to ensure the collapsible state is correctly updated in the UI
+    directContainerItem.id = `direct-connected-${EXTENSION_VERSION}`;
     directContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+    directContainerItem.description = `(${directContainerItem.children.length})`;
   }
 
   return directContainerItem;

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
+import { EXTENSION_ID } from "../../src/constants";
 import { setExtensionContext } from "../../src/context/extension";
 import { StorageManager } from "../../src/storage";
-
-const EXTENSION_ID = "confluentinc.vscode-confluent";
 
 /**
  * Convenience function to get the extension.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #681.

https://github.com/confluentinc/vscode/pull/554 introduced a regression while trying to avoid re-registering tree view items with the same `id` values, specifically that the top-level (static) container items in the Resources view -- ("Confluent Cloud", "Local", and the currently-experimental "Other") -- would get a new `id` at each refresh. This also meant VS Code would forget whatever the user-adjusted collapsible state was between refreshes, and always side with whatever the extension wanted that collapsible state to be.

To fix that regression while ensuring a smooth path between extension version changes, we're going back to static container item IDs that instead will only change depending on:
- the status of that connection group type (connected vs not-connected)
- the extension version

The video below demonstrates the fix, where changing connection states and refreshing the Resources view will keep the user-set collapsible states, and installing another version of the extension will temporarily reset the states upon new-version-activation until the user adjusts them again (after which they will be honored in the UI):


https://github.com/user-attachments/assets/d74f05c2-e9fb-48a1-ae7f-d0b7d6a8f9bd



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
