### PR TITLE
guard against non-KafkaTopics being passed through "delete topic" command logic

### DIFF
--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -36,6 +36,9 @@ async function selectKafkaClusterCommand(cluster?: KafkaCluster) {
 }
 
 async function deleteTopicCommand(topic: KafkaTopic) {
+  if (!(topic instanceof KafkaTopic)) {
+    return;
+  }
   // We won't have even gotten here if we didn't think the user has DELETE permissions on the topic.
   // BUT that was at the time we fetched the topic list, so we should check again before proceeding.
   const authorizedOperations = await fetchTopicAuthorizedOperations(topic);


### PR DESCRIPTION
Closes #771. 

No idea how we could even get here; I've only seen the above issue's behavior when clicking a view's nav/context actions when something else was highlighted.

Still, good practice to guard against unintended types coming through when we expect a command function argument.