### PR TITLE
cleanup: add `showErrorNotificationWithButtons()` convenience function for error notifications

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -2,6 +2,7 @@ import { Disposable, Uri, window, workspace, WorkspaceConfiguration } from "vsco
 import { registerCommandWithLogging } from ".";
 import { openDirectConnectionForm } from "../directConnect";
 import { DirectConnectionManager } from "../directConnectManager";
+import { logResponseError } from "../errors";
 import { Logger } from "../logging";
 import { DirectEnvironment } from "../models/environment";
 import { SSL_PEM_PATHS } from "../preferences/constants";
@@ -16,10 +17,12 @@ async function createCCloudConnection() {
   try {
     await getCCloudAuthSession(true);
   } catch (error) {
-    logger.error("error creating CCloud connection", { error });
     if (error instanceof Error) {
       // if the user clicks "Cancel" on the modal before the sign-in process, we don't need to do anything
-      if (error.message === "User did not consent to login.") {
+      const noConsent = error.message === "User did not consent to login.";
+      // log the response, but only send to Sentry if the user didn't cancel the sign-in process
+      logResponseError(error, "CCloud sign-in", {}, !noConsent);
+      if (noConsent) {
         return;
       }
       // any other errors will be caught by the error handler in src/commands/index.ts as part of the

--- a/src/commands/docker.test.ts
+++ b/src/commands/docker.test.ts
@@ -1,17 +1,20 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
+import { Uri, window, workspace } from "vscode";
 import * as dockerConfigs from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import * as dockerWorkflows from "../docker/workflows";
 import { ConfluentLocalWorkflow } from "../docker/workflows/confluent-local";
 import { ConfluentPlatformSchemaRegistryWorkflow } from "../docker/workflows/cp-schema-registry";
+import * as errors from "../errors";
+import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
 import * as quickpicks from "../quickpicks/localResources";
 import { addDockerPath, orderWorkflows, runWorkflowWithProgress } from "./docker";
-import { Uri, window, workspace } from "vscode";
-import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
 
 describe("commands/docker.ts runWorkflowWithProgress()", () => {
   let sandbox: sinon.SinonSandbox;
+
+  let showErrorNotificationStub: sinon.SinonStub;
 
   // Docker+workflow stubs
   let isDockerAvailableStub: sinon.SinonStub;
@@ -25,6 +28,8 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
+    showErrorNotificationStub = sandbox.stub(errors, "showErrorNotificationWithButtons").resolves();
 
     // default to Docker being available for majority of tests
     isDockerAvailableStub = sandbox.stub(dockerConfigs, "isDockerAvailable").resolves(true);
@@ -88,7 +93,7 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     assert.ok(stubKafkaWorkflow.start.calledOnce);
     assert.ok(stubKafkaWorkflow.stop.notCalled);
-    assert.ok(stubKafkaWorkflow.showErrorNotification.calledOnce);
+    assert.ok(showErrorNotificationStub.calledOnce);
   });
 
   it("should show an workflow's error notification for uncaught errors in the workflow .stop()", async () => {
@@ -98,7 +103,7 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     assert.ok(stubKafkaWorkflow.start.notCalled);
     assert.ok(stubKafkaWorkflow.stop.calledOnce);
-    assert.ok(stubKafkaWorkflow.showErrorNotification.calledOnce);
+    assert.ok(showErrorNotificationStub.calledOnce);
   });
 
   // TODO(shoup): update these in follow-on branch once multi-select quickpick is added

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -14,6 +14,7 @@ import { isDockerAvailable } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { getKafkaWorkflow, getSchemaRegistryWorkflow } from "../docker/workflows";
 import { LocalResourceWorkflow } from "../docker/workflows/base";
+import { showErrorNotificationWithButtons } from "../errors";
 import { Logger } from "../logging";
 import { ConnectionLabel } from "../models/resource";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
@@ -150,7 +151,7 @@ export async function runWorkflowWithProgress(
             } else {
               errorMsg = error.message;
             }
-            workflow.showErrorNotification(
+            showErrorNotificationWithButtons(
               `Error ${start ? "starting" : "stopping"} ${workflow.resourceKind}: ${errorMsg}`,
             );
           }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,9 +1,6 @@
 import * as vscode from "vscode";
 import { logResponseError, showErrorNotificationWithButtons } from "../errors";
-import { Logger } from "../logging";
 import { UserEvent, logUsage } from "../telemetry/events";
-
-const logger = new Logger("commands");
 
 export function registerCommandWithLogging(
   commandName: string,
@@ -14,13 +11,12 @@ export function registerCommandWithLogging(
     try {
       await command(...args);
     } catch (e) {
-      const msg = `Error invoking command "${commandName}":`;
       if (e instanceof Error) {
         // gather more (possibly-ResponseError) context and send to Sentry (only enabled in
         // production builds)
-        logResponseError(e, msg, { command: commandName }, true);
+        logResponseError(e, `${commandName}`, { command: commandName }, true);
         // also show error notification to the user with default buttons
-        showErrorNotificationWithButtons(`${msg} ${e}`);
+        showErrorNotificationWithButtons(`Error invoking command "${commandName}": ${e}`);
       }
     }
   };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
+import { showErrorNotificationWithButtons } from "../errors";
 import { Logger } from "../logging";
 import { UserEvent, logUsage } from "../telemetry/events";
 
@@ -20,11 +21,7 @@ export function registerCommandWithLogging(
         // capture error with Sentry (only enabled in production builds)
         Sentry.captureException(e, { tags: { command: commandName } });
         // also show error notification to the user
-        vscode.window.showErrorMessage(`${msg} ${e.message}`, "Open Logs").then(async (action) => {
-          if (action !== undefined) {
-            await vscode.commands.executeCommand("confluent.showOutputChannel");
-          }
-        });
+        showErrorNotificationWithButtons(`${msg} ${e.message}`);
       }
     }
   };

--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -100,7 +100,7 @@ describe("docker/configs functions", function () {
     assert.ok(
       showErrorMessageStub.calledOnceWith(
         "Docker is not available: Error 400: uh oh",
-        "Show Logs",
+        "Open Logs",
         "File Issue",
       ),
     );
@@ -120,7 +120,7 @@ describe("docker/configs functions", function () {
       showErrorMessageStub.calledOnceWith(
         "Docker is not available: Please install Docker and try again once it's running.",
         "Install Docker",
-        "Show Logs",
+        "Open Logs",
       ),
     );
   });
@@ -140,7 +140,7 @@ describe("docker/configs functions", function () {
       showErrorMessageStub.calledOnceWith(
         `Docker is not available: If Docker is currently running, please disable the "http.fetchAdditionalSupport" setting and try again.`,
         "Install Docker",
-        "Show Logs",
+        "Open Logs",
         "Update Settings",
       ),
     );

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -197,13 +197,13 @@ export async function showDockerUnavailableErrorNotification(error: unknown): Pr
     } catch {
       errorMessage = await error.response.clone().text();
     }
-    primaryButton = "Show Logs";
+    primaryButton = "Open Logs";
     secondaryButton = "File Issue";
     notificationMessage = `Error ${error.response.status}: ${errorMessage}`;
   } else {
     // likely FetchError->TypeError: connect ENOENT <socket path> but not a lot else we can do here
     primaryButton = "Install Docker";
-    secondaryButton = "Show Logs";
+    secondaryButton = "Open Logs";
     notificationMessage = "Please install Docker and try again once it's running.";
     // TEMPORARY: if the `http.fetchAdditionalSupport` setting is enabled, suggest disabling it
     // TODO(shoup): remove this once we have a better way to handle the behavior described in
@@ -229,7 +229,7 @@ export async function showDockerUnavailableErrorNotification(error: unknown): Pr
           env.openExternal(uri);
           break;
         }
-        case "Show Logs":
+        case "Open Logs":
           commands.executeCommand("confluent.showOutputChannel");
           break;
         case "File Issue":

--- a/src/docker/workflows/confluent-local.test.ts
+++ b/src/docker/workflows/confluent-local.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../clients/docker";
 import { LOCAL_KAFKA_REST_PORT } from "../../constants";
 import { localKafkaConnected } from "../../emitters";
+import * as errors from "../../errors";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../../preferences/constants";
 import { DEFAULT_UNIX_SOCKET_PATH } from "../configs";
 import * as dockerContainers from "../containers";
@@ -73,7 +74,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     checkForImageStub = sandbox.stub(workflow, "checkForImage").resolves();
     handleExistingContainersStub = sandbox.stub(workflow, "handleExistingContainers").resolves();
-    showErrorNotificationStub = sandbox.stub(workflow, "showErrorNotification").resolves();
+    showErrorNotificationStub = sandbox.stub(errors, "showErrorNotificationWithButtons").resolves();
     // assume the container is created successfully for most tests
     const fakeCreatedContainer: ContainerCreateResponse = { Id: "1", Warnings: [] };
     createContainerStub = sandbox

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -16,6 +16,7 @@ import {
 } from "../../clients/docker";
 import { LOCAL_KAFKA_REST_PORT } from "../../constants";
 import { localKafkaConnected } from "../../emitters";
+import { showErrorNotificationWithButtons } from "../../errors";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
 import { ResourceManager } from "../../storage/resourceManager";
@@ -131,7 +132,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
         containerEnvs,
       );
       if (!container) {
-        this.showErrorNotification(
+        showErrorNotificationWithButtons(
           `Failed to create ${this.resourceKind} container "${brokerConfig.containerName}".`,
         );
         success = false;

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -12,6 +12,7 @@ import {
   ContainerCreateResponse,
   ContainerInspectResponse,
 } from "../../clients/docker";
+import * as errors from "../../errors";
 import {
   LOCAL_DOCKER_SOCKET_PATH,
   LOCAL_KAFKA_IMAGE,
@@ -54,13 +55,13 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
   // base class stubs
   let checkForImageStub: sinon.SinonStub;
   let handleExistingContainersStub: sinon.SinonStub;
-  let workflowShowErrorNotificationStub: sinon.SinonStub;
   let fetchAndFilterKafkaContainersStub: sinon.SinonStub;
   let startContainerStub: sinon.SinonStub;
   let stopContainerStub: sinon.SinonStub;
   let waitForLocalResourceEventChangeStub: sinon.SinonStub;
 
   let updateLocalConnectionStub: sinon.SinonStub;
+  let showErrorNotificationStub: sinon.SinonStub;
 
   before(async () => {
     await getTestExtensionContext();
@@ -93,7 +94,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     checkForImageStub = sandbox.stub(workflow, "checkForImage").resolves();
     handleExistingContainersStub = sandbox.stub(workflow, "handleExistingContainers").resolves();
-    workflowShowErrorNotificationStub = sandbox.stub(workflow, "showErrorNotification").resolves();
+    showErrorNotificationStub = sandbox.stub(errors, "showErrorNotificationWithButtons").resolves();
     // assume we have Kafka containers to work off of for most tests
     fetchAndFilterKafkaContainersStub = sandbox
       .stub(workflow, "fetchAndFilterKafkaContainers")
@@ -141,7 +142,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     assert.ok(createContainerStub.calledOnce);
     assert.ok(startContainerStub.calledOnce);
-    assert.ok(workflowShowErrorNotificationStub.notCalled);
+    assert.ok(showErrorNotificationStub.notCalled);
 
     assert.ok(updateLocalConnectionStub.calledOnce);
 
@@ -269,7 +270,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     assert.ok(showErrorMessageStub.notCalled);
 
     assert.ok(createContainerStub.calledOnce);
-    assert.ok(workflowShowErrorNotificationStub.calledOnce);
+    assert.ok(showErrorNotificationStub.calledOnce);
     // bailing here
     assert.ok(startContainerStub.notCalled);
 

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -9,6 +9,7 @@ import {
   HostConfig,
 } from "../../clients/docker";
 import { localSchemaRegistryConnected } from "../../emitters";
+import { showErrorNotificationWithButtons } from "../../errors";
 import { Logger } from "../../logging";
 import { LOCAL_KAFKA_IMAGE, LOCAL_KAFKA_IMAGE_TAG } from "../../preferences/constants";
 import { updateLocalConnection } from "../../sidecar/connections";
@@ -138,7 +139,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       kafkaNetworks,
     );
     if (!container) {
-      this.showErrorNotification(`Failed to create ${this.resourceKind} container.`);
+      showErrorNotificationWithButtons(`Failed to create ${this.resourceKind} container.`);
       return;
     }
     this.sendTelemetryEvent(UserEvent.DockerContainerCreated, {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,176 @@
+import { SinonSandbox, SinonStub, assert, createSandbox } from "sinon";
+import { commands, window } from "vscode";
+import { showErrorNotificationWithButtons } from "./errors";
+import * as telemetryEvents from "./telemetry/events";
+
+const fakeMessage = "oh no, an error";
+const DEFAULT_BUTTONS = ["Open Logs", "File Issue"];
+
+describe.only("errors.ts", () => {
+  let sandbox: SinonSandbox;
+  let showErrorMessageStub: SinonStub;
+  let executeCommandStub: SinonStub;
+  let logUsageStub: SinonStub;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    showErrorMessageStub = sandbox.stub(window, "showErrorMessage").resolves(undefined);
+    executeCommandStub = sandbox.stub(commands, "executeCommand");
+    logUsageStub = sandbox.stub(telemetryEvents, "logUsage");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("showErrorNotificationWithButtons() should show an error notification with default buttons if none are provided", async () => {
+    // showErrorMessageStub simulates user dismissing the notification by default
+
+    await showErrorNotificationWithButtons(fakeMessage);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, ...DEFAULT_BUTTONS);
+    assert.notCalled(executeCommandStub);
+    assert.notCalled(logUsageStub);
+  });
+
+  it("showErrorNotificationWithButtons() should call the default 'Open Logs' callback function and send a usage event for telemetry for telemetry", async () => {
+    // simulate user clicking the "Open Logs" button on the notification
+    const buttonLabel = "Open Logs";
+    showErrorMessageStub.resolves(buttonLabel);
+
+    await showErrorNotificationWithButtons(fakeMessage);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, ...DEFAULT_BUTTONS);
+    assert.calledOnceWithExactly(executeCommandStub, "confluent.showOutputChannel");
+    assert.calledOnceWithExactly(
+      logUsageStub,
+      telemetryEvents.UserEvent.NotificationButtonClicked,
+      {
+        buttonLabel,
+        notificationType: "error",
+      },
+    );
+  });
+
+  it("showErrorNotificationWithButtons() should call the default 'File Issue' callback function and send a usage event for telemetry", async () => {
+    // simulate user clicking the "File Issue" button on the notification
+    const buttonLabel = "File Issue";
+    showErrorMessageStub.resolves(buttonLabel);
+
+    await showErrorNotificationWithButtons(fakeMessage);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, ...DEFAULT_BUTTONS);
+    assert.calledOnceWithExactly(executeCommandStub, "confluent.support.issue");
+    assert.calledOnceWithExactly(
+      logUsageStub,
+      telemetryEvents.UserEvent.NotificationButtonClicked,
+      {
+        buttonLabel,
+        notificationType: "error",
+      },
+    );
+  });
+
+  it("showErrorNotificationWithButtons() should show an error notification with custom buttons and callback functions", async () => {
+    // caller passes in a custom button and callback function
+    const buttonLabel = "Click Me";
+    const otherButtonLabel = "Do Something Else";
+    const customButtons = {
+      [buttonLabel]: sandbox.stub(),
+      [otherButtonLabel]: sandbox.stub(),
+    };
+    // showErrorMessageStub simulates user dismissing the notification by default
+
+    await showErrorNotificationWithButtons(fakeMessage, customButtons);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, buttonLabel, otherButtonLabel);
+    assert.notCalled(customButtons[buttonLabel]);
+    assert.notCalled(customButtons[otherButtonLabel]);
+  });
+
+  it("showErrorNotificationWithButtons() should call a custom callback function and send a usage event for telemetry", async () => {
+    // caller passes in a custom button and callback function
+    const buttonLabel = "Click Me";
+    const otherButtonLabel = "Do Something Else";
+    const customButtons = {
+      [buttonLabel]: sandbox.stub(),
+      [otherButtonLabel]: sandbox.stub(),
+    };
+    // simulate user clicking one of the buttons
+    showErrorMessageStub.resolves(buttonLabel);
+
+    await showErrorNotificationWithButtons(fakeMessage, customButtons);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, buttonLabel, otherButtonLabel);
+    assert.calledOnce(customButtons[buttonLabel]);
+    assert.notCalled(customButtons[otherButtonLabel]);
+
+    assert.calledOnceWithExactly(
+      logUsageStub,
+      telemetryEvents.UserEvent.NotificationButtonClicked,
+      {
+        buttonLabel,
+        notificationType: "error",
+      },
+    );
+  });
+
+  it("showErrorNotificationWithButtons() should preserve custom button ordering in the notification", async () => {
+    const orderedButtons = {
+      C: sandbox.stub(),
+      A: sandbox.stub(),
+      B: sandbox.stub(),
+    };
+
+    await showErrorNotificationWithButtons(fakeMessage, orderedButtons);
+
+    assert.calledWith(showErrorMessageStub, fakeMessage, "C", "A", "B");
+  });
+
+  it("showErrorNotificationWithButtons() should not throw in the event of a failed callback", async () => {
+    // caller passes in a custom button and callback function
+    const buttonLabel = "Click Me";
+    const customButtons = {
+      [buttonLabel]: sandbox.stub().throws(new Error("oh no")),
+    };
+    // simulate user clicking one of the buttons
+    showErrorMessageStub.resolves(buttonLabel);
+
+    // no throwing
+    await showErrorNotificationWithButtons(fakeMessage, customButtons);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, buttonLabel);
+  });
+
+  it("showErrorNotificationWithButtons() should handle async custom callbacks", async () => {
+    // caller passes in a custom button and callback function
+    const buttonLabel = "Click Me";
+    const asyncCallback = sandbox.stub().resolves();
+    const customButtons = {
+      [buttonLabel]: asyncCallback,
+    };
+    // simulate user clicking one of the buttons
+    showErrorMessageStub.resolves(buttonLabel);
+
+    await showErrorNotificationWithButtons(fakeMessage, customButtons);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, buttonLabel);
+    assert.calledOnce(asyncCallback);
+  });
+
+  it("showErrorNotificationWithButtons() should not throw/reject in the event of a failed async callback", async () => {
+    // caller passes in a custom button and callback function
+    const buttonLabel = "Click Me";
+    const asyncCallback = sandbox.stub().rejects(new Error("oh no"));
+    const customButtons = {
+      [buttonLabel]: asyncCallback,
+    };
+    // simulate user clicking one of the buttons
+    showErrorMessageStub.resolves(buttonLabel);
+
+    await showErrorNotificationWithButtons(fakeMessage, customButtons);
+
+    assert.calledOnceWithExactly(showErrorMessageStub, fakeMessage, buttonLabel);
+    assert.calledOnce(asyncCallback);
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/node";
 import { commands, window } from "vscode";
 import { ResponseError as DockerResponseError } from "./clients/docker";
 import { ResponseError as KafkaResponseError } from "./clients/kafkaRest";
+import { ResponseError as ScaffoldingServiceResponseError } from "./clients/scaffoldingService";
 import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRegistryRest";
 import { ResponseError as SidecarResponseError } from "./clients/sidecar";
 import { Logger } from "./logging";
@@ -22,6 +23,7 @@ type ResponseError =
   | SidecarResponseError
   | KafkaResponseError
   | SchemaRegistryResponseError
+  | ScaffoldingServiceResponseError
   | DockerResponseError;
 
 /** Log the possibly-ResponseError and any additional information, and optionally send to Sentry. */
@@ -49,7 +51,10 @@ export async function logResponseError(
     responseStatusCode = error.response.status;
   } else {
     // something we caught that wasn't actually a ResponseError type but was passed in here anyway
-    errorMessage = `[${message}] error:`;
+    errorMessage = `[${message}] error: ${e}`;
+    if (e instanceof Error) {
+      errorContext = { errorType: e.name, errorMessage: e.message };
+    }
   }
 
   logger.error(errorMessage, { ...errorContext, ...extra });
@@ -75,14 +80,20 @@ export async function showErrorNotificationWithButtons(
     "File Issue": () => commands.executeCommand("confluent.support.issue"),
   };
   const buttonMap = buttons || defaultButtons;
-  window.showErrorMessage(message, ...Object.keys(buttonMap)).then(async (selection) => {
-    if (selection) {
+  // we're awaiting the user's selection to more easily test the callback behavior, rather than
+  // chaining with .then()
+  const selection = await window.showErrorMessage(message, ...Object.keys(buttonMap));
+  if (selection) {
+    try {
       await buttonMap[selection]();
-      // send telemetry for which button was clicked
-      logUsage(UserEvent.NotificationButtonClicked, {
-        buttonLabel: selection,
-        notificationType: "error",
-      });
+    } catch (e) {
+      // log the error and send telemetry if the callback function throws an error
+      logResponseError(e, `"${selection}" button callback`, {}, true);
     }
-  });
+    // send telemetry for which button was clicked
+    logUsage(UserEvent.NotificationButtonClicked, {
+      buttonLabel: selection,
+      notificationType: "error",
+    });
+  }
 }

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -45,7 +45,7 @@ export async function getLocalResources(): Promise<LocalEnvironment[]> {
   try {
     response = await sidecar.query(query, LOCAL_CONNECTION_ID);
   } catch (error) {
-    logResponseError(error, "CCloud environments", { connectionId: LOCAL_CONNECTION_ID }, true);
+    logResponseError(error, "local resources", { connectionId: LOCAL_CONNECTION_ID }, true);
     showErrorNotificationWithButtons(`Failed to fetch local resources: ${error}`);
     return envs;
   }

--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -1,5 +1,6 @@
 import { graphql } from "gql.tada";
 import { CCLOUD_CONNECTION_ID } from "../constants";
+import { logResponseError, showErrorNotificationWithButtons } from "../errors";
 import { Logger } from "../logging";
 import { CCloudOrganization } from "../models/organization";
 import { getSidecar } from "../sidecar";
@@ -7,7 +8,7 @@ import { getSidecar } from "../sidecar";
 const logger = new Logger("graphql.organizations");
 
 export async function getOrganizations(): Promise<CCloudOrganization[]> {
-  let orgResponse: CCloudOrganization[] = [];
+  let orgs: CCloudOrganization[] = [];
 
   const query = graphql(`
     query connectionById($id: String!) {
@@ -22,23 +23,26 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   `);
 
   const sidecar = await getSidecar();
-
+  let response;
   try {
-    const response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
-    if (response.ccloudConnectionById?.organizations) {
-      response.ccloudConnectionById.organizations.forEach((org: any) => {
-        try {
-          orgResponse.push(CCloudOrganization.create(org));
-        } catch (e) {
-          logger.error("Failed to create organization:", e);
-        }
-      });
-    }
-  } catch (e) {
-    logger.error("Failed to fetch organizations:", e);
+    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
+  } catch (error) {
+    logResponseError(error, "CCloud organizations", { connectionId: CCLOUD_CONNECTION_ID }, true);
+    showErrorNotificationWithButtons(`Failed to fetch CCloud organizations: ${error}`);
+    return orgs;
   }
 
-  return orgResponse;
+  if (response.ccloudConnectionById?.organizations) {
+    response.ccloudConnectionById.organizations.forEach((org: any) => {
+      try {
+        orgs.push(CCloudOrganization.create(org));
+      } catch (e) {
+        logger.error("Failed to create organization:", e);
+      }
+    });
+  }
+
+  return orgs;
 }
 
 export async function getCurrentOrganization(): Promise<CCloudOrganization | undefined> {

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -501,7 +501,15 @@ export class SidecarManager {
           false,
         );
         if (notifySidecarExceptions) {
-          showErrorNotificationWithButtons(`Sidecar error: ${errorMatch[2]}`);
+          showErrorNotificationWithButtons(`[Debugging] Sidecar error: ${errorMatch[2]}`, {
+            "Open Sidecar Logs": () =>
+              vscode.commands.executeCommand("confluent.showSidecarOutputChannel"),
+            "Open Settings": () =>
+              vscode.commands.executeCommand(
+                "workbench.action.openSettings",
+                "@id:confluent.debugging.showSidecarExceptions",
+              ),
+          });
         }
       }
       sidecarOutputChannel.appendLine(line);

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -24,6 +24,7 @@ import { normalize } from "path";
 import { Tail } from "tail";
 import { EXTENSION_VERSION } from "../constants";
 import { observabilityContext } from "../context/observability";
+import { showErrorNotificationWithButtons } from "../errors";
 import { SecretStorageKeys } from "../storage/constants";
 
 /**
@@ -500,13 +501,7 @@ export class SidecarManager {
           false,
         );
         if (notifySidecarExceptions) {
-          vscode.window
-            .showErrorMessage(`Sidecar error: ${errorMatch[2]}`, "Open Logs")
-            .then((action) => {
-              if (action === "Open Logs") {
-                vscode.commands.executeCommand("confluent.showSidecarOutputChannel");
-              }
-            });
+          showErrorNotificationWithButtons(`Sidecar error: ${errorMatch[2]}`);
         }
       }
       sidecarOutputChannel.appendLine(line);

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -17,7 +17,7 @@ import {
   localKafkaConnected,
   localSchemaRegistryConnected,
 } from "../emitters";
-import { ExtensionContextNotSetError } from "../errors";
+import { ExtensionContextNotSetError, showErrorNotificationWithButtons } from "../errors";
 import { getDirectResources } from "../graphql/direct";
 import { getLocalResources } from "../graphql/local";
 import { getCurrentOrganization } from "../graphql/organizations";
@@ -375,13 +375,7 @@ export async function loadCCloudResources(
       const msg = `Failed to load Confluent Cloud environments for the "${currentOrg?.name}" organization.`;
       logger.error(msg, e);
       Sentry.captureException(e);
-      vscode.window.showErrorMessage(msg, "Open Logs", "File Issue").then(async (action) => {
-        if (action === "Open Logs") {
-          vscode.commands.executeCommand("confluent.showOutputChannel");
-        } else if (action === "File Issue") {
-          vscode.commands.executeCommand("confluent.support.issue");
-        }
-      });
+      showErrorNotificationWithButtons(msg);
     }
 
     cloudContainerItem.collapsibleState =


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We previously had a lot of `window.showErrorMessage(msg, btn1, btn2).then(...)` logic that was repeating the same "Open Logs" handling (occasionally with "File Issue"). This PR consolidates it to a single convenience function with the ability for callers to provide a map of `buttonLabel: callbackFn()` for any custom handling.

Example of the "custom buttons + callbacks" implementation for `showErrorNotificationWithButtons()`:
https://github.com/confluentinc/vscode/blob/638843c7dc08420d942e289e5ddfa3cd2c2fb969/src/sidecar/sidecarManager.ts#L504-L512

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #794 and aligns the general handling of GraphQL queries when awaiting a response from the sidecar.
- Renames the previous `Show Logs` button label (for local resource actions) to `Open Logs` for consistency
- Closes #696 since we don't need to log anything when the user cancels any portion of the CCloud auth flow
- Minor updates to the sidecar log error notifications to better hint that they're for debugging and not normally user-facing, namely the `[Debugging]` prefix and change in the notification buttons (ignore the rest of the notification message content below):

| Before | After |
|--------|--------|
| <img width="573" alt="image" src="https://github.com/user-attachments/assets/01e1c243-91c9-4281-bc68-72c30851348e" /> | <img width="582" alt="image" src="https://github.com/user-attachments/assets/c71f322c-52c0-4088-bf0b-d4e789e4f8d1" /> | 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
