### PR TITLE
update local resource quickpick

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -49,7 +49,12 @@ export async function runWorkflowWithProgress(
   // show multi-select quickpick to allow user to choose which resources to launch and determine
   // how the workflow should be run
   const resources: LocalResourceKind[] =
-    resourceKinds.length > 0 ? resourceKinds : await localResourcesQuickPick();
+    resourceKinds.length > 0
+      ? resourceKinds
+      : await localResourcesQuickPick(
+          start,
+          start ? "Select resources to start" : "Select resources to stop",
+        );
   if (resources.length === 0) {
     // nothing selected, or user clicked a quickpick button to adjust settings
     return;

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -53,6 +53,7 @@ export async function runWorkflowWithProgress(
       ? resourceKinds
       : await localResourcesQuickPick(
           start,
+          start ? "Local Resources to Start" : "Local Resources to Stop",
           start ? "Select resources to start" : "Select resources to stop",
         );
   if (resources.length === 0) {

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -87,11 +87,22 @@ export async function localResourcesQuickPick(
     if (
       !starting &&
       quickpick.items.includes(schemaRegistryItem) &&
+      items.includes(kafkaItem) &&
       !items.includes(schemaRegistryItem)
     ) {
       // if the user is attempting to stop Kafka and not Schema Registry, ensure Schema Registry is
       // selected
       quickpick.selectedItems = [...items, schemaRegistryItem];
+      window.showInformationMessage("Schema Registry must be stopped when stopping Kafka.");
+    } else if (
+      starting &&
+      quickpick.items.includes(kafkaItem) &&
+      items.includes(schemaRegistryItem) &&
+      !items.includes(kafkaItem)
+    ) {
+      // if the user is attempting to start Schema Registry and not Kafka, ensure Kafka is selected
+      quickpick.selectedItems = [kafkaItem, ...items];
+      window.showInformationMessage("Kafka must be available before starting Schema Registry.");
     }
   });
 

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -18,35 +18,39 @@ import {
 const logger = new Logger("quickpicks.localResources");
 
 /** Create a multi-select quickpick to allow the user to choose which resources to start/stop. */
-export async function localResourcesQuickPick(): Promise<LocalResourceKind[]> {
+export async function localResourcesQuickPick(
+  toStart: boolean = true,
+  placeholder?: string,
+): Promise<LocalResourceKind[]> {
   const quickpick: QuickPick<QuickPickItem> = window.createQuickPick();
   quickpick.title = "Local Resources";
   quickpick.ignoreFocusOut = true;
-  quickpick.placeholder = "Select resource types";
+  quickpick.placeholder = placeholder ?? "Select resource types";
   quickpick.canSelectMany = true;
 
   const kafkaRepoTag = `${getLocalKafkaImageName()}:${getLocalKafkaImageTag()}`;
+  const kafkaItem: QuickPickItem = {
+    label: LocalResourceKind.Kafka,
+    iconPath: new ThemeIcon(IconNames.KAFKA_CLUSTER),
+    description: kafkaRepoTag,
+    detail: "A local Kafka cluster with a user-specified number of broker containers",
+    buttons: [{ iconPath: new ThemeIcon("gear"), tooltip: `Select Kafka Docker Image` }],
+  };
+
   const schemaRegistryRepoTag = `${getLocalSchemaRegistryImageName()}:${getLocalSchemaRegistryImageTag()}`;
-  quickpick.items = [
-    {
-      label: LocalResourceKind.Kafka,
-      iconPath: new ThemeIcon(IconNames.KAFKA_CLUSTER),
-      description: kafkaRepoTag,
-      detail: "A local Kafka cluster with a user-specified number of broker containers",
-      picked: true,
-      buttons: [{ iconPath: new ThemeIcon("gear"), tooltip: `Select Kafka Docker Image` }],
-    },
-    {
-      label: LocalResourceKind.SchemaRegistry,
-      iconPath: new ThemeIcon(IconNames.SCHEMA_REGISTRY),
-      description: schemaRegistryRepoTag,
-      detail:
-        "A local Schema Registry instance that can be used to manage schemas for Kafka topics",
-      buttons: [
-        { iconPath: new ThemeIcon("gear"), tooltip: `Select Schema Registry Docker Image Tag` },
-      ],
-    },
-  ];
+  const schemaRegistryItem: QuickPickItem = {
+    label: LocalResourceKind.SchemaRegistry,
+    iconPath: new ThemeIcon(IconNames.SCHEMA_REGISTRY),
+    description: schemaRegistryRepoTag,
+    detail: "A local Schema Registry instance that can be used to manage schemas for Kafka topics",
+    buttons: [
+      { iconPath: new ThemeIcon("gear"), tooltip: `Select Schema Registry Docker Image Tag` },
+    ],
+  };
+
+  quickpick.items = [kafkaItem, schemaRegistryItem];
+  // set Kafka as selected by default if starting resources
+  quickpick.selectedItems = toStart ? [kafkaItem] : [];
   quickpick.show();
 
   const selectedItems: QuickPickItem[] = [];

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -21,12 +21,13 @@ const logger = new Logger("quickpicks.localResources");
 /** Create a multi-select quickpick to allow the user to choose which resources to start/stop. */
 export async function localResourcesQuickPick(
   starting: boolean = true,
-  placeholder?: string,
+  title: string,
+  placeholder: string,
 ): Promise<LocalResourceKind[]> {
   const quickpick: QuickPick<QuickPickItem> = window.createQuickPick();
-  quickpick.title = "Local Resources";
+  quickpick.title = title;
   quickpick.ignoreFocusOut = true;
-  quickpick.placeholder = placeholder ?? "Select resource types";
+  quickpick.placeholder = placeholder;
   quickpick.canSelectMany = true;
 
   const items: QuickPickItem[] = [];

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -83,6 +83,18 @@ export async function localResourcesQuickPick(
   quickpick.selectedItems = starting && !kafkaAvailable ? [kafkaItem] : [];
   quickpick.show();
 
+  quickpick.onDidChangeSelection((items: readonly QuickPickItem[]) => {
+    if (
+      !starting &&
+      quickpick.items.includes(schemaRegistryItem) &&
+      !items.includes(schemaRegistryItem)
+    ) {
+      // if the user is attempting to stop Kafka and not Schema Registry, ensure Schema Registry is
+      // selected
+      quickpick.selectedItems = [...items, schemaRegistryItem];
+    }
+  });
+
   const selectedItems: QuickPickItem[] = [];
   quickpick.onDidAccept(() => {
     logger.debug("selected items", { items: JSON.stringify(quickpick.selectedItems) });

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -83,6 +83,7 @@ export async function localResourcesQuickPick(
   quickpick.selectedItems = starting && !kafkaAvailable ? [kafkaItem] : [];
   quickpick.show();
 
+  // user selected/deselected an item from the list
   quickpick.onDidChangeSelection((items: readonly QuickPickItem[]) => {
     if (
       !starting &&
@@ -106,14 +107,7 @@ export async function localResourcesQuickPick(
     }
   });
 
-  const selectedItems: QuickPickItem[] = [];
-  quickpick.onDidAccept(() => {
-    logger.debug("selected items", { items: JSON.stringify(quickpick.selectedItems) });
-    selectedItems.push(...quickpick.selectedItems);
-    quickpick.hide();
-    return;
-  });
-
+  // user clicked one of the secondary buttons to the right of a quickpick item
   quickpick.onDidTriggerItemButton(
     async (event: { button: QuickInputButton; item: QuickPickItem }) => {
       quickpick.hide();
@@ -132,6 +126,15 @@ export async function localResourcesQuickPick(
       }
     },
   );
+
+  // user clicked "Ok" or hit Enter to accept the selected items, if any
+  const selectedItems: QuickPickItem[] = [];
+  quickpick.onDidAccept(() => {
+    logger.debug("selected items", { items: JSON.stringify(quickpick.selectedItems) });
+    selectedItems.push(...quickpick.selectedItems);
+    quickpick.hide();
+    return;
+  });
 
   // block until the quickpick is hidden
   await new Promise<void>((resolve) => {

--- a/src/quickpicks/localResources.ts
+++ b/src/quickpicks/localResources.ts
@@ -71,6 +71,13 @@ export async function localResourcesQuickPick(
     schemaRegistryAvailable,
   });
 
+  if (!starting && items.length === 1) {
+    // if only one resource kind is available, don't show the quickpick and just use it by default
+    // (we're not doing this for the start workflow because we want to show the user the options and
+    // additional details about the resources)
+    return [items[0].label as LocalResourceKind];
+  }
+
   quickpick.items = items;
   // set Kafka as selected by default if starting resources and it isn't already running
   quickpick.selectedItems = starting && !kafkaAvailable ? [kafkaItem] : [];


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This incorporates feedback on the local resource start/stop multi-select quickpick:
- Set the placeholder text describing whether the resources being selected are for starting or stopping
- Auto-select Kafka when starting resources and nothing is running:
  <img width="1137" alt="image" src="https://github.com/user-attachments/assets/ca67b847-3300-4a88-a177-07fa463490fb">
- Filter out already-running resources from the quickpick (which closes #536):
  <img width="1107" alt="image" src="https://github.com/user-attachments/assets/26a705d5-fae4-4cfa-b028-056dc9ecb30a">
- Auto-stop a resource if it's the only kind running (not treating "start" the same since a user may want to look at the image repo/tag and adjust first)
- Prevent stopping only Kafka if SR is also running


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
