### PR TITLE
MINOR: add "Sign out" action to CCloud item in Resources view + update icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ Again, no user-facing changes.)
   [#476](https://github.com/confluentinc/vscode/issues/476)
   [#520](https://github.com/confluentinc/vscode/issues/520)
 - When a CCloud connection expires, the extension will now properly clear the views in the sidebar,
-  and the associated error notification's "Log in to Confluent Cloud" button will now work as
+  and the associated error notification's "Sign in to Confluent Cloud" button will now work as
   expected. [#565](https://github.com/confluentinc/vscode/issues/565)
 
 ## 0.20.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this extension will be documented in this file.
 
 - Producing messages to a Kafka topic has been expanded to allow loading content from an unsaved
   editor or Message Viewer preview tab.
+- "Sign Out" action in the Resources view for the current Confluent Cloud connection.
 
 ### Changed
 
@@ -143,7 +144,7 @@ Again, no user-facing changes.)
   [#476](https://github.com/confluentinc/vscode/issues/476)
   [#520](https://github.com/confluentinc/vscode/issues/520)
 - When a CCloud connection expires, the extension will now properly clear the views in the sidebar,
-  and the associated error notification's "Sign in to Confluent Cloud" button will now work as
+  and the associated error notification's "Log in to Confluent Cloud" button will now work as
   expected. [#565](https://github.com/confluentinc/vscode/issues/565)
 
 ## 0.20.2

--- a/package.json
+++ b/package.json
@@ -59,9 +59,15 @@
     ],
     "commands": [
       {
-        "command": "confluent.connections.ccloud.logIn",
-        "icon": "$(plus)",
-        "title": "Log in to Confluent Cloud",
+        "command": "confluent.connections.ccloud.signIn",
+        "icon": "$(sign-in)",
+        "title": "Sign in to Confluent Cloud",
+        "category": "Confluent: Connections"
+      },
+      {
+        "command": "confluent.connections.ccloud.signOut",
+        "icon": "$(sign-out)",
+        "title": "Sign out from Confluent Cloud",
         "category": "Confluent: Connections"
       },
       {
@@ -489,7 +495,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nAlternatively, [start Schema Registry locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)\nAlternatively, [start Schema Registry locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
@@ -504,7 +510,7 @@
       },
       {
         "view": "confluent-topics",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.logIn)\nAlternatively, [start Kafka locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Kafka cluster.",
+        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)\nAlternatively, [start Kafka locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Kafka cluster.",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)"
       },
       {
@@ -521,8 +527,12 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "confluent.connections.ccloud.logIn",
+          "command": "confluent.connections.ccloud.signIn",
           "when": "!confluent.ccloudConnectionAvailable"
+        },
+        {
+          "command": "confluent.connections.ccloud.signOut",
+          "when": "confluent.ccloudConnectionAvailable"
         },
         {
           "command": "confluent.connections.direct.delete",
@@ -769,7 +779,7 @@
           "group": "inline@2"
         },
         {
-          "command": "confluent.connections.ccloud.logIn",
+          "command": "confluent.connections.ccloud.signIn",
           "when": "viewItem == resources-ccloud-container",
           "group": "inline@1"
         },
@@ -785,6 +795,11 @@
         },
         {
           "command": "confluent.organizations.use",
+          "when": "viewItem == resources-ccloud-container-connected",
+          "group": "inline@1"
+        },
+        {
+          "command": "confluent.connections.ccloud.signOut",
           "when": "viewItem == resources-ccloud-container-connected",
           "group": "inline@2"
         },
@@ -965,13 +980,13 @@
           {
             "id": "connect-local-cluster",
             "title": "Connect to Kafka",
-            "description": "**Confluent Cloud Clusters** \nLog in to your Confluent account to see your Confluent Cloud resources. \n[Log in](command:confluent.connections.ccloud.logIn)\n[Sign up for free](https://confluent.cloud/signup)\n**Local Clusters** \nIf you have Kafka running locally, it appears automatically in the Resources view. \n[Start Local Resources](command:confluent.docker.startLocalResources)",
+            "description": "**Confluent Cloud Clusters** \nLog in to your Confluent account to see your Confluent Cloud resources. \n[Log in](command:confluent.connections.ccloud.signIn)\n[Sign up for free](https://confluent.cloud/signup)\n**Local Clusters** \nIf you have Kafka running locally, it appears automatically in the Resources view. \n[Start Local Resources](command:confluent.docker.startLocalResources)",
             "media": {
               "image": "resources/walkthrough/connect.png",
               "altText": "Connect to Kafka clusters"
             },
             "completionEvents": [
-              "onCommand:command:confluent.connections.ccloud.logIn",
+              "onCommand:command:confluent.connections.ccloud.signIn",
               "onCommand:confluent.docker.startLocalResources"
             ]
           },

--- a/src/authn/ccloudPolling.ts
+++ b/src/authn/ccloudPolling.ts
@@ -28,7 +28,7 @@ export const REMIND_BUTTON_TEXT = "Remind Me Later";
 
 /** Singleton class to track the state of the various auth prompts that can be shown to the user. */
 export class AuthPromptTracker {
-  /** Keeps track of whether or not the user has been prompted to attempt logging in again after an
+  /** Keeps track of whether or not the user has been prompted to attempt signing in again after an
    * auth-related error status (not expiration-related). */
   public authErrorPromptOpen: boolean = false;
   /** Have we already shown a warning notification that the user's auth status is about to expire? */
@@ -276,7 +276,7 @@ export function checkAuthErrors(connection: Connection) {
     return;
   }
 
-  let authButton: string = "Log in to Confluent Cloud";
+  let authButton: string = "Sign in to Confluent Cloud";
   // show an error message to the user to retry the auth flow
   tracker.authErrorPromptOpen = true;
   vscode.window

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -157,7 +157,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       throw new Error("CCloud connection failed to become usable after authentication.");
     }
 
-    // User logged in successfully so we send an identify event to Segment
+    // User signed in successfully so we send an identify event to Segment
     if (authenticatedConnection.status.authentication.user) {
       sendTelemetryIdentifyEvent({
         eventName: UserEvent.SignedIn,
@@ -168,7 +168,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     // we want to continue regardless of whether or not the user dismisses the notification,
     // so we aren't awaiting this:
     vscode.window.showInformationMessage(
-      `Successfully logged in to Confluent Cloud as ${authenticatedConnection.status.authentication.user?.username}`,
+      `Successfully signed in to Confluent Cloud as ${authenticatedConnection.status.authentication.user?.username}`,
     );
     logger.debug("createSession() successfully authenticated with Confluent Cloud");
     // update the auth status in the secret store so other workspaces can be notified of the change
@@ -394,7 +394,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: `Logging in to [Confluent Cloud](${uri})...`,
+        title: `Signing in to [Confluent Cloud](${uri})...`,
         cancellable: true,
       },
       async (_, token) => {
@@ -427,7 +427,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     });
   }
 
-  /** Only used for when the user clicks "Cancel" during the "Logging in..." progress notification. */
+  /** Only used for when the user clicks "Cancel" during the "Signing in..." progress notification. */
   private waitForCancellationRequest(token: vscode.CancellationToken): Promise<void> {
     return new Promise<void>((_, reject) =>
       token.onCancellationRequested(async () => {
@@ -511,7 +511,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       createIfNone: false,
     });
     if (!session) {
-      // SCENARIO 1: user logged out / auth session was removed
+      // SCENARIO 1: user signed out / auth session was removed
       // if we had a session before, we need to remove it and stop polling for auth status, as well
       // as inform the Accounts action to show the sign-in badge again
       if (this._session) {
@@ -522,7 +522,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
         );
       }
     } else {
-      // SCENARIO 2: user logged in / auth session was added
+      // SCENARIO 2: user signed in / auth session was added
       // add a new auth session to the Accounts action, populate this instance's cached session state,
       // and start polling for auth status
       this.handleSessionCreated(session);

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -43,7 +43,7 @@ async function ccloudSignOut() {
   // the authentication API doesn't provide a way to sign out, so we'll mirror the confirmation
   // dialog from the Accounts section of the VS Code UI
   const yesButton = "Sign Out";
-  const confirmation = await window.showWarningMessage(
+  const confirmation = await window.showInformationMessage(
     `The account '${authSession.account.label}' has been used by: 
 
 Confluent

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -63,7 +63,7 @@ export async function kafkaClusterQuickPick(): Promise<KafkaCluster | undefined>
     let login: string = "";
     let local: string = "";
     if (!getContextValue(ContextValues.ccloudConnectionAvailable)) {
-      login = "Log in to Confluent Cloud";
+      login = "Sign in to Confluent Cloud";
     }
     if (!getContextValue(ContextValues.localKafkaClusterAvailable)) {
       local = "Start Local Resources";
@@ -71,7 +71,7 @@ export async function kafkaClusterQuickPick(): Promise<KafkaCluster | undefined>
     // TODO: offer button for creating a direct connection?
     window.showInformationMessage("No Kafka clusters available.", login, local).then((selected) => {
       if (selected === login) {
-        commands.executeCommand("confluent.connections.ccloud.logIn");
+        commands.executeCommand("confluent.connections.ccloud.signIn");
       } else if (selected === local) {
         commands.executeCommand("confluent.docker.startLocalResources");
       }

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -66,7 +66,7 @@ export async function schemaRegistryQuickPick(
     let login: string = "";
     let local: string = "";
     if (!getContextValue(ContextValues.ccloudConnectionAvailable)) {
-      login = "Log in to Confluent Cloud";
+      login = "Sign in to Confluent Cloud";
     }
     if (!getContextValue(ContextValues.localSchemaRegistryAvailable)) {
       local = "Start Local Resources";
@@ -76,7 +76,7 @@ export async function schemaRegistryQuickPick(
       .showInformationMessage("No Schema registries available.", login, local)
       .then((selected) => {
         if (selected === login) {
-          commands.executeCommand("confluent.connections.ccloud.logIn");
+          commands.executeCommand("confluent.connections.ccloud.signIn");
         } else if (selected === local) {
           commands.executeCommand("confluent.docker.startLocalResources");
         }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Changes the CCloud sign-in action's icon to `sign-in` since `plus` was being used elsewhere in other contexts and didn't really fit anymore.
- Adds a dedicated `sign-out` action (after a user signs in to CCloud) for easier discoverability
- Replaces "log* in/out" mentions with equivalent "sign* in/out" for consistency


https://github.com/user-attachments/assets/7becb84b-5720-4c88-9d9d-4f8905c665ba

*_Changed sign-out to use an info modal in https://github.com/confluentinc/vscode/pull/935/commits/9d422c909f01179782927a0ba0de58736de5be30_

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
