### PR TITLE
remove direct connection preview setting and enable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this extension will be documented in this file.
   with icons to indicate the type of connection chosen in the form.
 - Double-clicking on an event/message row in the topic message viewer will now open a read-only
   (preview) document with the message content.
+- Functionality to connect directly to Kafka and/or Schema Registry is now available by default, and
+  the associated "preview" setting has been removed.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -441,14 +441,6 @@
           "default": "latest",
           "markdownDescription": "Docker image tag to use when starting a local Schema Registry container. (By default, this will use the [`confluentinc/cp-schema-registry`](https://hub.docker.com/r/confluentinc/cp-schema-registry/tags) image.)"
         },
-        "confluent.preview.enableDirectConnections": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable direct connections to Kafka and Schema Registry resources.",
-          "tags": [
-            "preview"
-          ]
-        },
         "confluent.preview.enableProduceMessages": {
           "type": "boolean",
           "default": false,
@@ -531,10 +523,6 @@
         {
           "command": "confluent.connections.ccloud.logIn",
           "when": "!confluent.ccloudConnectionAvailable"
-        },
-        {
-          "command": "confluent.connections.direct",
-          "when": "confluent.directConnectionsEnabled"
         },
         {
           "command": "confluent.connections.direct.delete",
@@ -675,7 +663,7 @@
       "view/title": [
         {
           "command": "confluent.connections.direct",
-          "when": "view == confluent-resources && confluent.directConnectionsEnabled",
+          "when": "view == confluent-resources",
           "group": "navigation@1"
         },
         {
@@ -787,12 +775,12 @@
         },
         {
           "command": "confluent.connections.direct.delete",
-          "when": "viewItem == direct-environment && confluent.directConnectionsEnabled",
+          "when": "viewItem == direct-environment",
           "group": "inline@3"
         },
         {
           "command": "confluent.connections.direct.edit",
-          "when": "viewItem == direct-environment && confluent.directConnectionsEnabled",
+          "when": "viewItem == direct-environment",
           "group": "inline@2"
         },
         {

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -55,11 +55,6 @@ export enum ContextValues {
   /** The user clicked a Schema Registry tree item. */
   schemaRegistrySelected = "confluent.schemaRegistrySelected",
   /**
-   * PREVIEW: Are direct connections enabled at all?
-   * (This should go away once the `confluent.preview.enableDirectConnections` setting is removed.)
-   */
-  directConnectionsEnabled = "confluent.directConnectionsEnabled",
-  /**
    * PREVIEW: Is the "produce message" functionality enabled at all?
    * (This should go away once the `confluent.preview.enableProduceMessages` setting is removed.)
    */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,6 @@ import { MessageDocumentProvider } from "./documentProviders/message";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { Logger, outputChannel } from "./logging";
 import {
-  ENABLE_DIRECT_CONNECTIONS,
   ENABLE_PRODUCE_MESSAGES,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
@@ -231,10 +230,6 @@ async function _activateExtension(
 async function setupContextValues() {
   // PREVIEW: set default values for enabling the direct connection and message-produce features
   const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-  const directConnectionsEnabled = setContextValue(
-    ContextValues.directConnectionsEnabled,
-    config.get(ENABLE_DIRECT_CONNECTIONS, false),
-  );
   const produceMessagesEnabled = setContextValue(
     ContextValues.produceMessagesEnabled,
     config.get(ENABLE_PRODUCE_MESSAGES, false),
@@ -282,7 +277,6 @@ async function setupContextValues() {
     "direct-schema-registry",
   ]);
   await Promise.all([
-    directConnectionsEnabled,
     produceMessagesEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -25,5 +25,4 @@ export const LOCAL_KAFKA_IMAGE_TAG = prefix + "localDocker.kafkaImageTag";
 export const LOCAL_SCHEMA_REGISTRY_IMAGE = prefix + "localDocker.schemaRegistryImageRepo";
 export const LOCAL_SCHEMA_REGISTRY_IMAGE_TAG = prefix + "localDocker.schemaRegistryImageTag";
 
-export const ENABLE_DIRECT_CONNECTIONS = prefix + "preview.enableDirectConnections";
 export const ENABLE_PRODUCE_MESSAGES = prefix + "preview.enableProduceMessages";

--- a/src/preferences/listener.test.ts
+++ b/src/preferences/listener.test.ts
@@ -4,7 +4,6 @@ import { ConfigurationChangeEvent, workspace } from "vscode";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import * as contextValues from "../context/values";
 import {
-  ENABLE_DIRECT_CONNECTIONS,
   ENABLE_PRODUCE_MESSAGES,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
@@ -87,7 +86,6 @@ describe("preferences/listener", function () {
   });
 
   for (const [previewSetting, previewContextValue] of [
-    [ENABLE_DIRECT_CONNECTIONS, contextValues.ContextValues.directConnectionsEnabled],
     [ENABLE_PRODUCE_MESSAGES, contextValues.ContextValues.produceMessagesEnabled],
   ]) {
     for (const enabled of [true, false]) {

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,12 +1,7 @@
 import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration } from "vscode";
 import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
-import { isDirect } from "../models/resource";
-import { ResourceViewProvider } from "../viewProviders/resources";
-import { getSchemasViewProvider } from "../viewProviders/schemas";
-import { getTopicViewProvider } from "../viewProviders/topics";
 import {
-  ENABLE_DIRECT_CONNECTIONS,
   ENABLE_PRODUCE_MESSAGES,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
@@ -45,27 +40,6 @@ export function createConfigChangeListener(): Disposable {
       // --- PREVIEW SETTINGS --
       // Remove the sections below once the behavior is enabled by default and a setting is no
       // longer needed to opt-in to the feature.
-
-      if (event.affectsConfiguration(ENABLE_DIRECT_CONNECTIONS)) {
-        // user toggled the "Enable Direct Connections" preview setting
-        const enabled = configs.get(ENABLE_DIRECT_CONNECTIONS, false);
-        logger.debug(`"${ENABLE_DIRECT_CONNECTIONS}" config changed`, { enabled });
-        setContextValue(ContextValues.directConnectionsEnabled, enabled);
-        // "Other" container item will be toggled
-        ResourceViewProvider.getInstance().refresh();
-        // if the Topics/Schemas views are focused on a direct connection based resource, wipe them
-        if (!enabled) {
-          const topicsView = getTopicViewProvider();
-          if (topicsView.kafkaCluster && isDirect(topicsView.kafkaCluster)) {
-            topicsView.reset();
-          }
-          const schemasView = getSchemasViewProvider();
-          if (schemasView.schemaRegistry && isDirect(schemasView.schemaRegistry)) {
-            schemasView.reset();
-          }
-        }
-        return;
-      }
 
       if (event.affectsConfiguration(ENABLE_PRODUCE_MESSAGES)) {
         // user toggled the "Enable Produce Messages" preview setting

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { TreeItemCollapsibleState, workspace } from "vscode";
+import { TreeItemCollapsibleState } from "vscode";
 import {
   TEST_CCLOUD_ENVIRONMENT,
   TEST_CCLOUD_KAFKA_CLUSTER,
@@ -30,7 +30,6 @@ import { KafkaClusterTreeItem, LocalKafkaCluster } from "../models/kafkaCluster"
 import { ContainerTreeItem } from "../models/main";
 import { ConnectionLabel } from "../models/resource";
 import { LocalSchemaRegistry, SchemaRegistryTreeItem } from "../models/schemaRegistry";
-import { ENABLE_DIRECT_CONNECTIONS } from "../preferences/constants";
 import * as auth from "../sidecar/connections";
 import * as resourceManager from "../storage/resourceManager";
 import {
@@ -170,13 +169,7 @@ describe("ResourceViewProvider loading functions", () => {
   });
 
   it("loadDirectResources() should return an empty array when no direct connections exist", async () => {
-    // TODO(shoup): remove this once direct connections are enabled by default
-    // simulate the preview setting being enabled
-    const getConfigurationStub: sinon.SinonStub = sandbox.stub(workspace, "getConfiguration");
-    getConfigurationStub.returns({
-      get: sandbox.stub().withArgs(ENABLE_DIRECT_CONNECTIONS).returns(true),
-    });
-    // but no direct connections exist
+    // no direct connections exist
     sandbox.stub(direct, "getDirectResources").resolves([]);
 
     const result: DirectEnvironment[] = await loadDirectResources();
@@ -185,13 +178,7 @@ describe("ResourceViewProvider loading functions", () => {
   });
 
   it("loadDirectResources() should return an empty array if the preview setting is disabled, even when direct connections exist", async () => {
-    // TODO(shoup): remove this once direct connections are enabled by default
-    // simulate the preview setting being disabled
-    const getConfigurationStub: sinon.SinonStub = sandbox.stub(workspace, "getConfiguration");
-    getConfigurationStub.returns({
-      get: sandbox.stub().withArgs(ENABLE_DIRECT_CONNECTIONS).returns(false),
-    });
-    // and direct connections exist
+    // direct connections exist
     const testDirectEnv: DirectEnvironment = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
@@ -205,13 +192,7 @@ describe("ResourceViewProvider loading functions", () => {
   });
 
   it("loadDirectResources() should return an array of direct 'environments' if direct connections exist and the preview setting is enabled", async () => {
-    // TODO(shoup): remove this once direct connections are enabled by default
-    // simulate the preview setting being disabled
-    const getConfigurationStub: sinon.SinonStub = sandbox.stub(workspace, "getConfiguration");
-    getConfigurationStub.returns({
-      get: sandbox.stub().withArgs(ENABLE_DIRECT_CONNECTIONS).returns(true),
-    });
-    // and direct connections exist
+    // direct connections exist
     const testDirectEnv: DirectEnvironment = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,
       kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -177,21 +177,7 @@ describe("ResourceViewProvider loading functions", () => {
     assert.deepStrictEqual(result, []);
   });
 
-  it("loadDirectResources() should return an empty array if the preview setting is disabled, even when direct connections exist", async () => {
-    // direct connections exist
-    const testDirectEnv: DirectEnvironment = new DirectEnvironment({
-      ...TEST_DIRECT_ENVIRONMENT,
-      kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
-      schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
-    });
-    sandbox.stub(direct, "getDirectResources").resolves([testDirectEnv]);
-
-    const result: DirectEnvironment[] = await loadDirectResources();
-
-    assert.deepStrictEqual(result, []);
-  });
-
-  it("loadDirectResources() should return an array of direct 'environments' if direct connections exist and the preview setting is enabled", async () => {
+  it("loadDirectResources() should return an array of direct 'environments' if direct connections exist", async () => {
     // direct connections exist
     const testDirectEnv: DirectEnvironment = new DirectEnvironment({
       ...TEST_DIRECT_ENVIRONMENT,

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -46,7 +46,6 @@ import {
   SchemaRegistry,
   SchemaRegistryTreeItem,
 } from "../models/schemaRegistry";
-import { ENABLE_DIRECT_CONNECTIONS } from "../preferences/constants";
 import { hasCCloudAuthSession, updateLocalConnection } from "../sidecar/connections";
 import { CCloudResourceLoader } from "../storage/ccloudResourceLoader";
 import { getResourceManager } from "../storage/resourceManager";
@@ -409,14 +408,6 @@ export async function loadLocalResources(): Promise<
 }
 
 export async function loadDirectResources(): Promise<DirectEnvironment[]> {
-  // PREVIEW: check if direct connections are enabled in extension settings
-  // TODO(shoup): remove this once direct connections are enabled by default
-  const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-  const directConnectionsEnabled: boolean = config.get(ENABLE_DIRECT_CONNECTIONS, false);
-  if (!directConnectionsEnabled) {
-    return [];
-  }
-
   // fetch all direct connections and their resources; each connection will be treated the same as a
   // CCloud environment (connection ID and environment ID are the same)
   const directEnvs = await getDirectResources();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Removes all references/watchers for the `confluent.preview.enableDirectConnections` preview setting, as well as the `confluent.directConnectionsEnabled` context value.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
