### PR TITLE
fix for `409 Conflict` responses when updating `LOCAL` connections

### DIFF
--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -190,9 +190,10 @@ export async function updateLocalConnection(schemaRegistryUri?: string): Promise
 
   const currentLocalConnection: Connection | null = await getLocalConnection();
   // inform sidecar if the spec has changed (whether this is a new spec or if we're changing configs)
-  if (JSON.stringify(spec) !== JSON.stringify(currentLocalConnection?.spec)) {
-    await deleteLocalConnection();
+  if (!currentLocalConnection) {
     await tryToCreateConnection(spec);
+  } else if (JSON.stringify(spec) !== JSON.stringify(currentLocalConnection?.spec)) {
+    await tryToUpdateConnection(spec);
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #661.

In earlier versions of the sidecar, cluster caching was causing issues relating to using old configs when the extension would make `PUT` requests to update a connection (e.g. changing the local `schema_registry_uri`), so https://github.com/confluentinc/vscode/pull/544 went the aggressive route of trying to explicitly delete and then recreate the `LOCAL` connection.

This is no longer necessary, and we are now occasionally seeing `409 Conflict` error responses when multiple local connection updates fire off in quick succession, so it's safer to go with more of an upsert approach.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
