### PR TITLE
MINOR: prevent direct Kafka cluster items from showing the "Copy URI" action

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -282,7 +282,6 @@ async function setupContextValues() {
     "ccloud-schema-registry",
     "local-kafka-cluster",
     "local-schema-registry",
-    "direct-kafka-cluster",
     "direct-schema-registry",
   ]);
   await Promise.all([


### PR DESCRIPTION
The sidecar isn't able to populate the `uri` for Kafka clusters from direct connections, so we need to prevent that action altogether.

See https://github.com/confluentinc/ide-sidecar/issues/300#issuecomment-2596844086

(Direct connections to Schema Registry instances can still return a `uri` value though, so it's fine to leave in.)