### PR TITLE
Small cleanups

### DIFF
--- a/src/context/values.test.ts
+++ b/src/context/values.test.ts
@@ -1,7 +1,31 @@
 import * as assert from "assert";
+import sinon from "sinon";
+import { commands } from "vscode";
 import { ContextValues, getContextValue, setContextValue } from "./values";
 
 describe("ContextValue functions", () => {
+  let sandbox: sinon.SinonSandbox;
+  let executeCommandStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    executeCommandStub = sandbox.stub(commands, "executeCommand");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("setContextValue() should correctly context value and execute the setContext command", async () => {
+    const key = ContextValues.resourceSelectedForCompare;
+    const value = true;
+
+    await setContextValue(key, value);
+
+    assert.ok(executeCommandStub.calledWith("setContext", key, value));
+    assert.deepStrictEqual(getContextValue<boolean>(key), value);
+  });
+
   it("setContextValue() should throw an error for an untracked context value", async () => {
     await assert.rejects(
       () => setContextValue("invalidKey" as ContextValues, "value"),

--- a/src/context/values.test.ts
+++ b/src/context/values.test.ts
@@ -1,21 +1,7 @@
 import * as assert from "assert";
-import * as sinon from "sinon";
-import { commands } from "vscode";
 import { ContextValues, getContextValue, setContextValue } from "./values";
 
 describe("ContextValue functions", () => {
-  let sandbox: sinon.SinonSandbox;
-  let executeCommandStub: sinon.SinonStub;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    executeCommandStub = sandbox.stub(commands, "executeCommand");
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it("setContextValue() should throw an error for an untracked context value", async () => {
     await assert.rejects(
       () => setContextValue("invalidKey" as ContextValues, "value"),

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -71,9 +71,12 @@ export class WebsocketManager implements Disposable {
 
   /**
    * Connect websocket to the sidecar, then send a WORKSPACE_HELLO message with the workspace process id.
-   * Resolves the promise upon successful authorization.
-   * @param access_token
-   * @returns
+   * Resolves the promise upon successfully connecting, have the WORKSPACE_HELLO message accepted by
+   * sidecar, and sidecar sending the expected WORKSPACE_COUNT_CHANGED message, informing us of if there
+   * are other workspaces online (aka the general workspace -> sidecar websocket handshaking process).
+   *
+   * @param hostPortFragment The host and port fragment to connect to, e.g. "localhost:8080".
+   * @param accessToken The access token to use for authorization.
    */
   async connect(hostPortFragment: string, accessToken: string): Promise<void> {
     return new Promise<void>((resolve) => {

--- a/src/storage/directResourceLoader.ts
+++ b/src/storage/directResourceLoader.ts
@@ -1,7 +1,7 @@
 import { TopicData } from "../clients/kafkaRest";
 import { ConnectionType } from "../clients/sidecar";
 import { getDirectResources } from "../graphql/direct";
-=import { DirectEnvironment } from "../models/environment";
+import { DirectEnvironment } from "../models/environment";
 import { DirectKafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId, isDirect } from "../models/resource";
 import { Schema } from "../models/schema";

--- a/src/storage/directResourceLoader.ts
+++ b/src/storage/directResourceLoader.ts
@@ -1,8 +1,7 @@
 import { TopicData } from "../clients/kafkaRest";
 import { ConnectionType } from "../clients/sidecar";
 import { getDirectResources } from "../graphql/direct";
-import { Logger } from "../logging";
-import { DirectEnvironment } from "../models/environment";
+=import { DirectEnvironment } from "../models/environment";
 import { DirectKafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId, isDirect } from "../models/resource";
 import { Schema } from "../models/schema";
@@ -14,8 +13,6 @@ import {
   fetchTopics,
   ResourceLoader,
 } from "./resourceLoader";
-
-const logger = new Logger("storage.directResourceLoader");
 
 /**
  * {@link ResourceLoader} implementation for direct connections.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Two small things:
  1. Fix websocket docstring, pointed out by @alexeyraspopov in the [websocket PR ](https://github.com/confluentinc/vscode/pull/754)but queued for followup.
  2. Fix two 'gulp lint' identified issues:
 
```
  KCX6P9D7XG:vscode jlrobins$ gulp lint
[13:38:11] Using gulpfile ~/git/vscode/gulpfile.js
[13:38:11] Starting 'lint'...

/Users/jlrobins/git/vscode/src/context/values.test.ts
  8:7  warning  'executeCommandStub' is assigned a value but never used  @typescript-eslint/no-unused-vars

/Users/jlrobins/git/vscode/src/storage/directResourceLoader.ts
  18:7  warning  'logger' is assigned a value but never used  @typescript-eslint/no-unused-vars


```
