### PR TITLE
use a custom dev env instead of node

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -79,6 +79,7 @@ export function build(done) {
   if (result.error) throw result.error;
 
   if (production) {
+    process.env.SENTRY_ENV = "production";
     setupSegment();
     setupSentry();
   }
@@ -218,8 +219,10 @@ function getSentryReleaseVersion() {
     // add "dirty" to the revision instead of sha if there are uncommmited changes
     const isDirty =
       spawnSync("git", ["diff", "--quiet"], { stdio: "pipe", shell: IS_WINDOWS }).status !== 0;
-    if (isDirty) revision = "dirty";
-    else {
+    if (isDirty) {
+      revision = "dirty";
+      process.env.SENTRY_ENV = "development";
+    } else {
       revision = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
         stdio: "pipe",
         shell: IS_WINDOWS,

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -114,6 +114,7 @@ export function build(done) {
         "process.env.SENTRY_AUTH_TOKEN": JSON.stringify(process.env.SENTRY_AUTH_TOKEN),
         "process.env.SENTRY_RELEASE": JSON.stringify(process.env.SENTRY_RELEASE),
         "process.env.SENTRY_DSN": JSON.stringify(process.env.SENTRY_DSN),
+        "process.env.SENTRY_ENV": JSON.stringify(process.env.SENTRY_ENV),
         preventAssignment: true,
       }),
       copy({
@@ -221,6 +222,7 @@ function getSentryReleaseVersion() {
       spawnSync("git", ["diff", "--quiet"], { stdio: "pipe", shell: IS_WINDOWS }).status !== 0;
     if (isDirty) {
       revision = "dirty";
+      console.log("Using 'dirty' version suffix and setting SENTRY_ENV=development");
       process.env.SENTRY_ENV = "development";
     } else {
       revision = spawnSync("git", ["rev-parse", "--short", "HEAD"], {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ if (process.env.SENTRY_DSN) {
   Sentry.init({
     // debug: true, // enable for local "prod" debugging with dev console
     dsn: process.env.SENTRY_DSN,
-    environment: process.env.NODE_ENV,
+    environment: process.env.SENTRY_ENV,
     release: process.env.SENTRY_RELEASE,
     tracesSampleRate: 0,
     profilesSampleRate: 0,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Uses `SENTRY_ENV` instead of `NODE_ENV` to tell Sentry which environment is being used.
For real "production" releases, this will be `production`. For local builds that set `NODE_ENV=production`, this will be `development`.
<img width="365" alt="image" src="https://github.com/user-attachments/assets/f0b051aa-0894-4366-b9f1-33fcfe7fe819">


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
