### PR TITLE
fix: fire "usable" event if we time out waiting for direct connection to be usable

### DIFF
--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -312,6 +312,11 @@ export async function waitForConnectionToBeUsable(
 
   if (!connection) {
     const msg = `Connection ${id} did not become usable within ${timeoutMs}ms`;
+    // reset any "loading" state for this connection
+    connectionUsable.fire(id);
+    // and trigger any kind of Topics/Schemas refresh to reenforce the error state / clear out any
+    // old data
+    environmentChanged.fire(id);
     logger.error(msg);
     return null;
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #810.

If we hit a timeout waiting for a `DIRECT` connection to move past an `ATTEMPTING` connected state, we need to at least fire the `connectionUsable` event so the connection/"environment" tree item no longer looks like it's loading.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
