### PR TITLE
add SecretStorage migration for direct connections' SSL config(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this extension will be documented in this file.
 - Produce message button and commmand enabling schemaless production of JSON messages
 - "Direct" connections in the Resources view will provide more information when unable to connect to
   Kafka and/or Schema Registry
+- Storage migration for any previously-created "direct" connections to include `ssl` defaults based
+  on whether or not they were set to "Confluent Cloud" connections.
 
 ### Changed
 

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -54,3 +54,7 @@ export enum SecretStorageKeys {
    * header to Docker engine API requests. */
   DOCKER_CREDS_SECRET_KEY = "docker-creds",
 }
+
+/** Key used to store the current storage version across global/workspace state and SecretStorage. */
+export const DURABLE_STORAGE_VERSION_KEY = "storageVersion";
+export type MigrationStorageType = "global" | "workspace" | "secret";

--- a/src/storage/migrationManager.test.ts
+++ b/src/storage/migrationManager.test.ts
@@ -1,0 +1,87 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { StorageManager } from ".";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
+import { DURABLE_STORAGE_VERSION_KEY, MigrationStorageType } from "./constants";
+import {
+  CODEBASE_STORAGE_VERSION,
+  migrateGlobalState,
+  migrateSecretStorage,
+  migrateWorkspaceState,
+} from "./migrationManager";
+import * as migrationUtils from "./migrations/utils";
+
+describe("storage/migrationManager", () => {
+  let manager: StorageManager;
+  let sandbox: sinon.SinonSandbox;
+  let getStorageVersionStub: sinon.SinonStub;
+  let executeMigrationsStub: sinon.SinonStub;
+  let setStorageVersionStub: sinon.SinonStub;
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    executeMigrationsStub = sandbox.stub(migrationUtils, "executeMigrations");
+
+    manager = StorageManager.getInstance();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  type TestMigrationSetup = [
+    keyof StorageManager,
+    (manager: StorageManager) => Promise<void>,
+    MigrationStorageType,
+    keyof StorageManager,
+  ];
+  const testSetup: TestMigrationSetup[] = [
+    ["getGlobalState", migrateGlobalState, "global", "setGlobalState"],
+    ["getWorkspaceState", migrateWorkspaceState, "workspace", "setWorkspaceState"],
+    ["getSecret", migrateSecretStorage, "secret", "setSecret"],
+  ];
+
+  for (const [
+    managerGetMethodName,
+    migrationFunc,
+    storageType,
+    managerSetMethodName,
+  ] of testSetup) {
+    it(`migrate*() for "${storageType}" state/storage should call executeMigrations() when storage version is incorrect`, async () => {
+      // stub the storage version returned
+      const storedVersion = 1;
+      getStorageVersionStub = sandbox.stub(manager, managerGetMethodName).resolves(storedVersion);
+      setStorageVersionStub = sandbox.stub(manager, managerSetMethodName);
+
+      await migrationFunc(manager);
+
+      assert.ok(getStorageVersionStub.calledOnceWith(DURABLE_STORAGE_VERSION_KEY));
+      assert.ok(
+        executeMigrationsStub.calledOnceWith(storedVersion, CODEBASE_STORAGE_VERSION, storageType),
+      );
+      // also ensure we stamp the correct storage version after migration
+      // (secret storage version must be a string though)
+      const expectedVersion =
+        storageType === "secret" ? String(CODEBASE_STORAGE_VERSION) : CODEBASE_STORAGE_VERSION;
+      assert.ok(setStorageVersionStub.calledOnceWith(DURABLE_STORAGE_VERSION_KEY, expectedVersion));
+    });
+
+    it(`migrate*() for "${storageType}" state/storage should not call executeMigrations() when storage version is correct`, async () => {
+      // stub the correct storage version returned
+      getStorageVersionStub = sandbox
+        .stub(manager, managerGetMethodName)
+        .resolves(CODEBASE_STORAGE_VERSION);
+      setStorageVersionStub = sandbox.stub(manager, managerSetMethodName);
+
+      await migrationFunc(manager);
+
+      assert.ok(getStorageVersionStub.calledOnceWith(DURABLE_STORAGE_VERSION_KEY));
+      assert.ok(executeMigrationsStub.notCalled);
+      assert.ok(setStorageVersionStub.notCalled);
+    });
+  }
+});

--- a/src/storage/migrationManager.ts
+++ b/src/storage/migrationManager.ts
@@ -1,15 +1,14 @@
 import { StorageManager } from ".";
 import { Logger } from "../logging";
-import { DURABLE_STORAGE_VERSION_KEY, MigrationStorageType } from "./constants";
-import { BaseMigration } from "./migrations/base";
-import { migrations, migrationVersions } from "./migrations/registry";
+import { DURABLE_STORAGE_VERSION_KEY } from "./constants";
+import { executeMigrations } from "./migrations/utils";
 
 // The current storage version for the extension, set in global state, workspace state, and
 // SecretStorage after migrations are run during extension activation.
 // ---
 // This should be incremented whenever a breaking change is made to the global/workspace state or
 // SecretStorage data structures.
-const CODEBASE_STORAGE_VERSION = 2;
+export const CODEBASE_STORAGE_VERSION = 2;
 
 const logger = new Logger("storage.migrationManager");
 
@@ -27,7 +26,7 @@ export async function migrateStorageIfNeeded(manager: StorageManager): Promise<v
 }
 
 /** Check the storage version in **global state**, then migrate if necessary. */
