### PR TITLE
refactor schema upload to start from Schemas view and prompt for editor/file Uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this extension will be documented in this file.
 - Schema upload actions are now available in the Schemas view, as well as any Schema Registry shown
   in the Resources view. Schemas can also now be uploaded from an editor without needing to save to
   a file first.
+- Clicking a schema item in the Topics/Schemas view will now open the schema definition in a
+  read-only document without needing to click on the "View Schema" action.
 
 ## 0.22.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
 - Produce message button and commmand enabling schemaless production of JSON messages
+
+### Changed
+
+- Schema upload actions are now available in the Schemas view, as well as any Schema Registry shown
+  in the Resources view. Schemas can also now be uploaded from an editor without needing to save to
+  a file first.
 
 ## 0.22.1
 

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
         "category": "Confluent: Schemas"
       },
       {
-        "command": "confluent.schemas.evolveSchemaGroup",
+        "command": "confluent.schemas.evolveSchemaSubject",
         "icon": "$(plus)",
         "title": "Evolve Latest Schema",
         "category": "Confluent: Schemas"
@@ -608,7 +608,7 @@
           "when": "false"
         },
         {
-          "command": "confluent.schemas.evolveSchemaGroup",
+          "command": "confluent.schemas.evolveSchemaSubject",
           "when": "false"
         },
         {
@@ -660,11 +660,6 @@
           "when": "false"
         },
         {
-          "command": "confluent.schemas.upload",
-          "group": "navigation@3",
-          "when": "resourceFilename =~ /.*\\.(avsc|json|proto)/"
-        },
-        {
           "command": "confluent.topic.consume.duplicate",
           "group": "navigation@1",
           "when": "activeWebviewPanelId == message-viewer"
@@ -689,14 +684,19 @@
           "group": "navigation@2"
         },
         {
+          "command": "confluent.schemas.upload",
+          "group": "navigation@1",
+          "when": "view == confluent-schemas"
+        },
+        {
           "command": "confluent.resources.schema-registry.select",
           "when": "view == confluent-schemas",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "confluent.schemas.refresh",
           "when": "view == confluent-schemas",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",
@@ -762,7 +762,7 @@
         },
         {
           "command": "confluent.schemas.diffMostRecentVersions",
-          "when": "view == confluent-schemas && viewItem =~ /.*multiple-versions.*schema-group/",
+          "when": "view == confluent-schemas && viewItem =~ /.*multiple-versions.*schema-subject/",
           "group": "3_compare"
         },
         {
@@ -831,19 +831,19 @@
           "group": "4_copy@1"
         },
         {
+          "command": "confluent.schemas.evolveSchemaSubject",
+          "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/",
+          "group": "inline@2"
+        },
+        {
           "command": "confluent.schemas.evolve",
           "when": "view == confluent-schemas  && viewItem =~ /.*evolvable.*schema$/",
           "group": "inline@2"
         },
         {
           "command": "confluent.schemaViewer.viewLatestLocally",
-          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*schema-group$/",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*schema-subject$/",
           "group": "inline@1"
-        },
-        {
-          "command": "confluent.schemas.evolveSchemaGroup",
-          "when": "view == confluent-schemas && viewItem =~ /.*schema-group$/",
-          "group": "inline@2"
         },
         {
           "command": "confluent.schemaViewer.viewLocally",

--- a/package.json
+++ b/package.json
@@ -837,17 +837,17 @@
         },
         {
           "command": "confluent.schemas.evolve",
-          "when": "view == confluent-schemas  && viewItem =~ /.*evolvable.*schema$/",
+          "when": "view == confluent-schemas && viewItem =~ /.*evolvable.*schema$/",
           "group": "inline@2"
+        },
+        {
+          "command": "confluent.schemas.upload",
+          "group": "navigation@2",
+          "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/"
         },
         {
           "command": "confluent.schemaViewer.viewLatestLocally",
           "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*schema-subject$/",
-          "group": "inline@1"
-        },
-        {
-          "command": "confluent.schemaViewer.viewLocally",
-          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*-schema$/",
           "group": "inline@1"
         },
         {

--- a/package.json
+++ b/package.json
@@ -253,6 +253,12 @@
         "category": "Confluent: Schemas"
       },
       {
+        "command": "confluent.schemas.uploadForSubject",
+        "icon": "$(cloud-upload)",
+        "title": "Upload Schema to Schema Registry for Subject",
+        "category": "Confluent: Schemas"
+      },
+      {
         "command": "confluent.schemas.evolve",
         "icon": "$(plus)",
         "title": "Evolve Schema",
@@ -604,6 +610,10 @@
           "when": "false"
         },
         {
+          "command": "confluent.schemas.uploadForSubject",
+          "when": "false"
+        },
+        {
           "command": "confluent.schemas.evolve",
           "when": "false"
         },
@@ -841,7 +851,7 @@
           "group": "inline@2"
         },
         {
-          "command": "confluent.schemas.upload",
+          "command": "confluent.schemas.uploadForSubject",
           "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/",
           "group": "inline@2"
         },

