### PR TITLE
add `environmentChanged` event emitter to update Topics/Schemas view descriptions

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -11,7 +11,7 @@ import {
   SchemaRegistryConfig,
 } from "./clients/sidecar";
 import { getExtensionContext } from "./context/extension";
-import { directConnectionsChanged } from "./emitters";
+import { directConnectionsChanged, environmentChanged } from "./emitters";
 import { ExtensionContextNotSetError } from "./errors";
 import { Logger } from "./logging";
 import { ConnectionId, isDirect } from "./models/resource";
@@ -181,6 +181,9 @@ export class DirectConnectionManager {
 
     // update the connection in secret storage (via full replace of the connection by its id)
     await getResourceManager().addDirectConnection(connection.spec);
+    // notify subscribers that the "environment" has changed since direct connections are treated
+    // as environment-specific resources
+    environmentChanged.fire(connection.spec.id!);
     return { success: true, message: JSON.stringify(connection) };
   }
 

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -20,6 +20,10 @@ export const directConnectionsChanged = new vscode.EventEmitter<void>();
 export const localKafkaConnected = new vscode.EventEmitter<boolean>();
 export const localSchemaRegistryConnected = new vscode.EventEmitter<boolean>();
 
+/** Fired whenever a property of an {@link Environment} has changed. (Mainly to affect watchers in
+ * the Topics/Schemas views, or similar.) */
+export const environmentChanged = new vscode.EventEmitter<string>(); // TODO: update to EnvironmentId once used
+
 /**
  * Fired whenever a Kafka cluster is selected from the Resources view, chosen from the "Select Kafka
  * Cluster" action from the Topics view, or cleared out from a connection (or CCloud organization)

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -142,6 +142,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
             },
           );
           await this.updateTreeViewDescription();
+          this.refresh();
         }
       },
     );

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -4,6 +4,7 @@ import { ContextValues, setContextValue } from "../context/values";
 import {
   ccloudConnected,
   currentSchemaRegistryChanged,
+  environmentChanged,
   localSchemaRegistryConnected,
 } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
@@ -131,6 +132,20 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
 
   /** Set up event listeners for this view provider. */
   setEventListeners(): vscode.Disposable[] {
+    const environmentChangedSub: vscode.Disposable = environmentChanged.event(
+      async (envId: string) => {
+        if (this.schemaRegistry && this.schemaRegistry.environmentId === envId) {
+          logger.debug(
+            "environmentChanged event fired with matching SR env ID, updating view description",
+            {
+              envId,
+            },
+          );
+          await this.updateTreeViewDescription();
+        }
+      },
+    );
+
     const ccloudConnectedSub: vscode.Disposable = ccloudConnected.event((connected: boolean) => {
       if (this.schemaRegistry && isCCloud(this.schemaRegistry)) {
         logger.debug("ccloudConnected event fired, resetting", { connected });
@@ -156,23 +171,39 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
         } else {
           setContextValue(ContextValues.schemaRegistrySelected, true);
           this.schemaRegistry = schemaRegistry;
-          // update the tree view description to show the currently-focused Schema Registry's parent
-          // env name and the Schema Registry ID, then repopulate the tree
-          const loader = ResourceLoader.getInstance(schemaRegistry.connectionId);
-          const envs = await loader.getEnvironments();
-          const parentEnv = envs.find((env) => env.id === schemaRegistry.environmentId);
-          this.environment = parentEnv ?? null;
-          if (parentEnv) {
-            this.treeView.description = `${parentEnv.name} | ${schemaRegistry.id}`;
-          } else {
-            this.treeView.description = schemaRegistry.id;
-          }
+          await this.updateTreeViewDescription();
           this.refresh();
         }
       },
     );
 
-    return [ccloudConnectedSub, localSchemaRegistryConnectedSub, currentSchemaRegistryChangedSub];
+    return [
+      environmentChangedSub,
+      ccloudConnectedSub,
+      localSchemaRegistryConnectedSub,
+      currentSchemaRegistryChangedSub,
+    ];
+  }
+
+  /** Update the tree view description to show the currently-focused Schema Registry's parent env
+   * name and the Schema Registry ID. */
+  async updateTreeViewDescription(): Promise<void> {
+    const schemaRegistry = this.schemaRegistry;
+    if (!schemaRegistry) {
+      return;
+    }
+    const loader = ResourceLoader.getInstance(schemaRegistry.connectionId);
+    const envs = await loader.getEnvironments();
+    const parentEnv = envs.find((env) => env.id === schemaRegistry.environmentId);
+    this.environment = parentEnv ?? null;
+    if (parentEnv) {
+      this.treeView.description = `${parentEnv.name} | ${schemaRegistry.id}`;
+    } else {
+      logger.warn("couldn't find parent environment for Schema Registry", {
+        schemaRegistry,
+      });
+      this.treeView.description = schemaRegistry.id;
+    }
   }
 
   /** Try to reveal this particular schema, if present */

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -142,6 +142,7 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
             },
           );
           await this.updateTreeViewDescription();
