### PR TITLE
MINOR: clean up Topics/Schemas empty states and add links for direct connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,7 +489,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "Not connected to Confluent Cloud. Click below to get started.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Schema Registry locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nAlternatively, [start Schema Registry locally ](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
@@ -504,7 +504,7 @@
       },
       {
         "view": "confluent-topics",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nOr start Kafka locally with Docker.\n[Start Local Resources](command:confluent.docker.startLocalResources)",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nAlternatively, [start Kafka locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Kafka cluster.",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)"
       },
       {
@@ -683,7 +683,7 @@
         },
         {
           "command": "confluent.resources.schema-registry.select",
-          "when": "view == confluent-schemas",
+          "when": "view == confluent-schemas && (confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)",
           "group": "navigation@3"
         },
         {
@@ -703,7 +703,7 @@
         },
         {
           "command": "confluent.resources.kafka-cluster.select",
-          "when": "view == confluent-topics",
+          "when": "view == confluent-topics && (confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.localSchemaRegistryAvailable)",
           "group": "navigation@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -489,7 +489,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nAlternatively, [start Schema Registry locally ](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nAlternatively, [start Schema Registry locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
@@ -703,7 +703,7 @@
         },
         {
           "command": "confluent.resources.kafka-cluster.select",
-          "when": "view == confluent-topics && (confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.localSchemaRegistryAvailable)",
+          "when": "view == confluent-topics && (confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)",
           "group": "navigation@2"
         },
         {


### PR DESCRIPTION
## Summary

- Adds links for connecting directly to Kafka (for the Topics view) and Schema Registry (for the Schemas view) which will just open the direct connection form.
- Updates the `when` clauses for selecting Kafka/SR to only be available when we have at least one available (whether signed into CCloud, or a local instance is running, or a direct connected resource is available)
- Changes the Schemas view to use `No connections available.` above the CCloud button to match the Topics view

## Topics view

| Before | After |
|--------|--------|
| <img width="372" alt="image" src="https://github.com/user-attachments/assets/f4072e3f-153b-4657-88a7-54af0a9de72d" /> | <img width="369" alt="image" src="https://github.com/user-attachments/assets/8cf0cc5d-05a8-4dce-91f2-04c7224e61e2" /> | 

## Schemas view

| Before | After |
|--------|--------|
| <img width="367" alt="image" src="https://github.com/user-attachments/assets/89b4bb6f-8da6-421d-b430-40d95b49db60" /> | <img width="369" alt="image" src="https://github.com/user-attachments/assets/ae80e2f0-12ba-4fde-8fc7-e90b1df95088" /> | 


