### PR TITLE
Form checkbox to enable SSL on direct connections

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -122,6 +122,9 @@ export function getConnectionSpecFromFormData(
   if (formData["bootstrap_servers"]) {
     spec.kafka_cluster = {
       bootstrap_servers: formData["bootstrap_servers"],
+      ssl: {
+        enabled: formData["kafka_ssl"] === "on",
+      },
     };
     if (formData.kafka_auth_type === "Basic") {
       spec.kafka_cluster.credentials = {
@@ -139,6 +142,9 @@ export function getConnectionSpecFromFormData(
   if (formData["uri"]) {
     spec.schema_registry = {
       uri: formData["uri"],
+      ssl: {
+        enabled: formData["schema_ssl"] === "on",
+      },
     };
     if (formData.schema_auth_type === "Basic") {
       spec.schema_registry.credentials = {

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -120,6 +120,18 @@
               comma-separated list for more than one server)</span
             >
           </div>
+          <div class="toggle-container">
+            <label class="label" for="kafka_ssl">SSL enabled?</label>
+            <input
+              type="checkbox"
+              id="kafka_ssl"
+              name="kafka_ssl"
+              title="Is SSL enabled for the cluster?"
+              data-attr-checked="this.kafkaSslEnabled() ? true : false"
+              data-on-change="this.updateValue(event)"
+              data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
+            />
+          </div>
           <div class="radio-container">
             <legend class="label">Authentication Type</legend>
             <div>
@@ -245,6 +257,18 @@
               />
             </div>
             <span class="description">The URL of the Schema Registry to use for serialization</span>
+          </div>
+          <div class="toggle-container">
+            <label class="label" for="schema_ssl">SSL enabled?</label>
+            <input
+              type="checkbox"
+              id="schema_ssl"
+              name="schema_ssl"
+              title="Is SSL enabled for the schema registry?"
+              data-attr-checked="this.schemaSslEnabled() ? true : false"
+              data-on-change="this.updateValue(event)"
+              data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
+            />
           </div>
           <div class="radio-container">
             <legend class="label">Authentication Type</legend>
@@ -421,6 +445,14 @@
       }
       .input-container > * > * {
         width: 100%;
+      }
+      .toggle-container {
+        display: inline-flex;
+        gap: 10px;
+        align-items: center;
+      }
+      .toggle-container > .label {
+        margin-bottom: 0;
       }
       .radio-container {
         display: flex;

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -58,6 +58,9 @@ class DirectConnectFormViewModel extends ViewModel {
     // if credentials are there it means there is a secret. We handle the secrets in directConnect.ts
     return this.kafkaCreds() ? "fakeplaceholdersecrethere" : "";
   });
+  kafkaSslEnabled = this.derive(() => {
+    return this.spec()?.kafka_cluster?.ssl?.enabled || this.platformType() === "Confluent Cloud";
+  });
 
   /** Schema Registry */
   schemaUri = this.derive(() => {
@@ -80,6 +83,9 @@ class DirectConnectFormViewModel extends ViewModel {
   schemaSecret = this.derive(() => {
     // if credentials are there it means there is a secret. We handle the secrets in directConnect.ts
     return this.schemaCreds() ? "fakeplaceholdersecrethere" : "";
+  });
+  schemaSslEnabled = this.derive(() => {
+    return this.spec()?.schema_registry?.ssl?.enabled || this.platformType() === "Confluent Cloud";
   });
 
   /** Form State */
@@ -128,6 +134,8 @@ class DirectConnectFormViewModel extends ViewModel {
         if (input.value === "Confluent Cloud") {
           this.kafkaAuthType("API");
           this.schemaAuthType("API");
+          this.kafkaSslEnabled(true);
+          this.schemaSslEnabled(true);
         }
         break;
       // case "other-platform":
@@ -142,6 +150,9 @@ class DirectConnectFormViewModel extends ViewModel {
       case "kafka_auth_type":
         this.kafkaAuthType(input.value as SupportedAuthTypes);
         this.clearKafkaCreds();
+        break;
+      case "kafka_ssl":
+        this.kafkaSslEnabled(input.checked);
         break;
       case "schema_auth_type":
         this.schemaAuthType(input.value as SupportedAuthTypes);
@@ -161,6 +172,9 @@ class DirectConnectFormViewModel extends ViewModel {
         break;
       case "schema_api_key":
         this.schemaApiKey(input.value);
+        break;
+      case "schema_ssl":
+        this.schemaSslEnabled(input.checked);
         break;
       default:
         console.warn(`Unhandled input update: ${input.name}`);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #731 
- Adds a simple MVP checkbox to the form that sends the `ssl: {enabled: boolean}` part of the connection specs back to the Sidecar

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- With latest Sidecar changes, some connections may not work if SSL is `true` & this will allow users to specify. 
- Future PRs will add the remaining SSL options: `verify_hostname`, `truststore` and `keystore`

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
