### PR TITLE
dynamically update direct connection items in Resources view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ All notable changes to this extension will be documented in this file.
 - Double-clicking on an event/message row in the topic message viewer will now open a read-only
   (preview) document with the message content.
 
+### Fixed
+
+- Waiting for "direct" connections (to Kafka and/or Schema Registry) to be usable will no longer
+  block loading other items or interacting with the Resources view.
+
 ## 0.22.1
 
 - Additional information is now provided when attempting to start/stop local resources and the

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -7,7 +7,7 @@ import { DirectEnvironment } from "../models/environment";
 import { SSL_PEM_PATHS } from "../preferences/constants";
 import { getCCloudAuthSession } from "../sidecar/connections";
 import { CustomConnectionSpec, getResourceManager } from "../storage/resourceManager";
-import { getResourceViewProvider } from "../viewProviders/resources";
+import { ResourceViewProvider } from "../viewProviders/resources";
 
 const logger = new Logger("commands.connections");
 
@@ -108,7 +108,7 @@ export async function renameDirectConnection(item: DirectEnvironment) {
     logger.error("Direct connection not found, can't rename");
     // possibly stale Resources view? this shouldn't happen
     window.showErrorMessage("Connection not found.");
-    getResourceViewProvider().refresh();
+    ResourceViewProvider.getInstance().refresh();
     return;
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,7 @@ export enum IconNames {
   TOPIC = "confluent-topic",
   TOPIC_WITHOUT_SCHEMA = "confluent-topic-without-schema",
   EXPERIMENTAL = "beaker",
+  LOADING = "sync~spin",
 }
 
 export const DIFFABLE_READONLY_SCHEME = "confluent.resource";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export enum IconNames {
   TOPIC = "confluent-topic",
   TOPIC_WITHOUT_SCHEMA = "confluent-topic-without-schema",
   EXPERIMENTAL = "beaker",
-  LOADING = "sync~spin",
+  LOADING = "loading~spin",
 }
 
 export const DIFFABLE_READONLY_SCHEME = "confluent.resource";

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -278,7 +278,7 @@ export class DirectConnectionManager {
       // wait for all new connections to be created before checking their status
       await Promise.all(newConnectionPromises);
       // kick off background checks to ensure the new connections are usable
-      Promise.all(connectionIdsToCheck.map((id) => waitForConnectionToBeUsable(id)));
+      connectionIdsToCheck.map((id) => waitForConnectionToBeUsable(id));
       logger.debug(
         `created and checked ${connectionIdsToCheck.length} new connection(s), firing event`,
       );

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -204,7 +204,7 @@ export class DirectConnectionManager {
         : await tryToCreateConnection(spec, dryRun);
       const connectionId = connection.spec.id as ConnectionId;
       if (!dryRun) {
-        await window.withProgress(
+        window.withProgress(
           {
             location: ProgressLocation.Notification,
             title: `Waiting for "${connection.spec.name}" to be usable...`,
@@ -277,12 +277,11 @@ export class DirectConnectionManager {
     if (newConnectionPromises.length > 0) {
       // wait for all new connections to be created before checking their status
       await Promise.all(newConnectionPromises);
-      // ensure the new connections are usable before refreshing the Resources view
-      await Promise.all(connectionIdsToCheck.map((id) => waitForConnectionToBeUsable(id)));
+      // kick off background checks to ensure the new connections are usable
+      Promise.all(connectionIdsToCheck.map((id) => waitForConnectionToBeUsable(id)));
       logger.debug(
         `created and checked ${connectionIdsToCheck.length} new connection(s), firing event`,
       );
-      directConnectionsChanged.fire();
     }
   }
 }

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { KafkaCluster } from "./models/kafkaCluster";
+import { ConnectionId } from "./models/resource";
 import { SchemaRegistry } from "./models/schemaRegistry";
 
 // NOTE: these are kept at the global level to allow for easy access from any file and track where
@@ -36,3 +37,6 @@ export const currentKafkaClusterChanged = new vscode.EventEmitter<KafkaCluster |
  * (or CCloud organization) change.
  */
 export const currentSchemaRegistryChanged = new vscode.EventEmitter<SchemaRegistry | null>();
+
+export const connectionLoading = new vscode.EventEmitter<ConnectionId>();
+export const connectionUsable = new vscode.EventEmitter<ConnectionId>();

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -90,7 +90,7 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
         name: connection.name,
         kafkaClusters: kafkaCluster ? [kafkaCluster] : [],
         schemaRegistry,
-        formConnectionType: directSpec?.formConnectionType,
+        formConnectionType: directSpec?.formConnectionType ?? "Other",
         ...connectionInfo,
       });
       directResources.push(directEnv);

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -85,7 +85,7 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
         connection.id as ConnectionId,
       );
 
-      const directEnv = DirectEnvironment.create({
+      const directEnv = new DirectEnvironment({
         id: connection.id,
         name: connection.name,
         kafkaClusters: kafkaCluster ? [kafkaCluster] : [],

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -90,7 +90,7 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
         name: connection.name,
         kafkaClusters: kafkaCluster ? [kafkaCluster] : [],
         schemaRegistry,
-        formConnectionType: directSpec?.formConnectionType ?? "Other",
+        formConnectionType: directSpec?.formConnectionType,
         ...connectionInfo,
       });
       directResources.push(directEnv);

--- a/src/graphql/environments.ts
+++ b/src/graphql/environments.ts
@@ -75,7 +75,7 @@ export async function getEnvironments(): Promise<CCloudEnvironment[]> {
     }
 
     envs.push(
-      CCloudEnvironment.create({
+      new CCloudEnvironment({
         id: env.id,
         name: env.name,
         streamGovernancePackage: env.governancePackage,

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -90,7 +90,7 @@ export async function getLocalResources(): Promise<LocalEnvironment[]> {
     }
 
     envs.push(
-      LocalEnvironment.create({
+      new LocalEnvironment({
         id: connection.id,
         name: LOCAL_ENVIRONMENT_NAME,
         kafkaClusters,

--- a/src/models/environment.test.ts
+++ b/src/models/environment.test.ts
@@ -10,7 +10,7 @@ import { DirectEnvironment, EnvironmentTreeItem } from "./environment";
 
 describe("EnvironmentTreeItem", () => {
   it("should be collapsed when the environment has clusters", () => {
-    const env = DirectEnvironment.create({
+    const env = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
       schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
@@ -29,7 +29,7 @@ describe("EnvironmentTreeItem", () => {
   });
 
   it("should use a warning icon if it's a direct environment with no clusters", () => {
-    const env = DirectEnvironment.create({
+    const env = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [],
       schemaRegistry: undefined,
@@ -61,7 +61,7 @@ describe("EnvironmentTreeItem", () => {
   });
 
   it("should not include a warning in the tooltip for a direct environment with clusters", () => {
-    const directEnv = DirectEnvironment.create({
+    const directEnv = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
     });
@@ -78,7 +78,7 @@ describe("EnvironmentTreeItem", () => {
 
     // with a formConnectionType set
     const formConnectionType = "Apache Kafka";
-    const directEnvWithType = DirectEnvironment.create({
+    const directEnvWithType = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       formConnectionType: formConnectionType,
     });

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -62,7 +62,7 @@ export interface CCloudEnvironmentProps {
 }
 
 /** A Confluent Cloud {@link Environment} with additional properties. */
-export class CCloudEnvironment extends Environment implements CCloudEnvironmentProps {
+export class CCloudEnvironment extends Environment {
   readonly connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   readonly connectionType: ConnectionType = ConnectionType.Ccloud;
 
@@ -99,7 +99,7 @@ export interface DirectEnvironmentProps {
  * - one {@link KafkaCluster}
  * - one {@link SchemaRegistry}
  */
-export class DirectEnvironment extends Environment implements DirectEnvironmentProps {
+export class DirectEnvironment extends Environment {
   readonly connectionId!: ConnectionId; // dynamically assigned at connection creation time
   readonly connectionType: ConnectionType = ConnectionType.Direct;
 
@@ -143,7 +143,7 @@ export interface LocalEnvironmentProps {
 }
 
 /** A "local" {@link Environment} manageable by the extension via Docker. */
-export class LocalEnvironment extends Environment implements LocalEnvironmentProps {
+export class LocalEnvironment extends Environment {
   readonly connectionId: ConnectionId = LOCAL_CONNECTION_ID;
   readonly connectionType: ConnectionType = ConnectionType.Local;
 

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -173,10 +173,10 @@ export class EnvironmentTreeItem extends TreeItem {
     // user-facing properties
     this.description = isDirect(this.resource) ? "" : this.resource.id;
     this.iconPath = new ThemeIcon(this.resource.iconName);
-    if (isDirect(resource) && !resource.hasClusters) {
-      this.iconPath = new ThemeIcon("warning", new ThemeColor("problemsWarningIcon.foreground"));
-    } else if (this.resource.isLoading) {
+    if (this.resource.isLoading) {
       this.iconPath = new ThemeIcon(IconNames.LOADING);
+    } else if (isDirect(resource) && !resource.hasClusters) {
+      this.iconPath = new ThemeIcon("warning", new ThemeColor("problemsWarningIcon.foreground"));
     }
     this.tooltip = createEnvironmentTooltip(this.resource);
   }

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -46,6 +46,9 @@ export abstract class Environment extends Data implements IResourceBase {
   kafkaClusters!: KafkaCluster[];
   schemaRegistry?: SchemaRegistry | undefined;
 
+  // updated by the ResourceViewProvider from connectionLoading/connectionUsable events
+  isLoading: boolean = false;
+
   get hasClusters(): boolean {
     return this.kafkaClusters.length > 0 || !!this.schemaRegistry;
   }
@@ -128,6 +131,7 @@ export class EnvironmentTreeItem extends TreeItem {
     super(resource.name, collapseState);
 
     // internal properties
+    this.id = resource.id;
     this.resource = resource;
     this.contextValue = `${this.resource.connectionType.toLowerCase()}-environment`;
 

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -1,4 +1,3 @@
-import { Data, type Require as Enforced } from "dataclass";
 import { MarkdownString, ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import {
@@ -29,13 +28,13 @@ import {
  * - {@link SchemaRegistry}
  * ...more, in the future.
  */
-export abstract class Environment extends Data implements IResourceBase {
+export abstract class Environment implements IResourceBase {
   abstract connectionId: ConnectionId;
   abstract connectionType: ConnectionType;
   abstract iconName: IconNames;
 
-  id!: Enforced<string>;
-  name!: Enforced<string>;
+  id!: string;
+  name!: string;
 
   /**
    * Has at least one Kafka cluster or Schema Registry.
@@ -54,21 +53,45 @@ export abstract class Environment extends Data implements IResourceBase {
   }
 }
 
+export interface CCloudEnvironmentProps {
+  id: string;
+  name: string;
+  streamGovernancePackage: string;
+  kafkaClusters: CCloudKafkaCluster[];
+  schemaRegistry?: CCloudSchemaRegistry | undefined;
+}
+
 /** A Confluent Cloud {@link Environment} with additional properties. */
-export class CCloudEnvironment extends Environment {
+export class CCloudEnvironment extends Environment implements CCloudEnvironmentProps {
   readonly connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   readonly connectionType: ConnectionType = ConnectionType.Ccloud;
 
   readonly iconName: IconNames = IconNames.CCLOUD_ENVIRONMENT;
 
-  streamGovernancePackage!: Enforced<string>;
-  // set explicit CCloud* typing
-  kafkaClusters: CCloudKafkaCluster[] = [];
-  schemaRegistry: CCloudSchemaRegistry | undefined = undefined;
+  kafkaClusters: CCloudKafkaCluster[]; // explicitly typed
+  schemaRegistry?: CCloudSchemaRegistry | undefined; // explicitly typed
+  streamGovernancePackage: string;
+
+  constructor(props: CCloudEnvironmentProps) {
+    super();
+    this.id = props.id;
+    this.name = props.name;
+    this.streamGovernancePackage = props.streamGovernancePackage;
+    this.kafkaClusters = props.kafkaClusters;
+    this.schemaRegistry = props.schemaRegistry;
+  }
 
   get ccloudUrl(): string {
     return `https://confluent.cloud/environments/${this.id}/clusters`;
   }
+}
+
+export interface DirectEnvironmentProps {
+  connectionId: ConnectionId;
+  id: string;
+  name: string;
+  kafkaClusters: DirectKafkaCluster[];
+  schemaRegistry: DirectSchemaRegistry | undefined;
 }
 
 /**
@@ -76,8 +99,8 @@ export class CCloudEnvironment extends Environment {
  * - one {@link KafkaCluster}
  * - one {@link SchemaRegistry}
  */
-export class DirectEnvironment extends Environment {
-  readonly connectionId!: Enforced<ConnectionId>; // dynamically assigned at connection creation time
+export class DirectEnvironment extends Environment implements DirectEnvironmentProps {
+  readonly connectionId!: ConnectionId; // dynamically assigned at connection creation time
   readonly connectionType: ConnectionType = ConnectionType.Direct;
 
   // set explicit Direct* typing
@@ -86,6 +109,14 @@ export class DirectEnvironment extends Environment {
 
   /** What did the user choose as the source of this connection/environment? */
   formConnectionType: FormConnectionType = "Other";
+
+  constructor(props: DirectEnvironmentProps) {
+    super();
+    this.id = props.id;
+    this.name = props.name;
+    this.kafkaClusters = props.kafkaClusters;
+    this.schemaRegistry = props.schemaRegistry;
+  }
 
   get iconName(): IconNames {
     switch (this.formConnectionType) {
@@ -104,18 +135,33 @@ export class DirectEnvironment extends Environment {
   }
 }
 
+export interface LocalEnvironmentProps {
+  id: string;
+  name: string;
+  kafkaClusters: LocalKafkaCluster[];
+  schemaRegistry?: LocalSchemaRegistry | undefined;
+}
+
 /** A "local" {@link Environment} manageable by the extension via Docker. */
-export class LocalEnvironment extends Environment {
+export class LocalEnvironment extends Environment implements LocalEnvironmentProps {
   readonly connectionId: ConnectionId = LOCAL_CONNECTION_ID;
   readonly connectionType: ConnectionType = ConnectionType.Local;
 
   readonly iconName = IconNames.LOCAL_RESOURCE_GROUP;
 
-  name: Enforced<string> = LOCAL_ENVIRONMENT_NAME as Enforced<string>;
+  name: string = LOCAL_ENVIRONMENT_NAME as string;
 
   // set explicit Local* typing
   kafkaClusters: LocalKafkaCluster[] = [];
   schemaRegistry?: LocalSchemaRegistry | undefined = undefined;
+
+  constructor(props: LocalEnvironmentProps) {
+    super();
+    this.id = props.id;
+    this.name = props.name;
+    this.kafkaClusters = props.kafkaClusters;
+    this.schemaRegistry = props.schemaRegistry;
+  }
 }
 
 /** The representation of an {@link Environment} as a {@link TreeItem} in the VS Code UI. */

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -107,6 +107,7 @@ export class DirectEnvironment extends Environment {
     >,
   ) {
     super();
+    this.connectionId = props.connectionId;
     this.id = props.id;
     this.name = props.name;
     this.kafkaClusters = props.kafkaClusters;

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -177,7 +177,7 @@ export class EnvironmentTreeItem extends TreeItem {
     super(resource.name, collapseState);
 
     // internal properties
-    this.id = resource.id;
+    this.id = `${resource.connectionId}-${resource.id}${resource.isLoading ? "-loading" : ""}`;
     this.resource = resource;
     this.contextValue = `${this.resource.connectionType.toLowerCase()}-environment`;
 

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -140,6 +140,8 @@ export class EnvironmentTreeItem extends TreeItem {
     this.iconPath = new ThemeIcon(this.resource.iconName);
     if (isDirect(resource) && !resource.hasClusters) {
       this.iconPath = new ThemeIcon("warning", new ThemeColor("problemsWarningIcon.foreground"));
+    } else if (this.resource.isLoading) {
+      this.iconPath = new ThemeIcon(IconNames.LOADING);
     }
     this.tooltip = createEnvironmentTooltip(this.resource);
   }

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -103,7 +103,7 @@ export class DirectEnvironment extends Environment {
   constructor(
     props: Pick<
       DirectEnvironment,
-      "connectionId" | "id" | "name" | "kafkaClusters" | "schemaRegistry"
+      "connectionId" | "id" | "name" | "kafkaClusters" | "schemaRegistry" | "formConnectionType"
     >,
   ) {
     super();

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -98,7 +98,7 @@ export class DirectEnvironment extends Environment {
   schemaRegistry: DirectSchemaRegistry | undefined = undefined;
 
   /** What did the user choose as the source of this connection/environment? */
-  formConnectionType: FormConnectionType = "Other";
+  formConnectionType?: FormConnectionType = "Other";
 
   constructor(
     props: Pick<
@@ -111,6 +111,7 @@ export class DirectEnvironment extends Environment {
     this.name = props.name;
     this.kafkaClusters = props.kafkaClusters;
     this.schemaRegistry = props.schemaRegistry;
+    if (props.formConnectionType) this.formConnectionType = props.formConnectionType;
   }
 
   get iconName(): IconNames {

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -53,14 +53,6 @@ export abstract class Environment implements IResourceBase {
   }
 }
 
-export interface CCloudEnvironmentProps {
-  id: string;
-  name: string;
-  streamGovernancePackage: string;
-  kafkaClusters: CCloudKafkaCluster[];
-  schemaRegistry?: CCloudSchemaRegistry | undefined;
-}
-
 /** A Confluent Cloud {@link Environment} with additional properties. */
 export class CCloudEnvironment extends Environment {
   readonly connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
@@ -68,11 +60,17 @@ export class CCloudEnvironment extends Environment {
 
   readonly iconName: IconNames = IconNames.CCLOUD_ENVIRONMENT;
 
-  kafkaClusters: CCloudKafkaCluster[]; // explicitly typed
-  schemaRegistry?: CCloudSchemaRegistry | undefined; // explicitly typed
   streamGovernancePackage: string;
+  // set explicit CCloud* typing
+  kafkaClusters: CCloudKafkaCluster[];
+  schemaRegistry?: CCloudSchemaRegistry | undefined;
 
-  constructor(props: CCloudEnvironmentProps) {
+  constructor(
+    props: Pick<
+      CCloudEnvironment,
+      "id" | "name" | "streamGovernancePackage" | "kafkaClusters" | "schemaRegistry"
+    >,
+  ) {
     super();
     this.id = props.id;
     this.name = props.name;
@@ -84,14 +82,6 @@ export class CCloudEnvironment extends Environment {
   get ccloudUrl(): string {
     return `https://confluent.cloud/environments/${this.id}/clusters`;
   }
-}
-
-export interface DirectEnvironmentProps {
-  connectionId: ConnectionId;
-  id: string;
-  name: string;
-  kafkaClusters: DirectKafkaCluster[];
-  schemaRegistry: DirectSchemaRegistry | undefined;
 }
 
 /**
@@ -110,7 +100,12 @@ export class DirectEnvironment extends Environment {
   /** What did the user choose as the source of this connection/environment? */
   formConnectionType: FormConnectionType = "Other";
 
-  constructor(props: DirectEnvironmentProps) {
+  constructor(
+    props: Pick<
+      DirectEnvironment,
+      "connectionId" | "id" | "name" | "kafkaClusters" | "schemaRegistry"
+    >,
+  ) {
     super();
     this.id = props.id;
     this.name = props.name;
@@ -135,13 +130,6 @@ export class DirectEnvironment extends Environment {
   }
 }
 
-export interface LocalEnvironmentProps {
-  id: string;
-  name: string;
-  kafkaClusters: LocalKafkaCluster[];
-  schemaRegistry?: LocalSchemaRegistry | undefined;
-}
-
 /** A "local" {@link Environment} manageable by the extension via Docker. */
 export class LocalEnvironment extends Environment {
   readonly connectionId: ConnectionId = LOCAL_CONNECTION_ID;
@@ -149,13 +137,13 @@ export class LocalEnvironment extends Environment {
 
   readonly iconName = IconNames.LOCAL_RESOURCE_GROUP;
 
-  name: string = LOCAL_ENVIRONMENT_NAME as string;
+  name: string = LOCAL_ENVIRONMENT_NAME;
 
   // set explicit Local* typing
   kafkaClusters: LocalKafkaCluster[] = [];
   schemaRegistry?: LocalSchemaRegistry | undefined = undefined;
 
-  constructor(props: LocalEnvironmentProps) {
+  constructor(props: Pick<LocalEnvironment, "id" | "name" | "kafkaClusters" | "schemaRegistry">) {
     super();
     this.id = props.id;
     this.name = props.name;

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,8 +1,8 @@
-import { ConfigurationChangeEvent, Disposable, WorkspaceConfiguration, workspace } from "vscode";
+import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration } from "vscode";
 import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
 import { isDirect } from "../models/resource";
-import { getResourceViewProvider } from "../viewProviders/resources";
+import { ResourceViewProvider } from "../viewProviders/resources";
 import { getSchemasViewProvider } from "../viewProviders/schemas";
 import { getTopicViewProvider } from "../viewProviders/topics";
 import {
@@ -52,7 +52,7 @@ export function createConfigChangeListener(): Disposable {
         logger.debug(`"${ENABLE_DIRECT_CONNECTIONS}" config changed`, { enabled });
         setContextValue(ContextValues.directConnectionsEnabled, enabled);
         // "Other" container item will be toggled
-        getResourceViewProvider().refresh();
+        ResourceViewProvider.getInstance().refresh();
         // if the Topics/Schemas views are focused on a direct connection based resource, wipe them
         if (!enabled) {
           const topicsView = getTopicViewProvider();

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -25,7 +25,12 @@ import {
 } from "../docker/configs";
 import { MANAGED_CONTAINER_LABEL } from "../docker/constants";
 import { getContainersForImage } from "../docker/containers";
-import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../emitters";
+import {
+  connectionLoading,
+  connectionUsable,
+  currentKafkaClusterChanged,
+  currentSchemaRegistryChanged,
+} from "../emitters";
 import { logResponseError } from "../errors";
 import { Logger } from "../logging";
 import { ConnectionId } from "../models/resource";
@@ -245,6 +250,7 @@ export async function waitForConnectionToBeUsable(
         const schemaRegistryState: ConnectedState | undefined = status.schema_registry?.state;
         const isAttempting = kafkaState === "ATTEMPTING" || schemaRegistryState === "ATTEMPTING";
         if (isAttempting) {
+          connectionLoading.fire(id);
           logger.debug("still waiting for connection to be usable", {
             id,
             type,
@@ -254,6 +260,7 @@ export async function waitForConnectionToBeUsable(
           await new Promise((resolve) => setTimeout(resolve, waitTimeMs));
           continue;
         }
+        connectionUsable.fire(id);
         break;
       }
       case ConnectionType.Ccloud: {

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -40,8 +40,8 @@ describe("ResourceManager (CCloud) environment methods", function () {
     // extension needs to be activated before storage manager can be used
     storageManager = await getTestStorageManager();
     environments = [
-      CCloudEnvironment.create({ ...TEST_CCLOUD_ENVIRONMENT, id: "test-env-id-1" }),
-      CCloudEnvironment.create({ ...TEST_CCLOUD_ENVIRONMENT, id: "test-env-id-2" }),
+      new CCloudEnvironment({ ...TEST_CCLOUD_ENVIRONMENT, id: "test-env-id-1" }),
+      new CCloudEnvironment({ ...TEST_CCLOUD_ENVIRONMENT, id: "test-env-id-2" }),
     ];
   });
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -131,7 +131,7 @@ export class ResourceManager {
       )) ?? [];
 
     // Promote each member to be an instance of CCloudEnvironment
-    return plain_json_environments.map((env) => CCloudEnvironment.create(env));
+    return plain_json_environments.map((env) => new CCloudEnvironment(env));
   }
 
   /**

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -137,7 +137,7 @@ describe("ResourceViewProvider loading functions", () => {
   });
 
   it("loadLocalResources() should load local resources under the Local container tree item when clusters are discoverable", async () => {
-    const testLocalEnv: LocalEnvironment = LocalEnvironment.create({
+    const testLocalEnv: LocalEnvironment = new LocalEnvironment({
       ...TEST_LOCAL_ENVIRONMENT,
       kafkaClusters: [TEST_LOCAL_KAFKA_CLUSTER],
       schemaRegistry: TEST_LOCAL_SCHEMA_REGISTRY,
@@ -192,7 +192,7 @@ describe("ResourceViewProvider loading functions", () => {
       get: sandbox.stub().withArgs(ENABLE_DIRECT_CONNECTIONS).returns(false),
     });
     // and direct connections exist
-    const testDirectEnv: DirectEnvironment = DirectEnvironment.create({
+    const testDirectEnv: DirectEnvironment = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
       schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
@@ -212,7 +212,7 @@ describe("ResourceViewProvider loading functions", () => {
       get: sandbox.stub().withArgs(ENABLE_DIRECT_CONNECTIONS).returns(true),
     });
     // and direct connections exist
-    const testDirectEnv: DirectEnvironment = DirectEnvironment.create({
+    const testDirectEnv: DirectEnvironment = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
       schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -124,11 +124,7 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
   getTreeItem(element: ResourceViewProviderData): vscode.TreeItem {
     logger.debug("getTreeItem called", { element });
     if (element instanceof Environment) {
-      const envItem = new EnvironmentTreeItem(element);
-      envItem.iconPath = new vscode.ThemeIcon(
-        element.isLoading ? IconNames.LOADING : element.iconName,
-      );
-      return envItem;
+      return new EnvironmentTreeItem(element);
     } else if (element instanceof KafkaCluster) {
       return new KafkaClusterTreeItem(element);
     } else if (element instanceof SchemaRegistry) {
@@ -147,6 +143,7 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
     }
 
     if (element) {
+      logger.debug("getChildren called with element", { element });
       // --- CHILDREN OF TREE BRANCHES ---
       // NOTE: we end up here when expanding a (collapsed) treeItem
       if (element instanceof ContainerTreeItem) {

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -437,7 +437,7 @@ export async function loadDirectResources(): Promise<DirectEnvironment[]> {
  * @param environment: The CCloud environment to get children for
  * @returns
  */
-export async function getCCloudEnvironmentChildren(environment: CCloudEnvironment) {
+async function getCCloudEnvironmentChildren(environment: CCloudEnvironment) {
   const subItems: (CCloudKafkaCluster | CCloudSchemaRegistry)[] = [];
 
   const loader = CCloudResourceLoader.getInstance();

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -123,7 +123,11 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
 
   getTreeItem(element: ResourceViewProviderData): vscode.TreeItem {
     if (element instanceof Environment) {
-      return new EnvironmentTreeItem(element);
+      const envItem = new EnvironmentTreeItem(element);
+      envItem.iconPath = new vscode.ThemeIcon(
+        element.isLoading ? IconNames.LOADING : element.iconName,
+      );
+      return envItem;
     } else if (element instanceof KafkaCluster) {
       return new KafkaClusterTreeItem(element);
     } else if (element instanceof SchemaRegistry) {

--- a/tests/unit/testResources/environments.ts
+++ b/tests/unit/testResources/environments.ts
@@ -19,6 +19,7 @@ export const TEST_DIRECT_ENVIRONMENT: DirectEnvironment = new DirectEnvironment(
   name: "test-direct-environment",
   kafkaClusters: [],
   schemaRegistry: undefined,
+  formConnectionType: "Other",
 });
 
 export const TEST_LOCAL_ENVIRONMENT: LocalEnvironment = new LocalEnvironment({

--- a/tests/unit/testResources/environments.ts
+++ b/tests/unit/testResources/environments.ts
@@ -19,7 +19,6 @@ export const TEST_DIRECT_ENVIRONMENT: DirectEnvironment = new DirectEnvironment(
   name: "test-direct-environment",
   kafkaClusters: [],
   schemaRegistry: undefined,
-  formConnectionType: "Other",
 });
 
 export const TEST_LOCAL_ENVIRONMENT: LocalEnvironment = new LocalEnvironment({

--- a/tests/unit/testResources/environments.ts
+++ b/tests/unit/testResources/environments.ts
@@ -5,31 +5,27 @@ import {
 } from "../../../src/models/environment";
 import { TEST_DIRECT_CONNECTION_ID, TEST_LOCAL_CONNECTION } from "./connection";
 
-const TEST_ENVIRONMENT_BODY = {
-  id: "abc123",
-  name: "test-environment",
-  kafkaClusters: [],
-  schemaRegistry: undefined,
-};
-
-export const TEST_CCLOUD_ENVIRONMENT: CCloudEnvironment = CCloudEnvironment.create({
-  ...TEST_ENVIRONMENT_BODY,
+export const TEST_CCLOUD_ENVIRONMENT: CCloudEnvironment = new CCloudEnvironment({
   id: "env-abc123",
   name: "test-cloud-environment",
   streamGovernancePackage: "NONE",
+  kafkaClusters: [],
+  schemaRegistry: undefined,
 });
 
-export const TEST_DIRECT_ENVIRONMENT: DirectEnvironment = DirectEnvironment.create({
-  ...TEST_ENVIRONMENT_BODY,
+export const TEST_DIRECT_ENVIRONMENT: DirectEnvironment = new DirectEnvironment({
+  connectionId: TEST_DIRECT_CONNECTION_ID,
   id: "test-direct-connection",
   name: "test-direct-environment",
-  connectionId: TEST_DIRECT_CONNECTION_ID,
+  kafkaClusters: [],
+  schemaRegistry: undefined,
 });
 
-export const TEST_LOCAL_ENVIRONMENT: LocalEnvironment = LocalEnvironment.create({
-  ...TEST_ENVIRONMENT_BODY,
+export const TEST_LOCAL_ENVIRONMENT: LocalEnvironment = new LocalEnvironment({
   id: TEST_LOCAL_CONNECTION.id,
   name: "test-local-environment",
+  kafkaClusters: [],
+  schemaRegistry: undefined,
 });
 
 // not tied to the CCloud Environment specifically, but used by CCloud Kafka clusters and Schema Registry


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #774.


Until this PR, we've been doing "full tree" refreshes (for the Resources, Topics, and Schemas views) via `_onDidChangeTreeData.fire()`. This means that any time we had to update the state of one or more tree items, we would 
(re)load a lot of items that ultimately had no changes. This PR is the first time we're using `_onDidChangeTreeData.fire(item)` to update individual items within the tree data. 

For now, this is only happening for **direct connections** since they are the most affected by the async connection status checks done by the sidecar (see https://github.com/confluentinc/vscode/pull/728), and the current behavior on `main` effectively makes the entire Resources view unusable until the ["wait for connection to be usable"](https://github.com/confluentinc/vscode/blob/bbb14068f243ccad17c59c6f3b1cbc3c5d41ae53/src/sidecar/connections.ts#L222) flow completes _for each connection_.

https://github.com/user-attachments/assets/aaa391b8-6326-483e-a4a7-b6f1e11acbcf


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

An unfortunate realization while starting to implement `_onDidChangeTreeData.fire(item)` was that VS Code expects the exact instances returned from `getChildren()` to be passed -- it cannot be the same underlying data, and VS Code will not match on the `id` of the objects. This behavior is seen by the lack of `getTreeItem()` calls when a new instance of an `item` (with the same data as what was previously passed through `getChildren()`) is passed into `_onDidChangeTreeData.fire()`.

Here's a minimal example from [a dummy extension](https://github.com/shouples/vscode-view-item-updates):

https://github.com/user-attachments/assets/e2425a2a-edd8-4d98-a96c-813b85f3e198

Based on the fact that we need to update these instances returned from the view provider's `getChildren()`, this meant we couldn't use [dataclass](https://dataclass.js.org/) to make `*Environment` subclass instances. This also meant we needed the view provider to start tracking what items it was displaying.

Now, during the "wait for connection to be usable" process, we emit different events for when a connection is **loading** and when it's **usable**. (The latter only returns the connection ID, but should eventually change to including the full connection spec to include `ConnectedState` and any errors if it's `FAILED`.)

The view provider then reacts to those events by looking up the associated `*Environment` instance in its `environmentsMap`, changing its `isLoading` property (based on the fired event), and then firing `_onDidChangeTreeData.fire(<that environment instance>)`.

> [!NOTE]  
> Reminder: direct connections are treated the same as CCloud/local "environments" that can only show a Kafka cluster and/or a Schema Registry (each) when they are expanded.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
