### PR TITLE
Make test job build all files to run the extension

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -83,14 +83,6 @@ export function build(done) {
     setupSentry();
   }
 
-  /** @type {import("rollup").LogHandlerWithDefault} */
-  const handleBuildLog = (level, log, handler) => {
-    // skip log messages about circular dependencies inside node_modules
-    if (log.code === "CIRCULAR_DEPENDENCY" && log.ids.every((id) => id.includes("node_modules")))
-      return;
-    handler(level, log);
-  };
-
   /** @type {import("rollup").RollupOptions} */
   const extInput = {
     input: {
@@ -207,6 +199,14 @@ export function build(done) {
       .then(() => rollup(extInput))
       .then((bundle) => bundle.write(extOutput));
   }
+}
+
+/** @type {import("rollup").LogHandlerWithDefault} */
+function handleBuildLog(level, log, handler) {
+  // skip log messages about circular dependencies inside node_modules
+  if (log.code === "CIRCULAR_DEPENDENCY" && log.ids.every((id) => id.includes("node_modules")))
+    return;
+  handler(level, log);
 }
 
 /** Used by Sentry rollup plugin during build, we need a version to identify releases in Sentry so they can line up with source map uploads
@@ -564,6 +564,7 @@ export async function testBuild() {
         exclude: [/node_modules/, /\.test.ts$/, /src\/clients/],
       }),
     ],
+    onLog: handleBuildLog,
     external: ["vscode", "assert", "winston", "mocha", "@playwright/test", "dotenv", "glob"],
   };
   /** @type {import("rollup").OutputOptions} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "prettier": "3.2.5",
         "rimraf": "^6.0.1",
         "rollup": "^4.18.0",
-        "rollup-plugin-auto-external": "^2.0.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollwright": "^0.0.6",
@@ -5064,24 +5063,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/builtins": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-2.0.1.tgz",
-      "integrity": "sha512-XkkVe5QAb6guWPXTzpSrYpSlN3nqEmrrE2TkAr/tp7idSF6+MONh9WvKrAuR3HiKLvoSgmbs8l1U9IPmMrIoLw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      }
-    },
-    "node_modules/builtins/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/c8": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
@@ -6765,15 +6746,6 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
     },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -8062,12 +8034,6 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8475,12 +8441,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -8890,12 +8850,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -9367,21 +9321,6 @@
       "dev": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/locate-character": {
@@ -10454,27 +10393,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -10855,19 +10773,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dev": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -11018,18 +10923,6 @@
       "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
       "dev": true
     },
-    "node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -11107,15 +11000,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/playwright": {
@@ -11431,20 +11315,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
-      "dev": true,
-      "dependencies": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/readable-stream": {
@@ -11824,33 +11694,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-auto-external": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-auto-external/-/rollup-plugin-auto-external-2.0.0.tgz",
-      "integrity": "sha512-HQM3ZkZYfSam1uoZtAB9sK26EiAsfs1phrkf91c/YX+S07wugyRXSigBxrIwiLr5EPPilKYmoMxsrnlGBsXnuQ==",
-      "dev": true,
-      "dependencies": {
-        "builtins": "^2.0.0",
-        "read-pkg": "^3.0.0",
-        "safe-resolve": "^1.0.0",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "rollup": ">=0.45.2"
-      }
-    },
-    "node_modules/rollup-plugin-auto-external/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/rollup-plugin-copy": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.5.0.tgz",
@@ -12067,12 +11910,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/safe-resolve": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-resolve/-/safe-resolve-1.0.0.tgz",
-      "integrity": "sha512-aQpRvfxoi1y0UxKEU0tNO327kb0/LMo8Xrk64M2u172UqOOLCCM0khxN2OTClDiTqTJz5864GMD1X92j4YiHTg==",
-      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -12385,38 +12222,6 @@
       "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
       "dev": true
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "dev": true
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
-      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
-      "dev": true
-    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -12562,15 +12367,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -13472,16 +13268,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/value-or-function": {

--- a/package.json
+++ b/package.json
@@ -1082,7 +1082,6 @@
     "prettier": "3.2.5",
     "rimraf": "^6.0.1",
     "rollup": "^4.18.0",
-    "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-esbuild": "^6.1.1",
     "rollwright": "^0.0.6",

--- a/src/authn/ccloudPolling.test.ts
+++ b/src/authn/ccloudPolling.test.ts
@@ -3,7 +3,7 @@ import { configDotenv } from "dotenv";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { TEST_CCLOUD_CONNECTION } from "../../tests/unit/testResources/connection";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { Connection, Status } from "../clients/sidecar";
 import { nonInvalidTokenStatus } from "../emitters";
 import * as connections from "../sidecar/connections";
@@ -106,7 +106,7 @@ describe("authn/ccloudPolling.ts checkAuthExpiration()", () => {
   it("should show an error notification if auth has expired", async () => {
     // expired auth will cycle the CCloud connection, which requires the auth provider to be set up,
     // which requires the extension context to be available
-    await getExtensionContext();
+    await getTestExtensionContext();
     // check against a connection that expired already (5min ago)
     const expiredConnection = createFakeConnection(-5);
 
@@ -122,7 +122,7 @@ describe("authn/ccloudPolling.ts checkAuthExpiration()", () => {
   it("should show a warning notification and then an error notification if auth expiration is ignored long enough", async () => {
     // expired auth will cycle the CCloud connection, which requires the auth provider to be set up,
     // which requires the extension context to be available
-    await getExtensionContext();
+    await getTestExtensionContext();
     // simulate a user clicking "Reauthenticate" so we don't reset `.reauthWarningPromptOpen`
     showWarningMessageStub.resolves(REAUTH_BUTTON_TEXT);
 
@@ -173,7 +173,7 @@ describe("authn/ccloudPolling.ts watchCCloudConnectionStatus()", () => {
   let pollSlowStub: sinon.SinonStub;
 
   before(async () => {
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -7,7 +7,7 @@ import {
   TEST_CCLOUD_CONNECTION,
   TEST_CCLOUD_USER,
 } from "../../tests/unit/testResources/connection";
-import { getExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
+import { getTestExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
 import { Connection } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { getSidecar } from "../sidecar";
@@ -45,7 +45,7 @@ describe("ConfluentCloudAuthProvider", () => {
   >;
 
   before(async () => {
-    await getExtensionContext();
+    await getTestExtensionContext();
 
     uriHandler = getUriHandler();
   });

--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -6,7 +6,7 @@ import {
   TEST_CCLOUD_SCHEMA_REGISTRY,
   TEST_LOCAL_KAFKA_TOPIC,
 } from "../../tests/unit/testResources";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { ResponseError, SubjectsV1Api } from "../clients/schemaRegistryRest";
 import { SCHEMA_RBAC_WARNINGS_ENABLED } from "../preferences/constants";
 import * as sidecar from "../sidecar";
@@ -21,7 +21,7 @@ describe("authz.schemaRegistry", function () {
 
   beforeEach(async function () {
     // preload the schema registry in extension state
-    await getExtensionContext();
+    await getTestExtensionContext();
     resourceManager = getResourceManager();
     await resourceManager.setCCloudSchemaRegistries([TEST_CCLOUD_SCHEMA_REGISTRY]);
 

--- a/src/commands/connections.test.ts
+++ b/src/commands/connections.test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { TEST_DIRECT_ENVIRONMENT } from "../../tests/unit/testResources";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { DirectConnectionManager } from "../directConnectManager";
 import { SSL_PEM_PATHS } from "../preferences/constants";
 import * as connections from "./connections";
@@ -15,7 +15,7 @@ describe("commands/connections.ts", function () {
 
   before(async () => {
     // needed for the DirectConnectionManager to be initialized
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(function () {

--- a/src/context/extension.ts
+++ b/src/context/extension.ts
@@ -1,11 +1,16 @@
 import { type ExtensionContext } from "vscode";
 
-let context: ExtensionContext;
+let context: ExtensionContext | undefined;
 
 export function setExtensionContext(value: ExtensionContext) {
   context = value;
 }
 
-export function getExtensionContext(): ExtensionContext {
+export function getExtensionContext(): ExtensionContext | undefined {
   return context;
+}
+
+// XXX: should not be used outside of test environments
+export function clearExtensionContext() {
+  context = undefined;
 }

--- a/src/context/extension.ts
+++ b/src/context/extension.ts
@@ -6,8 +6,8 @@ export function setExtensionContext(value: ExtensionContext) {
   context = value;
 }
 
-export function getExtensionContext(): ExtensionContext | undefined {
-  return context;
+export function getExtensionContext(): ExtensionContext {
+  return context!;
 }
 
 // XXX: should not be used outside of test environments

--- a/src/context/observability.test.ts
+++ b/src/context/observability.test.ts
@@ -1,16 +1,41 @@
 import * as assert from "assert";
-import { version } from "ide-sidecar";
+import { version as sidecarVersion } from "ide-sidecar";
+import { Extension, ExtensionContext, extensions } from "vscode";
+import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "./observability";
 
 describe("ObservabilityContext", () => {
   it("should convert to markdown table correctly", async () => {
+    let extensionVersion = "";
+    let extensionActivated = false;
+
+    // if another test activated the extension, this will be set
+    const extensionInstance: Extension<ExtensionContext> | undefined =
+      extensions.getExtension(EXTENSION_ID);
+    if (extensionInstance) {
+      extensionActivated = extensionInstance.isActive;
+      if (extensionActivated) {
+        extensionVersion = extensionInstance.packageJSON.version;
+      }
+    }
+
     const table = observabilityContext.toMarkdownTable();
+
     // only check the first few rows of the table since the rest will be adjusted as needed
     const expectedTableHead = `| Key | Value |
-| --- | --- |
-| extensionVersion | "" |
-| extensionActivated | false |
-| sidecarVersion | "${version}" |`;
-    assert.ok(table.startsWith(expectedTableHead));
+| --- | --- |`;
+    assert.ok(table.startsWith(expectedTableHead), `Wrong markdown table head, got:\n${table}`);
+    assert.ok(
+      table.includes(`| extensionVersion | "${extensionVersion}"`),
+      `Wrong extensionVersion line, got:\n${table}\n\nExpected ${extensionVersion}`,
+    );
+    assert.ok(
+      table.includes(`| extensionActivated | ${extensionActivated}`),
+      `Wrong extensionActivated line, got:\n${table}\n\nExpected ${extensionActivated}`,
+    );
+    assert.ok(
+      table.includes(`| sidecarVersion | "${sidecarVersion}" |`),
+      `Wrong sidecarVersion line, got:\n${table}\n\nExpected ${sidecarVersion}`,
+    );
   });
 });

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -5,7 +5,7 @@ import {
   TEST_DIRECT_CONNECTION,
   TEST_DIRECT_CONNECTION_FORM_SPEC,
 } from "../tests/unit/testResources/connection";
-import { getExtensionContext } from "../tests/unit/testUtils";
+import { getTestExtensionContext } from "../tests/unit/testUtils";
 import {
   ConnectionsList,
   ConnectionSpec,
@@ -50,7 +50,7 @@ describe("DirectConnectionManager behavior", () => {
 
   before(async () => {
     // DirectConnectionManager requires the extension context to be set
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {

--- a/src/docker/eventListener.test.ts
+++ b/src/docker/eventListener.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import {
   ApiResponse,
   ContainerApi,
@@ -26,7 +26,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
   let eventListener: EventListener;
 
   before(async function () {
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(function () {

--- a/src/docker/workflows/confluent-local.test.ts
+++ b/src/docker/workflows/confluent-local.test.ts
@@ -5,7 +5,7 @@ import {
   TEST_BROKER_CONFIGS,
   TEST_CANCELLATION_TOKEN,
 } from "../../../tests/unit/testResources/docker";
-import { getExtensionContext } from "../../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../../tests/unit/testUtils";
 import {
   ContainerCreateResponse,
   ContainerInspectResponse,
@@ -49,7 +49,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
   let waitForLocalResourceEventChangeStub: sinon.SinonStub;
 
   before(async () => {
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -6,7 +6,7 @@ import {
   TEST_CANCELLATION_TOKEN,
   TEST_KAFKA_CONTAINERS,
 } from "../../../tests/unit/testResources/docker";
-import { getExtensionContext } from "../../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../../tests/unit/testUtils";
 import {
   ContainerCreateOperationRequest,
   ContainerCreateResponse,
@@ -63,7 +63,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
   let updateLocalConnectionStub: sinon.SinonStub;
 
   before(async () => {
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -2,6 +2,11 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getAndActivateExtension, getTestExtensionContext } from "../tests/unit/testUtils";
 import { ConfluentCloudAuthProvider } from "./authn/ccloudProvider";
+import {
+  clearExtensionContext,
+  getExtensionContext,
+  setExtensionContext,
+} from "./context/extension";
 import { ExtensionContextNotSetError } from "./errors";
 import { StorageManager } from "./storage";
 import { ResourceManager } from "./storage/resourceManager";
@@ -13,36 +18,60 @@ describe("Base Extension Test", () => {
   it("should activate the extension", async () => {
     await getAndActivateExtension();
   });
+});
+
+describe("ExtensionContext", () => {
+  // we don't have any good way of actually deactivating an extension instance, so we have to reset
+  // the extension context (and any singleton instances) for this test suite
+  let origExtensionContext: vscode.ExtensionContext | undefined;
+
+  before(() => {
+    origExtensionContext = getExtensionContext();
+    clearExtensionContext();
+  });
+
+  after(() => {
+    if (origExtensionContext) {
+      setExtensionContext(origExtensionContext);
+    }
+  });
 
   it("should not allow ExtensionContext-dependent singletons to be created before extension activation", async () => {
     const extensionContextSingletons = [
       {
         callable: () => ResourceViewProvider.getInstance(),
         source: "ResourceViewProvider",
+        clear: () => (ResourceViewProvider["instance"] = null),
       },
       {
         callable: () => TopicViewProvider.getInstance(),
         source: "TopicViewProvider",
+        clear: () => (TopicViewProvider["instance"] = null),
       },
       {
         callable: () => SchemasViewProvider.getInstance(),
         source: "SchemasViewProvider",
+        clear: () => (SchemasViewProvider["instance"] = null),
       },
       {
         callable: () => ConfluentCloudAuthProvider.getInstance(),
         source: "ConfluentCloudAuthProvider",
+        clear: () => (ConfluentCloudAuthProvider["instance"] = null),
       },
       {
         callable: () => StorageManager.getInstance(),
         source: "StorageManager",
+        clear: () => (StorageManager["instance"] = null),
       },
       {
         callable: () => ResourceManager.getInstance(),
         source: "ResourceManager",
+        clear: () => (ResourceManager["instance"] = null),
       },
     ];
 
-    extensionContextSingletons.forEach(({ callable, source }) => {
+    extensionContextSingletons.forEach(({ callable, source, clear }) => {
+      clear();
       assertThrowsExtensionContextNotSetError(callable, source);
     });
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getAndActivateExtension, getExtensionContext } from "../tests/unit/testUtils";
+import { getAndActivateExtension, getTestExtensionContext } from "../tests/unit/testUtils";
 import { ConfluentCloudAuthProvider } from "./authn/ccloudProvider";
 import { ExtensionContextNotSetError } from "./errors";
 import { StorageManager } from "./storage";
@@ -47,7 +47,7 @@ describe("Base Extension Test", () => {
     });
 
     // activate the extension and setExtensionContext()
-    await getExtensionContext();
+    await getTestExtensionContext();
 
     extensionContextSingletons.forEach(({ callable, source }) => {
       assertDoesNotThrowExtensionContextNotSetError(callable, source);
@@ -73,7 +73,7 @@ describe("Extension manifest tests", () => {
   let context: vscode.ExtensionContext;
 
   before(async () => {
-    context = await getExtensionContext();
+    context = await getTestExtensionContext();
   });
 
   it("should show the correct version format", async () => {
@@ -132,7 +132,7 @@ describe("ExtensionContext subscription tests", () => {
   let context: vscode.ExtensionContext;
 
   before(async () => {
-    context = await getExtensionContext();
+    context = await getTestExtensionContext();
   });
 
   it("should have at least one subscription", async () => {

--- a/src/preferences/listener.test.ts
+++ b/src/preferences/listener.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import { ConfigurationChangeEvent, workspace } from "vscode";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import * as contextValues from "../context/values";
 import {
   ENABLE_DIRECT_CONNECTIONS,
@@ -21,7 +21,7 @@ describe("preferences/listener", function () {
   before(async () => {
     // ResourceViewProvider interactions require the extension context to be set (used during changes
     // in the direct connection preview setting)
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(function () {

--- a/src/sidecar/connections.test.ts
+++ b/src/sidecar/connections.test.ts
@@ -6,7 +6,7 @@ import {
   TEST_DIRECT_CONNECTION,
   TEST_LOCAL_CONNECTION,
 } from "../../tests/unit/testResources/connection";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import {
   ConnectedState,
   Connection,
@@ -101,7 +101,7 @@ describe("sidecar/connections.ts", () => {
 
   it("clearCurrentCCloudResources() should clear resources and fire events", async () => {
     // just needed for this test, otherwise we'd put this in the before() block
-    await getExtensionContext();
+    await getTestExtensionContext();
 
     const resourceManager = getResourceManager();
     const deleteCCloudResourcesStub = sandbox.stub(resourceManager, "deleteCCloudResources");

--- a/src/sidecar/middlewares.test.ts
+++ b/src/sidecar/middlewares.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { RequestContext } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudAuthSessionInvalidated } from "../emitters";
@@ -31,7 +31,7 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
   let ccloudAuthSessionInvalidatedStub: sinon.SinonStub;
 
   before(async () => {
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -14,7 +14,7 @@ import {
   TEST_DIRECT_CONNECTION,
   TEST_DIRECT_CONNECTION_ID,
 } from "../../tests/unit/testResources/connection";
-import { getExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
+import { getTestExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
 import { ConnectionSpec } from "../clients/sidecar";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
@@ -970,7 +970,7 @@ describe("ResourceManager direct connection methods", function () {
 
   before(async () => {
     // extension needs to be activated before storage manager(s) can be used
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(async () => {

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -15,7 +15,7 @@ import {
   TEST_DIRECT_SCHEMA_REGISTRY,
   TEST_LOCAL_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources/schemaRegistry";
-import { getExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { EXTENSION_VERSION } from "../constants";
 import * as direct from "../graphql/direct";
 import * as local from "../graphql/local";
@@ -45,7 +45,7 @@ describe("ResourceViewProvider methods", () => {
 
   before(async () => {
     // ensure extension context is available for the ResourceViewProvider
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {
@@ -95,7 +95,7 @@ describe("ResourceViewProvider loading functions", () => {
 
   before(async () => {
     // activate the extension once before this test suite runs
-    await getExtensionContext();
+    await getTestExtensionContext();
   });
 
   beforeEach(() => {

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -1,7 +1,10 @@
 import * as vscode from "vscode";
 import { EXTENSION_ID } from "../../src/constants";
 import { setExtensionContext } from "../../src/context/extension";
+import { Logger } from "../../src/logging";
 import { StorageManager } from "../../src/storage";
+
+const logger = new Logger("tests.testUtils");
 
 /**
  * Convenience function to get the extension.
@@ -28,7 +31,12 @@ export async function getAndActivateExtension(
   id: string = EXTENSION_ID,
 ): Promise<vscode.Extension<any>> {
   const extension = await getExtension(id);
-  await extension.activate();
+  if (!extension.isActive) {
+    logger.info(`Activating extension: ${id}`);
+    await extension.activate();
+  } else {
+    logger.info(`Extension already activated: ${id}`);
+  }
   return extension;
 }
 

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -10,7 +10,7 @@ const logger = new Logger("tests.testUtils");
  * Convenience function to get the extension.
  * @remarks This does not activate the extension, so the {@link vscode.ExtensionContext} will not be
  * available. Use {@link getAndActivateExtension} to activate the extension, or
- * {@link getExtensionContext} to get the context directly.
+ * {@link getTestExtensionContext} to get the context directly.
  * @param id The extension ID to get. Defaults to the Confluent extension.
  * @returns A {@link vscode.Extension} instance.
  */
@@ -44,7 +44,7 @@ export async function getAndActivateExtension(
  * Convenience function to get the extension context for testing.
  * @returns A {@link vscode.ExtensionContext} instance.
  */
-export async function getExtensionContext(
+export async function getTestExtensionContext(
   id: string = EXTENSION_ID,
 ): Promise<vscode.ExtensionContext> {
   const extension = await getAndActivateExtension(id);
@@ -56,6 +56,6 @@ export async function getExtensionContext(
 
 export async function getTestStorageManager(): Promise<StorageManager> {
   // the extension needs to be activated before we can use the StorageManager
-  await getExtensionContext();
+  await getTestExtensionContext();
   return StorageManager.getInstance();
 }


### PR DESCRIPTION
The issue was uncovered during debugging of the test in https://github.com/confluentinc/vscode/pull/811. At different times we had different ideas about what has to be built for the tests to run. We have `build` task to build extension bundle (including production), and at some point the task started producing essentially a whole bundle as a single JS file. We have `testBuild` to build test scripts and their dependencies to run isolated tests. Those didn't have the same requirements as `build` task. At some point our tests started requiring the extension context, thus extension suppose to be activated before running tests. This means the bundle should be built before tests start, regardless of a test scenario dependencies. So we added `build` task to the `test` pipeline. Since `build` and `testBuild` are completely separate tasks, their Rollup applications share nothing about bundles of code that should be built. So what happened prior to this PR is that there may be some modules bundled with `build` task to `out/extension.js` while also being build by `testBuild` as a unique module somewhere inside `out` folder. If a test scenario happens to both activate the extension _and_ use one of those modules, we end up with presence of the same instance twice, since the extension bundle would have its code inlined. Nothing in test logs would hint that we have multiple instances of the same _class_.

We got to this state in incremental way, tweaking build tasks occasionally for their own purpose. With this PR I split their usage so the test pipeline doesn't rely on the build task we use for dev/prod builds.
