### PR TITLE
MINOR: set `SENTRY_ENV` to "development" if the microversion is included

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -242,6 +242,12 @@ function getSentryReleaseVersion() {
   } catch (e) {
     console.error("Failed to read version in package.json", e);
   }
+
+  if (version.includes("-")) {
+    // not a release version
+    process.env.SENTRY_ENV = "development";
+  }
+
   // If CI, don't use the revision
   if (IS_CI) {
     return "vscode-confluent@" + version;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to https://github.com/confluentinc/vscode/pull/719, where we may build the .vsix files through CI that include the microversion. We don't want those labeled with the "production" environment tag in Sentry, so those are set as "development". (I was tempted to use "pre-production" but that would likely involve more elaborate checks against the `revision` / `IS_CI` / etc, and the main thing we want is to just make it something other than "production")

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
