### PR TITLE
bug fix: api fields should only be required if bootstrap servers exist

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -211,7 +211,7 @@
                     id="api_key"
                     name="kafka_api_key"
                     type="text"
-                    required
+                    data-attr-required="this.kafkaBootstrapServers() !== ''"
                     data-attr-value="this.kafkaApiKey()"
                     data-on-change="this.updateValue(event)"
                   />
@@ -226,7 +226,7 @@
                     name="kafka_api_secret"
                     data-attr-value="this.kafkaSecret()"
                     type="password"
-                    required
+                    data-attr-required="this.kafkaBootstrapServers() !== ''"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Add a little check to these fields so users can submit _only_ SR for CCloud if necessary

