### PR TITLE
[v0.23.x] fix: update Topics/Schemas empty state when direct connections' resources change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Topics and Schemas views' empty states should now correctly indicate when a Kafka cluster or
+  Schema Registry is available through a direct connection.
+
 ## 0.23.2
 
-(The specified sidecar version did not have an associated Windows executable to build the VSIX with. 
+(The specified sidecar version did not have an associated Windows executable to build the VSIX with.
 Again, no user-facing changes.)
 
 ## 0.23.1

--- a/package.json
+++ b/package.json
@@ -489,7 +489,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Schema Registry locally through Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
+        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Schema Registry locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)\nOr connect to a Schema Registry instance directly.\n[Add New Connection](command:confluent.connections.direct)",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
@@ -504,7 +504,7 @@
       },
       {
         "view": "confluent-topics",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Kafka locally through Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Kafka locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)\nOr connect to a Kafka cluster directly.\n[Add New Connection](command:confluent.connections.direct)",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -490,32 +490,32 @@
       {
         "view": "confluent-schemas",
         "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Schema Registry locally through Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
-        "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable)"
+        "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
         "view": "confluent-schemas",
         "contents": "No Schema Registry selected. Click below to get started.\n[Select Schema Registry](command:confluent.resources.schema-registry.select)",
-        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable) && !confluent.schemaRegistrySelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable) && !confluent.schemaRegistrySelected"
       },
       {
         "view": "confluent-schemas",
         "contents": "No schemas found.\n[Create Schema](command:confluent.schemas.create)",
-        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable) && confluent.schemaRegistrySelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable) && confluent.schemaRegistrySelected"
       },
       {
         "view": "confluent-topics",
         "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Kafka locally through Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
-        "when": "!(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable)"
+        "when": "!(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)"
       },
       {
         "view": "confluent-topics",
         "contents": "No Kafka cluster selected. Click below to get started.\n[Select Kafka Cluster](command:confluent.resources.kafka-cluster.select)",
-        "when": "(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable) && !confluent.kafkaClusterSelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable) && !confluent.kafkaClusterSelected"
       },
       {
         "view": "confluent-topics",
         "contents": "No topics found.\n[Create Topic](command:confluent.topics.create)",
-        "when": "(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable) && confluent.kafkaClusterSelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable) && confluent.kafkaClusterSelected"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -489,7 +489,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Schema Registry locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)\nOr connect to a Schema Registry instance directly.\n[Add New Connection](command:confluent.connections.direct)",
+        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Schema Registry locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
@@ -504,7 +504,7 @@
       },
       {
         "view": "confluent-topics",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Kafka locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)\nOr connect to a Kafka cluster directly.\n[Add New Connection](command:confluent.connections.direct)",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Kafka locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)"
       },
       {

--- a/src/context/values.test.ts
+++ b/src/context/values.test.ts
@@ -16,6 +16,16 @@ describe("ContextValue functions", () => {
     sandbox.restore();
   });
 
+  it("setContextValue() should correctly context value and execute the setContext command", async () => {
+    const key = ContextValues.resourceSelectedForCompare;
+    const value = true;
+
+    await setContextValue(key, value);
+
+    assert.ok(executeCommandStub.calledWith("setContext", key, value));
+    assert.deepStrictEqual(getContextValue<boolean>(key), value);
+  });
+
   it("setContextValue() should throw an error for an untracked context value", async () => {
     await assert.rejects(
       () => setContextValue("invalidKey" as ContextValues, "value"),

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -48,6 +48,10 @@ export enum ContextValues {
   localKafkaClusterAvailable = "confluent.localKafkaClusterAvailable",
   /** A local connection has been made and a local Schema Registry is available for selecting in the Schemas view. */
   localSchemaRegistryAvailable = "confluent.localSchemaRegistryAvailable",
+  /** A direct connection has been made and a Kafka cluster is available for selecting in the Topics view. */
+  directKafkaClusterAvailable = "confluent.directKafkaClusterAvailable",
+  /** A direct connection has been made and a Schema Registry is available for selecting in the Schemas view. */
+  directSchemaRegistryAvailable = "confluent.directSchemaRegistryAvailable",
   /** A resource has been selected for comparison. */
   resourceSelectedForCompare = "confluent.resourceSelectedForCompare",
   /** The user clicked a Kafka cluster tree item. */

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -337,4 +337,23 @@ describe("ResourceViewProvider context value updates", () => {
       ),
     );
   });
+
+  it("refresh() should update context values correctly when no direct environments exist", () => {
+    provider.environmentsMap = new Map();
+
+    provider.refresh();
+
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directKafkaClusterAvailable,
+        false,
+      ),
+    );
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directSchemaRegistryAvailable,
+        false,
+      ),
+    );
+  });
 });

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../tests/unit/testResources/schemaRegistry";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { EXTENSION_VERSION } from "../constants";
+import * as contextValues from "../context/values";
 import * as direct from "../graphql/direct";
 import * as local from "../graphql/local";
 import * as org from "../graphql/organizations";
