### PR TITLE
More tests, cleanup for direct connect form

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from "crypto";
 import { ViewColumn, window } from "vscode";
-import { AuthErrors, ConnectedState, Connection, ConnectionType } from "./clients/sidecar";
+import {
+  AuthErrors,
+  ConnectedState,
+  Connection,
+  ConnectionType,
+  instanceOfApiKeyAndSecret,
+  instanceOfBasicCredentials,
+} from "./clients/sidecar";
 import { DirectConnectionManager } from "./directConnectManager";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
@@ -208,26 +215,18 @@ export function parseTestResult(connection: Connection): TestResponse {
 function cleanSpec(connection: CustomConnectionSpec): CustomConnectionSpec {
   const clean = { ...connection };
   if (clean.kafka_cluster?.credentials) {
-    // @ts-expect-error the types don't know which credentials are present
-    if (clean.kafka_cluster.credentials.password) {
-      // @ts-expect-error the types don't know which credentials are present
+    if (instanceOfBasicCredentials(clean.kafka_cluster.credentials)) {
       clean.kafka_cluster.credentials.password = "fakeplaceholdersecrethere";
     }
-    // @ts-expect-error the types don't know which credentials are present
-    if (clean.kafka_cluster.credentials.api_secret) {
-      // @ts-expect-error the types don't know which credentials are present
+    if (instanceOfApiKeyAndSecret(clean.kafka_cluster.credentials)) {
       clean.kafka_cluster.credentials.api_secret = "fakeplaceholdersecrethere";
     }
   }
   if (clean.schema_registry?.credentials) {
-    // @ts-expect-error the types don't know which credentials are present
-    if (clean.schema_registry.credentials.password) {
-      // @ts-expect-error the types don't know which credentials are present
+    if (instanceOfBasicCredentials(clean.schema_registry.credentials)) {
       clean.schema_registry.credentials.password = "fakeplaceholdersecrethere";
     }
-    // @ts-expect-error the types don't know which credentials are present
-    if (clean.schema_registry.credentials.api_secret) {
-      // @ts-expect-error the types don't know which credentials are present
+    if (instanceOfApiKeyAndSecret(clean.schema_registry.credentials)) {
       clean.schema_registry.credentials.api_secret = "fakeplaceholdersecrethere";
     }
   }

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -58,44 +58,6 @@ const BASIC_AUTH_SPEC: ConnectionSpec = {
   },
 };
 
-const NEW_BASIC_AUTH_SPEC: CustomConnectionSpec = {
-  id: BASIC_AUTH_SPEC.id as ConnectionId,
-  formConnectionType: "Apache Kafka",
-  kafka_cluster: {
-    bootstrap_servers: "bootstrapServers",
-    credentials: {
-      username: "newusername",
-      password: "fakeplaceholdersecrethere",
-    },
-  },
-  schema_registry: {
-    uri: "srUri",
-    credentials: {
-      username: "newusername",
-      password: "fakeplaceholdersecrethere",
-    },
-  },
-};
-
-const PASSWORD_UPDATE_BASIC_AUTH_SPEC: CustomConnectionSpec = {
-  id: BASIC_AUTH_SPEC.id as ConnectionId,
-  formConnectionType: "Apache Kafka",
-  kafka_cluster: {
-    bootstrap_servers: "bootstrapServers",
-    credentials: {
-      username: "username",
-      password: "newPassword",
-    },
-  },
-  schema_registry: {
-    uri: "srUri",
-    credentials: {
-      username: "username",
-      password: "newPassword",
-    },
-  },
-};
-
 const API_AUTH_SPEC: ConnectionSpec = {
   ...TEST_DIRECT_CONNECTION.spec,
   kafka_cluster: {
@@ -110,44 +72,6 @@ const API_AUTH_SPEC: ConnectionSpec = {
     credentials: {
       api_key: "apiKey  ",
       api_secret: "actualApiSecret",
-    },
-  },
-};
-
-const NEW_API_AUTH_SPEC: CustomConnectionSpec = {
-  id: API_AUTH_SPEC.id as ConnectionId,
-  formConnectionType: "Apache Kafka",
-  kafka_cluster: {
-    bootstrap_servers: "bootstrapServers",
-    credentials: {
-      api_key: "newKey",
-      api_secret: "fakeplaceholdersecrethere",
-    },
-  },
-  schema_registry: {
-    uri: "srUri",
-    credentials: {
-      api_key: "newKey",
-      api_secret: "fakeplaceholdersecrethere",
-    },
-  },
-};
-
-const PASSWORD_UPDATE_API_AUTH_SPEC: CustomConnectionSpec = {
-  id: API_AUTH_SPEC.id as ConnectionId,
-  formConnectionType: "Apache Kafka",
-  kafka_cluster: {
-    bootstrap_servers: "bootstrapServers",
-    credentials: {
-      api_key: "apiKey",
-      api_secret: "newApiSecret",
-    },
-  },
-  schema_registry: {
-    uri: "srUri",
-    credentials: {
-      api_key: "apiKey",
-      api_secret: "newApiSecret",
     },
   },
 };
@@ -379,7 +303,25 @@ describe("DirectConnectionManager behavior", () => {
 
 describe("mergeSecrets", () => {
   it("should replace placeholder basic auth passwords with current password", () => {
-    const result = mergeSecrets(BASIC_AUTH_SPEC, NEW_BASIC_AUTH_SPEC);
+    const newBasicAuthSpec: CustomConnectionSpec = {
+      id: BASIC_AUTH_SPEC.id as ConnectionId,
+      formConnectionType: "Apache Kafka",
+      kafka_cluster: {
+        bootstrap_servers: "bootstrapServers",
+        credentials: {
+          username: "newusername",
+          password: "fakeplaceholdersecrethere",
+        },
+      },
+      schema_registry: {
+        uri: "srUri",
+        credentials: {
+          username: "newusername",
+          password: "fakeplaceholdersecrethere",
+        },
+      },
+    };
+    const result = mergeSecrets(BASIC_AUTH_SPEC, newBasicAuthSpec);
     const finalKafkaPassword = (result.kafka_cluster?.credentials as any)?.password;
     assert.equal(finalKafkaPassword, "actualPassword");
     const finalSchemaPassword = (result.schema_registry?.credentials as any)?.password;
@@ -387,7 +329,25 @@ describe("mergeSecrets", () => {
   });
 
   it("should replace api_secret placeholders with current api_secrets", () => {
-    const result = mergeSecrets(API_AUTH_SPEC, NEW_API_AUTH_SPEC);
+    const newApiAuthSpec: CustomConnectionSpec = {
+      id: API_AUTH_SPEC.id as ConnectionId,
+      formConnectionType: "Apache Kafka",
+      kafka_cluster: {
+        bootstrap_servers: "bootstrapServers",
+        credentials: {
+          api_key: "newKey",
+          api_secret: "fakeplaceholdersecrethere",
+        },
+      },
+      schema_registry: {
+        uri: "srUri",
+        credentials: {
+          api_key: "newKey",
+          api_secret: "fakeplaceholdersecrethere",
+        },
+      },
+    };
+    const result = mergeSecrets(API_AUTH_SPEC, newApiAuthSpec);
     const finalKafkaSecret = (result.kafka_cluster?.credentials as any)?.api_secret;
     assert.equal(finalKafkaSecret, "actualApiSecret");
     const finalSchemaSecret = (result.schema_registry?.credentials as any)?.api_secret;
@@ -395,7 +355,25 @@ describe("mergeSecrets", () => {
   });
 
   it("should not replace basic auth passwords if they are not a placeholder", () => {
-    const result = mergeSecrets(BASIC_AUTH_SPEC, PASSWORD_UPDATE_BASIC_AUTH_SPEC);
+    const updatePasswordBasicSpec: CustomConnectionSpec = {
+      id: BASIC_AUTH_SPEC.id as ConnectionId,
+      formConnectionType: "Apache Kafka",
+      kafka_cluster: {
+        bootstrap_servers: "bootstrapServers",
+        credentials: {
+          username: "username",
+          password: "newPassword",
+        },
+      },
+      schema_registry: {
+        uri: "srUri",
+        credentials: {
+          username: "username",
+          password: "newPassword",
+        },
+      },
+    };
+    const result = mergeSecrets(BASIC_AUTH_SPEC, updatePasswordBasicSpec);
     const finalKafkaPassword = (result.kafka_cluster?.credentials as any)?.password;
     assert.equal(finalKafkaPassword, "newPassword");
     const finalSchemaPassword = (result.schema_registry?.credentials as any)?.password;
@@ -403,7 +381,25 @@ describe("mergeSecrets", () => {
   });
 
   it("should not replace api_secrets if they are not a placeholder", () => {
-    const result = mergeSecrets(API_AUTH_SPEC, PASSWORD_UPDATE_API_AUTH_SPEC);
+    const updateSecretApiSpec: CustomConnectionSpec = {
+      id: API_AUTH_SPEC.id as ConnectionId,
+      formConnectionType: "Apache Kafka",
+      kafka_cluster: {
+        bootstrap_servers: "bootstrapServers",
+        credentials: {
+          api_key: "apiKey",
+          api_secret: "newApiSecret",
+        },
+      },
+      schema_registry: {
+        uri: "srUri",
+        credentials: {
+          api_key: "apiKey",
+          api_secret: "newApiSecret",
+        },
+      },
+    };
+    const result = mergeSecrets(API_AUTH_SPEC, updateSecretApiSpec);
     const finalKafkaSecret = (result.kafka_cluster?.credentials as any)?.api_secret;
     assert.equal(finalKafkaSecret, "newApiSecret");
     const finalSchemaSecret = (result.schema_registry?.credentials as any)?.api_secret;

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -6,6 +6,8 @@ import {
   ConnectionSpec,
   ConnectionsResourceApi,
   ConnectionType,
+  instanceOfApiKeyAndSecret,
+  instanceOfBasicCredentials,
   ResponseError,
 } from "./clients/sidecar";
 import { getExtensionContext } from "./context/extension";
@@ -305,7 +307,7 @@ export class DirectConnectionManager {
     }
   }
 }
-function mergeSecrets(
+export function mergeSecrets(
   currentSpec: ConnectionSpec,
   incomingSpec: CustomConnectionSpec,
 ): ConnectionSpec {
@@ -313,12 +315,14 @@ function mergeSecrets(
   const currentKafkaCreds = currentSpec.kafka_cluster?.credentials;
   // if there are kafka credentials we need to check/replace the secrets
   if (incomingKafkaCreds) {
-    if ("password" in incomingKafkaCreds) {
+    if (instanceOfBasicCredentials(incomingKafkaCreds)) {
       if (incomingKafkaCreds.password === "fakeplaceholdersecrethere") {
-        // @ts-expect-error the types don't know which credentials are present
-        incomingKafkaCreds.password = currentKafkaCreds.password;
+        // FIXME what happens if they change the type of credentials?
+        if (currentKafkaCreds && instanceOfBasicCredentials(currentKafkaCreds)) {
+          incomingKafkaCreds.password = currentKafkaCreds.password;
+        }
       }
-    } else if ("api_secret" in incomingKafkaCreds) {
+    } else if (instanceOfApiKeyAndSecret(incomingKafkaCreds)) {
       if (incomingKafkaCreds.api_secret === "fakeplaceholdersecrethere") {
         // @ts-expect-error the types don't know which credentials are present
         incomingKafkaCreds.api_secret = currentKafkaCreds.api_secret;
@@ -329,12 +333,12 @@ function mergeSecrets(
   const incomingSchemaCreds = incomingSpec.schema_registry?.credentials;
   const currentSchemaCreds = currentSpec.schema_registry?.credentials;
   if (incomingSchemaCreds) {
-    if ("password" in incomingSchemaCreds) {
+    if (instanceOfBasicCredentials(incomingSchemaCreds)) {
       if (incomingSchemaCreds.password === "fakeplaceholdersecrethere") {
         // @ts-expect-error the types don't know which credentials are present
         incomingSchemaCreds.password = currentSchemaCreds.password;
       }
-    } else if ("api_secret" in incomingSchemaCreds) {
+    } else if (instanceOfApiKeyAndSecret(incomingSchemaCreds)) {
       if (incomingSchemaCreds.api_secret === "fakeplaceholdersecrethere") {
         // @ts-expect-error the types don't know which credentials are present
         incomingSchemaCreds.api_secret = currentSchemaCreds.api_secret;

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -317,15 +317,14 @@ export function mergeSecrets(
   if (incomingKafkaCreds) {
     if (instanceOfBasicCredentials(incomingKafkaCreds)) {
       if (incomingKafkaCreds.password === "fakeplaceholdersecrethere") {
-        // FIXME what happens if they change the type of credentials?
         if (currentKafkaCreds && instanceOfBasicCredentials(currentKafkaCreds)) {
           incomingKafkaCreds.password = currentKafkaCreds.password;
         }
       }
     } else if (instanceOfApiKeyAndSecret(incomingKafkaCreds)) {
       if (incomingKafkaCreds.api_secret === "fakeplaceholdersecrethere") {
-        // @ts-expect-error the types don't know which credentials are present
-        incomingKafkaCreds.api_secret = currentKafkaCreds.api_secret;
+        if (currentKafkaCreds && instanceOfApiKeyAndSecret(currentKafkaCreds))
+          incomingKafkaCreds.api_secret = currentKafkaCreds.api_secret;
       }
     }
   }
@@ -335,13 +334,13 @@ export function mergeSecrets(
   if (incomingSchemaCreds) {
     if (instanceOfBasicCredentials(incomingSchemaCreds)) {
       if (incomingSchemaCreds.password === "fakeplaceholdersecrethere") {
-        // @ts-expect-error the types don't know which credentials are present
-        incomingSchemaCreds.password = currentSchemaCreds.password;
+        if (currentSchemaCreds && instanceOfBasicCredentials(currentSchemaCreds))
+          incomingSchemaCreds.password = currentSchemaCreds.password;
       }
     } else if (instanceOfApiKeyAndSecret(incomingSchemaCreds)) {
       if (incomingSchemaCreds.api_secret === "fakeplaceholdersecrethere") {
-        // @ts-expect-error the types don't know which credentials are present
-        incomingSchemaCreds.api_secret = currentSchemaCreds.api_secret;
+        if (currentSchemaCreds && instanceOfApiKeyAndSecret(currentSchemaCreds))
+          incomingSchemaCreds.api_secret = currentSchemaCreds.api_secret;
       }
     }
   }

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -5,7 +5,6 @@ import esbuild from "rollup-plugin-esbuild";
 import virtual from "@rollup/plugin-virtual";
 import alias from "@rollup/plugin-alias";
 import { SinonStub } from "sinon";
-// import { TemplateManifest } from "../clients/sidecar";
 import { createFilter } from "@rollup/pluginutils";
 import { Plugin } from "rollup";
 

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -22,7 +22,6 @@ class DirectConnectFormViewModel extends ViewModel {
   /** Load connection spec if it exists (for Edit) */
   spec = this.resolve(async () => {
     const fromHost = await post("GetConnectionSpec", {});
-    console.log("GetConnectionSpec", fromHost);
     return fromHost;
   }, null);
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Backfills unit tests for `mergeSecrets` 
- Updates some checks so that we don't have to `@ts-expect-error` all over the place as much
- Adds basic functional (Playwright) tests to confirm form renders, submits in happy case

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Still a few `@ts-expect-error` comments in the form `ts` - it's proving hard to check these types include or are instances of the credential objects in this file where they are are actually `inertial` Signals under the hood. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [X] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