--- a/package.json
+++ b/package.json
@@ -690,7 +690,7 @@
         },
         {
           "command": "confluent.schemas.upload",
-          "when": "view == confluent-schemas",
+          "when": "view == confluent-schemas && confluent.schemaRegistrySelected",
           "group": "navigation@2"
         },
         {
@@ -710,7 +710,7 @@
         },
         {
           "command": "confluent.topics.create",
-          "when": "view == confluent-topics",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "navigation@1"
         },
         {
@@ -841,14 +841,14 @@
           "group": "inline@2"
         },
         {
-          "command": "confluent.schemas.evolve",
-          "when": "view == confluent-schemas && viewItem =~ /.*evolvable.*schema$/",
+          "command": "confluent.schemas.upload",
+          "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/",
           "group": "inline@2"
         },
         {
-          "command": "confluent.schemas.upload",
-          "group": "navigation@2",
-          "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/"
+          "command": "confluent.schemas.evolve",
+          "when": "view == confluent-schemas && viewItem =~ /.*evolvable.*schema$/",
+          "group": "inline@1"
         },
         {
           "command": "confluent.schemaViewer.viewLatestLocally",

--- a/package.json
+++ b/package.json
@@ -211,18 +211,6 @@
         "category": "Confluent: Project"
       },
       {
-        "command": "confluent.schemaViewer.refresh",
-        "icon": "$(sync)",
-        "title": "Refresh Schema",
-        "category": "Confluent: Schema"
-      },
-      {
-        "command": "confluent.schemaViewer.validate",
-        "icon": "$(check)",
-        "title": "Validate",
-        "category": "Confluent: Schema"
-      },
-      {
         "command": "confluent.schemaViewer.viewLocally",
         "icon": "$(file-code)",
         "title": "View Schema",
@@ -590,14 +578,6 @@
           "when": "false"
         },
         {
-          "command": "confluent.schemaViewer.refresh",
-          "when": "false"
-        },
-        {
-          "command": "confluent.schemaViewer.validate",
-          "when": "false"
-        },
-        {
           "command": "confluent.schemaViewer.viewLocally",
           "when": "false"
         },
