### PR TITLE
[v0.22.x] fix avro schema uploads when not using the Avro editor language ID

### DIFF
--- a/src/commands/schemaUpload.test.ts
+++ b/src/commands/schemaUpload.test.ts
@@ -1,6 +1,8 @@
 import * as assert from "assert";
+import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { SchemaType } from "../models/schema";
+import * as quickPicksSchemas from "../quickpicks/schemas";
 import {
   determineSchemaType,
   extractDetail,
@@ -12,59 +14,106 @@ import {
 import { TEST_CCLOUD_SCHEMA } from "../../tests/unit/testResources/schema";
 
 describe("commands/schemaUpload.ts determineSchemaType tests", function () {
-  it("determineSchemaType successfully determines schema type from file URI", () => {
+  let sandbox: sinon.SinonSandbox;
+  let schemaTypeQuickPickStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    schemaTypeQuickPickStub = sandbox
+      .stub(quickPicksSchemas, "schemaTypeQuickPick")
+      .resolves(undefined);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("determineSchemaType() should successfully determine schema type from file URI", async () => {
     // for pair of (file extension, expected schema type) from array of string pairs ...
     for (const [fileExtension, expectedSchemaType] of [
-      ["avsc", "AVRO"],
-      ["json", "JSON"],
-      ["proto", "PROTOBUF"],
+      ["avsc", SchemaType.Avro],
+      ["proto", SchemaType.Protobuf],
     ]) {
       const fileUri = vscode.Uri.file(`some-file.${fileExtension}`);
-      const schemaType = determineSchemaType(fileUri, null);
+      const schemaType = await determineSchemaType(fileUri);
+
       assert.strictEqual(
         schemaType,
         expectedSchemaType,
         `Expected ${expectedSchemaType} given ${fileExtension}, got ${schemaType} instead`,
       );
+      assert.ok(schemaTypeQuickPickStub.notCalled);
     }
   });
 
-  it("determineSchemaType successfully determines schema type from language ID", () => {
-    // for pair of (language ID, expected schema type) from array of string pairs ...
+  it("determineSchemaType() should show the schema type quickpick when unable to determine the schema type from the provided Uri and language ID", async () => {
+    const fileUri = vscode.Uri.file("some-file.txt");
+    await determineSchemaType(fileUri, "plaintext");
+
+    assert.ok(schemaTypeQuickPickStub.calledOnce);
+  });
+
+  it("determineSchemaType() should show the schema type quickpick when the provided Uri has a JSON file extension and language ID, but return undefined if the user cancels the quickpick", async () => {
+    // first, simulate the user cancelling the quickpick
+    schemaTypeQuickPickStub.resolves(undefined);
+    const fileUri = vscode.Uri.file("some-file.json");
+    const result = await determineSchemaType(fileUri, "json");
+
+    assert.ok(schemaTypeQuickPickStub.calledOnce);
+    assert.strictEqual(result, undefined);
+
+    // next, simulate the user selecting the JSON option
+    schemaTypeQuickPickStub.resolves("JSON");
+    const nextResult = await determineSchemaType(fileUri, "json");
+
+    assert.ok(schemaTypeQuickPickStub.calledTwice);
+    assert.strictEqual(nextResult, SchemaType.Json);
+  });
+
+  it("determineSchemaType() should successfully determine schema type from a valid provided language ID when failing to determine from file/editor Uri", async () => {
     for (const [languageId, expectedSchemaType] of [
-      ["avroavsc", "AVRO"],
-      ["json", "JSON"],
-      ["proto", "PROTOBUF"],
+      ["avroavsc", SchemaType.Avro],
+      ["proto", SchemaType.Protobuf],
+      ["proto3", SchemaType.Protobuf],
     ]) {
-      const schemaType = determineSchemaType(null, languageId);
+      const fileUri = vscode.Uri.file("some-file.txt");
+      const schemaType = await determineSchemaType(fileUri, languageId);
+
       assert.strictEqual(
         schemaType,
         expectedSchemaType,
         `Expected ${expectedSchemaType} given ${languageId}, got ${schemaType} instead`,
       );
+      assert.ok(schemaTypeQuickPickStub.notCalled);
     }
   });
 
-  it("determineSchemaType successfully determines schema type from language ID when file URI is also provided", () => {
-    for (const [fileExtension, languageId, expectedSchemaType] of [
-      ["avsc", "avroavsc", "AVRO"],
-      ["json", "json", "JSON"],
-      ["proto", "proto", "PROTOBUF"],
+  it("determineSchemaType() should successfully determine schema type from language ID when file URI has an ambiguous file extension", async () => {
+    for (const [languageId, expectedSchemaType] of [
+      ["avroavsc", "AVRO"],
+      ["proto", "PROTOBUF"],
     ]) {
-      const fileUri = vscode.Uri.file(`some-file.${fileExtension}`);
-      const schemaType = determineSchemaType(fileUri, languageId);
+      // unhelpful file extension
+      const fileUri = vscode.Uri.file(`some-file.txt`);
+      const schemaType = await determineSchemaType(fileUri, languageId);
+
       assert.strictEqual(
         schemaType,
         expectedSchemaType,
-        `Expected ${expectedSchemaType} given ${fileExtension} and ${languageId}, got ${schemaType} instead`,
+        `Expected ${expectedSchemaType} given .txt and ${languageId}, got ${schemaType} instead`,
       );
+      assert.ok(schemaTypeQuickPickStub.notCalled);
     }
   });
 
-  it("determineSchemaType should raise Error when neither file URI nor languageID is provided", () => {
-    assert.throws(() => {
-      determineSchemaType(null, null);
-    }, /Must call with either a file or document/);
+  it("determineSchemaType() should return undefined when a schema type can't be determined from the Uri, no language ID is passed, and the user cancels the quickpick", async () => {
+    // simulate the user cancelling the quickpick
+    schemaTypeQuickPickStub.resolves(undefined);
+    const fileUri = vscode.Uri.file("some-file.txt");
+
+    const result = await determineSchemaType(fileUri);
+
+    assert.strictEqual(result, undefined);
   });
 });
 

--- a/src/commands/schemaUpload.test.ts
+++ b/src/commands/schemaUpload.test.ts
@@ -28,7 +28,7 @@ describe("commands/schemaUpload.ts determineSchemaType tests", function () {
     sandbox.restore();
   });
 
-  it("determineSchemaType() should successfully determine schema type from file URI", async () => {
+  it("should successfully determine schema type from file URI", async () => {
     // for pair of (file extension, expected schema type) from array of string pairs ...
     for (const [fileExtension, expectedSchemaType] of [
       ["avsc", SchemaType.Avro],
@@ -46,14 +46,14 @@ describe("commands/schemaUpload.ts determineSchemaType tests", function () {
     }
   });
 
-  it("determineSchemaType() should show the schema type quickpick when unable to determine the schema type from the provided Uri and language ID", async () => {
+  it("should show the schema type quickpick when unable to determine the schema type from the provided Uri and language ID", async () => {
     const fileUri = vscode.Uri.file("some-file.txt");
     await determineSchemaType(fileUri, "plaintext");
 
     assert.ok(schemaTypeQuickPickStub.calledOnce);
   });
 
-  it("determineSchemaType() should show the schema type quickpick when the provided Uri has a JSON file extension and language ID, but return undefined if the user cancels the quickpick", async () => {
+  it("should show the schema type quickpick when the provided Uri has a JSON file extension and language ID", async () => {
     // first, simulate the user cancelling the quickpick
     schemaTypeQuickPickStub.resolves(undefined);
     const fileUri = vscode.Uri.file("some-file.json");
@@ -70,7 +70,7 @@ describe("commands/schemaUpload.ts determineSchemaType tests", function () {
     assert.strictEqual(nextResult, SchemaType.Json);
   });
 
-  it("determineSchemaType() should successfully determine schema type from a valid provided language ID when failing to determine from file/editor Uri", async () => {
+  it("should successfully determine schema type from a valid provided language ID when failing to determine from file/editor Uri", async () => {
     for (const [languageId, expectedSchemaType] of [
       ["avroavsc", SchemaType.Avro],
       ["proto", SchemaType.Protobuf],
@@ -88,7 +88,7 @@ describe("commands/schemaUpload.ts determineSchemaType tests", function () {
     }
   });
 
-  it("determineSchemaType() should successfully determine schema type from language ID when file URI has an ambiguous file extension", async () => {
+  it("should successfully determine schema type from language ID when file URI has an ambiguous file extension", async () => {
     for (const [languageId, expectedSchemaType] of [
       ["avroavsc", "AVRO"],
       ["proto", "PROTOBUF"],
@@ -106,7 +106,7 @@ describe("commands/schemaUpload.ts determineSchemaType tests", function () {
     }
   });
 
-  it("determineSchemaType() should return undefined when a schema type can't be determined from the Uri, no language ID is passed, and the user cancels the quickpick", async () => {
+  it("should return undefined when a schema type can't be determined from the Uri, no language ID is passed, and the user cancels the quickpick", async () => {
     // simulate the user cancelling the quickpick
     schemaTypeQuickPickStub.resolves(undefined);
     const fileUri = vscode.Uri.file("some-file.txt");

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -313,24 +313,18 @@ export function schemaRegistrationMessage(
 }
 
 /**
- * Limited map to associate the Avro and Protobuf language IDs to their associated {@link SchemaType}s.
+ * General map for associating Avro and Protobuf to their associated {@link SchemaType}s based on
+ * either file extension or language ID.
  *
  * This does not include `json` because it may be used when editing an Avro schema without an Avro
  * language extension installed.
  */
-export const LANGUAGE_ID_TO_SCHEMA_TYPE = new Map([
+export const AVRO_PROTOBUF_SCHEMA_TYPE_MAP = new Map([
+  // language IDs
   ["avroavsc", SchemaType.Avro],
   ["proto", SchemaType.Protobuf],
   ["proto3", SchemaType.Protobuf],
-]);
-
-/**
- * Limited map to associate the Avro and Protobuf file extensions to their associated {@link SchemaType}s.
- *
- * This does not include `json` because it may be used when editing an Avro schema without an Avro
- * language extension installed.
- */
-export const FILE_EXTENSION_TO_SCHEMA_TYPE = new Map([
+  // file extensions
   ["avsc", SchemaType.Avro],
   ["proto", SchemaType.Protobuf],
 ]);
@@ -352,7 +346,7 @@ export async function determineSchemaType(
       // extract the file extension from file.path
       const ext = uri.path.split(".").pop();
       if (ext) {
-        schemaType = FILE_EXTENSION_TO_SCHEMA_TYPE.get(ext);
+        schemaType = AVRO_PROTOBUF_SCHEMA_TYPE_MAP.get(ext);
       }
       break;
     }
@@ -363,7 +357,7 @@ export async function determineSchemaType(
       );
       if (editor) {
         // only match against Avro/Protobuf, if available
-        schemaType = LANGUAGE_ID_TO_SCHEMA_TYPE.get(editor.document.languageId);
+        schemaType = AVRO_PROTOBUF_SCHEMA_TYPE_MAP.get(editor.document.languageId);
       }
       break;
     }
@@ -371,7 +365,7 @@ export async function determineSchemaType(
 
   if (languageId && !schemaType) {
     // fall back on any language ID, if provided
-    schemaType = LANGUAGE_ID_TO_SCHEMA_TYPE.get(languageId);
+    schemaType = AVRO_PROTOBUF_SCHEMA_TYPE_MAP.get(languageId);
   }
 
   logger.info("schemaType before quickpick", { schemaType });

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -11,7 +11,7 @@ import { Logger } from "../logging";
 import { Schema, SchemaType } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { schemaRegistryQuickPick } from "../quickpicks/schemaRegistries";
-import { schemaSubjectQuickPick } from "../quickpicks/schemas";
+import { schemaSubjectQuickPick, schemaTypeQuickPick } from "../quickpicks/schemas";
 import { getSidecar } from "../sidecar";
 import { ResourceLoader } from "../storage/resourceLoader";
 import { getSchemasViewProvider, SchemasViewProvider } from "../viewProviders/schemas";
@@ -51,11 +51,13 @@ export async function uploadNewSchema(fileUri: vscode.Uri) {
   const defaults: Schema | undefined = fileUri.query ? schemaFromString(fileUri.query) : undefined;
 
   // What kind of schema is this? We must tell the schema registry.
-  let schemaType: SchemaType;
-  try {
-    schemaType = determineSchemaType(fileUri, activeEditor.document.languageId, defaults?.type);
-  } catch (e) {
-    vscode.window.showErrorMessage((e as Error).message);
+  const schemaType: SchemaType | undefined = await determineSchemaType(
+    fileUri,
+    activeEditor.document.languageId,
+  );
+  if (!schemaType) {
+    // the only way we get here is if the user bailed on the schema type quickpick after we failed
+    // to figure out what the type was (due to lack of language ID supporting extensions or otherwise)
     return;
   }
 
@@ -311,51 +313,67 @@ export function schemaRegistrationMessage(
 }
 
 /**
- * Given a file and / or a language id, determine the schema type of the file.
+ * Limited map to associate the Avro and Protobuf language IDs to their associated {@link SchemaType}s.
+ *
+ * This does not include `json` because it may be used when editing an Avro schema without an Avro
+ * language extension installed.
  */
-export function determineSchemaType(
-  file: vscode.Uri | null,
-  languageId: string | null,
-  defaultType: SchemaType | undefined = undefined,
-): SchemaType {
-  if (!file && !languageId) {
-    throw new Error("Must call with either a file or document");
-  }
+export const LANGUAGE_ID_TO_SCHEMA_TYPE = new Map([
+  ["avroavsc", SchemaType.Avro],
+  ["proto", SchemaType.Protobuf],
+  ["proto3", SchemaType.Protobuf],
+]);
 
-  let schemaType: SchemaType | unknown = defaultType;
+/**
+ * Given a file/editor {@link vscode.Uri Uri}, determine the {@link SchemaType}.
+ *
+ * If a `languageId` is passed, it will be used if we can't determine a schema type from the Uri.
+ * If we still can't determine the schema type, we'll show a quickpick to the user so they can choose.
+ */
+export async function determineSchemaType(
+  uri: vscode.Uri,
+  languageId?: string,
+): Promise<SchemaType | undefined> {
+  let schemaType: SchemaType | undefined;
 
-  // If the schema type was provided in the defaults, use that.
-  if (schemaType) {
-    return schemaType as SchemaType;
-  }
-
-  if (languageId) {
-    const languageIdToSchemaType = new Map([
-      ["avroavsc", SchemaType.Avro],
-      ["proto", SchemaType.Protobuf],
-      ["json", SchemaType.Json],
-    ]);
-    schemaType = languageIdToSchemaType.get(languageId);
-  }
-
-  if (!schemaType && file) {
-    // extract the file extension from file.path
-    const ext = file.path.split(".").pop();
-    if (ext) {
-      const extensionToSchemaType = new Map([
-        ["avsc", SchemaType.Avro],
-        ["proto", SchemaType.Protobuf],
-        ["json", SchemaType.Json],
-      ]);
-      schemaType = extensionToSchemaType.get(ext);
+  switch (uri.scheme) {
+    case "file": {
+      // extract the file extension from file.path
+      const ext = uri.path.split(".").pop();
+      if (ext) {
+        const extensionToSchemaType = new Map([
+          ["avsc", SchemaType.Avro],
+          ["proto", SchemaType.Protobuf],
+          // don't include "json" here, as it may be used for Avro schemas without an Avro language extension
+        ]);
+        schemaType = extensionToSchemaType.get(ext);
+      }
+      break;
+    }
+    case "untitled": {
+      // look up the editor belonging to the Uri
+      const editor = vscode.window.visibleTextEditors.find(
+        (e) => e.document.uri.toString() === uri.toString(),
+      );
+      if (editor) {
+        // only match against Avro/Protobuf, if available
+        schemaType = LANGUAGE_ID_TO_SCHEMA_TYPE.get(editor.document.languageId);
+      }
+      break;
     }
   }
 
-  if (!schemaType) {
-    throw new Error("Could not determine schema type from file or document");
+  if (languageId && !schemaType) {
+    // fall back on any language ID, if provided
+    schemaType = LANGUAGE_ID_TO_SCHEMA_TYPE.get(languageId);
   }
 
-  return schemaType as SchemaType;
+  logger.info("schemaType before quickpick", { schemaType });
+  if (!schemaType) {
+    // can't determine schema type from file/editor (or language ID, if passed), let the user pick
+    return await schemaTypeQuickPick();
+  }
+  return schemaType;
 }
 
 /**

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -368,7 +368,7 @@ export async function determineSchemaType(
     schemaType = AVRO_PROTOBUF_SCHEMA_TYPE_MAP.get(languageId);
   }
 
-  logger.info("schemaType before quickpick", { schemaType });
+  logger.debug("schemaType before quickpick", { schemaType });
   if (!schemaType) {
     // can't determine schema type from file/editor (or language ID, if passed), let the user pick
     return await schemaTypeQuickPick();

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -325,6 +325,17 @@ export const LANGUAGE_ID_TO_SCHEMA_TYPE = new Map([
 ]);
 
 /**
+ * Limited map to associate the Avro and Protobuf file extensions to their associated {@link SchemaType}s.
+ *
+ * This does not include `json` because it may be used when editing an Avro schema without an Avro
+ * language extension installed.
+ */
+export const FILE_EXTENSION_TO_SCHEMA_TYPE = new Map([
+  ["avsc", SchemaType.Avro],
+  ["proto", SchemaType.Protobuf],
+]);
+
+/**
  * Given a file/editor {@link vscode.Uri Uri}, determine the {@link SchemaType}.
  *
  * If a `languageId` is passed, it will be used if we can't determine a schema type from the Uri.
@@ -341,12 +352,7 @@ export async function determineSchemaType(
       // extract the file extension from file.path
       const ext = uri.path.split(".").pop();
       if (ext) {
-        const extensionToSchemaType = new Map([
-          ["avsc", SchemaType.Avro],
-          ["proto", SchemaType.Protobuf],
-          // don't include "json" here, as it may be used for Avro schemas without an Avro language extension
-        ]);
-        schemaType = extensionToSchemaType.get(ext);
+        schemaType = FILE_EXTENSION_TO_SCHEMA_TYPE.get(ext);
       }
       break;
     }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #675.

This mainly refactors our logic when determining the schema type to be used from a file URI in some different scenarios:
- If a user does not have any extension installed that enables the use of the "Avro" (`avroavsc`) editor language, the VS Code default is to use JSON for Avro schema definitions in an editor. We can't trust this, so we need to show the schema type quickpick to the user so they can specify AVRO or JSON.
- If a user has an extension that supports the "Avro" (`avroavsc`) editor language but is working in a `.json` document, we'll ignore the file extension and go with the language ID. This bypasses the need to use the quickpick.
- If the user has an Avro extension installed but is still using the JSON editor language with a .json file extension, we don't trust it and ask anyway via the quickpick.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
