### PR TITLE
remove "The 'this' keyword is equivalent to 'undefined' at the top level of an ES module" warnings for `node_modules`

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -206,6 +206,8 @@ function handleBuildLog(level, log, handler) {
   // skip log messages about circular dependencies inside node_modules
   if (log.code === "CIRCULAR_DEPENDENCY" && log.ids.every((id) => id.includes("node_modules")))
     return;
+  // as well as any "The 'this' keyword is equivalent to 'undefined' at the top level of an ES module" warnings
+  if (log.code === "THIS_IS_UNDEFINED" && log.id.includes("node_modules")) return;
   handler(level, log);
 }
 


### PR DESCRIPTION
Mostly affects `testBuild`:

Before:
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/fad1a354-1ad9-4ed6-9bd1-fbdcc86f6715" />

After:
<img width="921" alt="image" src="https://github.com/user-attachments/assets/50ca01db-731b-4758-88d7-01ec5ffc05a2" />
