### PR TITLE
use progress notification while waiting for connection to be usable

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { Disposable, SecretStorageChangeEvent, window } from "vscode";
+import { Disposable, ProgressLocation, SecretStorageChangeEvent, window } from "vscode";
 import {
   Connection,
   ConnectionsList,
@@ -205,7 +205,15 @@ export class DirectConnectionManager {
     try {
       connection = update ? await tryToUpdateConnection(spec) : await tryToCreateConnection(spec);
       const connectionId = connection.spec.id as ConnectionId;
-      await waitForConnectionToBeUsable(connectionId);
+      await window.withProgress(
+        {
+          location: ProgressLocation.Notification,
+          title: `Waiting for "${connection.spec.name}" to be usable...`,
+        },
+        async () => {
+          await waitForConnectionToBeUsable(connectionId);
+        },
+      );
     } catch (error) {
       // logging happens in the above call
       if (error instanceof ResponseError) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #736.

Only shows a progress notification during single-connection create/update actions, not during the rehydrate step informing the sidecar of any connections it isn't tracking (since that will show up through the loader in the Resources view).


https://github.com/user-attachments/assets/316e4108-a3d8-4cbe-88fa-fc5a004cef44



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
