### PR TITLE
feat: add "Enable Produce Messages" preview setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this extension will be documented in this file.
   schema row within the group to download the schema into a new editor. Add or remove columns, etc.,
   then use the existing 'cloud upload' icon in the editor's top bar to start the process to submit
   it back to the schema registry.
+- "Preview" settings to opt into upcoming functionality as it's being developed:
+  - Connecting directly to Kafka clusters and/or Schema Registries.
+  - Producing messages to a Kafka topic.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -379,14 +379,6 @@
           "default": true,
           "description": "Whether or not warning notifications will appear when consuming messages without permission to access the associated Schema Registry."
         },
-        "confluent.experimental.enableDirectConnections": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable direct connections to Kafka and Schema Registry resources.",
-          "tags": [
-            "experimental"
-          ]
-        },
         "confluent.debugging.showSidecarExceptions": {
           "type": "boolean",
           "default": false,
@@ -427,6 +419,22 @@
           "type": "string",
           "default": "latest",
           "markdownDescription": "Docker image tag to use when starting a local Schema Registry container. (By default, this will use the [`confluentinc/cp-schema-registry`](https://hub.docker.com/r/confluentinc/cp-schema-registry/tags) image.)"
+        },
+        "confluent.preview.enableDirectConnections": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable direct connections to Kafka and Schema Registry resources.",
+          "tags": [
+            "preview"
+          ]
+        },
+        "confluent.preview.enableProduceMessages": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable message production for Kafka topics.",
+          "tags": [
+            "preview"
+          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -431,7 +431,7 @@
         "confluent.preview.enableProduceMessages": {
           "type": "boolean",
           "default": false,
-          "description": "Enable message production for Kafka topics.",
+          "markdownDescription": "Enable message production for Kafka topics.\n\n---\n\n⚠️ **WARNING**: This setting may allow you to produce messages without schemas to topics that expect them, which can lead to data loss or corruption.",
           "tags": [
             "preview"
           ]

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -55,8 +55,13 @@ export enum ContextValues {
   /** The user clicked a Schema Registry tree item. */
   schemaRegistrySelected = "confluent.schemaRegistrySelected",
   /**
-   * EXPERIMENTAL: Are direct connections enabled at all?
-   * (This should go away once the `confluent.experimental.enableDirectConnections` setting is removed.)
+   * PREVIEW: Are direct connections enabled at all?
+   * (This should go away once the `confluent.preview.enableDirectConnections` setting is removed.)
    */
   directConnectionsEnabled = "confluent.directConnectionsEnabled",
+  /**
+   * PREVIEW: Is the "produce message" functionality enabled at all?
+   * (This should go away once the `confluent.preview.enableProduceMessages` setting is removed.)
+   */
+  produceMessagesEnabled = "confluent.produceMessagesEnabled",
 }

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { ConfigurationChangeEvent, workspace } from "vscode";
+import { workspace } from "vscode";
 import { TEST_LOCAL_KAFKA_CLUSTER, TEST_LOCAL_SCHEMA_REGISTRY } from "../tests/unit/testResources";
 import { TEST_DIRECT_CONNECTION } from "../tests/unit/testResources/connection";
 import { getExtensionContext } from "../tests/unit/testUtils";
@@ -13,7 +13,6 @@ import {
 import * as contextValues from "./context/values";
 import { DirectConnectionManager } from "./directConnectManager";
 import { ConnectionId } from "./models/resource";
-import { ENABLE_DIRECT_CONNECTIONS } from "./preferences/constants";
 import * as sidecar from "./sidecar";
 import * as connections from "./sidecar/connections";
 import { DirectConnectionsById, getResourceManager } from "./storage/resourceManager";
@@ -85,29 +84,6 @@ describe("DirectConnectionManager behavior", () => {
 
     sandbox.restore();
   });
-
-  for (const enabled of [true, false]) {
-    it(`should update the "${contextValues.ContextValues.directConnectionsEnabled}" context value when the "${ENABLE_DIRECT_CONNECTIONS}" setting is changed to ${enabled} (REMOVE ONCE EXPERIMENTAL SETTING IS NO LONGER USED)`, async () => {
-      getConfigurationStub.returns({
-        get: sandbox.stub().withArgs(ENABLE_DIRECT_CONNECTIONS).returns(enabled),
-      });
-      const mockEvent = {
-        affectsConfiguration: (config: string) => config === ENABLE_DIRECT_CONNECTIONS,
-      } as ConfigurationChangeEvent;
-      onDidChangeConfigurationStub.yields(mockEvent);
-
-      DirectConnectionManager.getInstance();
-      // simulate the setting being changed by the user
-      await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
-
-      assert.ok(
-        setContextValueStub.calledWith(
-          contextValues.ContextValues.directConnectionsEnabled,
-          enabled,
-        ),
-      );
-    });
-  }
 
   it("createConnection() should not include `kafkaClusterConfig` in the ConnectionSpec if not provided", async () => {
     const testSpec: ConnectionSpec = PLAIN_LOCAL_KAFKA_SR_SPEC;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,6 +229,10 @@ async function setupContextValues() {
     ContextValues.directConnectionsEnabled,
     config.get(ENABLE_DIRECT_CONNECTIONS, false),
   );
+  const produceMessagesEnabled = setContextValue(
+    ContextValues.produceMessagesEnabled,
+    config.get("confluent.preview.enableProduceMessages", false),
+  );
   // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
   const kafkaClusterSelected = setContextValue(ContextValues.kafkaClusterSelected, false);
   const schemaRegistrySelected = setContextValue(ContextValues.schemaRegistrySelected, false);
@@ -273,6 +277,7 @@ async function setupContextValues() {
   ]);
   await Promise.all([
     directConnectionsEnabled,
+    produceMessagesEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,
     openInCCloudResources,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { Logger, outputChannel } from "./logging";
 import {
   ENABLE_DIRECT_CONNECTIONS,
+  ENABLE_PRODUCE_MESSAGES,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
 } from "./preferences/constants";
@@ -231,7 +232,7 @@ async function setupContextValues() {
   );
   const produceMessagesEnabled = setContextValue(
     ContextValues.produceMessagesEnabled,
-    config.get("confluent.preview.enableProduceMessages", false),
+    config.get(ENABLE_PRODUCE_MESSAGES, false),
   );
   // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
   const kafkaClusterSelected = setContextValue(ContextValues.kafkaClusterSelected, false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -223,7 +223,7 @@ async function _activateExtension(
 
 /** Configure any starting contextValues to use for view/menu controls during activation. */
 async function setupContextValues() {
-  // EXPERIMENTAL: set default value for direct connection enablement
+  // PREVIEW: set default values for enabling the direct connection and message-produce features
   const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
   const directConnectionsEnabled = setContextValue(
     ContextValues.directConnectionsEnabled,

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -25,4 +25,5 @@ export const LOCAL_KAFKA_IMAGE_TAG = prefix + "localDocker.kafkaImageTag";
 export const LOCAL_SCHEMA_REGISTRY_IMAGE = prefix + "localDocker.schemaRegistryImageRepo";
 export const LOCAL_SCHEMA_REGISTRY_IMAGE_TAG = prefix + "localDocker.schemaRegistryImageTag";
 
-export const ENABLE_DIRECT_CONNECTIONS = prefix + "experimental.enableDirectConnections";
+export const ENABLE_DIRECT_CONNECTIONS = prefix + "preview.enableDirectConnections";
+export const ENABLE_PRODUCE_MESSAGES = prefix + "preview.enableProduceMessages";

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -72,6 +72,8 @@ export function createConfigChangeListener(): Disposable {
         const enabled = configs.get(ENABLE_PRODUCE_MESSAGES, false);
         logger.debug(`"${ENABLE_PRODUCE_MESSAGES}" config changed`, { enabled });
         setContextValue(ContextValues.produceMessagesEnabled, enabled);
+        // no need to refresh the Topics view here since no items are being changed; VS Code will
+        // handle changing the actions to make any actions visible/enabled
       }
     },
   );

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,16 +1,21 @@
 import { ConfigurationChangeEvent, Disposable, WorkspaceConfiguration, workspace } from "vscode";
-import { PreferencesResourceApi } from "../clients/sidecar";
+import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
-import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
+import { isDirect } from "../models/resource";
+import { getResourceViewProvider } from "../viewProviders/resources";
+import { getSchemasViewProvider } from "../viewProviders/schemas";
+import { getTopicViewProvider } from "../viewProviders/topics";
+import {
+  ENABLE_DIRECT_CONNECTIONS,
+  ENABLE_PRODUCE_MESSAGES,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 import { updatePreferences } from "./updates";
 
 const logger = new Logger("preferences.listener");
 
-/**
- * Listen to changes to {@link WorkspaceConfiguration} and send requests to the sidecar's
- * {@link PreferencesResourceApi} according to any configurations that need to stay in sync between
- * the extension and the sidecar.
- */
+/** Main listener for any changes to {@link WorkspaceConfiguration} that affect this extension. */
 export function createConfigChangeListener(): Disposable {
   // NOTE: this fires from any VS Code configuration, not just configs from our extension
   const disposable: Disposable = workspace.onDidChangeConfiguration(
@@ -19,16 +24,54 @@ export function createConfigChangeListener(): Disposable {
       const configs: WorkspaceConfiguration = workspace.getConfiguration();
 
       if (event.affectsConfiguration(SSL_PEM_PATHS)) {
+        // inform the sidecar that the SSL/TLS .pem paths have changed
         logger.debug(`"${SSL_PEM_PATHS}" config changed`);
         const pemPaths: string[] = configs.get(SSL_PEM_PATHS, []);
         await updatePreferences({
           tls_pem_paths: pemPaths,
         });
-      } else if (event.affectsConfiguration(SSL_VERIFY_SERVER_CERT_DISABLED)) {
+        return;
+      }
+
+      if (event.affectsConfiguration(SSL_VERIFY_SERVER_CERT_DISABLED)) {
+        // inform the sidecar that the server cert verification has changed
         logger.debug(`"${SSL_VERIFY_SERVER_CERT_DISABLED}" config changed`);
         // if the user disables server cert verification, trust all certs
         const trustAllCerts: boolean = configs.get(SSL_VERIFY_SERVER_CERT_DISABLED, false);
         await updatePreferences({ trust_all_certificates: trustAllCerts });
+        return;
+      }
+
+      // --- PREVIEW SETTINGS --
+      // Remove the sections below once the behavior is enabled by default and a setting is no
+      // longer needed to opt-in to the feature.
+
+      if (event.affectsConfiguration(ENABLE_DIRECT_CONNECTIONS)) {
+        // user toggled the "Enable Direct Connections" preview setting
+        const enabled = configs.get(ENABLE_DIRECT_CONNECTIONS, false);
+        logger.debug(`"${ENABLE_DIRECT_CONNECTIONS}" config changed`, { enabled });
+        setContextValue(ContextValues.directConnectionsEnabled, enabled);
+        // "Other" container item will be toggled
+        getResourceViewProvider().refresh();
+        // if the Topics/Schemas views are focused on a direct connection based resource, wipe them
+        if (!enabled) {
+          const topicsView = getTopicViewProvider();
+          if (topicsView.kafkaCluster && isDirect(topicsView.kafkaCluster)) {
+            topicsView.reset();
+          }
+          const schemasView = getSchemasViewProvider();
+          if (schemasView.schemaRegistry && isDirect(schemasView.schemaRegistry)) {
+            schemasView.reset();
+          }
+        }
+        return;
+      }
+
+      if (event.affectsConfiguration(ENABLE_PRODUCE_MESSAGES)) {
+        // user toggled the "Enable Produce Messages" preview setting
+        const enabled = configs.get(ENABLE_PRODUCE_MESSAGES, false);
+        logger.debug(`"${ENABLE_PRODUCE_MESSAGES}" config changed`, { enabled });
+        setContextValue(ContextValues.produceMessagesEnabled, enabled);
       }
     },
   );

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -73,7 +73,7 @@ export function createConfigChangeListener(): Disposable {
         logger.debug(`"${ENABLE_PRODUCE_MESSAGES}" config changed`, { enabled });
         setContextValue(ContextValues.produceMessagesEnabled, enabled);
         // no need to refresh the Topics view here since no items are being changed; VS Code will
-        // handle changing the actions to make any actions visible/enabled
+        // handle updating the UI to toggle any actions' visibility/enablement
       }
     },
   );


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #721.

This PR adds a "preview" setting to allow users to opt-in to the message producing functionality before it's feature-complete. It doesn't currently affect anything, but it will be used in follow-on branches that expose message producing actions and elements, similar to how we're currently using the direct connection setting.

<img width="926" alt="image" src="https://github.com/user-attachments/assets/6c5ddb00-b127-4010-b03b-c0837f1daebb">


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

This included a minor renaming and re-tagging of our existing direct connection setting since it wasn't really an "experiment".

This also required a minor reorganizing of the settings listener to get out of the `DirectConnectionManager` class and into the listener that previously only watched for SSL-related settings changes. Having them all under one place made the most sense.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