-async function migrateGlobalState(manager: StorageManager): Promise<void> {
+export async function migrateGlobalState(manager: StorageManager): Promise<void> {
   const globalStorageVersion = await manager.getGlobalState<number>(DURABLE_STORAGE_VERSION_KEY);
   if (globalStorageVersion !== CODEBASE_STORAGE_VERSION) {
     logger.debug(
@@ -41,7 +40,7 @@ async function migrateGlobalState(manager: StorageManager): Promise<void> {
 }
 
 /** Check the storage version in **workspace state**, then migrate if necessary. */
-async function migrateWorkspaceState(manager: StorageManager): Promise<void> {
+export async function migrateWorkspaceState(manager: StorageManager): Promise<void> {
   const workspaceStorageVersion = await manager.getWorkspaceState<number>(
     DURABLE_STORAGE_VERSION_KEY,
   );
@@ -57,11 +56,11 @@ async function migrateWorkspaceState(manager: StorageManager): Promise<void> {
 }
 
 /** Check the storage version in **secret storage**, then migrate if necessary. */
-async function migrateSecretStorage(manager: StorageManager): Promise<void> {
+export async function migrateSecretStorage(manager: StorageManager): Promise<void> {
   const secretStorageVersion: string | undefined = await manager.getSecret(
     DURABLE_STORAGE_VERSION_KEY,
   );
-  if (secretStorageVersion !== String(CODEBASE_STORAGE_VERSION)) {
+  if (String(secretStorageVersion) !== String(CODEBASE_STORAGE_VERSION)) {
     logger.debug(
       `secret storage version is incorrect: "${secretStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
     );
@@ -69,43 +68,5 @@ async function migrateSecretStorage(manager: StorageManager): Promise<void> {
     manager.setSecret(DURABLE_STORAGE_VERSION_KEY, String(CODEBASE_STORAGE_VERSION));
   } else {
     logger.debug(`secret storage version is correct: "${secretStorageVersion}"`);
-  }
-}
-
-/**
- * Determine the migration versions/steps required to move between two storage versions, which may
- * be multiple versions apart.
- */
-function getMigrationVersions(
-  sourceVersion: number | undefined,
-  targetVersion: number,
-): {
-  versions: number[];
-  isUpgrade: boolean;
-} {
-  // either the source version or the lowest migration version (2)
-  const current: number = sourceVersion ?? Math.min(...migrationVersions);
-  const isUpgrade = current < targetVersion;
-  const versions: number[] = isUpgrade
-    ? migrationVersions.filter((v) => v > current && v <= targetVersion)
-    : migrationVersions.filter((v) => v <= current && v > targetVersion).reverse();
-
-  return { versions, isUpgrade };
-}
-
-/** Execute the necessary migrations to move between two storage versions. */
-async function executeMigrations(
-  sourceVersion: number | undefined,
-  targetVersion: number,
-  storageType: MigrationStorageType,
-): Promise<void> {
-  const { versions, isUpgrade } = getMigrationVersions(sourceVersion, targetVersion);
-
-  for (const version of versions) {
-    const migration: BaseMigration = migrations[version];
-    if (!migration) {
-      continue;
-    }
-    await migration.run(isUpgrade, storageType);
   }
 }

--- a/src/storage/migrationManager.ts
+++ b/src/storage/migrationManager.ts
@@ -1,50 +1,111 @@
 import { StorageManager } from ".";
 import { Logger } from "../logging";
+import { DURABLE_STORAGE_VERSION_KEY, MigrationStorageType } from "./constants";
+import { BaseMigration } from "./migrations/base";
+import { migrations, migrationVersions } from "./migrations/registry";
 
-// Define the current storage version for the extension. This should be incremented whenever a
-// breaking change is made to the storage format.
-const CODEBASE_STORAGE_VERSION = 1;
-const DURABLE_STORAGE_VERSION_KEY = "storageVersion";
+// The current storage version for the extension, set in global state, workspace state, and
+// SecretStorage after migrations are run during extension activation.
+// ---
+// This should be incremented whenever a breaking change is made to the global/workspace state or
+// SecretStorage data structures.
+const CODEBASE_STORAGE_VERSION = 2;
 
 const logger = new Logger("storage.migrationManager");
 
-/**
- * Drive migrations of either global or workspace state as needed at startup time.
- */
 export async function migrateStorageIfNeeded(manager: StorageManager): Promise<void> {
-  // While in EA, just blow away the storage every time. We don't want to deal with migrations
-  // yet, and there's nothing critical in the extension right now that depends on persisted state
-  // across extension reloads.
-  await manager.clearGlobalState();
+  // TEMPORARY: clear workspace state every time since there isn't anything that must be persisted
+  // between sessions (yet)
   await manager.clearWorkspaceState();
 
-  // But when we do want to start migrating storage, we can use the following logic to check the
-  // current storage version and migrate as needed.
+  // handle global/workspace state + secret storage migrations and setting the new storage version
+  await Promise.all([
+    migrateGlobalState(manager),
+    migrateWorkspaceState(manager),
+    migrateSecretStorage(manager),
+  ]);
+}
+
+/** Check the storage version in **global state**, then migrate if necessary. */
+async function migrateGlobalState(manager: StorageManager): Promise<void> {
   const globalStorageVersion = await manager.getGlobalState<number>(DURABLE_STORAGE_VERSION_KEY);
   if (globalStorageVersion !== CODEBASE_STORAGE_VERSION) {
-    logger.info(
-      `Migrating global storage from ${globalStorageVersion} to ${CODEBASE_STORAGE_VERSION}`,
+    logger.debug(
+      `global storage version is incorrect: "${globalStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
     );
-
-    // Add global migration logic here. Have fun with that.
-
-    // Stamp current global state
-    await manager.setGlobalState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+    await executeMigrations(globalStorageVersion, CODEBASE_STORAGE_VERSION, "global");
+    manager.setGlobalState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+  } else {
+    logger.debug(`global storage storage version is correct: "${globalStorageVersion}"`);
   }
+}
 
-  // also check workspace state for storage versioning. This may be first time running the extension
-  // in this workspace in quite some time.
+/** Check the storage version in **workspace state**, then migrate if necessary. */
+async function migrateWorkspaceState(manager: StorageManager): Promise<void> {
   const workspaceStorageVersion = await manager.getWorkspaceState<number>(
     DURABLE_STORAGE_VERSION_KEY,
   );
   if (workspaceStorageVersion !== CODEBASE_STORAGE_VERSION) {
-    logger.info(
-      `Migrating workspace storage from ${workspaceStorageVersion} to ${CODEBASE_STORAGE_VERSION}`,
+    logger.debug(
+      `workspace storage version is incorrect: "${workspaceStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
     );
+    await executeMigrations(workspaceStorageVersion, CODEBASE_STORAGE_VERSION, "workspace");
+    manager.setWorkspaceState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+  } else {
+    logger.debug(`workspace storage storage version is correct: v${workspaceStorageVersion}`);
+  }
+}
 
-    // Add workspace migration logic here. Have fun with that.
+/** Check the storage version in **secret storage**, then migrate if necessary. */
+async function migrateSecretStorage(manager: StorageManager): Promise<void> {
+  const secretStorageVersion: string | undefined = await manager.getSecret(
+    DURABLE_STORAGE_VERSION_KEY,
+  );
+  if (secretStorageVersion !== String(CODEBASE_STORAGE_VERSION)) {
+    logger.debug(
+      `secret storage version is incorrect: "${secretStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
+    );
+    await executeMigrations(Number(secretStorageVersion), CODEBASE_STORAGE_VERSION, "secret");
+    manager.setSecret(DURABLE_STORAGE_VERSION_KEY, String(CODEBASE_STORAGE_VERSION));
+  } else {
+    logger.debug(`secret storage version is correct: "${secretStorageVersion}"`);
+  }
+}
 
-    // Stamp current workspace state
-    await manager.setWorkspaceState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+/**
+ * Determine the migration versions/steps required to move between two storage versions, which may
+ * be multiple versions apart.
+ */
+function getMigrationVersions(
+  sourceVersion: number | undefined,
+  targetVersion: number,
+): {
+  versions: number[];
+  isUpgrade: boolean;
+} {
+  // either the source version or the lowest migration version (1)
+  const current: number = sourceVersion ?? Math.min(...migrationVersions);
+  const isUpgrade = current < targetVersion;
+  const versions: number[] = isUpgrade
+    ? migrationVersions.filter((v) => v > current && v <= targetVersion)
+    : migrationVersions.filter((v) => v <= current && v > targetVersion).reverse();
+
+  return { versions, isUpgrade };
+}
+
+/** Execute the necessary migrations to move between two storage versions. */
+async function executeMigrations(
+  sourceVersion: number | undefined,
+  targetVersion: number,
+  storageType: MigrationStorageType,
+): Promise<void> {
+  const { versions, isUpgrade } = getMigrationVersions(sourceVersion, targetVersion);
+
+  for (const version of versions) {
+    const migration: BaseMigration = migrations[version];
+    if (!migration) {
+      continue;
+    }
+    await migration.run(isUpgrade, storageType);
   }
 }

--- a/src/storage/migrationManager.ts
+++ b/src/storage/migrationManager.ts
@@ -33,7 +33,7 @@ export async function migrateGlobalState(manager: StorageManager): Promise<void>
       `global storage version is incorrect: "${globalStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
     );
     await executeMigrations(globalStorageVersion, CODEBASE_STORAGE_VERSION, "global");
-    manager.setGlobalState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+    await manager.setGlobalState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
   } else {
     logger.debug(`global storage storage version is correct: "${globalStorageVersion}"`);
   }
@@ -49,7 +49,7 @@ export async function migrateWorkspaceState(manager: StorageManager): Promise<vo
       `workspace storage version is incorrect: "${workspaceStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
     );
     await executeMigrations(workspaceStorageVersion, CODEBASE_STORAGE_VERSION, "workspace");
-    manager.setWorkspaceState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+    await manager.setWorkspaceState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
   } else {
     logger.debug(`workspace storage storage version is correct: v${workspaceStorageVersion}`);
   }
@@ -65,7 +65,7 @@ export async function migrateSecretStorage(manager: StorageManager): Promise<voi
       `secret storage version is incorrect: "${secretStorageVersion}", should be "${CODEBASE_STORAGE_VERSION}"`,
     );
     await executeMigrations(Number(secretStorageVersion), CODEBASE_STORAGE_VERSION, "secret");
-    manager.setSecret(DURABLE_STORAGE_VERSION_KEY, String(CODEBASE_STORAGE_VERSION));
+    await manager.setSecret(DURABLE_STORAGE_VERSION_KEY, String(CODEBASE_STORAGE_VERSION));
   } else {
     logger.debug(`secret storage version is correct: "${secretStorageVersion}"`);
   }

--- a/src/storage/migrationManager.ts
+++ b/src/storage/migrationManager.ts
@@ -34,8 +34,9 @@ export async function migrateGlobalState(manager: StorageManager): Promise<void>
     );
     await executeMigrations(globalStorageVersion, CODEBASE_STORAGE_VERSION, "global");
     await manager.setGlobalState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+    logger.debug(`global storage version set to "${CODEBASE_STORAGE_VERSION}"`);
   } else {
-    logger.debug(`global storage storage version is correct: "${globalStorageVersion}"`);
+    logger.debug(`global storage version is correct: "${globalStorageVersion}"`);
   }
 }
 
@@ -50,8 +51,9 @@ export async function migrateWorkspaceState(manager: StorageManager): Promise<vo
     );
     await executeMigrations(workspaceStorageVersion, CODEBASE_STORAGE_VERSION, "workspace");
     await manager.setWorkspaceState(DURABLE_STORAGE_VERSION_KEY, CODEBASE_STORAGE_VERSION);
+    logger.debug(`workspace storage version set to "${CODEBASE_STORAGE_VERSION}"`);
   } else {
-    logger.debug(`workspace storage storage version is correct: v${workspaceStorageVersion}`);
+    logger.debug(`workspace storage version is correct: ${workspaceStorageVersion}`);
   }
 }
 
