### PR TITLE
feat: allow producing messages to a Kafka topic from an editor or message viewer document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Producing messages to a Kafka topic has been expanded to allow loading content from an unsaved
+  editor or Message Viewer preview tab.
+
 ### Changed
-- React to websocket events pushed from sidecar instead of polling for some connection change monitoring.
+
+- React to websocket events pushed from sidecar instead of polling for some connection change
+  monitoring.
 
 ## 0.23.3
 

--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
         "enablement": "false"
       },
       {
-        "command": "confluent.topic.produce.fromFile",
+        "command": "confluent.topic.produce.fromDocument",
         "title": "Produce Message to Kafka Topic from schemaless JSON file",
         "icon": "$(send)",
         "category": "Confluent: Topic"
@@ -545,7 +545,7 @@
           "when": "false"
         },
         {
-          "command": "confluent.topic.produce.fromFile",
+          "command": "confluent.topic.produce.fromDocument",
           "when": "false"
         },
         {
@@ -879,7 +879,7 @@
           "group": "4_copy@3"
         },
         {
-          "command": "confluent.topic.produce.fromFile",
+          "command": "confluent.topic.produce.fromDocument",
           "when": "view == confluent-topics && viewItem =~ /.*-topic.*-authzWRITE.*/ && confluent.produceMessagesEnabled",
           "group": "inline@1"
         },

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -1,0 +1,204 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import {
+  TEST_CCLOUD_KAFKA_TOPIC,
+  TEST_DIRECT_KAFKA_TOPIC,
+  TEST_LOCAL_KAFKA_TOPIC,
+} from "../../tests/unit/testResources";
+import { TEST_DIRECT_CONNECTION_FORM_SPEC } from "../../tests/unit/testResources/connection";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
+import { RecordsV3Api, ResponseError } from "../clients/kafkaRest";
+import * as quickpicks from "../quickpicks/uris";
+import * as sidecar from "../sidecar";
+import { CustomConnectionSpec, getResourceManager } from "../storage/resourceManager";
+import { createProduceRequestData, produceMessageFromDocument } from "./topics";
+
+const fakeMessage = {
+  key: "test-key",
+  value: "test-value",
+  headers: [{ key: "test-header", value: "test-header-value" }],
+};
+
+describe("commands/topics.ts produceMessageFromDocument()", function () {
+  let sandbox: sinon.SinonSandbox;
+  let showErrorMessageStub: sinon.SinonStub;
+  let uriQuickpickStub: sinon.SinonStub;
+  let loadDocumentContentStub: sinon.SinonStub;
+  let clientStub: sinon.SinonStubbedInstance<RecordsV3Api>;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+
+    showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
+
+    // stub the quickpick for file/editor URI and the resulting content
+    uriQuickpickStub = sandbox
+      .stub(quickpicks, "uriQuickpick")
+      .resolves(vscode.Uri.file("test.json"));
+    loadDocumentContentStub = sandbox
+      .stub(quickpicks, "loadDocumentContent")
+      .resolves({ content: JSON.stringify(fakeMessage) });
+
+    // create the stubs for the sidecar + service client
+    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
+      sandbox.createStubInstance(sidecar.SidecarHandle);
+    clientStub = sandbox.createStubInstance(RecordsV3Api);
+    mockSidecarHandle.getRecordsV3Api.returns(clientStub);
+    // stub the getSidecar function to return the mock sidecar handle
+    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should show an error notification if no topic is provided", async function () {
+    // shouldn't be possible based on the package.json configs, but just in case
+    await produceMessageFromDocument(null as any);
+
+    assert.ok(showErrorMessageStub.calledOnceWith("No topic selected."));
+  });
+
+  it("should exit early if no file/editor is selected from the URI quickpick", async function () {
+    uriQuickpickStub.resolves(undefined);
+
+    // using local so we don't need to deal with the `type` lookups in `createProduceRequestData`;
+    // see tests in suite below
+    await produceMessageFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.ok(showErrorMessageStub.notCalled);
+  });
+
+  it("should show an error notification for an invalid JSON message", async function () {
+    loadDocumentContentStub.resolves({ content: "{}" });
+
+    await produceMessageFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.ok(showErrorMessageStub.calledOnceWith("Message must have a key, value, and headers."));
+  });
+
+  it("should show a success (info) notification after valid produce response", async function () {
+    clientStub.produceRecord.resolves({
+      error_code: 200,
+      timestamp: new Date(),
+      partition_id: 0,
+    });
+    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
+
+    await produceMessageFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.ok(clientStub.produceRecord.calledOnce);
+    assert.ok(showInfoStub.calledOnce);
+    assert.ok(showErrorMessageStub.notCalled);
+  });
+
+  it("should show an error notification for any ResponseErrors", async function () {
+    clientStub.produceRecord.rejects(
+      new ResponseError(
+        new Response("", {
+          status: 400,
+          statusText: "Bad Request",
+        }),
+      ),
+    );
+
+    await produceMessageFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.ok(showErrorMessageStub.calledOnce);
+    const errorMsg = showErrorMessageStub.firstCall.args[0];
+    assert.ok(errorMsg.startsWith("Error response while trying to produce message"));
+  });
+
+  it("should show an error notification for any nested error_code>=400 responses", async function () {
+    // response will show status 200, but the error is nested in the response body
+    clientStub.produceRecord.resolves({
+      error_code: 422,
+      message: "uh oh",
+      timestamp: new Date(),
+      partition_id: 0,
+    });
+
+    await produceMessageFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.ok(showErrorMessageStub.calledOnce);
+    const errorMsg = showErrorMessageStub.firstCall.args[0];
+    assert.ok(errorMsg.startsWith("Error response while trying to produce message"));
+  });
+});
+
+describe("commands/topics.ts createProduceRequestData()", function () {
+  let sandbox: sinon.SinonSandbox;
+  let getDirectConnectionStub: sinon.SinonStub;
+
+  before(async function () {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+
+    getDirectConnectionStub = sandbox.stub(getResourceManager(), "getDirectConnection");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should create request data with 'type' set for CCloud topics", async function () {
+    const result = await createProduceRequestData(
+      TEST_CCLOUD_KAFKA_TOPIC,
+      "test-key",
+      "test-value",
+    );
+
+    assert.deepStrictEqual(result, {
+      keyData: {
+        type: "JSON",
+        data: "test-key",
+      },
+      valueData: {
+        type: "JSON",
+        data: "test-value",
+      },
+    });
+  });
+
+  it("should create request data without 'type' for local topics", async function () {
+    const result = await createProduceRequestData(TEST_LOCAL_KAFKA_TOPIC, "test-key", "test-value");
+
+    assert.deepStrictEqual(result, {
+      keyData: {
+        data: "test-key",
+      },
+      valueData: {
+        data: "test-value",
+      },
+    });
+  });
+
+  it("should create request data with 'type' set for direct connections with the 'Confluent Cloud' form type", async function () {
+    const fakeSpec: CustomConnectionSpec = {
+      ...TEST_DIRECT_CONNECTION_FORM_SPEC,
+      formConnectionType: "Confluent Cloud",
+    };
+    getDirectConnectionStub.resolves(fakeSpec);
+
+    const result = await createProduceRequestData(
+      TEST_DIRECT_KAFKA_TOPIC,
+      "test-key",
+      "test-value",
+    );
+
+    assert.deepStrictEqual(result, {
+      keyData: {
+        type: "JSON",
+        data: "test-key",
+      },
+      valueData: {
+        type: "JSON",
+        data: "test-value",
+      },
+    });
+  });
+});

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -95,3 +95,32 @@ export async function uriQuickpick(
     return uri ? uri[0] : undefined;
   }
 }
