### PR TITLE
minor: improve readability for disconnect warning

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -71,8 +71,12 @@ export async function deleteDirectConnection(item: DirectEnvironment) {
 
   const yesButton = "Yes, disconnect";
   const confirmation = await window.showWarningMessage(
-    `Are you sure you want to disconnect "${item.name}"? To reconnect, you will need to re-enter the associated connection details. (This will not delete any associated resources.)`,
-    { modal: true },
+    `Are you sure you want to disconnect "${item.name}"? `,
+    {
+      modal: true,
+      detail:
+        "You will need to re-enter the associated connection details to reconnect. This will not delete any associated resources.",
+    },
     yesButton,
     // "Cancel" is added by default
   );


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- nitpicky update - I think it's more readable to use the `detail` attribute?

| Before | After |
| -- | -- |
| <img width="291" alt="Screenshot 2024-12-06 at 12 48 58 PM" src="https://github.com/user-attachments/assets/7bb9ca78-7e18-4bb2-b16c-38e1c1c1feac"> | <img width="288" alt="Screenshot 2024-12-06 at 12 47 18 PM" src="https://github.com/user-attachments/assets/556b202e-5cc7-4e7d-86b9-24e4d4cc89ad"> |

