### PR TITLE
feat: store form connection type with `CustomConnectionSpec` interface

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -1,13 +1,12 @@
 import { Disposable, Uri, window, workspace, WorkspaceConfiguration } from "vscode";
 import { registerCommandWithLogging } from ".";
-import { ConnectionSpec } from "../clients/sidecar";
 import { openDirectConnectionForm } from "../directConnect";
 import { DirectConnectionManager } from "../directConnectManager";
 import { Logger } from "../logging";
 import { DirectEnvironment } from "../models/environment";
 import { SSL_PEM_PATHS } from "../preferences/constants";
 import { getCCloudAuthSession } from "../sidecar/connections";
-import { getResourceManager } from "../storage/resourceManager";
+import { CustomConnectionSpec, getResourceManager } from "../storage/resourceManager";
 import { getResourceViewProvider } from "../viewProviders/resources";
 
 const logger = new Logger("commands.connections");
@@ -102,7 +101,7 @@ export async function renameDirectConnection(item: DirectEnvironment) {
   }
 
   // look up the associated ConnectionSpec
-  const spec: ConnectionSpec | null = await getResourceManager().getDirectConnection(
+  const spec: CustomConnectionSpec | null = await getResourceManager().getDirectConnection(
     item.connectionId,
   );
   if (!spec) {
@@ -114,7 +113,7 @@ export async function renameDirectConnection(item: DirectEnvironment) {
   }
 
   // update and send it to the manager to update the sidecar + secret storage
-  const updatedSpec: ConnectionSpec = {
+  const updatedSpec: CustomConnectionSpec = {
     ...spec,
     name: newName,
   };

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -56,8 +56,8 @@ export function openDirectConnectionForm(): void {
     const result = await manager.createConnection(
       kafkaConfig,
       schemaRegistryConfig,
-      body["name"],
       body["platform"],
+      body["name"],
     );
     let name = body["name"] || "the connection";
     if (result.success) {

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -21,7 +21,6 @@ import {
   DirectConnectionsById,
   getResourceManager,
 } from "./storage/resourceManager";
-import { FormConnectionType } from "./webview/direct-connect-form";
 
 const fakeConnectionsList: ConnectionsList = {
   api_version: "v1",
@@ -40,8 +39,6 @@ const PLAIN_LOCAL_KAFKA_SR_SPEC: ConnectionSpec = {
     uri: TEST_LOCAL_SCHEMA_REGISTRY.uri,
   },
 };
-
-const fakeFormConnectionType: FormConnectionType = "Apache Kafka";
 
 describe("DirectConnectionManager behavior", () => {
   let sandbox: sinon.SinonSandbox;
@@ -95,7 +92,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       testSpec.kafka_cluster,
       testSpec.schema_registry,
-      fakeFormConnectionType,
+      TEST_DIRECT_CONNECTION_FORM_SPEC.formConnectionType,
       testSpec.name,
     );
 
@@ -116,7 +113,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       testSpec.kafka_cluster,
       testSpec.schema_registry,
-      fakeFormConnectionType,
+      TEST_DIRECT_CONNECTION_FORM_SPEC.formConnectionType,
       testSpec.name,
     );
 
@@ -139,7 +136,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       PLAIN_LOCAL_KAFKA_SR_SPEC.kafka_cluster,
       PLAIN_LOCAL_KAFKA_SR_SPEC.schema_registry,
-      fakeFormConnectionType,
+      TEST_DIRECT_CONNECTION_FORM_SPEC.formConnectionType,
       PLAIN_LOCAL_KAFKA_SR_SPEC.name,
     );
 
@@ -157,7 +154,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       PLAIN_LOCAL_KAFKA_SR_SPEC.kafka_cluster,
       PLAIN_LOCAL_KAFKA_SR_SPEC.schema_registry,
-      fakeFormConnectionType,
+      TEST_DIRECT_CONNECTION_FORM_SPEC.formConnectionType,
       PLAIN_LOCAL_KAFKA_SR_SPEC.name,
     );
 

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -1,7 +1,10 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import { TEST_LOCAL_KAFKA_CLUSTER, TEST_LOCAL_SCHEMA_REGISTRY } from "../tests/unit/testResources";
-import { TEST_DIRECT_CONNECTION } from "../tests/unit/testResources/connection";
+import {
+  TEST_DIRECT_CONNECTION,
+  TEST_DIRECT_CONNECTION_FORM_SPEC,
+} from "../tests/unit/testResources/connection";
 import { getExtensionContext } from "../tests/unit/testUtils";
 import {
   ConnectionsList,
@@ -13,7 +16,12 @@ import { DirectConnectionManager } from "./directConnectManager";
 import { ConnectionId } from "./models/resource";
 import * as sidecar from "./sidecar";
 import * as connections from "./sidecar/connections";
-import { DirectConnectionsById, getResourceManager } from "./storage/resourceManager";
+import {
+  CustomConnectionSpec,
+  DirectConnectionsById,
+  getResourceManager,
+} from "./storage/resourceManager";
+import { FormConnectionType } from "./webview/direct-connect-form";
 
 const fakeConnectionsList: ConnectionsList = {
   api_version: "v1",
@@ -32,6 +40,8 @@ const PLAIN_LOCAL_KAFKA_SR_SPEC: ConnectionSpec = {
     uri: TEST_LOCAL_SCHEMA_REGISTRY.uri,
   },
 };
+
+const fakeFormConnectionType: FormConnectionType = "Apache Kafka";
 
 describe("DirectConnectionManager behavior", () => {
   let sandbox: sinon.SinonSandbox;
@@ -85,6 +95,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       testSpec.kafka_cluster,
       testSpec.schema_registry,
+      fakeFormConnectionType,
       testSpec.name,
     );
 
@@ -105,6 +116,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       testSpec.kafka_cluster,
       testSpec.schema_registry,
+      fakeFormConnectionType,
       testSpec.name,
     );
 
@@ -127,6 +139,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       PLAIN_LOCAL_KAFKA_SR_SPEC.kafka_cluster,
       PLAIN_LOCAL_KAFKA_SR_SPEC.schema_registry,
+      fakeFormConnectionType,
       PLAIN_LOCAL_KAFKA_SR_SPEC.name,
     );
 
@@ -144,6 +157,7 @@ describe("DirectConnectionManager behavior", () => {
     const result = await DirectConnectionManager.getInstance().createConnection(
       PLAIN_LOCAL_KAFKA_SR_SPEC.kafka_cluster,
       PLAIN_LOCAL_KAFKA_SR_SPEC.schema_registry,
+      fakeFormConnectionType,
       PLAIN_LOCAL_KAFKA_SR_SPEC.name,
     );
 
@@ -155,10 +169,13 @@ describe("DirectConnectionManager behavior", () => {
 
   it("updateConnection() should store the updated connection spec after successful response from the sidecar", async () => {
     // preload a direct connection
-    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION.spec);
+    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION_FORM_SPEC);
 
     const newName = "Updated Connection";
-    const updatedSpec = { ...TEST_DIRECT_CONNECTION.spec, name: newName };
+    const updatedSpec: CustomConnectionSpec = {
+      ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+      name: newName,
+    };
     tryToUpdateConnectionStub.resolves({ ...TEST_DIRECT_CONNECTION, spec: updatedSpec });
 
     const result = await DirectConnectionManager.getInstance().updateConnection(updatedSpec);
@@ -177,10 +194,13 @@ describe("DirectConnectionManager behavior", () => {
 
   it("updateConnection() should not store the updated connection spec if the sidecar response is unsuccessful", async () => {
     // preload a direct connection
-    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION.spec);
+    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION_FORM_SPEC);
 
     const newName = "Updated Connection";
-    const updatedSpec = { ...TEST_DIRECT_CONNECTION.spec, name: newName };
+    const updatedSpec: CustomConnectionSpec = {
+      ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+      name: newName,
+    };
     tryToUpdateConnectionStub.rejects(new ResponseError(new Response("oh no", { status: 500 })));
 
     const result = await DirectConnectionManager.getInstance().updateConnection(updatedSpec);
@@ -190,7 +210,7 @@ describe("DirectConnectionManager behavior", () => {
       await getResourceManager().getDirectConnections();
     assert.equal(storedConnections.size, 1);
     const storedConnection: ConnectionSpec | undefined = storedConnections.get(
-      TEST_DIRECT_CONNECTION.spec.id as ConnectionId,
+      TEST_DIRECT_CONNECTION_FORM_SPEC.id,
     );
     assert.ok(storedConnection);
     assert.equal(storedConnection.name, TEST_DIRECT_CONNECTION.spec.name);
@@ -198,18 +218,18 @@ describe("DirectConnectionManager behavior", () => {
 
   it("rehydrateConnections() should inform the sidecar of new/untracked connections", async () => {
     // preload a direct connection
-    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION.spec);
+    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION_FORM_SPEC);
     // stub the sidecar not knowing about it
     stubbedConnectionsResourceApi.gatewayV1ConnectionsGet.resolves(fakeConnectionsList);
 
     await DirectConnectionManager.getInstance().rehydrateConnections();
 
-    assert.ok(tryToCreateConnectionStub.calledOnceWith(TEST_DIRECT_CONNECTION.spec));
+    assert.ok(tryToCreateConnectionStub.calledOnceWith(TEST_DIRECT_CONNECTION_FORM_SPEC));
   });
 
   it("rehydrateConnections() should not inform the sidecar of existing/tracked connections", async () => {
     // preload a direct connection
-    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION.spec);
+    await getResourceManager().addDirectConnection(TEST_DIRECT_CONNECTION_FORM_SPEC);
     // stub the sidecar already tracking it
     const connectionsList: ConnectionsList = {
       ...fakeConnectionsList,

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -45,7 +45,7 @@ export interface CustomConnectionSpec extends ConnectionSpec {
   formConnectionType: FormConnectionType;
 }
 
-/** Map of connection id to ConnectionSpec; only used for `DIRECT` connections. */
+/** Map of {@link ConnectionId} to {@link CustomConnectionSpec}; only used for `DIRECT` connections. */
 export type DirectConnectionsById = Map<ConnectionId, CustomConnectionSpec>;
 
 /**

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -9,6 +9,7 @@ import { ConnectionId, isCCloud, isLocal } from "../models/resource";
 import { Schema } from "../models/schema";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
+import { FormConnectionType } from "../webview/direct-connect-form";
 import { SecretStorageKeys, UriMetadataKeys, WorkspaceStorageKeys } from "./constants";
 
 const logger = new Logger("storage.resourceManager");
@@ -37,8 +38,15 @@ export type UriMetadata = Map<UriMetadataKeys, string>;
 /** Map of string of uri for a file -> dict of its confluent-extension-centric metadata */
 export type AllUriMetadata = Map<string, UriMetadata>;
 
+export interface CustomConnectionSpec extends ConnectionSpec {
+  // enforce `ConnectionId` type over `string`
+  id: ConnectionId;
+  /** The option chosen by the user to describe this connection. Similar to {@link ConnectionSpec} */
+  formConnectionType: FormConnectionType;
+}
+
 /** Map of connection id to ConnectionSpec; only used for `DIRECT` connections. */
-export type DirectConnectionsById = Map<ConnectionId, ConnectionSpec>;
+export type DirectConnectionsById = Map<ConnectionId, CustomConnectionSpec>;
 
 /**
  * Singleton helper for interacting with Confluent-/Kafka-specific global/workspace state items and secrets.
@@ -678,16 +686,16 @@ export class ResourceManager {
       SecretStorageKeys.DIRECT_CONNECTIONS,
     );
     if (!connectionsString) {
-      return new Map<ConnectionId, ConnectionSpec>();
+      return new Map<ConnectionId, CustomConnectionSpec>();
     }
-    const connections: Map<ConnectionId, ConnectionSpec> = JSON.parse(connectionsString);
+    const connections: Map<ConnectionId, CustomConnectionSpec> = JSON.parse(connectionsString);
     const connectionsById: DirectConnectionsById = new Map(
       Object.entries(connections),
     ) as DirectConnectionsById;
     return connectionsById;
   }
 
-  async getDirectConnection(id: ConnectionId): Promise<ConnectionSpec | null> {
+  async getDirectConnection(id: ConnectionId): Promise<CustomConnectionSpec | null> {
     const connections: DirectConnectionsById = await this.getDirectConnections();
     return connections.get(id) ?? null;
   }
@@ -696,7 +704,7 @@ export class ResourceManager {
    * Add a direct connection to the extension state by looking up the existing
    * {@link DirectConnectionsById} map and adding/overwriting the `connection` by its `id`.
    */
-  async addDirectConnection(connection: ConnectionSpec): Promise<void> {
+  async addDirectConnection(connection: CustomConnectionSpec): Promise<void> {
     const key = SecretStorageKeys.DIRECT_CONNECTIONS;
     return await this.runWithMutex(key, async () => {
       const connectionIds: DirectConnectionsById = await this.getDirectConnections();

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -41,7 +41,7 @@ export type AllUriMetadata = Map<string, UriMetadata>;
 export interface CustomConnectionSpec extends ConnectionSpec {
   // enforce `ConnectionId` type over `string`
   id: ConnectionId;
-  /** The option chosen by the user to describe this connection. Similar to {@link ConnectionSpec} */
+  /** The option chosen by the user to describe this connection. Similar to {@link ConnectionType} */
   formConnectionType: FormConnectionType;
 }
 

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -1,8 +1,8 @@
 import { ObservableScope } from "inertial";
+import { KafkaClusterConfig, SchemaRegistryConfig } from "../clients/sidecar";
 import { applyBindings } from "./bindings/bindings";
 import { ViewModel } from "./bindings/view-model";
 import { sendWebviewMessage } from "./comms/comms";
-import { KafkaClusterConfig, SchemaRegistryConfig } from "../clients/sidecar";
 
 /** Instantiate the Inertial scope, document root,
  * and a "view model", an intermediary between the view (UI: .html) and the model (data: directConnect.ts) */
@@ -15,7 +15,7 @@ addEventListener("DOMContentLoaded", () => {
 
 class DirectConnectFormViewModel extends ViewModel {
   /** Form Input Values */
-  platformType = this.signal<PlatformOptions>("Apache Kafka");
+  platformType = this.signal<FormConnectionType>("Apache Kafka");
   kafkaAuthType = this.signal<SupportedAuthTypes>("None");
   schemaAuthType = this.signal<SupportedAuthTypes>("None");
   schemaUri = this.signal("");
@@ -29,7 +29,7 @@ class DirectConnectFormViewModel extends ViewModel {
     const input = event.target as HTMLInputElement;
     switch (input.name) {
       case "platform":
-        this.platformType(input.value as PlatformOptions);
+        this.platformType(input.value as FormConnectionType);
         if (input.value === "Confluent Cloud") {
           this.kafkaAuthType("API");
           this.schemaAuthType("API");
@@ -115,7 +115,12 @@ export function post(type: any, body: any): Promise<unknown> {
   return sendWebviewMessage(type, body);
 }
 
-type PlatformOptions = "Apache Kafka" | "Confluent Cloud" | "Confluent Platform" | "Other";
+/** Similar to {@link ConnectionType}, but only used for telemetry purposes. */
+export type FormConnectionType =
+  | "Apache Kafka"
+  | "Confluent Cloud"
+  | "Confluent Platform"
+  | "Other";
 
 type SupportedAuthTypes = "None" | "Basic" | "API";
 

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../src/constants";
 import { ConnectionId } from "../../../src/models/resource";
 import { SIDECAR_PORT } from "../../../src/sidecar/constants";
+import { CustomConnectionSpec } from "../../../src/storage/resourceManager";
 import { TEST_CCLOUD_ORGANIZATION } from "./organization";
 
 export const TEST_CCLOUD_USER: UserInfo = {
@@ -89,4 +90,11 @@ export const TEST_DIRECT_CONNECTION: Connection = {
       status: "NO_TOKEN",
     },
   },
+};
+
+/** Fake spec augmented with `formConnectionType` for test purposes. */
+export const TEST_DIRECT_CONNECTION_FORM_SPEC: CustomConnectionSpec = {
+  ...TEST_DIRECT_CONNECTION.spec,
+  id: TEST_DIRECT_CONNECTION_ID, // enforced ConnectionId type
+  formConnectionType: "Apache Kafka",
 };


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR mainly adjusts the data we're storing from the direct connection webview form to make it easier to a) log telemetry events, and b) repopulate the webview form when a user wants to edit the config of that connection.

Example logging before firing telemetry events for a direct connection create+delete where we store the `type` from the webview form:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/d8db7f4d-f30d-4f82-b2c5-1f613574d3b4">


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