+          this.refresh();
         }
       },
     );

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -1,7 +1,12 @@
 import * as vscode from "vscode";
 import { getExtensionContext } from "../context/extension";
 import { ContextValues, setContextValue } from "../context/values";
-import { ccloudConnected, currentKafkaClusterChanged, localKafkaConnected } from "../emitters";
+import {
+  ccloudConnected,
+  currentKafkaClusterChanged,
+  environmentChanged,
+  localKafkaConnected,
+} from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
@@ -127,6 +132,20 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
 
   /** Set up event listeners for this view provider. */
   setEventListeners(): vscode.Disposable[] {
+    const environmentChangedSub: vscode.Disposable = environmentChanged.event(
+      async (envId: string) => {
+        if (this.kafkaCluster && this.kafkaCluster.environmentId === envId) {
+          logger.debug(
+            "environmentChanged event fired with matching Kafka cluster env ID, updating view description",
+            {
+              envId,
+            },
+          );
+          await this.updateTreeViewDescription();
+        }
+      },
+    );
+
     const ccloudConnectedSub: vscode.Disposable = ccloudConnected.event((connected: boolean) => {
       if (this.kafkaCluster && isCCloud(this.kafkaCluster)) {
         // any transition of CCloud connection state should reset the tree view if we're focused on
@@ -161,26 +180,39 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
         } else {
           setContextValue(ContextValues.kafkaClusterSelected, true);
           this.kafkaCluster = cluster;
-          // update the tree view description to show the currently-focused Kafka cluster's parent
-          // env name and the Schema Registry ID, then repopulate the tree
-          const loader = ResourceLoader.getInstance(cluster.connectionId);
-          const envs = await loader.getEnvironments();
-          const parentEnv = envs.find((env) => env.id === cluster.environmentId);
-          this.environment = parentEnv ?? null;
-          if (parentEnv) {
-            this.treeView.description = `${parentEnv.name} | ${cluster.name}`;
-          } else {
-            logger.warn("couldn't find parent environment for Kafka cluster", {
-              cluster,
-            });
-            this.treeView.description = cluster.id;
-          }
+          await this.updateTreeViewDescription();
           this.refresh();
         }
       },
     );
 
-    return [ccloudConnectedSub, localKafkaConnectedSub, currentKafkaClusterChangedSub];
+    return [
+      environmentChangedSub,
+      ccloudConnectedSub,
+      localKafkaConnectedSub,
+      currentKafkaClusterChangedSub,
+    ];
+  }
+
+  /** Update the tree view description to show the currently-focused Kafka cluster's parent env
+   * name and the Kafka cluster name. */
+  async updateTreeViewDescription(): Promise<void> {
+    const cluster = this.kafkaCluster;
+    if (!cluster) {
+      return;
+    }
+    const loader = ResourceLoader.getInstance(cluster.connectionId);
+    const envs = await loader.getEnvironments();
+    const parentEnv = envs.find((env) => env.id === cluster.environmentId);
+    this.environment = parentEnv ?? null;
+    if (parentEnv) {
+      this.treeView.description = `${parentEnv.name} | ${cluster.name}`;
+    } else {
+      logger.warn("couldn't find parent environment for Kafka cluster", {
+        cluster,
+      });
+      this.treeView.description = cluster.name;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #718.

When an environment (or direct connection, which is treated as an environment) changes -- (for now, that just includes renames) -- we need to make sure the `description` used in the tree view reflects any updates to the environment `name`, as well as refresh the underlying items (if this includes a config change).


https://github.com/user-attachments/assets/eaa4c5f1-268a-449d-b377-7da0a4709b55



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
