### PR TITLE
add "View Message in Topic Messages" button after producing

### DIFF
--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -235,18 +235,19 @@ async function produceMessageFromFile(topic: KafkaTopic) {
         )
         .then((selection) => {
           if (selection) {
-            // open the message viewer to show the last ~15sec of messages for the topic
-            // with the message key used to search, and partition filtered if available
+            // open the message viewer to show a ~1sec window around the produced message
+            const msgTime = resp.timestamp ? resp.timestamp.getTime() : Date.now() - 500;
+            // ...with the message key used to search, and partition filtered if available
             const messageViewerConfig = MessageViewerConfig.create({
               // don't change the consume query params, just filter to show this last message
-              timestampFilter: [Date.now() - 15_000, Date.now()],
+              timestampFilter: [msgTime, msgTime + 500],
               partitionFilter: resp.partition_id ? [resp.partition_id] : undefined,
               textFilter: String(message.key),
             });
             vscode.commands.executeCommand(
               "confluent.topic.consume",
               topic,
-              true,
+              true, // duplicate MV to show updated filters
               messageViewerConfig,
             );
           }

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -906,7 +906,7 @@ function prepare(
  * Represents static snapshot of message viewer state that can be serialized.
  * Provides static method to deserialize the snapshot from a URI's query.
  */
-class MessageViewerConfig extends Data {
+export class MessageViewerConfig extends Data {
   consumeMode: "beginning" | "latest" | "timestamp" = "beginning";
   consumeTimestamp: number | null = null;
   partitionConsumed: number[] | null = null;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #821. Also re-adds the "success" info notification accidentally removed in https://github.com/confluentinc/vscode/pull/823, but with a new "View Message in Topic Messages" button that will filter to the message's timestamp and use its `key` as a text filter to open a new message viewer tab.


https://github.com/user-attachments/assets/dadb19bf-bf67-4d3d-9e7f-ab5d381752ba



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
