### PR TITLE
hint to extension Support commands for logs in GH issue template [ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,7 +68,8 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: |
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks. (You can also download extension or sidecar logs from the extension's "Confluent: Support: Save Logs" and "Confluent: Support: Save Sidecar Logs" commands, respectively.)
       render: shell
   - type: dropdown
     attributes:


### PR DESCRIPTION
Closes #628.

We offer commands in the extension to download the full log file(s) for the extension and the sidecar, and we should hint at that when a user is filing an issue for this repo.
<img width="401" alt="image" src="https://github.com/user-attachments/assets/dc141922-41c2-43da-bb5a-c1a6ddaff43c" />
