### PR TITLE
preserve #672 as a spec patch to run on `gulp apigen`

### DIFF
--- a/src/clients/sidecar-openapi-specs/patches/add_dryrun_and_extend_produce.patch
+++ b/src/clients/sidecar-openapi-specs/patches/add_dryrun_and_extend_produce.patch
@@ -1,0 +1,47 @@
+diff --git a/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml b/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
+index f00bacd9..94333ecd 100644
+--- a/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
++++ b/src/clients/sidecar-openapi-specs/ce-kafka-rest.openapi.yaml
+@@ -980,6 +980,7 @@ paths:
+     parameters:
+       - $ref: "#/components/parameters/ClusterId"
+       - $ref: "#/components/parameters/TopicName"
++      - $ref: "#/components/parameters/DryRun"
+ 
+     post:
+       summary: Produce Records
+@@ -1746,6 +1747,14 @@ components:
+         type: string
+       example: consumer-1
+ 
++    DryRun:
++      name: dry_run
++      description: "To validate the action can be performed successfully or not. Default: false"
++      in: query
++      required: false
++      schema:
++        type: boolean
++
+     IncludeAuthorizedOperations:
+       name: include_authorized_operations
+       description: Specify if authorized operations should be included in the response.
+@@ -2650,6 +2659,19 @@ components:
+             - BINARY
+             - JSON
+             - STRING
++        subject:
++          type: string
++          nullable: true
++        subject_name_strategy:
++          type: string
++          x-extensible-enum:
++            - TOPIC_NAME
++            - RECORD_NAME
++            - TOPIC_RECORD_NAME
++          nullable: true
++        schema_version:
++          type: integer
++          nullable: true
+         data:
+           $ref: "#/components/schemas/AnyValue"
+       nullable: true


### PR DESCRIPTION
After https://github.com/confluentinc/vscode/pull/914, we now have a way to re-apply OpenAPI spec changes before (re)generating the `openapi-generator` Typescript (fetch) client code: https://github.com/confluentinc/vscode/blob/55b590900c3e28fa54b3fa296da6f204c74736e1/Gulpfile.js#L648

One of the other manual changes was in #672, which we want to preserve and automatically apply in the event we need to update the Kafka REST API spec and re-run`gulp apigen`.