### PR TITLE
include VS Code + extension versions in sidecar envs

### DIFF
--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -21,6 +21,7 @@ import { SidecarHandle } from "./sidecarHandle";
 
 import { normalize } from "path";
 import { Tail } from "tail";
+import { EXTENSION_VERSION } from "../constants";
 import { observabilityContext } from "../context/observability";
 
 /**
@@ -569,6 +570,8 @@ export function constructSidecarEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   sidecar_env["QUARKUS_LOG_FILE_ENABLE"] = "true";
   sidecar_env["QUARKUS_LOG_FILE_ROTATION_ROTATE_ON_BOOT"] = "false";
   sidecar_env["QUARKUS_LOG_FILE_PATH"] = SIDECAR_LOGFILE_PATH;
+  sidecar_env["VSCODE_VERSION"] = vscode.version;
+  sidecar_env["VSCODE_EXTENSION_VERSION"] = EXTENSION_VERSION;
 
   // If we are running within WSL, then need to have sidecar bind to 0.0.0.0 instead of its default
   // localhost so that browsers running on Windows can connect to it during OAuth flow. The server


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #679. Sample from sidecar logs:
```
2024-12-05 18:10:39,071 ... INFO  [io.con.ide.res.app.SidecarInfo] (main) OS: Mac OS X 14.7.1 (MacOS); VS Code 1.95.3, extension version 0.22.0
```

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
