### PR TITLE
set `kafkaConfigured` and `schemaRegistryConfigured` to inform direct connection icon+tooltip

### DIFF
--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -48,6 +48,7 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
     // look up the connectionId:spec map from storage
     const directConnectionMap: DirectConnectionsById =
       await getResourceManager().getDirectConnections();
+
     response.directConnections.forEach((connection) => {
       if (!connection) {
         return;

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -48,7 +48,6 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
     // look up the connectionId:spec map from storage
     const directConnectionMap: DirectConnectionsById =
       await getResourceManager().getDirectConnections();
-
     response.directConnections.forEach((connection) => {
       if (!connection) {
         return;
@@ -89,7 +88,9 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
         id: connection.id,
         name: connection.name,
         kafkaClusters: kafkaCluster ? [kafkaCluster] : [],
+        kafkaConfigured: !!directSpec?.kafka_cluster,
         schemaRegistry,
+        schemaRegistryConfigured: !!directSpec?.schema_registry,
         formConnectionType: directSpec?.formConnectionType,
         ...connectionInfo,
       });

--- a/src/models/environment.test.ts
+++ b/src/models/environment.test.ts
@@ -43,7 +43,9 @@ describe("EnvironmentTreeItem", () => {
     [true, true],
     [false, false],
   ]) {
-    it("should use an error icon if it's a direct environment with no clusters", () => {
+    const missingInfo = JSON.stringify({ missingKafka, missingSR });
+    const haveOrNot = missingKafka || missingSR ? "have" : "not have";
+    it(`should ${haveOrNot} an error icon for a direct environment ${missingInfo}`, () => {
       const env = new DirectEnvironment({
         ...TEST_DIRECT_ENVIRONMENT,
         kafkaClusters: [],
@@ -67,7 +69,7 @@ describe("EnvironmentTreeItem", () => {
       }
     });
 
-    it(`should create correct tooltip for a direct environment where Kafka is missing (${missingKafka}) and SR is missing (${missingSR})`, () => {
+    it(`should ${haveOrNot} a tooltip warning for a direct environment ${missingInfo}`, () => {
       // no Kafka cluster or Schema Registry by default
       const resource = new DirectEnvironment({
         ...TEST_DIRECT_ENVIRONMENT,
@@ -82,17 +84,6 @@ describe("EnvironmentTreeItem", () => {
       assert.equal(tooltip.value.includes("Unable to connect"), missingKafka || missingSR);
     });
   }
-
-  it("should not include a warning in the tooltip for a direct environment with clusters", () => {
-    const directEnv = new DirectEnvironment({
-      ...TEST_DIRECT_ENVIRONMENT,
-      kafkaClusters: [TEST_DIRECT_KAFKA_CLUSTER],
-    });
-    const treeItem = new EnvironmentTreeItem(directEnv);
-
-    const tooltip = treeItem.tooltip as MarkdownString;
-    assert.ok(!tooltip.value.includes("Unable to connect"));
-  });
 
   it("should include the form connection type for a direct environment/connection", () => {
     // without a formConnectionType set

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -96,7 +96,12 @@ export class DirectEnvironment extends Environment {
 
   // set explicit Direct* typing
   kafkaClusters: DirectKafkaCluster[] = [];
+  /** Was a Kafka cluster configuration provided for this environment (via the `ConnectionSpec`)? */
+  kafkaConfigured: boolean = false;
+
   schemaRegistry: DirectSchemaRegistry | undefined = undefined;
+  /** Was a Schema Registry configuration provided for this environment (via the `ConnectionSpec`)? */
+  schemaRegistryConfigured: boolean = false;
 
   /** What did the user choose as the source of this connection/environment? */
   formConnectionType?: FormConnectionType = "Other";
@@ -104,15 +109,28 @@ export class DirectEnvironment extends Environment {
   constructor(
     props: Pick<
       DirectEnvironment,
-      "connectionId" | "id" | "name" | "kafkaClusters" | "schemaRegistry" | "formConnectionType"
+      | "connectionId"
+      | "id"
+      | "name"
+      | "kafkaClusters"
+      | "kafkaConfigured"
+      | "schemaRegistry"
+      | "schemaRegistryConfigured"
+      | "formConnectionType"
     >,
   ) {
     super();
     this.connectionId = props.connectionId;
     this.id = props.id;
     this.name = props.name;
+
     this.kafkaClusters = props.kafkaClusters;
+    if (props.kafkaConfigured) this.kafkaConfigured = props.kafkaConfigured;
+
     this.schemaRegistry = props.schemaRegistry;
+    if (props.schemaRegistryConfigured)
+      this.schemaRegistryConfigured = props.schemaRegistryConfigured;
+
     if (props.formConnectionType) this.formConnectionType = props.formConnectionType;
 
     // newly born direct connections are loading unless we already have children.
@@ -184,11 +202,23 @@ export class EnvironmentTreeItem extends TreeItem {
 
     if (this.resource.isLoading) {
       this.iconPath = new ThemeIcon(IconNames.LOADING);
-    } else if (isDirect(resource) && !resource.hasClusters) {
-      this.iconPath = new ThemeIcon("warning", new ThemeColor("problemsWarningIcon.foreground"));
+    } else if (isDirect(resource)) {
+      const { missingKafka, missingSR } = checkForMissingResources(resource);
+      if (missingKafka || missingSR) {
+        this.iconPath = new ThemeIcon("error", new ThemeColor("problemsErrorIcon.foreground"));
+      }
     }
     this.tooltip = createEnvironmentTooltip(this.resource);
   }
+}
+
+/** Compare provided `kafkaClusters` against `kafkaConfigured` and `schemaRegistry` against
+ * `schemaRegistryConfigured` to determine whether or not expected resources are missing, */
+function checkForMissingResources(resource: Environment) {
+  const directEnv = resource as DirectEnvironment;
+  const missingKafka: boolean = directEnv.kafkaConfigured && !directEnv.kafkaClusters.length;
+  const missingSR: boolean = directEnv.schemaRegistryConfigured && !directEnv.schemaRegistry;
+  return { missingKafka, missingSR };
 }
 
 function createEnvironmentTooltip(resource: Environment): MarkdownString {
@@ -213,11 +243,16 @@ function createEnvironmentTooltip(resource: Environment): MarkdownString {
       .appendMarkdown(
         `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudEnv.ccloudUrl})`,
       );
-  } else if (isDirectResource && !resource.hasClusters) {
-    tooltip
-      .appendMarkdown("\n\n---")
-      .appendMarkdown(`\n\n⚠️ Unable to connect to Kafka and/or Schema Registry.`);
-    // TODO(shoup): add link to edit connection here
+  } else if (isDirectResource) {
+    const { missingKafka, missingSR } = checkForMissingResources(resource);
+    if (missingKafka || missingSR) {
+      const missing = [];
+      if (missingKafka) missing.push("Kafka");
+      if (missingSR) missing.push("Schema Registry");
+      tooltip
+        .appendMarkdown("\n\n---")
+        .appendMarkdown(`\n\n⚠️ Unable to connect to ${missing.join(" and ")}.`);
+    }
   }
 
   return tooltip;

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -125,11 +125,10 @@ export class DirectEnvironment extends Environment {
     this.name = props.name;
 
     this.kafkaClusters = props.kafkaClusters;
-    if (props.kafkaConfigured) this.kafkaConfigured = props.kafkaConfigured;
+    this.kafkaConfigured = props.kafkaConfigured;
 
     this.schemaRegistry = props.schemaRegistry;
-    if (props.schemaRegistryConfigured)
-      this.schemaRegistryConfigured = props.schemaRegistryConfigured;
+    this.schemaRegistryConfigured = props.schemaRegistryConfigured;
 
     if (props.formConnectionType) this.formConnectionType = props.formConnectionType;
 

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -250,7 +250,7 @@ function createEnvironmentTooltip(resource: Environment): MarkdownString {
       if (missingSR) missing.push("Schema Registry");
       tooltip
         .appendMarkdown("\n\n---")
-        .appendMarkdown(`\n\n⚠️ Unable to connect to ${missing.join(" and ")}.`);
+        .appendMarkdown(`\n\n$(error) Unable to connect to ${missing.join(" and ")}.`);
     }
   }
 

--- a/tests/unit/testResources/environments.ts
+++ b/tests/unit/testResources/environments.ts
@@ -18,7 +18,9 @@ export const TEST_DIRECT_ENVIRONMENT: DirectEnvironment = new DirectEnvironment(
   id: "test-direct-connection",
   name: "test-direct-environment",
   kafkaClusters: [],
+  kafkaConfigured: false,
   schemaRegistry: undefined,
+  schemaRegistryConfigured: false,
 });
 
 export const TEST_LOCAL_ENVIRONMENT: LocalEnvironment = new LocalEnvironment({


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes some behavior we previously saw where we would show a normal icon in the Resources view for a connection that could only connect to either Kafka _**or**_ Schema Registry when both were configured. With this change, the (previously `warning`) `error` icon will show when a direct connection is configured but we didn't get the expected resource back from the GraphQL query.

When Kafka and SR are unreachable:
<img width="529" alt="image" src="https://github.com/user-attachments/assets/18699318-7566-4cce-b2eb-4e71fbf7c203" />

When only Kafka is unreachable:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/4eeda93c-2d5f-49a8-8426-673fe60ca03f" />

When only Schema Registry is unreachable:
<img width="479" alt="image" src="https://github.com/user-attachments/assets/f74a0252-09aa-4e8b-ad82-54b47946bc73" />

Ideally we'll also provide _why_ we couldn't connect to one or more of those resources within the tooltip, but that's not quite ready yet.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
