### PR TITLE
add Sentry processor for including observability context

### DIFF
--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1,13 +1,10 @@
-import { type Event } from "@sentry/node";
 import * as assert from "assert";
-import sinon from "sinon";
 import * as vscode from "vscode";
 import { getAndActivateExtension, getExtensionContext } from "../tests/unit/testUtils";
 import { ConfluentCloudAuthProvider } from "./authn/ccloudProvider";
 import { ExtensionContextNotSetError } from "./errors";
 import { StorageManager } from "./storage";
 import { ResourceManager } from "./storage/resourceManager";
-import { checkTelemetrySettings } from "./telemetry/telemetry";
 import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { TopicViewProvider } from "./viewProviders/topics";
@@ -143,48 +140,5 @@ describe("ExtensionContext subscription tests", () => {
       context.subscriptions.length > 0,
       "No subscriptions found; did activate() run correctly?",
     );
-  });
-});
-
-describe("Sentry user settings check", () => {
-  let sandbox: sinon.SinonSandbox;
-  let getConfigurationStub: sinon.SinonStub;
-  let isTelemetryEnabledStub: sinon.SinonStub;
-
-  before(() => {
-    sandbox = sinon.createSandbox();
-    getConfigurationStub = sandbox.stub(vscode.workspace, "getConfiguration");
-    isTelemetryEnabledStub = sandbox.stub(vscode.env, "isTelemetryEnabled");
-  });
-
-  after(() => {
-    sandbox.restore();
-  });
-
-  it("should return null when telemetry is disabled", () => {
-    isTelemetryEnabledStub.value(false);
-    const event = { message: "Test event" } as Event;
-    const result = checkTelemetrySettings(event);
-    assert.strictEqual(result, null);
-  });
-
-  it("should return null when telemetry level is 'off'", () => {
-    isTelemetryEnabledStub.value(true);
-    getConfigurationStub.returns({
-      get: (key: string) => (key === "telemetry.telemetryLevel" ? "off" : undefined),
-    });
-    const event = { message: "Test event" } as Event;
-    const result = checkTelemetrySettings(event);
-    assert.strictEqual(result, null);
-  });
-
-  it("should return the event when telemetry level is not 'off'", () => {
-    isTelemetryEnabledStub.value(true);
-    getConfigurationStub.returns({
-      get: (key: string) => (key === "telemetry.telemetryLevel" ? "all" : undefined),
-    });
-    const event = { message: "Test event" } as Event;
-    const result = checkTelemetrySettings(event);
-    assert.deepStrictEqual(result, event);
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,9 +32,10 @@ if (process.env.SENTRY_DSN) {
 }
 
 import * as vscode from "vscode";
-import { checkTelemetrySettings } from "./telemetry/telemetry";
+import { checkTelemetrySettings, includeObservabilityContext } from "./telemetry/eventProcessors";
 if (process.env.SENTRY_DSN) {
   Sentry.addEventProcessor(checkTelemetrySettings);
+  Sentry.addEventProcessor(includeObservabilityContext);
 }
 
 import { ConfluentCloudAuthProvider, getAuthProvider } from "./authn/ccloudProvider";

--- a/src/telemetry/eventProcessors.test.ts
+++ b/src/telemetry/eventProcessors.test.ts
@@ -1,0 +1,79 @@
+import { type Event } from "@sentry/node";
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { env, workspace } from "vscode";
+import { observabilityContext } from "../context/observability";
+import { checkTelemetrySettings, includeObservabilityContext } from "./eventProcessors";
+
+describe("Sentry user settings check", () => {
+  let sandbox: sinon.SinonSandbox;
+  let getConfigurationStub: sinon.SinonStub;
+  let isTelemetryEnabledStub: sinon.SinonStub;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    getConfigurationStub = sandbox.stub(workspace, "getConfiguration");
+    isTelemetryEnabledStub = sandbox.stub(env, "isTelemetryEnabled");
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it("should return null when telemetry is disabled", () => {
+    isTelemetryEnabledStub.value(false);
+    const event = { message: "Test event" } as Event;
+    const result = checkTelemetrySettings(event);
+    assert.strictEqual(result, null);
+  });
+
+  it("should return null when telemetry level is 'off'", () => {
+    isTelemetryEnabledStub.value(true);
+    getConfigurationStub.returns({
+      get: (key: string) => (key === "telemetry.telemetryLevel" ? "off" : undefined),
+    });
+    const event = { message: "Test event" } as Event;
+    const result = checkTelemetrySettings(event);
+    assert.strictEqual(result, null);
+  });
+
+  it("should return the event when telemetry level is not 'off'", () => {
+    isTelemetryEnabledStub.value(true);
+    getConfigurationStub.returns({
+      get: (key: string) => (key === "telemetry.telemetryLevel" ? "all" : undefined),
+    });
+    const event = { message: "Test event" } as Event;
+    const result = checkTelemetrySettings(event);
+    assert.deepStrictEqual(result, event);
+  });
+});
+
+describe("eventProcessors.ts includeObservabilityContext()", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should include observability context in the event", () => {
+    // stub the observability context's toRecord method to return some fake data
+    const fakeObservabilityContext = {
+      extensionVersion: "1.0.0",
+      extensionActivated: true,
+      sidecarVersion: "1.0.0",
+    };
+    sandbox.stub(observabilityContext, "toRecord").returns(fakeObservabilityContext);
+
+    const event = { message: "Test event" } as Event;
+    const result: Event = includeObservabilityContext(event);
+
+    assert.ok(result.extra);
+    assert.equal(result.extra.extensionVersion, fakeObservabilityContext.extensionVersion);
+    assert.equal(result.extra.extensionActivated, fakeObservabilityContext.extensionActivated);
+    assert.equal(result.extra.sidecarVersion, fakeObservabilityContext.sidecarVersion);
+  });
+});

--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -1,0 +1,19 @@
+import * as Sentry from "@sentry/node";
+import { env, workspace } from "vscode";
+import { observabilityContext } from "../context/observability";
+
+/** Helper function to make sure the user has Telemetry ON before sending Sentry error events */
+export function checkTelemetrySettings(event: Sentry.Event) {
+  const telemetryLevel = workspace.getConfiguration()?.get("telemetry.telemetryLevel");
+  if (!env.isTelemetryEnabled || telemetryLevel === "off") {
+    // Returning `null` will drop the event
+    return null;
+  }
+  return event;
+}
+
+/** Include this extension instance's {@link observabilityContext} under the `extra` context. */
+export function includeObservabilityContext(event: Sentry.Event): Sentry.Event {
+  event.extra = { ...event.extra, ...observabilityContext.toRecord() };
+  return event;
+}

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import { UserInfo } from "../clients/sidecar/models/UserInfo";
 import { getTelemetryLogger } from "./telemetryLogger";
-import * as Sentry from "@sentry/node";
 
 /** Given authenticated session and/or userInfo, clean the data & send an Identify event to Segment via TelemetryLogger
  * @param eventName - The event name to be sent to Segment as a follow up per docs: "follow the Identify call with a Track event that records what caused the user to be identified"
@@ -38,14 +37,4 @@ export function sendTelemetryIdentifyEvent({
       user: { id, domain, social_connection },
     });
   }
-}
-
-/** Helper function to make sure the user has Telemetry ON before sending Sentry error events */
-export function checkTelemetrySettings(event: Sentry.Event) {
-  const telemetryLevel = vscode.workspace.getConfiguration()?.get("telemetry.telemetryLevel");
-  if (!vscode.env.isTelemetryEnabled || telemetryLevel === "off") {
-    // Returning `null` will drop the event
-    return null;
-  }
-  return event;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Continuation of https://github.com/confluentinc/vscode/pull/592 that ensures our `ObservabilityContext` data is included with any events sent to Sentry. The data shows up under "Additional Data":
<img width="359" alt="image" src="https://github.com/user-attachments/assets/4676ad73-89b0-4248-a927-b27aa83a643e">

This also reorganized a bit of code to put all of our Sentry event processors under one place - `telemetry/eventProcessors.ts`, and similarly moved the previous Sentry telemetry config tests into `eventProcessors.test.ts` (along with a new test).

Closes #599. (Isn't a wrapper in this case, but treating it as an event processor seems like the more effective and straightforward approach.)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