+
+/** Representation of content retrieved from a file or editor. `openDocument` will be provided if
+ * the content came from an open editor, or if the associated file is open in an editor for the
+ * current workspace. */
+export interface LoadedDocumentContent {
+  content: string;
+  openDocument?: TextDocument;
+}
+
+/** Load the content of a document, either from an open editor or directly from the file system. */
+export async function loadDocumentContent(uri: Uri): Promise<LoadedDocumentContent> {
+  let content: string | undefined;
+  let document: TextDocument | undefined;
+  if (uri.scheme === "file") {
+    // file may not be open/visible, so read it directly
+    const contentArray: Uint8Array = await workspace.fs.readFile(uri);
+    content = Buffer.from(contentArray).toString("utf-8");
+    // check if the file is already open in an editor
+    document = workspace.textDocuments.find(
+      (doc: TextDocument) => doc.uri.toString() === uri.toString(),
+    );
+  } else {
+    // "untitled" and custom URI schemes are treated the same way since they aren't saved to
+    // the file system and are always open in an editor if they were chosen through the quickpick
+    document = await workspace.openTextDocument(uri);
+    content = document.getText();
+  }
+  return { openDocument: document, content: content };
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #763, closes #764, closes #910.

**If any editors or read-only documents are open in the current workspace**, instead of showing the open-file dialog for producing a message to a topic, we're now showing the same "URI quickpick" that we use for schema upload actions, which means any `.json` files/documents or `JSON`-language editors can be used to produce a message:
![image](https://github.com/user-attachments/assets/869e16bc-4c8f-4dd8-aef0-0972384d42bd)

So a user can now effectively re-produce a message that was opened as a message viewer preview (https://github.com/confluentinc/vscode/pull/799), or one they were working on in a new editor (but didn't save to a file on disk).

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Also closes #910 by adding some placeholder `type: "JSON"` values where we'll need to look up other schema-related information in follow-up PRs while simultaneously making sure we float any nested `error_code: >=400` scenarios even if we get a `status: 200` back from the sidecar proxied request.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
