### PR TITLE
MINOR: normalize log file URIs before `fs.read`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this extension will be documented in this file.
 
 ### Fixed
 
-- Extension/sidecar logs and the support zip can now be downloaded on Windows as expected.
+- Extension/sidecar logs and the support zip can now be saved as expected on Windows.
 
 ## 0.23.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this extension will be documented in this file.
 - React to websocket events pushed from sidecar instead of polling for some connection change
   monitoring.
 
+### Fixed
+
+- Extension/sidecar logs and the support zip can now be downloaded on Windows as expected.
+
 ## 0.23.3
 
 ### Fixed

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -68,10 +68,10 @@ function sidecarLogFileUri(): Uri {
 }
 
 /**
- * Download the extension log file to the user's local file system, prompting for a save location.
- * The default save location is the user's home directory.
+ * Save the extension log file to the user's local file system, prompting for a save location.
+ * The default parent directory is the user's home directory.
  */
-async function downloadLogs() {
+async function saveExtensionLogFile() {
   // prompt where to save the file, using the home directory as the default
   const defaultPath = join(homedir(), LOGFILE_NAME);
   const saveUri = await window.showSaveDialog({
@@ -79,7 +79,7 @@ async function downloadLogs() {
     filters: {
       "Log files": ["log"],
     },
-    title: "Download Confluent Extension Log",
+    title: "Save Confluent Extension Log",
   });
   if (saveUri) {
     await handleLogFileSave(extensionLogFileUri(), saveUri, true);
@@ -87,10 +87,10 @@ async function downloadLogs() {
 }
 
 /**
- * Download the sidecar log file to the user's local file system, prompting for a save location.
+ * Save the sidecar log file to the user's local file system, prompting for a save location.
  * The default save location is the user's home directory.
  */
-async function downloadSidecarLogs() {
+async function saveSidecarLogFile() {
   // prompt where to save the file, using the home directory as the default
   const defaultPath = join(homedir(), "vscode-confluent-sidecar.log");
   const saveUri: Uri | undefined = await window.showSaveDialog({
@@ -98,7 +98,7 @@ async function downloadSidecarLogs() {
     filters: {
       "Log files": ["log"],
     },
-    title: "Download Confluent Extension Sidecar Log",
+    title: "Save Confluent Extension Sidecar Log",
   });
   if (saveUri) {
     await handleLogFileSave(sidecarLogFileUri(), saveUri, true);
@@ -133,7 +133,7 @@ async function handleLogFileSave(readUri: Uri, writeUri: Uri, forSidecar: boolea
     return;
   }
 
-  const successMsg = `Confluent extension ${forSidecar ? "sidecar " : ""}log file downloaded successfully.`;
+  const successMsg = `Confluent extension ${forSidecar ? "sidecar " : ""}log file saved successfully.`;
   logger.debug(successMsg);
   const openButton = "Open File";
   window.showInformationMessage(successMsg, openButton).then((value) => {
@@ -144,12 +144,12 @@ async function handleLogFileSave(readUri: Uri, writeUri: Uri, forSidecar: boolea
 }
 
 /**
- * Download a .zip of the following:
+ * Save a .zip of the following:
  * - "Confluent" output channel log file
  * - "Confluent: Sidecar" output channel log file
  * - Observability context (as a .json file)
  */
-async function downloadSupportZip() {
+async function saveSupportZip() {
   // use a date-time string like YYYYmmddHHMMSS for the .zip filename, not the full ISO format
   const dateTimeString = new Date().toISOString().replace(/[-:T]/g, "").slice(0, -5);
   const defaultPath = join(homedir(), `vscode-confluent-support-${dateTimeString}.zip`);
@@ -169,10 +169,7 @@ async function downloadSupportZip() {
   const closeListener = output.on("close", () => {
     const openButton = "Open";
     window
-      .showInformationMessage(
-        "Confluent extension support .zip downloaded successfully",
-        openButton,
-      )
+      .showInformationMessage("Confluent extension support .zip saved successfully", openButton)
       .then((value) => {
         if (value === openButton) {
           // show in OS file explorer, don't try to open it in VS Code
@@ -210,9 +207,9 @@ export function registerSupportCommands(): Disposable[] {
       "confluent.support.confluent-walkthrough.launch",
       openWalkthroughCommand,
     ),
-    registerCommandWithLogging("confluent.support.saveLogs", downloadLogs),
-    registerCommandWithLogging("confluent.support.saveSidecarLogs", downloadSidecarLogs),
-    registerCommandWithLogging("confluent.support.saveSupportZip", downloadSupportZip),
+    registerCommandWithLogging("confluent.support.saveLogs", saveExtensionLogFile),
+    registerCommandWithLogging("confluent.support.saveSidecarLogs", saveSidecarLogFile),
+    registerCommandWithLogging("confluent.support.saveSupportZip", saveSupportZip),
     registerCommandWithLogging("confluent.support.feedback", feedbackCommand),
     registerCommandWithLogging("confluent.support.issue", issueCommand),
     registerCommandWithLogging("confluent.support.openSettings", openSettings),

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -169,7 +169,7 @@ async function saveSupportZip() {
   const closeListener = output.on("close", () => {
     const openButton = "Open";
     window
-      .showInformationMessage("Confluent extension support .zip saved successfully", openButton)
+      .showInformationMessage("Confluent extension support .zip saved successfully.", openButton)
       .then((value) => {
         if (value === openButton) {
           // show in OS file explorer, don't try to open it in VS Code


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #899.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
