### PR TITLE
fix: local resource Docker image pulling with registry credentials / proxy requirement

### DIFF
--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -53,10 +53,10 @@ describe("docker/configs functions", function () {
     assert.ok(getConfigStub.calledOnce);
   });
 
-  it("defaultRequestInit() should set the dispatcher as an Agent", function () {
+  it("defaultRequestInit() should set the dispatcher as an Agent", async function () {
     sandbox.stub(configs, "getSocketPath").returns("/var/run/docker.sock");
 
-    const init = configs.defaultRequestInit() as UndiciRequestInit;
+    const init = (await configs.defaultRequestInit()) as UndiciRequestInit;
 
     assert.ok(init.dispatcher);
     assert.ok(init.dispatcher instanceof Agent);

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -117,7 +117,7 @@ async function getDockerCredentials(): Promise<string | undefined> {
       serveraddress: "https://index.docker.io/v1/",
     };
     const encodedCreds: string = Buffer.from(JSON.stringify(authConfig)).toString("base64");
-    storageManager.setSecret(SecretStorageKeys.DOCKER_CREDS_SECRET_KEY, encodedCreds);
+    await storageManager.setSecret(SecretStorageKeys.DOCKER_CREDS_SECRET_KEY, encodedCreds);
     return encodedCreds;
   } catch (error) {
     logger.debug("failed to load Docker credentials:", error);

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -18,7 +18,7 @@ export async function getContainersForImage(
   request: ContainerListRequest,
 ): Promise<ContainerSummary[]> {
   const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
   try {
     const response: ContainerSummary[] = await client.containerList(request, init);
     const containerIdsAndNames = response.map((container) => ({
@@ -56,7 +56,7 @@ export async function createContainer(
   request.body.Labels[MANAGED_CONTAINER_LABEL] = "true";
 
   const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
   try {
     const response: ContainerCreateResponse = await client.containerCreate(request, init);
     logger.info("Container created successfully:", response);
@@ -77,7 +77,7 @@ export async function createContainer(
 
 export async function startContainer(containerId: string): Promise<void> {
   const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
 
   try {
     await client.containerStart({ id: containerId }, init);
@@ -97,7 +97,7 @@ export async function startContainer(containerId: string): Promise<void> {
 
 export async function stopContainer(id: string): Promise<void> {
   const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
 
   try {
     logger.debug("Stopping container", { id });
@@ -123,7 +123,7 @@ export async function restartContainer(id: string) {
 
 export async function getContainer(id: string): Promise<ContainerInspectResponse> {
   const client = new ContainerApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
 
   try {
     return await client.containerInspect({ id }, init);

--- a/src/docker/eventListener.test.ts
+++ b/src/docker/eventListener.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
+import { getExtensionContext } from "../../tests/unit/testUtils";
 import {
   ApiResponse,
   ContainerApi,
@@ -24,6 +25,10 @@ describe("docker/eventListener.ts EventListener methods", function () {
   let clock: sinon.SinonFakeTimers;
   let eventListener: EventListener;
 
+  before(async function () {
+    await getExtensionContext();
+  });
+
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     // IMPORTANT: we need to use the fake timers here so we can control the timing of the event listener
@@ -31,12 +36,14 @@ describe("docker/eventListener.ts EventListener methods", function () {
     // is we're using a polling mechanism to check for events, and we want to be able to advance the
     // clock in a controlled way to ensure that the polling logic executes as expected
     clock = sandbox.useFakeTimers(Date.now());
-    // reset the singleton instance so we can re-instantiate it with fresh properties between tests
-    EventListener["instance"] = null;
+    // stub defaultRequestInit() so we don't try to load Docker credentials or the socket path
+    sandbox.stub(configs, "defaultRequestInit").resolves({});
     eventListener = EventListener.getInstance();
   });
 
   afterEach(function () {
+    // reset the singleton instance so we can re-instantiate it with fresh properties between tests
+    EventListener["instance"] = null;
     sandbox.restore();
   });
 

--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -140,7 +140,7 @@ export class EventListener {
     const queryParams: SystemEventsRequest = {
       filters: JSON.stringify(EVENT_FILTERS),
     };
-    const init: RequestInit = defaultRequestInit();
+    const init: RequestInit = await defaultRequestInit();
 
     let stream: ReadableStream<Uint8Array> | null = null;
     try {
@@ -396,7 +396,7 @@ export class EventListener {
     state: ContainerStateStatusEnum,
   ): Promise<boolean> {
     const client = new ContainerApi();
-    const init: RequestInit = defaultRequestInit();
+    const init: RequestInit = await defaultRequestInit();
     try {
       const container: ContainerInspectResponse = await client.containerInspect(
         { id: containerId },
@@ -426,7 +426,7 @@ export class EventListener {
     let logLineFound = false;
 
     const client = new ContainerApi();
-    const init: RequestInit = defaultRequestInit();
+    const init: RequestInit = await defaultRequestInit();
 
     let stream: ReadableStream<Uint8Array> | null = null;
     try {

--- a/src/docker/images.test.ts
+++ b/src/docker/images.test.ts
@@ -6,7 +6,7 @@ import { imageExists, pullImage } from "./images";
 describe("docker/images.ts ImageApi wrappers", () => {
   let sandbox: sinon.SinonSandbox;
 
-  let imageInspectStub: sinon.SinonStub;
+  let imageListStub: sinon.SinonStub;
   let imageCreateRawStub: sinon.SinonStub;
 
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
     // because the functions below are constructing new instances of the ImageApi class each time
     // and if we stubbed the instance, the stubs would not be applied to the new instances and the
     // tests would try to call the real methods
-    imageInspectStub = sandbox.stub(ImageApi.prototype, "imageInspect");
+    imageListStub = sandbox.stub(ImageApi.prototype, "imageList");
     imageCreateRawStub = sandbox.stub(ImageApi.prototype, "imageCreateRaw");
   });
 
@@ -39,12 +39,12 @@ describe("docker/images.ts ImageApi wrappers", () => {
         Containers: 1,
       },
     ];
-    imageInspectStub.resolves(fakeResponse);
+    imageListStub.resolves(fakeResponse);
 
     const result = await imageExists("repo", "tag");
 
     assert.strictEqual(result, true);
-    assert.ok(imageInspectStub.calledOnce);
+    assert.ok(imageListStub.calledOnce);
   });
 
   it("imageExists() should return false if the image repo+tag does not exist in the image listing", async () => {
@@ -62,22 +62,22 @@ describe("docker/images.ts ImageApi wrappers", () => {
         Containers: 1,
       },
     ];
-    imageInspectStub.resolves(fakeResponse);
+    imageListStub.resolves(fakeResponse);
 
     const result = await imageExists("repo", "tag");
 
     assert.strictEqual(result, false);
-    assert.ok(imageInspectStub.calledOnce);
+    assert.ok(imageListStub.calledOnce);
   });
 
   it("imageExists() should return false if there is a non-ResponseError error", async () => {
     const fakeError = new Error("Some other error");
-    imageInspectStub.rejects(fakeError);
+    imageListStub.rejects(fakeError);
 
     const result = await imageExists("repo", "tag");
 
     assert.strictEqual(result, false);
-    assert.ok(imageInspectStub.calledOnce);
+    assert.ok(imageListStub.calledOnce);
   });
 
   it("pullImage() should return nothing after successfully pulling an image", async () => {

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -10,7 +10,7 @@ export async function imageExists(repo: string, tag: string): Promise<boolean> {
   const repoTag = `${repo}:${tag}`;
 
   const client = new ImageApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
 
   try {
     const response: ImageSummary[] = await client.imageList({}, init);
@@ -36,7 +36,7 @@ export async function pullImage(repo: string, tag: string): Promise<void> {
   const repoTag = `${repo}:${tag}`;
 
   const client = new ImageApi();
-  const init: RequestInit = defaultRequestInit();
+  const init: RequestInit = await defaultRequestInit();
 
   try {
     // use the `imageCreateRaw` method to get the raw response text, because otherwise we get a void response

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -1,4 +1,4 @@
-import { ImageApi, ImageInspect, ImageSummary, ResponseError } from "../clients/docker";
+import { ImageApi, ImageSummary, ResponseError } from "../clients/docker";
 import { Logger } from "../logging";
 import { UserEvent, logUsage } from "../telemetry/events";
 import { defaultRequestInit } from "./configs";

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -1,4 +1,4 @@
-import { ImageApi, ImageInspect, ResponseError } from "../clients/docker";
+import { ImageApi, ImageInspect, ImageSummary, ResponseError } from "../clients/docker";
 import { Logger } from "../logging";
 import { UserEvent, logUsage } from "../telemetry/events";
 import { defaultRequestInit } from "./configs";
@@ -13,26 +13,17 @@ export async function imageExists(repo: string, tag: string): Promise<boolean> {
   const init: RequestInit = defaultRequestInit();
 
   try {
-    const response: ImageInspect = await client.imageInspect({ name: repo }, init);
-    const repoTagFound = `${response.RepoTags}`.includes(repoTag);
-    logger.debug(`Checked "${repoTag}" in available repo+tags:`, {
-      repoTagFound,
-      repoTag,
-      responseRepoTags: response.RepoTags,
-    });
-    return repoTagFound;
+    const response: ImageSummary[] = await client.imageList({}, init);
+    const matchingImage = response.find((imageSummary) => imageSummary.RepoTags.includes(repoTag));
+    logger.debug(`"${repoTag}" image exists:`, !!matchingImage);
+    return !!matchingImage;
   } catch (error) {
     if (error instanceof ResponseError) {
-      if (error.response.status === 404) {
-        // image not found, callers will probably need to pull it after this returns
-        return false;
-      } else {
-        logger.error("Error response inspecting image:", {
-          status: error.response.status,
-          statusText: error.response.statusText,
-          body: await error.response.clone().text(),
-        });
-      }
+      logger.error("Error response listing images:", {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        body: await error.response.clone().text(),
+      });
     } else {
       logger.error("Error inspecting image:", error);
     }

--- a/src/docker/networks.ts
+++ b/src/docker/networks.ts
@@ -6,7 +6,7 @@ const logger = new Logger("docker.networks");
 
 export async function createNetwork(name: string, driver: string = "bridge"): Promise<void> {
   const networkClient = new NetworkApi();
-  const init = defaultRequestInit();
+  const init = await defaultRequestInit();
 
   try {
     await networkClient.networkCreate({ networkConfig: { Name: name, Driver: driver } }, init);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,8 @@ import { updatePreferences } from "./preferences/updates";
 import { registerProjectGenerationCommand } from "./scaffold";
 import { sidecarOutputChannel } from "./sidecar";
 import { getCCloudAuthSession } from "./sidecar/connections";
-import { StorageManager } from "./storage";
+import { getStorageManager, StorageManager } from "./storage";
+import { SecretStorageKeys } from "./storage/constants";
 import { migrateStorageIfNeeded } from "./storage/migrationManager";
 import { constructResourceLoaderSingletons } from "./storage/resourceLoaderInitialization";
 import { logUsage, UserEvent } from "./telemetry/events";
@@ -215,6 +216,8 @@ async function _activateExtension(
 
   // set up the local Docker event listener singleton and start watching for system events
   EventListener.getInstance().start();
+  // reset the Docker credentials secret so `src/docker/configs.ts` can pull it fresh
+  getStorageManager().deleteSecret(SecretStorageKeys.DOCKER_CREDS_SECRET_KEY);
 
   const directConnectionManager = DirectConnectionManager.getInstance();
   context.subscriptions.push(...directConnectionManager.disposables);

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -49,4 +49,8 @@ export enum SecretStorageKeys {
 
   /** A map of connection id:ConnectionSpec */
   DIRECT_CONNECTIONS = "directConnections",
+
+  /** Any user credentials gathered from `docker-credential-*` to pass via the X-Registry-Auth
+   * header to Docker engine API requests. */
+  DOCKER_CREDS_SECRET_KEY = "docker-creds",
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #788.

Also migrates to the [ImageList](https://docs.docker.com/reference/api/engine/version/v1.43/#tag/Image/operation/ImageList) endpoint instead of image attempting to [inspect](https://docs.docker.com/reference/api/engine/version/v1.43/#tag/Image/operation/ImageInspect) a specific image. I was seeing some odd behavior where a locally-present image would throw 404s, even though we weren't filtering by `tag`:
<img width="1471" alt="image" src="https://github.com/user-attachments/assets/36ecdd0d-4576-4734-92be-772df138a7b5" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
