### PR TITLE
Avoid building source maps in production mode

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,7 +6,7 @@ src/**
 vsc-extension-quickstart.md
 **/tsconfig.json
 **/.eslintrc.json
-**/*.map
+*.map
 **/*.ts
 **/.vscode-test.*
 **/*.tmp

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -142,7 +142,7 @@ export function build(done) {
   const extOutput = {
     dir: DESTINATION,
     format: "cjs",
-    sourcemap: true,
+    sourcemap: !production,
     sourcemapBaseUrl: `file://${process.cwd()}/${DESTINATION}/`,
     exports: "named",
   };


### PR DESCRIPTION
Currently we build source map for extension code in both dev and production modes which adds extra 6MB+ to the bundle size (at least uncompressed). We don't need to ship those source maps since we upload them separately to Sentry.
