### PR TITLE
use `logResponseError` for response errors from preferences API

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,7 +42,7 @@ export async function logResponseError(
       status: error.response.status,
       statusText: error.response.statusText,
       body: errorBody.slice(0, 5000), // limit to 5000 characters
-      errorType: error.constructor.name,
+      errorType: error.name,
     };
     responseStatusCode = error.response.status;
   } else {


### PR DESCRIPTION
Closes #619.

Also fixes the `errorType` since the error names were getting minified.

Sample error data:
<img width="394" alt="image" src="https://github.com/user-attachments/assets/a5eaa254-7845-4d02-8e9c-ff69466e816b" />