@@ -659,16 +639,6 @@
         }
       ],
       "editor/title": [
-        {
-          "command": "confluent.schemaViewer.refresh",
-          "group": "navigation@1",
-          "when": "false"
-        },
-        {
-          "command": "confluent.schemaViewer.validate",
-          "group": "navigation@2",
-          "when": "false"
-        },
         {
           "command": "confluent.topic.consume.duplicate",
           "group": "navigation@1",

--- a/package.json
+++ b/package.json
@@ -746,16 +746,6 @@
           "group": "inline"
         },
         {
-          "command": "confluent.schemas.diffMostRecentVersions",
-          "when": "view == confluent-schemas && viewItem =~ /.*multiple-versions.*schema-subject/",
-          "group": "3_compare"
-        },
-        {
-          "command": "confluent.topic.produce.fromFile",
-          "when": "view == confluent-topics && viewItem =~ /.*-topic.*-authzWrite.*/ && confluent.produceMessagesEnabled",
-          "group": "inline@1"
-        },
-        {
           "command": "confluent.diff.selectForCompare",
           "when": "view == confluent-schemas && viewItem =~ /.*-schema$/",
           "group": "3_compare"
@@ -812,12 +802,22 @@
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",
-          "when": "view == confluent-schemas && viewItem =~ /.*-schema*/",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*-schema*/",
           "group": "4_copy@1"
         },
         {
+          "command": "confluent.schemas.diffMostRecentVersions",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*multiple-versions.*schema-subject/",
+          "group": "3_compare"
+        },
+        {
+          "command": "confluent.schemas.evolve",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*evolvable.*schema$/",
+          "group": "inline@1"
+        },
+        {
           "command": "confluent.schemas.evolveSchemaSubject",
-          "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*schema-subject$/",
           "group": "inline@2"
         },
         {
@@ -827,13 +827,8 @@
         },
         {
           "command": "confluent.schemas.uploadForSubject",
-          "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*schema-subject$/",
           "group": "inline@2"
-        },
-        {
-          "command": "confluent.schemas.evolve",
-          "when": "view == confluent-schemas && viewItem =~ /.*evolvable.*schema$/",
-          "group": "inline@1"
         },
         {
           "command": "confluent.schemaViewer.viewLatestLocally",
@@ -879,6 +874,11 @@
           "command": "confluent.topics.copyKafkaClusterBootstrapServers",
           "when": "view == confluent-topics && viewItem =~ /.*-topic.*/",
           "group": "4_copy@3"
+        },
+        {
+          "command": "confluent.topic.produce.fromFile",
+          "when": "view == confluent-topics && viewItem =~ /.*-topic.*-authzWrite.*/ && confluent.produceMessagesEnabled",
+          "group": "inline@1"
         },
         {
           "command": "confluent.openCCloudLink",

--- a/package.json
+++ b/package.json
@@ -684,19 +684,24 @@
           "group": "navigation@2"
         },
         {
-          "command": "confluent.schemas.upload",
-          "group": "navigation@1",
-          "when": "view == confluent-schemas"
+          "command": "confluent.schemas.create",
+          "when": "view == confluent-schemas",
+          "group": "navigation@1"
         },
         {
-          "command": "confluent.resources.schema-registry.select",
+          "command": "confluent.schemas.upload",
           "when": "view == confluent-schemas",
           "group": "navigation@2"
         },
         {
-          "command": "confluent.schemas.refresh",
+          "command": "confluent.resources.schema-registry.select",
           "when": "view == confluent-schemas",
           "group": "navigation@3"
+        },
+        {
+          "command": "confluent.schemas.refresh",
+          "when": "view == confluent-schemas",
+          "group": "navigation@4"
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",

--- a/package.json
+++ b/package.json
@@ -248,13 +248,13 @@
       },
       {
         "command": "confluent.schemas.evolve",
-        "icon": "$(plus)",
+        "icon": "$(versions)",
         "title": "Evolve Schema",
         "category": "Confluent: Schemas"
       },
       {
         "command": "confluent.schemas.evolveSchemaSubject",
-        "icon": "$(plus)",
+        "icon": "$(versions)",
         "title": "Evolve Latest Schema",
         "category": "Confluent: Schemas"
       },

--- a/package.json
+++ b/package.json
@@ -821,6 +821,11 @@
           "group": "inline@2"
         },
         {
+          "command": "confluent.schemas.upload",
+          "when": "view == confluent-resources && viewItem =~ /.*-schema-registry/",
+          "group": "inline@1"
+        },
+        {
           "command": "confluent.schemas.uploadForSubject",
           "when": "view == confluent-schemas && viewItem =~ /.*schema-subject$/",
           "group": "inline@2"

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -78,7 +78,8 @@ export async function uploadSchemaFromFile(registry?: SchemaRegistry, subject?: 
     const contentArray: Uint8Array = await vscode.workspace.fs.readFile(schemaUri);
     content = Buffer.from(contentArray).toString("utf-8");
   } else {
-    // "untitled" and SCHEMA_URI_SCHEME URIs are treated the same way
+    // "untitled" and SCHEMA_URI_SCHEME URIs are treated the same way since they aren't saved to
+    // the file system and are always open in an editor if they were chosen through the quickpick
     document = await vscode.workspace.openTextDocument(schemaUri);
     content = document.getText();
     languageId = document.languageId;

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -8,10 +8,11 @@ import {
 } from "../clients/schemaRegistryRest";
 import { currentSchemaRegistryChanged } from "../emitters";
 import { Logger } from "../logging";
+import { ContainerTreeItem } from "../models/main";
 import { Schema, SchemaType } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
-import { schemaRegistryQuickPick } from "../quickpicks/schemaRegistries";
 import { schemaSubjectQuickPick, schemaTypeQuickPick } from "../quickpicks/schemas";
+import { uriQuickpick } from "../quickpicks/uris";
 import { getSidecar } from "../sidecar";
 import { ResourceLoader } from "../storage/resourceLoader";
 import { getSchemasViewProvider, SchemasViewProvider } from "../viewProviders/schemas";
@@ -25,34 +26,40 @@ const logger = new Logger("commands.schemaUpload");
  */
 
 /**
- * Command backing "Upload a new schema".
+ * Command backing "Upload a new schema" action, triggered either from a Schema Registry item in the
+ * Resources view, the nav action in the Schemas view (with a Schema Registry selected), or from a
+ * single schema subject container in the Schemas view.
+ *
+ * Instead of starting from a file/editor and trying to attach the SR+subject info, we start from the
+ * SR and/or subject and then ask for the file/editor.
  */
-export async function uploadNewSchema(fileUri: vscode.Uri) {
-  if (!fileUri) {
-    vscode.window.showErrorMessage("Must be invoked with an Avro, JSON Schema, or Protobuf file");
-    return;
-  }
-
-  let activeEditor = vscode.window.activeTextEditor;
-  if (!activeEditor) {
-    vscode.window.showErrorMessage("Must be invoked from an active editor");
+export async function uploadSchemaFromFile(item?: SchemaRegistry | ContainerTreeItem<Schema>) {
+  // prompt for the editor/file first
+  const schemaUri: vscode.Uri | undefined = await uriQuickpick([], {
+    "Schema files": [".avsc", ".avro", ".json", ".proto"],
+  });
+  if (!schemaUri) {
     return;
   }
 
   // If the document has (locally marked) errors, don't proceed.
-  if (await documentHasErrors(activeEditor)) {
+  if (await documentHasErrors(schemaUri)) {
     logger.error("Document has errors, aborting schema upload");
     return;
   }
 
-  // If there's a query string in the URL, it should be the encoding of a Schema
-  // object. Parse it into a Schema object if possible to use it for default
-  // values
-  const defaults: Schema | undefined = fileUri.query ? schemaFromString(fileUri.query) : undefined;
+  const fileExt: string | undefined = schemaUri.path.split(".").pop();
+  if (!fileExt) {
+    vscode.window.showErrorMessage("Could not determine file extension");
+    return;
+  }
+
+  const contentArray: Uint8Array = await vscode.workspace.fs.readFile(schemaUri);
+  const content = Buffer.from(contentArray).toString("utf-8");
 
   // What kind of schema is this? We must tell the schema registry.
   const schemaType: SchemaType | undefined = await determineSchemaType(
-    fileUri,
+    schemaUri,
     activeEditor.document.languageId,
   );
   if (!schemaType) {
@@ -61,22 +68,44 @@ export async function uploadNewSchema(fileUri: vscode.Uri) {
     return;
   }
 
-  // Ask the user to choose a schema registry to upload to.
-  const registry = await schemaRegistryQuickPick(defaults?.schemaRegistryId);
+  let registry: SchemaRegistry | undefined;
+  let subject: string | undefined;
+  if (!item) {
+    // the only way we get here is if the user clicked the action in the Schemas view nav area, so
+    // we need to get the focused schema registry
+    const schemaViewProvider = getSchemasViewProvider();
+    registry = schemaViewProvider.schemaRegistry!;
+  } else if (item instanceof SchemaRegistry) {
+    registry = item;
+    // prompt for subject
+  } else if (item instanceof ContainerTreeItem) {
+    // starting from a schema subject container in the Schemas view
+    const sampleSchema: Schema = item.children[0];
+    const loader = ResourceLoader.getInstance(sampleSchema.connectionId);
+    registry = await loader.getSchemaRegistryForEnvironmentId(sampleSchema.connectionId);
+    subject = item.label as string;
+  }
+
   if (!registry) {
-    logger.info("No registry chosen, aborting schema upload");
+    logger.error("Could not determine schema registry");
     return;
   }
 
-  // Ask the user to choose a subject to bind the schema to.
-  const subject = await chooseSubject(registry, schemaType, defaults?.subject);
+  subject = subject ? subject : await chooseSubject(registry, schemaType);
   if (!subject) {
-    logger.info("No subject chosen, aborting schema upload");
-    vscode.window.showInformationMessage("Schema upload aborted.");
+    logger.error("Could not determine schema subject");
     return;
   }
 
-  // OK, all the user input is in. Let's upload the schema.
+  await uploadSchema(registry, subject, schemaType, content);
+}
+
+async function uploadSchema(
+  registry: SchemaRegistry,
+  subject: string,
+  schemaType: SchemaType,
+  content: string,
+) {
   const sidecar = await getSidecar();
   // Has the route for registering a schema under a subject.
   const schemaSubjectsApi = sidecar.getSubjectsV1Api(registry.id, registry.connectionId);
@@ -100,13 +129,7 @@ export async function uploadNewSchema(fileUri: vscode.Uri) {
     // todo ask if want to normalize schema? They ... probably do?
     const normalize = true;
 
-    maybeNewId = await registerSchema(
-      schemaSubjectsApi,
-      subject,
-      schemaType,
-      activeEditor.document.getText(),
-      normalize,
-    );
+    maybeNewId = await registerSchema(schemaSubjectsApi, subject, schemaType, content, normalize);
 
     logger.info(
       `Schema registered successfully as subject "${subject}" in registry "${registry.id}" as schema id ${maybeNewId}`,
@@ -152,11 +175,9 @@ export async function uploadNewSchema(fileUri: vscode.Uri) {
   }
 }
 
-/**
- * Does the document have any self-contained errors? If so, don't proceed with upload.
- */
-async function documentHasErrors(activeEditor: vscode.TextEditor): Promise<boolean> {
-  const diagnostics = vscode.languages.getDiagnostics(activeEditor.document.uri);
+/** Does the given URI have any self-contained errors? If so, don't proceed with upload. */
+async function documentHasErrors(uri: vscode.Uri): Promise<boolean> {
+  const diagnostics = vscode.languages.getDiagnostics(uri);
   const errorDiagnostics = diagnostics.filter(
     (d) => d.severity === vscode.DiagnosticSeverity.Error,
   );

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -35,9 +35,12 @@ const logger = new Logger("commands.schemaUpload");
  */
 export async function uploadSchemaFromFile(item?: SchemaRegistry | ContainerTreeItem<Schema>) {
   // prompt for the editor/file first
-  const schemaUri: vscode.Uri | undefined = await uriQuickpick([], {
-    "Schema files": [".avsc", ".avro", ".json", ".proto"],
-  });
+  const schemaUri: vscode.Uri | undefined = await uriQuickpick(
+    ["plaintext", "avroavsc", "protobuf", "proto3", "json"],
+    {
+      "Schema files": [".avsc", ".avro", ".json", ".proto"],
+    },
+  );
   if (!schemaUri) {
     return;
   }

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -70,25 +70,22 @@ export async function uploadSchemaFromFile(registry?: SchemaRegistry, subject?: 
   }
 
   let content: string | undefined;
+  let activeEditor: vscode.TextEditor | undefined;
+  let languageId: string | undefined;
   if (schemaUri.scheme === "file") {
     const contentArray: Uint8Array = await vscode.workspace.fs.readFile(schemaUri);
     content = Buffer.from(contentArray).toString("utf-8");
   } else if (schemaUri.scheme === "untitled") {
-    const editor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find(
+    activeEditor = vscode.window.visibleTextEditors.find(
       (e) => e.document.uri.toString() === schemaUri.toString(),
     );
-    content = editor?.document.getText();
+    content = activeEditor?.document.getText();
+    languageId = activeEditor?.document.languageId;
   }
   if (content === undefined) {
     vscode.window.showErrorMessage("Could not read schema file");
     return;
   }
-
-  // check if the Uri belongs to an active editor
-  const activeEditor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find(
-    (e) => e.document.uri.toString() === schemaUri.toString(),
-  );
-  const languageId: string | undefined = activeEditor?.document.languageId;
 
   // What kind of schema is this? We must tell the schema registry.
   const schemaType: SchemaType | undefined = await determineSchemaType(schemaUri, languageId);

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -54,8 +54,20 @@ export async function uploadSchemaFromFile(item?: SchemaRegistry | ContainerTree
     return;
   }
 
-  const contentArray: Uint8Array = await vscode.workspace.fs.readFile(schemaUri);
-  const content = Buffer.from(contentArray).toString("utf-8");
+  let content: string | undefined;
+  if (schemaUri.scheme === "file") {
+    const contentArray: Uint8Array = await vscode.workspace.fs.readFile(schemaUri);
+    content = Buffer.from(contentArray).toString("utf-8");
+  } else if (schemaUri.scheme === "untitled") {
+    const editor: vscode.TextEditor | undefined = vscode.window.visibleTextEditors.find(
+      (e) => e.document.uri.toString() === schemaUri.toString(),
+    );
+    content = editor?.document.getText();
+  }
+  if (content === undefined) {
+    vscode.window.showErrorMessage("Could not read schema file");
+    return;
+  }
 
   // What kind of schema is this? We must tell the schema registry.
   const schemaType: SchemaType | undefined = await determineSchemaType(

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -6,6 +6,7 @@ import {
   SubjectsV1Api,
   SubjectVersion,
 } from "../clients/schemaRegistryRest";
+import { SCHEMA_URI_SCHEME } from "../documentProviders/schema";
 import { currentSchemaRegistryChanged } from "../emitters";
 import { Logger } from "../logging";
 import { ContainerTreeItem } from "../models/main";
@@ -46,12 +47,16 @@ export async function uploadSchemaForSubjectFromfile(item: ContainerTreeItem<Sch
  * Schema Registry and then ask for the file/editor (and schema subject if not provided).
  */
 export async function uploadSchemaFromFile(registry?: SchemaRegistry, subject?: string) {
-  // prompt for the editor/file first
+  // prompt for the editor/file first via the URI quickpick
+  const uriSchemes = ["file", "untitled", SCHEMA_URI_SCHEME];
+  const languageIds = ["plaintext", "avroavsc", "protobuf", "proto3", "json"];
+  const fileFilters = {
+    "Schema files": [".avsc", ".avro", ".json", ".proto"],
+  };
   const schemaUri: vscode.Uri | undefined = await uriQuickpick(
-    ["plaintext", "avroavsc", "protobuf", "proto3", "json"],
-    {
-      "Schema files": [".avsc", ".avro", ".json", ".proto"],
-    },
+    uriSchemes,
+    languageIds,
+    fileFilters,
   );
   if (!schemaUri) {
     return;

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -10,7 +10,7 @@ import { KafkaTopic } from "../models/topic";
 import { schemaTypeQuickPick } from "../quickpicks/schemas";
 import { ResourceLoader } from "../storage/resourceLoader";
 import { getSchemasViewProvider } from "../viewProviders/schemas";
-import { uploadSchemaFromFile } from "./schemaUpload";
+import { uploadSchemaForSubjectFromfile, uploadSchemaFromFile } from "./schemaUpload";
 
 const logger = new Logger("commands.schemas");
 
@@ -20,6 +20,10 @@ export function registerSchemaCommands(): vscode.Disposable[] {
     registerCommandWithLogging("confluent.schemaViewer.validate", validateCommand),
     registerCommandWithLogging("confluent.schemas.create", createSchemaCommand),
     registerCommandWithLogging("confluent.schemas.upload", uploadSchemaFromFile),
+    registerCommandWithLogging(
+      "confluent.schemas.uploadForSubject",
+      uploadSchemaForSubjectFromfile,
+    ),
     registerCommandWithLogging("confluent.schemas.evolveSchemaSubject", evolveSchemaSubjectCommand),
     registerCommandWithLogging("confluent.schemas.evolve", evolveSchemaCommand),
     registerCommandWithLogging("confluent.schemaViewer.viewLocally", viewLocallyCommand),

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -10,7 +10,7 @@ import { KafkaTopic } from "../models/topic";
 import { schemaTypeQuickPick } from "../quickpicks/schemas";
 import { ResourceLoader } from "../storage/resourceLoader";
 import { getSchemasViewProvider } from "../viewProviders/schemas";
-import { uploadNewSchema } from "./schemaUpload";
+import { uploadSchemaFromFile } from "./schemaUpload";
 
 const logger = new Logger("commands.schemas");
 
@@ -19,7 +19,7 @@ export function registerSchemaCommands(): vscode.Disposable[] {
     registerCommandWithLogging("confluent.schemaViewer.refresh", refreshCommand),
     registerCommandWithLogging("confluent.schemaViewer.validate", validateCommand),
     registerCommandWithLogging("confluent.schemas.create", createSchemaCommand),
-    registerCommandWithLogging("confluent.schemas.upload", uploadNewSchema),
+    registerCommandWithLogging("confluent.schemas.upload", uploadSchemaFromFile),
     registerCommandWithLogging("confluent.schemas.evolveSchemaSubject", evolveSchemaSubjectCommand),
     registerCommandWithLogging("confluent.schemas.evolve", evolveSchemaCommand),
     registerCommandWithLogging("confluent.schemaViewer.viewLocally", viewLocallyCommand),
@@ -301,9 +301,9 @@ async function setEditorLanguageForSchema(textDoc: vscode.TextEditor, type: Sche
   }
 
   const preferredLanguage = languageTypes[0];
+  const marketplaceUrl = `https://marketplace.visualstudio.com/search?term=${preferredLanguage}&target=VSCode&category=All%20categories&sortBy=Relevance`;
   vscode.window.showWarningMessage(
-    `Could not find a matching language for ${type}. ` +
-      `Perhaps install a language extension for ${preferredLanguage}?`,
+    `Could not find a matching editor language for "${type}". Try again after installing [an extension that supports "${preferredLanguage}"](${marketplaceUrl}).`,
   );
 
   logger.warn("Could not find a matching language for schema ${schema.subject}");

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -20,7 +20,7 @@ export function registerSchemaCommands(): vscode.Disposable[] {
     registerCommandWithLogging("confluent.schemaViewer.validate", validateCommand),
     registerCommandWithLogging("confluent.schemas.create", createSchemaCommand),
     registerCommandWithLogging("confluent.schemas.upload", uploadNewSchema),
-    registerCommandWithLogging("confluent.schemas.evolveSchemaGroup", evolveSchemaGroupCommand),
+    registerCommandWithLogging("confluent.schemas.evolveSchemaSubject", evolveSchemaSubjectCommand),
     registerCommandWithLogging("confluent.schemas.evolve", evolveSchemaCommand),
     registerCommandWithLogging("confluent.schemaViewer.viewLocally", viewLocallyCommand),
     registerCommandWithLogging(
@@ -209,14 +209,14 @@ async function evolveSchemaCommand(schema: Schema) {
 }
 
 /** Drop into evolving the latest version of the schema in the subject group. */
-async function evolveSchemaGroupCommand(schemaGroup: ContainerTreeItem<Schema>) {
+async function evolveSchemaSubjectCommand(schemaGroup: ContainerTreeItem<Schema>) {
   if (!(schemaGroup instanceof ContainerTreeItem)) {
-    logger.error("evolveSchemaGroupCommand called with invalid argument type", schemaGroup);
+    logger.error("evolveSchemaSubjectCommand called with invalid argument type", schemaGroup);
     return;
   }
 
   if (schemaGroup.children.length === 0) {
-    logger.error("evolveSchemaGroupCommand called with no schemas", schemaGroup);
+    logger.error("evolveSchemaSubjectCommand called with no schemas", schemaGroup);
     return;
   }
 

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -16,8 +16,6 @@ const logger = new Logger("commands.schemas");
 
 export function registerSchemaCommands(): vscode.Disposable[] {
   return [
-    registerCommandWithLogging("confluent.schemaViewer.refresh", refreshCommand),
-    registerCommandWithLogging("confluent.schemaViewer.validate", validateCommand),
     registerCommandWithLogging("confluent.schemas.create", createSchemaCommand),
     registerCommandWithLogging("confluent.schemas.upload", uploadSchemaFromFile),
     registerCommandWithLogging(
@@ -68,18 +66,6 @@ async function copySchemaRegistryId() {
   }
   await vscode.env.clipboard.writeText(schemaRegistry.id);
   vscode.window.showInformationMessage(`Copied "${schemaRegistry.id}" to clipboard.`);
-}
-
-// refer to https://github.com/confluentinc/vscode/pull/420 for reverting changes to package.json for
-// the following three commands:
-function refreshCommand(item: any) {
-  logger.info("item", item);
-  // TODO: implement this
-}
-
-function validateCommand(item: any) {
-  logger.info("item", item);
-  // TODO: implement this
 }
 
 /** User has gestured to create a new schema from scratch relative to the currently selected schema registry. */
@@ -297,7 +283,7 @@ async function setEditorLanguageForSchema(textDoc: vscode.TextEditor, type: Sche
   for (const language of languageTypes) {
     if (installedLanguages.indexOf(language) !== -1) {
       vscode.languages.setTextDocumentLanguage(textDoc.document, language);
-      logger.info(`Set document language to ${language}`);
+      logger.debug(`Set document language to "${language}"`);
       return;
     } else {
       logger.warn(`Language ${language} not installed type ${type}`);

--- a/src/documentProviders/schema.ts
+++ b/src/documentProviders/schema.ts
@@ -4,10 +4,12 @@ import { SchemaString, SchemasV1Api } from "../clients/schemaRegistryRest";
 import { Schema } from "../models/schema";
 import { getSidecar } from "../sidecar";
 
+export const SCHEMA_URI_SCHEME = "confluent.schema";
+
 /** Makes a read-only editor buffer holding a schema */
 export class SchemaDocumentProvider extends ResourceDocumentProvider {
   // non-file, non-untitled URIs cause the resulting buffer to be read-only
-  scheme = "confluent.schema";
+  scheme = SCHEMA_URI_SCHEME;
 
   public async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
     // parse the query string into the JSON respresentation of the original schema object

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -197,10 +197,10 @@ describe("Schema helper functions", () => {
     assert.equal(mvRe.test(anotherTopicGroup!.contextValue!), false);
   });
 
-  it("generateSchemaSubjectGroups() should set the context value to end with 'schema-group'", () => {
+  it("generateSchemaSubjectGroups() should set the context value to end with 'schema-subject'", () => {
     const groups = generateSchemaSubjectGroups(schemas);
 
-    const schemaGroupRe = /schema-group$/;
+    const schemaGroupRe = /schema-subject$/;
     const testTopicGroup = groups.find((group) => group.label === valueSubject);
     assert.equal(schemaGroupRe.test(testTopicGroup!.contextValue!), true);
 

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -206,7 +206,7 @@ export function generateSchemaSubjectGroups(
     }
 
     // set context value identifying this as a schema group
-    contextValueParts.push("schema-group");
+    contextValueParts.push("schema-subject");
 
     // dash-join all parts, assign to context value
     schemaContainerItem.contextValue = contextValueParts.join("-");

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -120,6 +120,12 @@ export class SchemaTreeItem extends vscode.TreeItem {
     this.description = resource.id.toString();
     this.iconPath = new vscode.ThemeIcon(IconNames.SCHEMA);
     this.tooltip = createSchemaTooltip(this.resource);
+
+    this.command = {
+      command: "confluent.schemaViewer.viewLocally",
+      title: "View Schema",
+      arguments: [this.resource],
+    };
   }
 }
 

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -1,0 +1,59 @@
+import { QuickPickItem, QuickPickItemKind, TextEditor, ThemeIcon, Uri, window } from "vscode";
+
+/** Create a quickpick to list all open editors, as well as an item to select a file from the open
+ * dialog. */
+export async function uriQuickpick(
+  editorLanguageIds: string[] = [],
+  fileFilters: { [name: string]: string[] } = {},
+): Promise<Uri | undefined> {
+  const selectFileLabel = "Select a file";
+  const quickpickItems: QuickPickItem[] = [
+    {
+      label: selectFileLabel,
+      iconPath: new ThemeIcon("search"),
+      alwaysShow: true,
+    },
+  ];
+
+  const filenameUriMap: Map<string, Uri> = new Map();
+  // filter open editors by languageId if provided, otherwise show all open editors
+  const editors: readonly TextEditor[] = window.visibleTextEditors.filter((editor) =>
+    editorLanguageIds ? editorLanguageIds.includes(editor.document.languageId) : true,
+  );
+  let pickedItem: QuickPickItem | undefined;
+  if (editors.length > 0) {
+    quickpickItems.push({
+      kind: QuickPickItemKind.Separator,
+      label: "Open editors",
+    });
+    quickpickItems.push(
+      ...editors.map((editor) => {
+        filenameUriMap.set(editor.document.fileName, editor.document.uri);
+        return {
+          label: editor.document.fileName,
+          description: editor.document.languageId,
+          iconPath: new ThemeIcon("file"),
+        };
+      }),
+    );
+    pickedItem = await window.showQuickPick(quickpickItems, {
+      placeHolder: "Select a file",
+      canPickMany: false,
+    });
+    // return URI from the selected editor
+    if (pickedItem && filenameUriMap.has(pickedItem.label)) {
+      return filenameUriMap.get(pickedItem.label);
+    }
+  }
+  // either there are no open editors, or the user selected the "Select a file" option
+  if (editors.length === 0 || pickedItem?.label === selectFileLabel) {
+    const uri: Uri[] | undefined = await window.showOpenDialog({
+      openLabel: "Select a file",
+      canSelectFiles: true,
+      canSelectFolders: false,
+      canSelectMany: false,
+      filters: fileFilters,
+    });
+    return uri ? uri[0] : undefined;
+  }
+}

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -14,6 +14,7 @@ import {
 /** Create a quickpick to list all open editors, as well as an item to select a file from the open
  * dialog. */
 export async function uriQuickpick(
+  uriSchemes: string[] = [],
   editorLanguageIds: string[] = [],
   fileFilters: { [name: string]: string[] } = {},
 ): Promise<Uri | undefined> {
@@ -37,8 +38,8 @@ export async function uriQuickpick(
         return;
       }
       const tabInput: TabInputText = tab.input as TabInputText;
-      if (tabInput.uri.scheme === "output") {
-        // ignore output channels
+      if (uriSchemes && !uriSchemes.includes(tabInput.uri.scheme)) {
+        // skip URIs that don't match the provided schemes
         return;
       }
       // look up document based on Uri

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -16,10 +16,23 @@ export async function uriQuickpick(
   ];
 
   const filenameUriMap: Map<string, Uri> = new Map();
-  // filter open editors by languageId if provided, otherwise show all open editors
-  const editors: readonly TextEditor[] = window.visibleTextEditors.filter((editor) =>
-    editorLanguageIds ? editorLanguageIds.includes(editor.document.languageId) : true,
-  );
+
+  const editors: TextEditor[] = [];
+  window.visibleTextEditors.forEach((editor) => {
+    if (editor.document.uri.scheme === "output") {
+      // ignore output channels
+      return;
+    }
+    // filter open editors by languageId if provided, otherwise show all open editors
+    if (
+      editorLanguageIds.length === 0 ||
+      (editorLanguageIds.length > 0 && editorLanguageIds.includes(editor.document.languageId))
+    ) {
+      editors.push(editor);
+      filenameUriMap.set(editor.document.fileName, editor.document.uri);
+    }
+  });
+
   let pickedItem: QuickPickItem | undefined;
   if (editors.length > 0) {
     quickpickItems.push({
@@ -28,7 +41,6 @@ export async function uriQuickpick(
     });
     quickpickItems.push(
       ...editors.map((editor) => {
-        filenameUriMap.set(editor.document.fileName, editor.document.uri);
         return {
           label: editor.document.fileName,
           description: editor.document.languageId,

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -6,7 +6,7 @@ export async function uriQuickpick(
   editorLanguageIds: string[] = [],
   fileFilters: { [name: string]: string[] } = {},
 ): Promise<Uri | undefined> {
-  const selectFileLabel = "Select a file";
+  const selectFileLabel = "Open File...";
   const quickpickItems: QuickPickItem[] = [
     {
       label: selectFileLabel,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Enables "Create Schema" nav action from Schemas view (doesn't require SR to be focused first since it's just opening an empty editor)
  <img width="337" alt="image" src="https://github.com/user-attachments/assets/b0c4ec89-cc72-4197-9569-146f41449833">
- Moves the "Upload" action to the Schemas view nav area once SR is focused, instead of showing up for any `.json`/`.avsc`/`.proto` editor
  <img width="376" alt="image" src="https://github.com/user-attachments/assets/2aea8388-8d9a-49bb-b212-0a59fc780873">
  ...also available in the Resources view for a specific SR:
  <img width="482" alt="image" src="https://github.com/user-attachments/assets/6089fc06-1daf-47ec-a64d-1926e184c710" />
- New command to bypass the schema subject quickpick and allow uploading **directly to a subject**


- New "URI quickpick" that loads open editors and/or offers an open file dialog for given language IDs / file filters
  <img width="1709" alt="image" src="https://github.com/user-attachments/assets/cffa97e4-7e9e-4a32-8dd3-4d9b04cf0d33">
- Falling back to using the schema type quickpick from https://github.com/confluentinc/vscode/pull/738 if we can't determine the type from the chosen Uri

Other changes:
- Changes the "Evolve Schema" actions' icons from `plus` to `versions` to avoid confusion with the "Create Schema" action being more prominently displayed.
  <img width="389" alt="image" src="https://github.com/user-attachments/assets/2affeedb-309a-4239-ad29-3d199208dd02" />

- Updates the warning notification for creating a new schema with unsupported languageId to link to the Marketplace
  <img width="482" alt="image" src="https://github.com/user-attachments/assets/2509298c-f268-428f-ace9-eccabcb8db13">

- Only shows the "Create Topic" action in the Topics view after a Kafka cluster is selected

| No Kafka cluster selected | Kafka cluster selected |
|--------|--------|
| <img width="334" alt="image" src="https://github.com/user-attachments/assets/bc2a9cfb-e76d-4ccb-903d-a5bf71be87a4"> | <img width="335" alt="image" src="https://github.com/user-attachments/assets/234820ab-68ca-4bac-a012-14e300d1d7f4"> |

- Removes the placeholder `confluent.schemaViewer.refresh` and `confluent.schemaViewer.validate` commands that weren't being used and were disabled from appearing in the UI entirely.
- Renames "schema group" references to "schema subject" for consistency
- Minor updates to the `contributes.menus.view/item/context` sections for schema-related actions to make sure they're available in the Topics view as well as Schemas view

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
