### PR TITLE
UI/UX updates for direct connections in the Resources view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this extension will be documented in this file.
 ### Added
 
 - Produce message button and commmand enabling schemaless production of JSON messages
+- "Direct" connections in the Resources view will provide more information when unable to connect to
+  Kafka and/or Schema Registry
 
 ### Changed
 
@@ -15,6 +17,9 @@ All notable changes to this extension will be documented in this file.
   a file first.
 - Clicking a schema item in the Topics/Schemas view will now open the schema definition in a
   read-only document without needing to click on the "View Schema" action.
+- Connecting directly to Kafka and/or Schema Registry is now available from the navigation area of
+  the Resources view, and the connections will now appear at the top level of the Resources view,
+  with icons to indicate the type of connection chosen in the form.
 
 ## 0.22.1
 

--- a/package.json
+++ b/package.json
@@ -659,6 +659,11 @@
       ],
       "view/title": [
         {
+          "command": "confluent.connections.direct",
+          "when": "view == confluent-resources && confluent.directConnectionsEnabled",
+          "group": "navigation@1"
+        },
+        {
           "command": "confluent.resources.refresh",
           "when": "view == confluent-resources",
           "group": "navigation@2"
@@ -763,11 +768,6 @@
         {
           "command": "confluent.connections.ccloud.logIn",
           "when": "viewItem == resources-ccloud-container",
-          "group": "inline@1"
-        },
-        {
-          "command": "confluent.connections.direct",
-          "when": "viewItem == resources-direct-container && confluent.directConnectionsEnabled",
           "group": "inline@1"
         },
         {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const EXTENSION_VERSION: string = extensions.getExtension(EXTENSION_ID)!.
  * @remarks Any custom icon IDs must match the `contributes.icons` section of package.json.
  */
 export enum IconNames {
+  APACHE_LOGO = "apache-kafka",
   CURRENT_RESOURCE = "check",
   CONNECTION = "plug",
   ORGANIZATION = "account",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const EXTENSION_VERSION: string = extensions.getExtension(EXTENSION_ID)!.
  * @remarks Any custom icon IDs must match the `contributes.icons` section of package.json.
  */
 export enum IconNames {
-  APACHE_LOGO = "apache-kafka",
+  APACHE_KAFKA_LOGO = "apache-kafka",
   CURRENT_RESOURCE = "check",
   CONNECTION = "plug",
   ORGANIZATION = "account",

--- a/src/models/environment.test.ts
+++ b/src/models/environment.test.ts
@@ -1,0 +1,93 @@
+import * as assert from "assert";
+import { MarkdownString, ThemeColor, ThemeIcon, TreeItemCollapsibleState } from "vscode";
+import {
+  TEST_CCLOUD_ENVIRONMENT,
+  TEST_DIRECT_ENVIRONMENT,
+  TEST_DIRECT_KAFKA_CLUSTER,
+  TEST_DIRECT_SCHEMA_REGISTRY,
+} from "../../tests/unit/testResources";
+import { DirectEnvironment, EnvironmentTreeItem } from "./environment";
+
+describe("EnvironmentTreeItem", () => {
+  it("should be collapsed when the environment has clusters", () => {
+    const env = DirectEnvironment.create({
+      ...TEST_DIRECT_ENVIRONMENT,
+      kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
+      schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
+    });
+
+    const treeItem = new EnvironmentTreeItem(env);
+
+    assert.strictEqual(treeItem.collapsibleState, TreeItemCollapsibleState.Collapsed);
+  });
+
+  it("should be not be collapsible/expandable when the environment doesn't have clusters", () => {
+    // no Kafka/SR by default
+    const treeItem = new EnvironmentTreeItem(TEST_DIRECT_ENVIRONMENT);
+
+    assert.strictEqual(treeItem.collapsibleState, TreeItemCollapsibleState.None);
+  });
+
+  it("should use a warning icon if it's a direct environment with no clusters", () => {
+    const env = DirectEnvironment.create({
+      ...TEST_DIRECT_ENVIRONMENT,
+      kafkaClusters: [],
+      schemaRegistry: undefined,
+    });
+
+    const treeItem = new EnvironmentTreeItem(env);
+
+    assert.deepStrictEqual(
+      treeItem.iconPath,
+      new ThemeIcon("warning", new ThemeColor("problemsWarningIcon.foreground")),
+    );
+  });
+
+  it("should create correct tooltip for a CCloud environment", () => {
+    const treeItem = new EnvironmentTreeItem(TEST_CCLOUD_ENVIRONMENT);
+
+    const tooltip = treeItem.tooltip as MarkdownString;
+    assert.ok(tooltip.value.includes("Environment"));
+    assert.ok(tooltip.value.includes("Stream Governance Package"));
+    assert.ok(tooltip.value.includes("confluent.cloud/environments"));
+  });
+
+  it("should create correct tooltip for a direct environment without clusters", () => {
+    // no Kafka cluster or Schema Registry by default
+    const treeItem = new EnvironmentTreeItem(TEST_DIRECT_ENVIRONMENT);
+
+    const tooltip = treeItem.tooltip as MarkdownString;
+    assert.ok(tooltip.value.includes("Unable to connect"));
+  });
+
+  it("should not include a warning in the tooltip for a direct environment with clusters", () => {
+    const directEnv = DirectEnvironment.create({
+      ...TEST_DIRECT_ENVIRONMENT,
+      kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
+    });
+    const treeItem = new EnvironmentTreeItem(directEnv);
+
+    const tooltip = treeItem.tooltip as MarkdownString;
+    assert.ok(!tooltip.value.includes("Unable to connect"));
+  });
+
+  it("should include the form connection type for a direct environment/connection", () => {
+    // without a formConnectionType set
+    const treeItemWithoutType = new EnvironmentTreeItem(TEST_DIRECT_ENVIRONMENT);
+    assert.ok((treeItemWithoutType.tooltip as MarkdownString).value.includes("Other Connection"));
+
+    // with a formConnectionType set
+    const formConnectionType = "Apache Kafka";
+    const directEnvWithType = DirectEnvironment.create({
+      ...TEST_DIRECT_ENVIRONMENT,
+      formConnectionType: formConnectionType,
+    });
+    const treeItemWithType = new EnvironmentTreeItem(directEnvWithType);
+
+    assert.ok(
+      (treeItemWithType.tooltip as MarkdownString).value.includes(
+        `${formConnectionType} Connection`,
+      ),
+    );
+  });
+});

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -87,7 +87,7 @@ export class DirectEnvironment extends Environment {
   get iconName(): IconNames {
     switch (this.formConnectionType) {
       case "Apache Kafka": {
-        return IconNames.APACHE_LOGO;
+        return IconNames.APACHE_KAFKA_LOGO;
       }
       case "Confluent Cloud":
       case "Confluent Platform": {

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -82,7 +82,7 @@ export class DirectEnvironment extends Environment {
   schemaRegistry: DirectSchemaRegistry | undefined = undefined;
 
   /** What did the user choose as the source of this connection/environment? */
-  formConnectionType?: FormConnectionType | undefined;
+  formConnectionType: FormConnectionType = "Other";
 
   get iconName(): IconNames {
     switch (this.formConnectionType) {

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -1,5 +1,5 @@
 import { Data, type Require as Enforced } from "dataclass";
-import { MarkdownString, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { MarkdownString, ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import {
   CCLOUD_CONNECTION_ID,
@@ -7,6 +7,7 @@ import {
   LOCAL_CONNECTION_ID,
   LOCAL_ENVIRONMENT_NAME,
 } from "../constants";
+import { FormConnectionType } from "../webview/direct-connect-form";
 import {
   CCloudKafkaCluster,
   DirectKafkaCluster,
@@ -14,7 +15,7 @@ import {
   LocalKafkaCluster,
 } from "./kafkaCluster";
 import { CustomMarkdownString } from "./main";
-import { ConnectionId, IResourceBase, isCCloud } from "./resource";
+import { ConnectionId, IResourceBase, isCCloud, isDirect } from "./resource";
 import {
   CCloudSchemaRegistry,
   DirectSchemaRegistry,
@@ -76,12 +77,28 @@ export class DirectEnvironment extends Environment {
   readonly connectionId!: Enforced<ConnectionId>; // dynamically assigned at connection creation time
   readonly connectionType: ConnectionType = ConnectionType.Direct;
 
-  // TODO: update this based on feedback from product+design
-  readonly iconName = IconNames.EXPERIMENTAL;
-
   // set explicit Direct* typing
   kafkaClusters: DirectKafkaCluster[] = [];
   schemaRegistry: DirectSchemaRegistry | undefined = undefined;
+
+  /** What did the user choose as the source of this connection/environment? */
+  formConnectionType?: FormConnectionType | undefined;
+
+  get iconName(): IconNames {
+    switch (this.formConnectionType) {
+      case "Apache Kafka": {
+        return IconNames.APACHE_LOGO;
+      }
+      case "Confluent Cloud":
+      case "Confluent Platform": {
+        return IconNames.CONFLUENT_LOGO;
+      }
+      default: {
+        // "Other" or unknown
+        return IconNames.CONNECTION;
+      }
+    }
+  }
 }
 
 /** A "local" {@link Environment} manageable by the extension via Docker. */
@@ -115,16 +132,24 @@ export class EnvironmentTreeItem extends TreeItem {
     this.contextValue = `${this.resource.connectionType.toLowerCase()}-environment`;
 
     // user-facing properties
-    this.description = this.resource.id;
+    this.description = isDirect(this.resource) ? "" : this.resource.id;
     this.iconPath = new ThemeIcon(this.resource.iconName);
+    if (isDirect(resource) && !resource.hasClusters) {
+      this.iconPath = new ThemeIcon("warning", new ThemeColor("problemsWarningIcon.foreground"));
+    }
     this.tooltip = createEnvironmentTooltip(this.resource);
   }
 }
 
 function createEnvironmentTooltip(resource: Environment): MarkdownString {
-  // Direct connections are treated like environments, but calling it an environment will feel weird
-  const resourceLabel =
-    resource.connectionType === ConnectionType.Direct ? "Connection" : "Environment";
+  let resourceLabel = "Environment";
+  const isDirectResource = isDirect(resource);
+  if (isDirectResource) {
+    // Direct connections are treated like environments, but calling it an environment will feel weird
+    const directEnv = resource as DirectEnvironment;
+    resourceLabel = `${directEnv.formConnectionType} Connection`;
+  }
+
   const tooltip = new CustomMarkdownString()
     .appendMarkdown(`#### $(${resource.iconName}) ${resourceLabel}`)
     .appendMarkdown("\n\n---")
@@ -138,6 +163,12 @@ function createEnvironmentTooltip(resource: Environment): MarkdownString {
       .appendMarkdown(
         `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudEnv.ccloudUrl})`,
       );
+  } else if (isDirectResource && !resource.hasClusters) {
+    tooltip
+      .appendMarkdown("\n\n---")
+      .appendMarkdown(`\n\n⚠️ Unable to connect to Kafka and/or Schema Registry.`);
+    // TODO(shoup): add link to edit connection here
   }
+
   return tooltip;
 }

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -34,7 +34,7 @@ import * as auth from "../sidecar/connections";
 import * as resourceManager from "../storage/resourceManager";
 import {
   loadCCloudResources,
-  loadDirectConnectResources,
+  loadDirectResources,
   loadLocalResources,
   ResourceViewProvider,
 } from "./resources";
@@ -171,7 +171,7 @@ describe("ResourceViewProvider loading functions", () => {
   it("loadDirectConnectResources() should return a direct connection placeholder item when no direct connections exist", async () => {
     sandbox.stub(direct, "getDirectResources").resolves([]);
 
-    const result: ContainerTreeItem<DirectEnvironment> = await loadDirectConnectResources();
+    const result: ContainerTreeItem<DirectEnvironment> = await loadDirectResources();
 
     assert.ok(result instanceof ContainerTreeItem);
     assert.equal(result.label, ConnectionLabel.DIRECT);
@@ -189,7 +189,7 @@ describe("ResourceViewProvider loading functions", () => {
     });
     sandbox.stub(direct, "getDirectResources").resolves([testDirectEnv]);
 
-    const result: ContainerTreeItem<DirectEnvironment> = await loadDirectConnectResources();
+    const result: ContainerTreeItem<DirectEnvironment> = await loadDirectResources();
 
     assert.ok(result instanceof ContainerTreeItem);
     assert.equal(result.label, ConnectionLabel.DIRECT);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Removed the "Other" container item
- Moved the "Add New Connection" action from being inline on the "Other" item to a nav action on the Resources view
- Brought `DirectEnvironment`s up one level, to be siblings to the existing "Confluent Cloud"/"Local" container items
- Added `formConnectionType` to the `DirectEnvironment` model so it could change the icon depending on the connection type defined in the form
  - CC/CP use the Confluent logo
  - AK uses the new icon from https://github.com/confluentinc/vscode/pull/782
  - everything else gets the 🔌 
<img width="631" alt="image" src="https://github.com/user-attachments/assets/bb753b52-a819-42c3-81e9-784986ef3925" />

- Added `formConnectionType` to the tooltips with some temporary helper text if we don't get any Kafka/SR results from the GraphQL query
  - once we have [dynamic item updating](https://github.com/confluentinc/vscode/pull/780) integrated, we can pass the actual `ConnectedState` and error info here
  - we can also add a `command:_____` markdown link here for opening the webview form to edit the connection after that's available as well

| Before | After |
|--------|--------|
| <img width="635" alt="image" src="https://github.com/user-attachments/assets/c39288b4-4489-441a-87fe-bbb52a19e744" /> | <img width="574" alt="image" src="https://github.com/user-attachments/assets/a273c9ba-e162-4e53-b90c-1729a091d022" /> |


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
