### PR TITLE
MINOR: add more filters to Sentry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ if (process.env.SENTRY_DSN) {
       "ENOENT: no such file or directory",
       "EPERM: operation not permitted",
       "Cancelled",
+      "captureException", // only ever floated by the Sentry SDK itself
     ],
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,8 @@ if (process.env.SENTRY_DSN) {
     ignoreErrors: [
       "The request failed and the interceptors did not return an alternative response",
       "ENOENT: no such file or directory",
+      "EPERM: operation not permitted",
+      "Cancelled",
     ],
   });
 }


### PR DESCRIPTION
Closes #693, closes #796 (by filtering out `captureException` which we only ever see from `node_modules/@sentry/*` errors), closes #866.