### PR TITLE
fix: don't refresh Topics/Schemas views after direct connection change until in a usable connected state

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { Disposable, ProgressLocation, SecretStorageChangeEvent, window } from "vscode";
 import {
   Connection,
@@ -8,7 +9,7 @@ import {
   ResponseError,
 } from "./clients/sidecar";
 import { getExtensionContext } from "./context/extension";
-import { directConnectionsChanged, environmentChanged } from "./emitters";
+import { directConnectionsChanged } from "./emitters";
 import { ExtensionContextNotSetError } from "./errors";
 import { Logger } from "./logging";
 import { ConnectionId, isDirect } from "./models/resource";
@@ -30,7 +31,6 @@ import {
 import { logUsage, UserEvent } from "./telemetry/events";
 import { getSchemasViewProvider } from "./viewProviders/schemas";
 import { getTopicViewProvider } from "./viewProviders/topics";
-import { randomUUID } from "crypto";
 
 const logger = new Logger("directConnectManager");
 
@@ -199,9 +199,6 @@ export class DirectConnectionManager {
     };
     // update the connection in secret storage (via full replace of the connection by its id)
     await getResourceManager().addDirectConnection(mergedSpec);
-    // notify subscribers that the "environment" has changed since direct connections are treated
-    // as environment-specific resources
-    environmentChanged.fire(mergedSpec.id);
     return;
   }
 

--- a/src/sidecar/connections.ts
+++ b/src/sidecar/connections.ts
@@ -30,6 +30,7 @@ import {
   connectionUsable,
   currentKafkaClusterChanged,
   currentSchemaRegistryChanged,
+  environmentChanged,
 } from "../emitters";
 import { logResponseError } from "../errors";
 import { Logger } from "../logging";
@@ -265,6 +266,9 @@ export async function waitForConnectionToBeUsable(
           continue;
         }
         connectionUsable.fire(id);
+        // notify subscribers that the "environment" has changed since direct connections are treated
+        // as environment-specific resources
+        environmentChanged.fire(id);
         if (kafkaState === "FAILED") {
           kafkaFailed = status.kafka_cluster?.errors?.sign_in?.message;
         }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This fixes a race condition we hit when trying to refresh the Topics/Schemas views during a direct connection update. Previously, we wouldn't wait for the connection to be in a non-`ATTEMPTING` connected state, so we would erroneously attempt making a list topics/schemas type request before the sidecar was able to repopulate its cluster cache with the associated cluster(s).

Now we wait until the connection is not `ATTEMPTING` before firing this event, which ensures the sidecar has transitioned the connected state to either `SUCCESS` or `FAILED`, and we can then safely re-request the topic/schemas list (which will either list any available topics/schemas, or show the error if communication to the associated resource is lost).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
