### PR TITLE
minor: improve required logic for auth fields

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -90,6 +90,8 @@
                 name="bootstrap_servers"
                 type="text"
                 placeholder="host:port, host2:port2"
+                data-attr-value="this.kafkaBootstrapServers()"
+                data-on-change="this.updateValue(event)"
               />
             </div>
             <span class="description"
@@ -105,7 +107,7 @@
                 id="kafka-auth-none"
                 name="kafka_auth_type"
                 value="None"
-                required
+                data-attr-required="this.kafkaBootstrapServers() !== ''"
                 data-on-change="this.updateValue(event)"
                 data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
               />
@@ -198,6 +200,8 @@
                 pattern="https?://.*"
                 title="URL must begin with http or https"
                 placeholder="https://example.com"
+                data-attr-value="this.schemaUri()"
+                data-on-change="this.updateValue(event)"
               />
             </div>
             <span class="description">The URL of the Schema Registry to use for serialization</span>
@@ -210,7 +214,7 @@
                 id="schema-auth-none"
                 name="schema_auth_type"
                 value="None"
-                required
+                data-attr-required="this.schemaUri() !== ''"
                 data-on-change="this.updateValue(event)"
                 data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
               />

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -14,11 +14,16 @@ addEventListener("DOMContentLoaded", () => {
 });
 
 class DirectConnectFormViewModel extends ViewModel {
-  errorMessage = this.signal("");
-  success = this.signal(false);
+  /** Form Input Values */
   platformType = this.signal<PlatformOptions>("Apache Kafka");
   kafkaAuthType = this.signal<SupportedAuthTypes>("None");
   schemaAuthType = this.signal<SupportedAuthTypes>("None");
+  schemaUri = this.signal("");
+  kafkaBootstrapServers = this.signal("");
+
+  /** Form State */
+  errorMessage = this.signal("");
+  success = this.signal(false);
 
   updateValue(event: Event) {
     const input = event.target as HTMLInputElement;
@@ -38,6 +43,12 @@ class DirectConnectFormViewModel extends ViewModel {
         break;
       case "schema_auth_type":
         this.schemaAuthType(input.value as SupportedAuthTypes);
+        break;
+      case "uri":
+        this.schemaUri(input.value);
+        break;
+      case "bootstrap_servers":
+        this.kafkaBootstrapServers(input.value);
         break;
       default:
         console.warn(`Unhandled key: ${input.name}`);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Now we'll track the `bootstrap servers` and `uri` fields' state and use it to determine if auth type is required. This will also set us up to save inputs when the form is blurred (#712)

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