@@ -189,5 +190,141 @@ describe("ResourceViewProvider loading functions", () => {
     const result: DirectEnvironment[] = await loadDirectResources();
 
     assert.deepStrictEqual(result, [testDirectEnv]);
+  });
+});
+
+describe("ResourceViewProvider context value updates", () => {
+  let provider: ResourceViewProvider;
+  let sandbox: sinon.SinonSandbox;
+  let setContextValueStub: sinon.SinonStub;
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    provider = ResourceViewProvider.getInstance();
+    setContextValueStub = sandbox.stub(contextValues, "setContextValue");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    ResourceViewProvider["instance"] = null;
+  });
+
+  it("getTreeItem() should update context values correctly when a direct environment has no resources", async () => {
+    const emptyDirectEnv = new DirectEnvironment({
+      ...TEST_DIRECT_ENVIRONMENT,
+      kafkaClusters: [],
+      schemaRegistry: undefined,
+    });
+    provider.environmentsMap.set(emptyDirectEnv.id, emptyDirectEnv);
+
+    await provider.getTreeItem(emptyDirectEnv);
+
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directKafkaClusterAvailable,
+        false,
+      ),
+    );
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directSchemaRegistryAvailable,
+        false,
+      ),
+    );
+  });
+
+  it("getTreeItem() should update context values correctly when a direct environment only has a Kafka cluster", async () => {
+    const kafkaOnlyDirectEnv = new DirectEnvironment({
+      ...TEST_DIRECT_ENVIRONMENT,
+      kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
+      schemaRegistry: undefined,
+    });
+    provider.environmentsMap.set(kafkaOnlyDirectEnv.id, kafkaOnlyDirectEnv);
+
+    await provider.getTreeItem(kafkaOnlyDirectEnv);
+
+    assert.ok(
+      setContextValueStub.calledWith(contextValues.ContextValues.directKafkaClusterAvailable, true),
+    );
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directSchemaRegistryAvailable,
+        false,
+      ),
+    );
+  });
+
+  it("getTreeItem() should update context values correctly when a direct environment only has a Schema Registry", async () => {
+    const srOnlyDirectEnv = new DirectEnvironment({
+      ...TEST_DIRECT_ENVIRONMENT,
+      kafkaClusters: [],
+      schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
+    });
+    provider.environmentsMap.set(srOnlyDirectEnv.id, srOnlyDirectEnv);
+
+    await provider.getTreeItem(srOnlyDirectEnv);
+
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directKafkaClusterAvailable,
+        false,
+      ),
+    );
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directSchemaRegistryAvailable,
+        true,
+      ),
+    );
+  });
+
+  it("getTreeItem() should handle multiple direct environments correctly when updating context values", async () => {
+    const env1 = new DirectEnvironment({
+      ...TEST_DIRECT_ENVIRONMENT,
+      id: "env1",
+      kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
+      schemaRegistry: undefined,
+    });
+    const env2 = new DirectEnvironment({
+      ...TEST_DIRECT_ENVIRONMENT,
+      id: "env2",
+      kafkaClusters: [],
+      schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
+    });
+
+    provider.environmentsMap.set(env1.id, env1);
+    provider.environmentsMap.set(env2.id, env2);
+
+    await provider.getTreeItem(env1);
+
+    // from env1
+    assert.ok(
+      setContextValueStub.calledWith(contextValues.ContextValues.directKafkaClusterAvailable, true),
+    );
+    // from env2
+    assert.ok(
+      setContextValueStub.calledWith(
+        contextValues.ContextValues.directSchemaRegistryAvailable,
+        true,
+      ),
+    );
+    // should not set `false` since env1 has a Kafka cluster
+    assert.ok(
+      setContextValueStub.neverCalledWith(
+        contextValues.ContextValues.directKafkaClusterAvailable,
+        false,
+      ),
+    );
+    // should not set `false` since env2 has a Schema Registry
+    assert.ok(
+      setContextValueStub.neverCalledWith(
+        contextValues.ContextValues.directSchemaRegistryAvailable,
+        false,
+      ),
+    );
   });
 });

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -56,36 +56,46 @@ describe("ResourceViewProvider methods", () => {
     ResourceViewProvider["instance"] = null;
   });
 
