### PR TITLE
[v0.22.x] suggest disabling `http.fetchAdditionalSupport` for local Docker actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+- Additional information is now provided when attempting to start/stop local resources and the
+  extension cannot communcate with the Docker engine API if the new `http.fetchAdditionalSupport`
+  setting is enabled.
+
 ## 0.22.0
 
 ### Added


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Related to https://github.com/confluentinc/vscode/issues/751 but does not fix the underlying issue (see [discussion](https://github.com/microsoft/vscode-discussions/discussions/2438)). Best we can do for right now is check if the setting is enabled and provide a suggestion for the user to disable the setting when they go to start/stop any local resources.

https://github.com/user-attachments/assets/b42f1fa2-8ba1-41bb-a577-bef22121228a

(The notification wording was slightly [updated](https://github.com/confluentinc/vscode/blob/djs/fetch-setting-notification-update/src/docker/configs.ts#L150) after this video was recorded.)

> [!WARNING]  
> This will not provide any notifications for our background system event listening, so if users are expecting the Resources view to change when external changes happen to trigger a container `start`/`die` event, we will not pick up on it with the setting enabled, and will not float any notifications like we do here.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
