### PR TITLE
remove sidecar executable from extension build process and download on activation

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -84,8 +84,10 @@ export function build(done) {
   const extInput = {
     input: {
       extension: "src/extension.ts",
+      sidecar: "ide-sidecar",
     },
     plugins: [
+      sidecar(),
       pkgjson(),
       node({ preferBuiltins: true, exportConditions: ["node"] }),
       commonjs(),
@@ -342,15 +344,12 @@ function pkgjson() {
  */
 function sidecar() {
   const sidecarVersion = readFileSync(".versions/ide-sidecar.txt", "utf-8").replace(/[v\n\s]/g, "");
-  // this will be downloaded on extension activation if it doesn't exist already:
-  const sidecarFilename = `ide-sidecar-${sidecarVersion}-runner${IS_WINDOWS ? ".exe" : ""}`;
-
   return [
     virtual({
-      "ide-sidecar": `export const version = "${sidecarVersion}"; export default decodeURIComponent(new URL("./${sidecarFilename}", import.meta.url).pathname);`,
-    }),
-    copy({
-      copyOnce: true,
+      "ide-sidecar": `
+        export const version = "${sidecarVersion}";
+        export default { version };
+      `,
     }),
   ];
 }

--- a/src/ide-sidecar.d.ts
+++ b/src/ide-sidecar.d.ts
@@ -1,7 +1,5 @@
 declare module "ide-sidecar" {
-  /** Path to ide-sidecar binary file. The version is resolved at build time. */
-  const path: string;
   /** The ide-sidecar version is resolved at build time. */
   export const version: string;
-  export default path;
+  export default version;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes https://github.com/confluentinc/vscode/issues/755.

Instead of including the `ide-sidecar*` executable in the build process and potentially blowing up the extension `.vsix` file size, we can check before starting up the sidecar process and download straight from the GitHub release artifacts `browser_download_url` into the directory the extension is currently running.


https://github.com/user-attachments/assets/7099d8a4-b825-474a-a940-16bf58886769



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