-  // TODO: add LocalEnvironment if/when we start showing that in the Resources view
-  for (const resource of [TEST_CCLOUD_ENVIRONMENT, TEST_DIRECT_ENVIRONMENT]) {
-    it(`getTreeItem() should return an EnvironmentTreeItem for a ${resource.constructor.name} instance`, () => {
-      const treeItem = provider.getTreeItem(resource);
+  for (const resource of [
+    TEST_CCLOUD_ENVIRONMENT,
+    TEST_LOCAL_ENVIRONMENT,
+    TEST_DIRECT_ENVIRONMENT,
+  ]) {
+    it(`getTreeItem() should return an EnvironmentTreeItem for a ${resource.constructor.name} instance`, async () => {
+      const treeItem = await provider.getTreeItem(resource);
       assert.ok(treeItem instanceof EnvironmentTreeItem);
     });
   }
 
-  it("getTreeItem() should return a KafkaClusterTreeItem for a LocalKafkaCluster instance", () => {
-    const treeItem = provider.getTreeItem(TEST_LOCAL_KAFKA_CLUSTER);
-    assert.ok(treeItem instanceof KafkaClusterTreeItem);
-  });
+  for (const cluster of [
+    TEST_CCLOUD_KAFKA_CLUSTER,
+    TEST_DIRECT_KAFKA_CLUSTER,
+    TEST_LOCAL_KAFKA_CLUSTER,
+  ]) {
+    it(`getTreeItem() should return a KafkaClusterTreeItem for a ${cluster.connectionType} Kafka cluster instance`, async () => {
+      const treeItem = await provider.getTreeItem(cluster);
+      assert.ok(treeItem instanceof KafkaClusterTreeItem);
+    });
+  }
 
-  it("getTreeItem() should return a KafkaClusterTreeItem for a CCloudKafkaCluster instance", () => {
-    const treeItem = provider.getTreeItem(TEST_CCLOUD_KAFKA_CLUSTER);
-    assert.ok(treeItem instanceof KafkaClusterTreeItem);
-  });
+  for (const registry of [
+    TEST_CCLOUD_SCHEMA_REGISTRY,
+    TEST_DIRECT_SCHEMA_REGISTRY,
+    TEST_LOCAL_SCHEMA_REGISTRY,
+  ]) {
+    it(`getTreeItem() should return a SchemaRegistryTreeItem for a ${registry.connectionType} Schema Registry instance`, async () => {
+      const treeItem = await provider.getTreeItem(registry);
+      assert.ok(treeItem instanceof SchemaRegistryTreeItem);
+    });
+  }
 
-  it("getTreeItem() should return a SchemaRegistryTreeItem for a SchemaRegistry instance", () => {
-    const treeItem = provider.getTreeItem(TEST_CCLOUD_SCHEMA_REGISTRY);
-    assert.ok(treeItem instanceof SchemaRegistryTreeItem);
-  });
-
-  it("getTreeItem() should pass ContainerTreeItems through directly", () => {
+  it("getTreeItem() should pass ContainerTreeItems through directly", async () => {
     const container = new ContainerTreeItem<CCloudEnvironment>(
       "test",
       TreeItemCollapsibleState.Collapsed,
       [TEST_CCLOUD_ENVIRONMENT],
     );
-    const treeItem = provider.getTreeItem(container);
+    const treeItem = await provider.getTreeItem(container);
     assert.deepStrictEqual(treeItem, container);
   });
 });

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -81,7 +81,7 @@ describe("ResourceViewProvider methods", () => {
     TEST_DIRECT_KAFKA_CLUSTER,
     TEST_LOCAL_KAFKA_CLUSTER,
   ]) {
-    it(`getTreeItem() should return a KafkaClusterTreeItem for a ${cluster.connectionType} Kafka cluster instance`, async () => {
+    it(`getTreeItem() should return a KafkaClusterTreeItem for a ${cluster.constructor.name} instance`, async () => {
       const treeItem = await provider.getTreeItem(cluster);
       assert.ok(treeItem instanceof KafkaClusterTreeItem);
     });
@@ -92,7 +92,7 @@ describe("ResourceViewProvider methods", () => {
     TEST_DIRECT_SCHEMA_REGISTRY,
     TEST_LOCAL_SCHEMA_REGISTRY,
   ]) {
-    it(`getTreeItem() should return a SchemaRegistryTreeItem for a ${registry.connectionType} Schema Registry instance`, async () => {
+    it(`getTreeItem() should return a SchemaRegistryTreeItem for a ${registry.constructor.name} instance`, async () => {
       const treeItem = await provider.getTreeItem(registry);
       assert.ok(treeItem instanceof SchemaRegistryTreeItem);
     });

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -455,7 +455,7 @@ export async function loadDirectResources(): Promise<DirectEnvironment[]> {
   // fetch all direct connections and their resources; each connection will be treated the same as a
   // CCloud environment (connection ID and environment ID are the same)
   const directEnvs = await getDirectResources();
-  logger.info(`got ${directEnvs.length} direct environment(s) from GQL query`);
+  logger.debug(`got ${directEnvs.length} direct environment(s) from GQL query`);
   return directEnvs;
 }
 

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -213,6 +213,8 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
     const directConnectionsChangedSub: vscode.Disposable = directConnectionsChanged.event(
       async () => {
         logger.debug("directConnectionsChanged event fired, refreshing");
+        // remove any unused environments from the environmentsMap before refreshing the tree so
+        // contextValue changes are accurately reflected in the UI
         await this.removeUnusedEnvironments();
         this.refresh();
       },


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #852.

We now have `confluent.directKafkaClusterAvailable` and `confluent.directSchemaRegistryAvailable` context values that will update when the direct "environments" update and load their respective resources:


https://github.com/user-attachments/assets/5b86d274-1fcb-4079-babb-6c688810d2c6



## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

This ended up being more involved than initially expected since we handle per-"environment" updates and don't have as convenient of a place to check whether direct connections have Kafka clusters and/or Schema Registries like we do after loading all CCloud or local resources.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