@@ -66,6 +68,7 @@ export async function migrateSecretStorage(manager: StorageManager): Promise<voi
     );
     await executeMigrations(Number(secretStorageVersion), CODEBASE_STORAGE_VERSION, "secret");
     await manager.setSecret(DURABLE_STORAGE_VERSION_KEY, String(CODEBASE_STORAGE_VERSION));
+    logger.debug(`secret storage version set to "${CODEBASE_STORAGE_VERSION}"`);
   } else {
     logger.debug(`secret storage version is correct: "${secretStorageVersion}"`);
   }

--- a/src/storage/migrationManager.ts
+++ b/src/storage/migrationManager.ts
@@ -83,7 +83,7 @@ function getMigrationVersions(
   versions: number[];
   isUpgrade: boolean;
 } {
-  // either the source version or the lowest migration version (1)
+  // either the source version or the lowest migration version (2)
   const current: number = sourceVersion ?? Math.min(...migrationVersions);
   const isUpgrade = current < targetVersion;
   const versions: number[] = isUpgrade

--- a/src/storage/migrations/base.ts
+++ b/src/storage/migrations/base.ts
@@ -7,7 +7,7 @@ export abstract class BaseMigration {
   logger = new Logger("storage.migrations");
 
   async run(isUpgrade: boolean = true, storageType: MigrationStorageType): Promise<void> {
-    const logMsg = `${storageType} storage to version "${this.version}"`;
+    const logMsg = `${storageType} storage to version "${isUpgrade ? this.version : this.version - 1}"`;
 
     this.logger.debug(`${isUpgrade ? "upgrading" : "downgrading"} ${logMsg}...`);
     try {

--- a/src/storage/migrations/base.ts
+++ b/src/storage/migrations/base.ts
@@ -1,0 +1,44 @@
+import { Logger } from "../../logging";
+import { MigrationStorageType } from "../constants";
+
+export abstract class BaseMigration {
+  abstract readonly version: number;
+
+  logger = new Logger("storage.migrations");
+
+  async run(isUpgrade: boolean = true, storageType: MigrationStorageType): Promise<void> {
+    const logMsg = `${storageType} storage to version "${this.version}"`;
+
+    this.logger.debug(`${isUpgrade ? "upgrading" : "downgrading"} ${logMsg}...`);
+    try {
+      switch (storageType) {
+        case "global":
+          await (isUpgrade ? this.upgradeGlobalState() : this.downgradeGlobalState());
+          break;
+        case "workspace":
+          await (isUpgrade ? this.upgradeWorkspaceState() : this.downgradeWorkspaceState());
+          break;
+        case "secret":
+          await (isUpgrade ? this.upgradeSecretStorage() : this.downgradeSecretStorage());
+          break;
+        default:
+          throw new Error(`Unknown storage type: ${storageType}`);
+      }
+      this.logger.debug(`successfully ${isUpgrade ? "upgraded" : "downgraded"} ${logMsg}`);
+    } catch (e) {
+      if (e instanceof Error) {
+        this.logger.error(
+          `error ${isUpgrade ? "upgrading" : "downgrading"} ${logMsg}: ${e.message}`,
+        );
+      }
+    }
+  }
+
+  // default no-op implementations, to be overridden by subclasses as needed
+  protected async upgradeGlobalState(): Promise<void> {}
+  protected async upgradeWorkspaceState(): Promise<void> {}
+  protected async upgradeSecretStorage(): Promise<void> {}
+  protected async downgradeGlobalState(): Promise<void> {}
+  protected async downgradeWorkspaceState(): Promise<void> {}
+  protected async downgradeSecretStorage(): Promise<void> {}
+}

--- a/src/storage/migrations/registry.ts
+++ b/src/storage/migrations/registry.ts
@@ -1,0 +1,13 @@
+// import future migration versions here
+import { BaseMigration } from "./base";
+import { MigrationV2 } from "./v2";
+
+/** Mapping of storage version numbers to migration class instances. */
+export const migrations: Record<number, BaseMigration> = {
+  // 1 doesn't exist since there is no undefined<->1 migration
+  2: new MigrationV2(),
+  // add future storage versions here
+};
+
+/** Ordered list of migration version numbers. */
+export const migrationVersions: number[] = Object.keys(migrations).map(Number).sort();

--- a/src/storage/migrations/utils.ts
+++ b/src/storage/migrations/utils.ts
@@ -1,0 +1,41 @@
+import { MigrationStorageType } from "../constants";
+import { BaseMigration } from "./base";
+import { migrations, migrationVersions } from "./registry";
+
+/**
+ * Determine the migration versions/steps required to move between two storage versions, which may
+ * be multiple versions apart.
+ */
+export function getMigrationVersions(
+  sourceVersion: number | undefined,
+  targetVersion: number,
+): {
+  versions: number[];
+  isUpgrade: boolean;
+} {
+  // either the source version or the lowest migration version (2)
+  const current: number = sourceVersion ?? Math.min(...migrationVersions);
+  const isUpgrade = current < targetVersion;
+  const versions: number[] = isUpgrade
+    ? migrationVersions.filter((v) => v > current && v <= targetVersion)
+    : migrationVersions.filter((v) => v <= current && v > targetVersion).reverse();
+
+  return { versions, isUpgrade };
+}
+
+/** Execute the necessary migrations to move between two storage versions. */
+export async function executeMigrations(
+  sourceVersion: number | undefined,
+  targetVersion: number,
+  storageType: MigrationStorageType,
+): Promise<void> {
+  const { versions, isUpgrade } = getMigrationVersions(sourceVersion, targetVersion);
+
+  for (const version of versions) {
+    const migration: BaseMigration = migrations[version];
+    if (!migration) {
+      continue;
+    }
+    await migration.run(isUpgrade, storageType);
+  }
+}

--- a/src/storage/migrations/v2.test.ts
+++ b/src/storage/migrations/v2.test.ts
@@ -1,0 +1,174 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import {
+  TEST_LOCAL_KAFKA_CLUSTER,
+  TEST_LOCAL_SCHEMA_REGISTRY,
+} from "../../../tests/unit/testResources";
+import { TEST_DIRECT_CONNECTION_FORM_SPEC } from "../../../tests/unit/testResources/connection";
+import { getTestExtensionContext } from "../../../tests/unit/testUtils";
+import { ConnectionId } from "../../models/resource";
+import { FormConnectionType } from "../../webview/direct-connect-form";
+import {
+  CustomConnectionSpec,
+  DirectConnectionsById,
+  getResourceManager,
+  ResourceManager,
+} from "../resourceManager";
+import { MigrationV2 } from "./v2";
+
+describe("MigrationV2", () => {
+  let sandbox: sinon.SinonSandbox;
+  let rm: ResourceManager;
+  let getDirectConnectionsStub: sinon.SinonStub;
+  let addDirectConnectionStub: sinon.SinonStub;
+
+  let migration: MigrationV2;
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    // only stub the methods we need to test so we aren't interfering with SecretStorage; just test
+    // the call arguments for `addDirectConnection` based on returned `getDirectConnections` values
+    rm = getResourceManager();
+    getDirectConnectionsStub = sandbox.stub(rm, "getDirectConnections");
+    addDirectConnectionStub = sandbox.stub(rm, "addDirectConnection");
+
+    migration = new MigrationV2();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  type ConnectionTypeSSLEnabled = [FormConnectionType, boolean];
+  const testConfigs: ConnectionTypeSSLEnabled[] = [
+    ["Confluent Cloud", true],
+    ["Other", false],
+  ];
+
+  for (const [formConnectionType, expectedSsl] of testConfigs) {
+    it(`upgradeSecretStorage() should set ssl.enabled=${expectedSsl} for form connection type "${formConnectionType}"`, async () => {
+      // if v1 test connections are returned, they should be updated to v2
+      const testSpecs: CustomConnectionSpec[] = [
+        {
+          ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+          kafka_cluster: {
+            bootstrap_servers: TEST_LOCAL_KAFKA_CLUSTER.bootstrapServers,
+            ssl: undefined,
+          },
+          schema_registry: { uri: TEST_LOCAL_SCHEMA_REGISTRY.uri, ssl: undefined },
+          formConnectionType,
+        },
+      ];
+      console.info("***TEST SPECS***", testSpecs[0]);
+      const testV1Map: DirectConnectionsById = new Map(
+        testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
+      );
+      getDirectConnectionsStub.resolves(testV1Map);
+
+      await migration.upgradeSecretStorage();
+
+      // addDirectConnection should be called once per migrated spec
+      assert.strictEqual(addDirectConnectionStub.callCount, 1);
+      const addDirectConnectionCallArgs: CustomConnectionSpec = addDirectConnectionStub.args[0][0];
+      assert.strictEqual(addDirectConnectionCallArgs.kafka_cluster!.ssl!.enabled, expectedSsl);
+      assert.strictEqual(addDirectConnectionCallArgs.schema_registry!.ssl!.enabled, expectedSsl);
+    });
+
+    it(`upgradeSecretStorage() should not update specs with 'ssl' already set (formConnectionType=${formConnectionType})`, async () => {
+      const testSpecs: CustomConnectionSpec[] = [
+        {
+          ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+          kafka_cluster: {
+            bootstrap_servers: TEST_LOCAL_KAFKA_CLUSTER.bootstrapServers,
+            ssl: { enabled: expectedSsl },
+          },
+          schema_registry: {
+            uri: TEST_LOCAL_SCHEMA_REGISTRY.uri,
+            ssl: { enabled: expectedSsl },
+          },
+          formConnectionType,
+        },
+      ];
+      const testV1Map: DirectConnectionsById = new Map(
+        testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
+      );
+      getDirectConnectionsStub.resolves(testV1Map);
+
+      await migration.upgradeSecretStorage();
+
+      assert.ok(addDirectConnectionStub.notCalled);
+    });
+  }
+
+  it("upgradeSecretStorage() should handle empty connection spec map", async () => {
+    getDirectConnectionsStub.resolves(new Map());
+
+    await migration.upgradeSecretStorage();
+
+    assert.ok(addDirectConnectionStub.notCalled);
+  });
+
+  it("downgradeSecretStorage() should remove 'ssl' configs from connection specs", async () => {
+    const testSpecs: CustomConnectionSpec[] = [
+      {
+        ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+        kafka_cluster: {
+          bootstrap_servers: TEST_LOCAL_KAFKA_CLUSTER.bootstrapServers,
+          ssl: { enabled: true },
+        },
+        schema_registry: {
+          uri: TEST_LOCAL_SCHEMA_REGISTRY.uri,
+          ssl: { enabled: true },
+        },
+      },
+    ];
+    const testV2Map: DirectConnectionsById = new Map(
+      testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
+    );
+    getDirectConnectionsStub.resolves(testV2Map);
+
+    await migration.downgradeSecretStorage();
+
+    // addDirectConnection should be called once per migrated spec
+    assert.strictEqual(addDirectConnectionStub.callCount, 1);
+    const addDirectConnectionCallArgs: CustomConnectionSpec = addDirectConnectionStub.args[0][0];
+    assert.strictEqual(addDirectConnectionCallArgs.kafka_cluster!.ssl, undefined);
+    assert.strictEqual(addDirectConnectionCallArgs.schema_registry!.ssl, undefined);
+  });
+
+  it("downgradeSecretStorage() should not update specs that don't have 'ssl' configs set", async () => {
+    const testSpecs: CustomConnectionSpec[] = [
+      {
+        ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+        kafka_cluster: {
+          bootstrap_servers: TEST_LOCAL_KAFKA_CLUSTER.bootstrapServers,
+          ssl: undefined,
+        },
+        schema_registry: {
+          uri: TEST_LOCAL_SCHEMA_REGISTRY.uri,
+          ssl: undefined,
+        },
+      },
+    ];
+    const testV2Map: DirectConnectionsById = new Map(
+      testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
+    );
+    getDirectConnectionsStub.resolves(testV2Map);
+
+    await migration.downgradeSecretStorage();
+
+    assert.ok(addDirectConnectionStub.notCalled);
+  });
+
+  it("downgradeSecretStorage() should handle empty connection spec map", async () => {
+    getDirectConnectionsStub.resolves(new Map());
+
+    await migration.downgradeSecretStorage();
+
+    assert.ok(addDirectConnectionStub.notCalled);
+  });
+});

--- a/src/storage/migrations/v2.test.ts
+++ b/src/storage/migrations/v2.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
+import { ExtensionContext } from "vscode";
 import {
   TEST_LOCAL_KAFKA_CLUSTER,
   TEST_LOCAL_SCHEMA_REGISTRY,
@@ -8,33 +9,26 @@ import { TEST_DIRECT_CONNECTION_FORM_SPEC } from "../../../tests/unit/testResour
 import { getTestExtensionContext } from "../../../tests/unit/testUtils";
 import { ConnectionId } from "../../models/resource";
 import { FormConnectionType } from "../../webview/direct-connect-form";
-import {
-  CustomConnectionSpec,
-  DirectConnectionsById,
-  getResourceManager,
-  ResourceManager,
-} from "../resourceManager";
+import { CustomConnectionSpec, DirectConnectionsById } from "../resourceManager";
 import { MigrationV2 } from "./v2";
 
 describe("MigrationV2", () => {
   let sandbox: sinon.SinonSandbox;
-  let rm: ResourceManager;
-  let getDirectConnectionsStub: sinon.SinonStub;
-  let addDirectConnectionStub: sinon.SinonStub;
-
+  let secretsGetStub: sinon.SinonStub;
+  let secretsStoreStub: sinon.SinonStub;
+  let context: ExtensionContext;
   let migration: MigrationV2;
 
   before(async () => {
-    await getTestExtensionContext();
+    context = await getTestExtensionContext();
   });
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     // only stub the methods we need to test so we aren't interfering with SecretStorage; just test
-    // the call arguments for `addDirectConnection` based on returned `getDirectConnections` values
-    rm = getResourceManager();
-    getDirectConnectionsStub = sandbox.stub(rm, "getDirectConnections");
-    addDirectConnectionStub = sandbox.stub(rm, "addDirectConnection");
+    // the call arguments for `store()` based on returned `get()` values
+    secretsGetStub = sandbox.stub(context.secrets, "get");
+    secretsStoreStub = sandbox.stub(context.secrets, "store");
 
     migration = new MigrationV2();
   });
@@ -66,18 +60,20 @@ describe("MigrationV2", () => {
       const testV1Map: DirectConnectionsById = new Map(
         testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
       );
-      getDirectConnectionsStub.resolves(testV1Map);
+      secretsGetStub.resolves(JSON.stringify(Object.fromEntries(testV1Map)));
 
       await migration.upgradeSecretStorage();
 
-      // addDirectConnection should be called once per migrated spec
-      assert.strictEqual(addDirectConnectionStub.callCount, 1);
-      const addDirectConnectionCallArgs: CustomConnectionSpec = addDirectConnectionStub.args[0][0];
-      assert.strictEqual(addDirectConnectionCallArgs.kafka_cluster!.ssl!.enabled, expectedSsl);
-      assert.strictEqual(addDirectConnectionCallArgs.schema_registry!.ssl!.enabled, expectedSsl);
+      // secrets.store() should be called once during an upgrade
+      assert.strictEqual(secretsStoreStub.callCount, 1);
+      // and now we have to pull out the stringified Map that was used for the call
+      const mapStringArg = JSON.parse(secretsStoreStub.args[0][1]);
+      const secretsStoreCallArgs: any = Object.values(mapStringArg)[0];
+      assert.strictEqual(secretsStoreCallArgs.kafka_cluster!.ssl!.enabled, expectedSsl);
+      assert.strictEqual(secretsStoreCallArgs.schema_registry!.ssl!.enabled, expectedSsl);
     });
 
-    it(`upgradeSecretStorage() should not update specs with 'ssl' already set (formConnectionType=${formConnectionType})`, async () => {
+    it(`upgradeSecretStorage() should not change specs with 'ssl' already set (formConnectionType=${formConnectionType})`, async () => {
       const testSpecs: CustomConnectionSpec[] = [
         {
           ...TEST_DIRECT_CONNECTION_FORM_SPEC,
@@ -95,20 +91,35 @@ describe("MigrationV2", () => {
       const testV1Map: DirectConnectionsById = new Map(
         testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
       );
-      getDirectConnectionsStub.resolves(testV1Map);
+      secretsGetStub.resolves(JSON.stringify(Object.fromEntries(testV1Map)));
 
       await migration.upgradeSecretStorage();
 
-      assert.ok(addDirectConnectionStub.notCalled);
+      // still going to write to SecretStorage, but the data should be unchanged
+      assert.strictEqual(secretsStoreStub.callCount, 1);
+      // and now we have to pull out the stringified Map that was used for the call
+      const mapStringArg = JSON.parse(secretsStoreStub.args[0][1]);
+      const secretsStoreCallArgs: any = Object.values(mapStringArg)[0];
+      assert.strictEqual(secretsStoreCallArgs.kafka_cluster!.ssl!.enabled, expectedSsl);
+      assert.strictEqual(
+        secretsStoreCallArgs.kafka_cluster!.ssl!.enabled,
+        testSpecs[0].kafka_cluster!.ssl!.enabled,
+      );
+      assert.strictEqual(secretsStoreCallArgs.schema_registry!.ssl!.enabled, expectedSsl);
+      assert.strictEqual(
+        secretsStoreCallArgs.schema_registry!.ssl!.enabled,
+        testSpecs[0].schema_registry!.ssl!.enabled,
+      );
     });
   }
 
   it("upgradeSecretStorage() should handle empty connection spec map", async () => {
-    getDirectConnectionsStub.resolves(new Map());
+    // we could just use "{}" but my trust is shaken
+    secretsGetStub.resolves(JSON.stringify(Object.fromEntries(new Map())));
 
     await migration.upgradeSecretStorage();
 
-    assert.ok(addDirectConnectionStub.notCalled);
+    assert.ok(secretsStoreStub.notCalled);
   });
 
   it("downgradeSecretStorage() should remove 'ssl' configs from connection specs", async () => {
@@ -128,18 +139,20 @@ describe("MigrationV2", () => {
     const testV2Map: DirectConnectionsById = new Map(
       testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
     );
-    getDirectConnectionsStub.resolves(testV2Map);
+    secretsGetStub.resolves(JSON.stringify(Object.fromEntries(testV2Map)));
 
     await migration.downgradeSecretStorage();
 
-    // addDirectConnection should be called once per migrated spec
-    assert.strictEqual(addDirectConnectionStub.callCount, 1);
-    const addDirectConnectionCallArgs: CustomConnectionSpec = addDirectConnectionStub.args[0][0];
-    assert.strictEqual(addDirectConnectionCallArgs.kafka_cluster!.ssl, undefined);
-    assert.strictEqual(addDirectConnectionCallArgs.schema_registry!.ssl, undefined);
+    // secrets.store() should be called once during a downgrade
+    assert.strictEqual(secretsStoreStub.callCount, 1);
+    // and now we have to pull out the stringified Map that was used for the call
+    const mapStringArg = JSON.parse(secretsStoreStub.args[0][1]);
+    const secretsStoreCallArgs: any = Object.values(mapStringArg)[0];
+    assert.strictEqual(secretsStoreCallArgs.kafka_cluster!.ssl, undefined);
+    assert.strictEqual(secretsStoreCallArgs.schema_registry!.ssl, undefined);
   });
 
-  it("downgradeSecretStorage() should not update specs that don't have 'ssl' configs set", async () => {
+  it("downgradeSecretStorage() should not change specs that don't have 'ssl' configs set", async () => {
     const testSpecs: CustomConnectionSpec[] = [
       {
         ...TEST_DIRECT_CONNECTION_FORM_SPEC,
@@ -156,18 +169,30 @@ describe("MigrationV2", () => {
     const testV2Map: DirectConnectionsById = new Map(
       testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
     );
-    getDirectConnectionsStub.resolves(testV2Map);
+    secretsGetStub.resolves(JSON.stringify(Object.fromEntries(testV2Map)));
 
     await migration.downgradeSecretStorage();
 
-    assert.ok(addDirectConnectionStub.notCalled);
+    // secrets.store() should be called once during a downgrade
+    assert.ok(secretsStoreStub.calledOnce);
+    // and now we have to pull out the stringified Map that was used for the call
+    const mapStringArg = JSON.parse(secretsStoreStub.args[0][1]);
+    const secretsStoreCallArgs: any = Object.values(mapStringArg)[0];
+    assert.strictEqual(secretsStoreCallArgs.kafka_cluster!.ssl, undefined);
+    assert.strictEqual(secretsStoreCallArgs.kafka_cluster!.ssl, testSpecs[0].kafka_cluster!.ssl);
+    assert.strictEqual(secretsStoreCallArgs.schema_registry!.ssl, undefined);
+    assert.strictEqual(
+      secretsStoreCallArgs.schema_registry!.ssl,
+      testSpecs[0].schema_registry!.ssl,
+    );
   });
 
   it("downgradeSecretStorage() should handle empty connection spec map", async () => {
-    getDirectConnectionsStub.resolves(new Map());
+    // we could just use "{}" but my trust is shaken
+    secretsGetStub.resolves(JSON.stringify(Object.fromEntries(new Map())));
 
     await migration.downgradeSecretStorage();
 
-    assert.ok(addDirectConnectionStub.notCalled);
+    assert.ok(secretsStoreStub.notCalled);
   });
 });

--- a/src/storage/migrations/v2.test.ts
+++ b/src/storage/migrations/v2.test.ts
@@ -63,7 +63,6 @@ describe("MigrationV2", () => {
           formConnectionType,
         },
       ];
-      console.info("***TEST SPECS***", testSpecs[0]);
       const testV1Map: DirectConnectionsById = new Map(
         testSpecs.map((spec): [ConnectionId, CustomConnectionSpec] => [spec.id, spec]),
       );

--- a/src/storage/migrations/v2.test.ts
+++ b/src/storage/migrations/v2.test.ts
@@ -12,7 +12,7 @@ import { FormConnectionType } from "../../webview/direct-connect-form";
 import { CustomConnectionSpec, DirectConnectionsById } from "../resourceManager";
 import { MigrationV2 } from "./v2";
 
-describe("MigrationV2", () => {
+describe("storage/migrations/v2", () => {
   let sandbox: sinon.SinonSandbox;
   let secretsGetStub: sinon.SinonStub;
   let secretsStoreStub: sinon.SinonStub;

--- a/src/storage/migrations/v2.ts
+++ b/src/storage/migrations/v2.ts
@@ -19,14 +19,15 @@ export class MigrationV2 extends BaseMigration {
     const connectionSpecs: DirectConnectionsById = await rm.getDirectConnections();
     const connectionSpecUpdates: Promise<void>[] = [];
     for (const spec of connectionSpecs.values()) {
-      if (spec.kafka_cluster) {
+      if (spec.kafka_cluster && spec.kafka_cluster.ssl === undefined) {
         spec.kafka_cluster.ssl = { enabled: spec.formConnectionType === "Confluent Cloud" };
       }
-      if (spec.schema_registry) {
+      if (spec.schema_registry && spec.schema_registry.ssl === undefined) {
         spec.schema_registry.ssl = { enabled: spec.formConnectionType === "Confluent Cloud" };
       }
       connectionSpecUpdates.push(rm.addDirectConnection(spec));
     }
+
     if (connectionSpecUpdates.length > 0) {
       logger.debug(`Adding 'ssl' defaults to ${connectionSpecUpdates.length} ConnectionSpec(s)`);
       await Promise.all(connectionSpecUpdates);
@@ -45,14 +46,15 @@ export class MigrationV2 extends BaseMigration {
     const connectionSpecs: DirectConnectionsById = await rm.getDirectConnections();
     const connectionSpecUpdates: Promise<void>[] = [];
     for (const spec of connectionSpecs.values()) {
-      if (spec.kafka_cluster) {
+      if (spec.kafka_cluster && spec.kafka_cluster.ssl !== undefined) {
         delete spec.kafka_cluster.ssl;
       }
-      if (spec.schema_registry) {
+      if (spec.schema_registry && spec.schema_registry.ssl !== undefined) {
         delete spec.schema_registry.ssl;
       }
       connectionSpecUpdates.push(rm.addDirectConnection(spec));
     }
+
     if (connectionSpecUpdates.length > 0) {
       logger.debug(
         `Removing 'ssl' defaults from ${connectionSpecUpdates.length} ConnectionSpec(s)`,

--- a/src/storage/migrations/v2.ts
+++ b/src/storage/migrations/v2.ts
@@ -1,5 +1,7 @@
+import { ExtensionContext } from "vscode";
+import { getExtensionContext } from "../../context/extension";
 import { Logger } from "../../logging";
-import { DirectConnectionsById, getResourceManager } from "../resourceManager";
+import { SecretStorageKeys } from "../constants";
 import { BaseMigration } from "./base";
 
 const logger = new Logger("storage.migrations.v2");
@@ -13,31 +15,55 @@ export class MigrationV2 extends BaseMigration {
    *  the `formConnectionType` field.
    */
   async upgradeSecretStorage(): Promise<void> {
-    const rm = getResourceManager();
+    const context: ExtensionContext = getExtensionContext();
 
-    // direct connection `ssl` defaults: `enabled` if `formConnectionType` is "Confluent Cloud"
-    const connectionSpecs: DirectConnectionsById = await rm.getDirectConnections();
-    const connectionSpecUpdates: Promise<void>[] = [];
-    for (const spec of connectionSpecs.values()) {
-      let shouldMigrate: boolean = false;
-      const isCCloud = spec.formConnectionType === "Confluent Cloud";
+    // NOTE: we aren't using other helper methods, types, interfaces, etc. here to avoid having to
+    // migrate those as well, but the storage key should be fine on its own
+    const connectionSpecsStr: string | undefined = await context.secrets.get(
+      SecretStorageKeys.DIRECT_CONNECTIONS,
+    );
+    if (!connectionSpecsStr) {
+      logger.debug("no ConnectionSpecs to check for upgrade");
+      return;
+    }
+
+    // should be a map-like structure of connection ID -> ConnectionSpec
+    const connectionSpecs = JSON.parse(connectionSpecsStr);
+    if (typeof connectionSpecs !== "object" || connectionSpecs === null) {
+      throw new Error("ConnectionSpecs must be an object");
+    }
+
+    // copy over existing+updated specs into a new map to write once later
+    const updatedConnectionSpecs: Map<string, any> = new Map();
+    const specs: any[] = Object.values(connectionSpecs);
+    for (const spec of specs) {
+      if (typeof spec !== "object" || spec === null || !spec.id) {
+        continue;
+      }
+
+      // direct connection `ssl` defaults: `enabled` if `formConnectionType` is "Confluent Cloud",
+      // defaulting to "true" otherwise (users should be able to adjust this for non-CCloud
+      // connections anyway)
+      const isCCloud = spec.formConnectionType
+        ? spec.formConnectionType === "Confluent Cloud"
+        : true;
+
       if (spec.kafka_cluster && spec.kafka_cluster.ssl === undefined) {
         spec.kafka_cluster.ssl = { enabled: isCCloud };
-        shouldMigrate = true;
       }
       if (spec.schema_registry && spec.schema_registry.ssl === undefined) {
         spec.schema_registry.ssl = { enabled: isCCloud };
-        shouldMigrate = true;
       }
 
-      if (shouldMigrate) {
-        connectionSpecUpdates.push(rm.addDirectConnection(spec));
-      }
+      updatedConnectionSpecs.set(spec.id, spec);
     }
 
-    if (connectionSpecUpdates.length > 0) {
-      logger.debug(`Adding 'ssl' defaults to ${connectionSpecUpdates.length} ConnectionSpec(s)`);
-      await Promise.all(connectionSpecUpdates);
+    if (updatedConnectionSpecs.size > 0) {
+      logger.debug(`Adding 'ssl' defaults to ${updatedConnectionSpecs.size} ConnectionSpec(s)`);
+      await context.secrets.store(
+        SecretStorageKeys.DIRECT_CONNECTIONS,
+        JSON.stringify(Object.fromEntries(updatedConnectionSpecs)),
+      );
     } else {
       logger.debug("No ConnectionSpecs to upgrade");
     }
@@ -48,30 +74,48 @@ export class MigrationV2 extends BaseMigration {
    * - Remove `ssl` fields from ConnectionSpecs' `kafka_cluster` and `schema_registry` configs.
    */
   async downgradeSecretStorage(): Promise<void> {
-    const rm = getResourceManager();
+    const context: ExtensionContext = getExtensionContext();
 
-    const connectionSpecs: DirectConnectionsById = await rm.getDirectConnections();
-    const connectionSpecUpdates: Promise<void>[] = [];
-    for (const spec of connectionSpecs.values()) {
-      let shouldMigrate: boolean = false;
+    // NOTE: we aren't using other helper methods, types, interfaces, etc. here to avoid having to
+    // migrate those as well, but the storage key should be fine on its own
+    const connectionSpecsStr: string | undefined = await context.secrets.get(
+      SecretStorageKeys.DIRECT_CONNECTIONS,
+    );
+    if (!connectionSpecsStr) {
+      logger.debug("no ConnectionSpecs to check for downgrade");
+      return;
+    }
+
+    // should be a map-like structure of connection ID -> ConnectionSpec
+    const connectionSpecs = JSON.parse(connectionSpecsStr);
+    if (typeof connectionSpecs !== "object" || connectionSpecs === null) {
+      throw new Error("ConnectionSpecs must be an object");
+    }
+
+    // copy over existing+updated specs into a new map to write once later
+    const updatedConnectionSpecs: Map<string, any> = new Map();
+    const specs: any[] = Object.values(connectionSpecs);
+    for (const spec of specs) {
+      if (typeof spec !== "object" || spec === null || !spec.id) {
+        continue;
+      }
+
       if (spec.kafka_cluster && spec.kafka_cluster.ssl !== undefined) {
         delete spec.kafka_cluster.ssl;
-        shouldMigrate = true;
       }
       if (spec.schema_registry && spec.schema_registry.ssl !== undefined) {
         delete spec.schema_registry.ssl;
-        shouldMigrate = true;
       }
-      if (shouldMigrate) {
-        connectionSpecUpdates.push(rm.addDirectConnection(spec));
-      }
+
+      updatedConnectionSpecs.set(spec.id, spec);
     }
 
-    if (connectionSpecUpdates.length > 0) {
-      logger.debug(
-        `Removing 'ssl' defaults from ${connectionSpecUpdates.length} ConnectionSpec(s)`,
+    if (updatedConnectionSpecs.size > 0) {
+      logger.debug(`Removing 'ssl' defaults from ${updatedConnectionSpecs.size} ConnectionSpec(s)`);
+      await context.secrets.store(
+        SecretStorageKeys.DIRECT_CONNECTIONS,
+        JSON.stringify(Object.fromEntries(updatedConnectionSpecs)),
       );
-      await Promise.all(connectionSpecUpdates);
     } else {
       logger.debug("No ConnectionSpecs to downgrade");
     }

--- a/src/storage/migrations/v2.ts
+++ b/src/storage/migrations/v2.ts
@@ -1,0 +1,65 @@
+import { Logger } from "../../logging";
+import { DirectConnectionsById, getResourceManager } from "../resourceManager";
+import { BaseMigration } from "./base";
+
+const logger = new Logger("storage.migrations.v2");
+
+export class MigrationV2 extends BaseMigration {
+  readonly version = 2;
+
+  /**
+   * V1 to V2:
+   * - Add `ssl` defaults to ConnectionSpecs' `kafka_cluster` and `schema_registry` configs based on
+   *  the `formConnectionType` field.
+   */
+  async upgradeSecretStorage(): Promise<void> {
+    const rm = getResourceManager();
+
+    // direct connection `ssl` defaults: `enabled` if `formConnectionType` is "Confluent Cloud"
+    const connectionSpecs: DirectConnectionsById = await rm.getDirectConnections();
+    const connectionSpecUpdates: Promise<void>[] = [];
+    for (const spec of connectionSpecs.values()) {
+      if (spec.kafka_cluster) {
+        spec.kafka_cluster.ssl = { enabled: spec.formConnectionType === "Confluent Cloud" };
+      }
+      if (spec.schema_registry) {
+        spec.schema_registry.ssl = { enabled: spec.formConnectionType === "Confluent Cloud" };
+      }
+      connectionSpecUpdates.push(rm.addDirectConnection(spec));
+    }
+    if (connectionSpecUpdates.length > 0) {
+      logger.debug(`Adding 'ssl' defaults to ${connectionSpecUpdates.length} ConnectionSpec(s)`);
+      await Promise.all(connectionSpecUpdates);
+    } else {
+      logger.debug("No ConnectionSpecs to upgrade");
+    }
+  }
+
+  /**
+   * V2 to V1:
+   * - Remove `ssl` fields from ConnectionSpecs' `kafka_cluster` and `schema_registry` configs.
+   */
+  async downgradeSecretStorage(): Promise<void> {
+    const rm = getResourceManager();
+
+    const connectionSpecs: DirectConnectionsById = await rm.getDirectConnections();
+    const connectionSpecUpdates: Promise<void>[] = [];
+    for (const spec of connectionSpecs.values()) {
+      if (spec.kafka_cluster) {
+        delete spec.kafka_cluster.ssl;
+      }
+      if (spec.schema_registry) {
+        delete spec.schema_registry.ssl;
+      }
+      connectionSpecUpdates.push(rm.addDirectConnection(spec));
+    }
+    if (connectionSpecUpdates.length > 0) {
+      logger.debug(
+        `Removing 'ssl' defaults from ${connectionSpecUpdates.length} ConnectionSpec(s)`,
+      );
+      await Promise.all(connectionSpecUpdates);
+    } else {
+      logger.debug("No ConnectionSpecs to downgrade");
+    }
+  }
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #818.

Adds a `SecretStorage` migration to account for SSL configs being required for different kinds of `DIRECT` connections -- "Confluent Cloud" connections should have SSL enabled by default (see https://github.com/confluentinc/vscode/pull/822), and anything else should be set to `ssl.enabled = false` by default.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

This PR also sets up some basic patterns for how we may want to handle future migrations across the global/workspace state(s) and secret storage, so future migration branches should be smaller / more focused.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
