### PR TITLE
cleanup(testing): swap most workspace config `callsFake` references for `withArgs`

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -129,9 +129,7 @@ describe("authz.schemaRegistry", function () {
   // showNoSchemaAccessWarningNotification() tests
   it("showNoSchemaAccessWarningNotification() should show warning if warnings are enabled", function () {
     const mockConfig = {
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === SCHEMA_RBAC_WARNINGS_ENABLED) return true;
-      }),
+      get: sandbox.stub().withArgs(SCHEMA_RBAC_WARNINGS_ENABLED).returns(true),
     };
     getConfigurationStub.returns(mockConfig);
 
@@ -142,9 +140,7 @@ describe("authz.schemaRegistry", function () {
 
   it("showNoSchemaAccessWarningNotification() should not show warning if warnings are disabled", function () {
     const mockConfig = {
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === SCHEMA_RBAC_WARNINGS_ENABLED) return false;
-      }),
+      get: sandbox.stub().withArgs(SCHEMA_RBAC_WARNINGS_ENABLED).returns(false),
     };
     getConfigurationStub.returns(mockConfig);
 

--- a/src/commands/connections.test.ts
+++ b/src/commands/connections.test.ts
@@ -98,9 +98,7 @@ describe("commands/connections.ts", function () {
 
   it("getSSLPemPaths() should return paths if they exists in the config", function () {
     const mockConfig = {
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === SSL_PEM_PATHS) return ["path/to/file.pem"];
-      }),
+      get: sandbox.stub().withArgs(SSL_PEM_PATHS).returns(["path/to/file.pem"]),
     };
     getConfigurationStub.returns(mockConfig);
 
@@ -111,9 +109,7 @@ describe("commands/connections.ts", function () {
 
   it("getSSLPemPaths() should return an empty array if the path is an empty array", function () {
     const emptyStringConfig = {
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === SSL_PEM_PATHS) return [];
-      }),
+      get: sandbox.stub().withArgs(SSL_PEM_PATHS).returns([]),
     };
     getConfigurationStub.returns(emptyStringConfig);
 
@@ -124,9 +120,7 @@ describe("commands/connections.ts", function () {
 
   it("getSSLPemPaths() should return an empty array if the path is not set", function () {
     const nullConfig = {
-      get: sandbox.stub().callsFake((key: string, defaultValue?: unknown) => {
-        if (key === SSL_PEM_PATHS) return defaultValue;
-      }),
+      get: sandbox.stub().withArgs(SSL_PEM_PATHS, []).returns([]),
     };
     getConfigurationStub.returns(nullConfig);
 
@@ -137,9 +131,7 @@ describe("commands/connections.ts", function () {
 
   it("getSSLPemPaths() should only return valid .pem paths and not other string values", function () {
     const mixedConfig = {
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === SSL_PEM_PATHS) return ["path/to/file.pem", "invalid/path", ""];
-      }),
+      get: sandbox.stub().withArgs(SSL_PEM_PATHS).returns(["path/to/file.pem", "invalid/path", ""]),
     };
     getConfigurationStub.returns(mixedConfig);
 

--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -42,9 +42,7 @@ describe("docker/configs functions", function () {
 
   it("getSocketPath() should return socket path from user settings", function () {
     const getConfigStub = sandbox.stub(workspace, "getConfiguration").returns({
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === LOCAL_DOCKER_SOCKET_PATH) return "/custom/path/docker.sock";
-      }),
+      get: sandbox.stub().withArgs(LOCAL_DOCKER_SOCKET_PATH).returns("/custom/path/docker.sock"),
     } as any);
 
     const path: string = configs.getSocketPath();

--- a/src/docker/workflows/confluent-local.test.ts
+++ b/src/docker/workflows/confluent-local.test.ts
@@ -60,12 +60,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
     // this should probably live in a separate test helper file
     getConfigurationStub = sandbox.stub(workspace, "getConfiguration");
     getConfigurationStub.returns({
-      get: sandbox.stub().callsFake((key: string) => {
-        switch (key) {
-          case LOCAL_DOCKER_SOCKET_PATH:
-            return DEFAULT_UNIX_SOCKET_PATH;
-        }
-      }),
+      get: sandbox.stub().withArgs(LOCAL_DOCKER_SOCKET_PATH).returns(DEFAULT_UNIX_SOCKET_PATH),
     });
 
     // assume no running containers matching this workflow image for most tests

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -73,17 +73,14 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     executeCommandStub = sandbox.stub(commands, "executeCommand").resolves();
     // this should probably live in a separate test helper file
     getConfigurationStub = sandbox.stub(workspace, "getConfiguration");
+    const configMap = {
+      [LOCAL_KAFKA_IMAGE]: DEFAULT_KAFKA_IMAGE_REPO,
+      [LOCAL_KAFKA_IMAGE_TAG]: DEFAULT_KAFKA_IMAGE_TAG,
+      [LOCAL_DOCKER_SOCKET_PATH]: DEFAULT_UNIX_SOCKET_PATH,
+      // add others as needed
+    };
     getConfigurationStub.returns({
-      get: sandbox.stub().callsFake((key: string) => {
-        switch (key) {
-          case LOCAL_KAFKA_IMAGE:
-            return DEFAULT_KAFKA_IMAGE_REPO;
-          case LOCAL_KAFKA_IMAGE_TAG:
-            return DEFAULT_KAFKA_IMAGE_TAG;
-          case LOCAL_DOCKER_SOCKET_PATH:
-            return DEFAULT_UNIX_SOCKET_PATH;
-        }
-      }),
+      get: sandbox.stub().callsFake((arg) => configMap[arg]),
     });
 
     // assume no running containers matching this workflow image for most tests

--- a/src/docker/workflows/index.test.ts
+++ b/src/docker/workflows/index.test.ts
@@ -26,9 +26,7 @@ describe("docker/workflows/index.ts", () => {
   it(`getKafkaWorkflow() should show an error notification and throw an error if no workflow matches the "${LOCAL_KAFKA_IMAGE}" config`, async () => {
     const unsupportedImageRepo = "unsupported/image-name";
     getConfigurationStub.returns({
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === LOCAL_KAFKA_IMAGE) return unsupportedImageRepo;
-      }),
+      get: sandbox.stub().withArgs(LOCAL_KAFKA_IMAGE).returns(unsupportedImageRepo),
     });
 
     assert.throws(
@@ -40,9 +38,7 @@ describe("docker/workflows/index.ts", () => {
 
   it(`getKafkaWorkflow() should return a ConfluentLocalWorkflow instance for the correct "${LOCAL_KAFKA_IMAGE}" config`, async () => {
     getConfigurationStub.returns({
-      get: sandbox.stub().callsFake((key: string) => {
-        if (key === LOCAL_KAFKA_IMAGE) return ConfluentLocalWorkflow.imageRepo;
-      }),
+      get: sandbox.stub().withArgs(LOCAL_KAFKA_IMAGE).returns(ConfluentLocalWorkflow.imageRepo),
     });
 
     const workflow = getKafkaWorkflow();


### PR DESCRIPTION
Closes #656.

We had some mixed use between `callsFake` and `withArgs`, and generally, for workspace config-related testing, `withArgs` does the trick just fine.