### PR TITLE
use read-only document provider for topic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this extension will be documented in this file.
 - Connecting directly to Kafka and/or Schema Registry is now available from the navigation area of
   the Resources view, and the connections will now appear at the top level of the Resources view,
   with icons to indicate the type of connection chosen in the form.
+- Double-clicking on an event/message row in the topic message viewer will now open a read-only
+  (preview) document with the message content.
 
 ## 0.22.1
 

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -668,7 +668,7 @@ function messageViewerStartPollingCommand(
             preserveFocus: false,
           })
           .then((editor) => {
-            languages.setTextDocumentLanguage(editor.document, "jsonc");
+            languages.setTextDocumentLanguage(editor.document, "json");
           });
         return null;
       }

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -658,9 +658,16 @@ function messageViewerStartPollingCommand(
           serialized.value.includes(index),
         );
 
-        // read-only document buffer with the message content
+        // use a single-instance provider to display a read-only document buffer with the message
+        // content
         const filename = `${topic.name}-message-${index}.json`;
-        const uri: Uri = new MessageDocumentProvider().resourceToUri(payload, filename);
+        const provider = new MessageDocumentProvider();
+        MessageDocumentProvider.message = JSON.stringify(payload, null, 2);
+        // this is really only used for the filename:
+        const uri: Uri = provider.resourceToUri(
+          { partition: payload.partition_id, offset: payload.offset },
+          filename,
+        );
         window
           .showTextDocument(uri, {
             preview: true,

--- a/src/documentProviders/index.ts
+++ b/src/documentProviders/index.ts
@@ -15,7 +15,6 @@ export abstract class ResourceDocumentProvider implements vscode.TextDocumentCon
 
   /**
    * Convert a resource object to a URI that can be used to display the resource in a read-only editor.
-   * @param kind The kind of resource (e.g. "schema")
    * @param resource The resource object
    * @param filename The filename to use for the URI
    */

--- a/src/documentProviders/message.ts
+++ b/src/documentProviders/message.ts
@@ -1,4 +1,3 @@
-import { Uri } from "vscode";
 import { ResourceDocumentProvider } from ".";
 
 export const MESSAGE_URI_SCHEME = "confluent.topic.message";
@@ -8,8 +7,21 @@ export class MessageDocumentProvider extends ResourceDocumentProvider {
   // non-file, non-untitled URIs cause the resulting buffer to be read-only
   scheme = MESSAGE_URI_SCHEME;
 
-  public async provideTextDocumentContent(uri: Uri): Promise<string> {
-    const messagePayload = this.parseUriQueryBody(uri.query);
-    return JSON.stringify(messagePayload, null, 2);
+  static currentMessage: string | null = null;
+
+  public async provideTextDocumentContent(): Promise<string> {
+    // currentMessage must be set before calling `showTextDocument` or `openTextDocument`
+    if (!MessageDocumentProvider.currentMessage) {
+      throw new Error("No message available to display");
+    }
+    // grab a reference and reset it
+    const documentContent = MessageDocumentProvider.currentMessage;
+    MessageDocumentProvider.currentMessage = null;
+    return documentContent;
+  }
+
+  /** Set the message to display in the read-only editor buffer. */
+  public static set message(message: string) {
+    MessageDocumentProvider.currentMessage = message;
   }
 }

--- a/src/documentProviders/message.ts
+++ b/src/documentProviders/message.ts
@@ -1,0 +1,15 @@
+import { Uri } from "vscode";
+import { ResourceDocumentProvider } from ".";
+
+export const MESSAGE_URI_SCHEME = "confluent.topic.message";
+
+/** Makes a read-only editor buffer holding the contents of an event/message on a Kafka topic. */
+export class MessageDocumentProvider extends ResourceDocumentProvider {
+  // non-file, non-untitled URIs cause the resulting buffer to be read-only
+  scheme = MESSAGE_URI_SCHEME;
+
+  public async provideTextDocumentContent(uri: Uri): Promise<string> {
+    const messagePayload = this.parseUriQueryBody(uri.query);
+    return JSON.stringify(messagePayload, null, 2);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,7 @@ import { observabilityContext } from "./context/observability";
 import { ContextValues, setContextValue } from "./context/values";
 import { DirectConnectionManager } from "./directConnectManager";
 import { EventListener } from "./docker/eventListener";
+import { MessageDocumentProvider } from "./documentProviders/message";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { Logger, outputChannel } from "./logging";
 import {
@@ -361,7 +362,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
 function setupDocumentProviders(): vscode.Disposable[] {
   const disposables: vscode.Disposable[] = [];
   // any document providers set here must provide their own `scheme` to register with
-  const providerClasses = [SchemaDocumentProvider];
+  const providerClasses = [SchemaDocumentProvider, MessageDocumentProvider];
   for (const providerClass of providerClasses) {
     const provider = new providerClass();
     disposables.push(


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #458.

Adds a text document provider to open per-message read-only JSON documents to the side of the message viewer that will also show up in `preview` mode if the user has editor previews enabled:
<img width="2214" alt="image" src="https://github.com/user-attachments/assets/b8c64dc8-bf35-4fdd-b688-8954fc404c3d" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
