### PR TITLE
DO NOT MERGE: minimal example of multi-EXTENSION_INSTANCE_ID

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { extensions } from "vscode";
 import { ConnectionSpec } from "./clients/sidecar";
 import { ConnectionId } from "./models/resource";
@@ -5,6 +6,8 @@ import { ConnectionId } from "./models/resource";
 export const EXTENSION_ID = "confluentinc.vscode-confluent";
 /** The version of the extension, as defined in package.json. */
 export const EXTENSION_VERSION: string = extensions.getExtension(EXTENSION_ID)!.packageJSON.version;
+
+export const EXTENSION_INSTANCE_ID = randomUUID();
 
 /**
  * Ids to use with ThemeIcons for different Confluent/Kafka resources

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
+import { EXTENSION_INSTANCE_ID } from "../constants";
 import { getExtensionContext } from "../context/extension";
 import { ExtensionContextNotSetError } from "../errors";
+import { Logger } from "../logging";
 
 export class StorageManager {
   private globalState: vscode.Memento;
@@ -20,6 +22,8 @@ export class StorageManager {
 
   static getInstance(): StorageManager {
     if (!StorageManager.instance) {
+      const logger = new Logger("StorageManager");
+      logger.info("Creating new StorageManager instance", { instanceId: EXTENSION_INSTANCE_ID });
       StorageManager.instance = new StorageManager();
     }
     return StorageManager.instance;

--- a/src/storage/storageManager.test.ts
+++ b/src/storage/storageManager.test.ts
@@ -14,7 +14,11 @@ describe("StorageManager Tests", function () {
     testKey = `test-key-${Math.random().toString(36).substring(4)}`;
   });
 
-  it.only("should successfully get/set/delete SecretStorage items", async () => {
+  it.only("PLACEHOLDER", () => {
+    assert.strictEqual(1, 1);
+  });
+
+  it("should successfully get/set/delete SecretStorage items", async () => {
     // SecretStorage only holds strings, so no object or array values here
     const testValue = `test-value-${Math.random().toString(36).substring(4)}`;
 

--- a/src/storage/storageManager.test.ts
+++ b/src/storage/storageManager.test.ts
@@ -14,7 +14,7 @@ describe("StorageManager Tests", function () {
     testKey = `test-key-${Math.random().toString(36).substring(4)}`;
   });
 
-  it("should successfully get/set/delete SecretStorage items", async () => {
+  it.only("should successfully get/set/delete SecretStorage items", async () => {
     // SecretStorage only holds strings, so no object or array values here
     const testValue = `test-value-${Math.random().toString(36).substring(4)}`;
 


### PR DESCRIPTION
Run `gulp test` and see multiple `instanceId`s in the logs:
```
2025-01-02T17:23:36.158Z [info] [StorageManager] Creating new StorageManager instance { instanceId: 'a8ac5279-a13e-4e32-a73b-7758b48ba898' }
...
2025-01-02T17:23:37.839Z [info] [extension] Extension fully activated
2025-01-02T17:23:37.839Z [info] [StorageManager] Creating new StorageManager instance { instanceId: 'e998813a-8282-4727-9d83-5665c0e799a1' }
```