### PR TITLE
Updates for scaffold service: client-side form validation

### DIFF
--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -21,7 +21,7 @@
       </div>
       <form class="section" data-on-submit="this.handleSubmit(event)">
         <template data-if="this.noOptions()">
-          <p class="info">
+          <p class="form-description">
             There are no configurable options for this template. Click Generate & Save to continue.
           </p>
         </template>
@@ -79,12 +79,18 @@
             </template>
           </div>
         </template>
-        <input
-          class="button"
-          type="submit"
-          value="Generate & Save"
-          data-attr-disabled="this.hasValidationErrors() === true ? true : false"
-        />
+        <div>
+          <input
+            class="button"
+            type="submit"
+            value="Generate & Save"
+            data-attr-disabled="this.hasValidationErrors() === true ? true : false"
+          />
+          <span
+            data-attr-class="this.success() ? 'help-text' : 'help-text error'"
+            data-text="this.message()"
+          ></span>
+        </div>
       </form>
     </main>
 
@@ -129,26 +135,28 @@
       .input-container > .input {
         width: 100%;
       }
+      .input-container > .label {
+        margin-bottom: 0;
+      }
 
       input:disabled {
         cursor: not-allowed;
       }
+      .dropdown > label > vscode-dropdown {
+        width: 100%;
+      }
       .button[type="submit"] {
         margin-top: 24px;
       }
-
       .help-text {
         font-weight: 500;
         color: var(--vscode-descriptionForeground);
         font-size: 11px;
       }
-      .dropdown > label > vscode-dropdown {
-        width: 100%;
-      }
-      .info {
-        color: var(--vscode-descriptionForeground);
-        font-weight: 700;
-        font-style: italic;
+      .help-text.error::before {
+        content: " X ";
+        font-size: 16px;
+        color: var(--vscode-errorForeground);
       }
       .input-container.error .pattern {
         color: var(--vscode-errorForeground);

--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -27,14 +27,14 @@
         </template>
         <template data-for="field of this.options()">
           <div class="content-wrapper">
-            <template data-if="this.isEnumField(this.field())">
+            <template data-if="this.getEnumField(this.field())">
               <div class="input-container dropdown">
                 <label class="label" data-text="this.field()[1].display_name"> </label>
                 <vscode-dropdown
                   data-attr-name="this.field()[0]"
                   data-prop-value="this.field()[1].initial_value"
                 >
-                  <template data-for="option of this.field()[1].enum"
+                  <template data-for="option of this.getEnumField(this.field())"
                     ><vscode-option
                       data-attr-value="this.option()"
                       data-text="this.option()"
@@ -47,7 +47,7 @@
                 </div>
               </div>
             </template>
-            <template data-if="!this.isEnumField(this.field())">
+            <template data-if="!this.getEnumField(this.field())">
               <div class="input-container" data-attr-id="'input_' + this.field()[0]">
                 <label
                   data-text="this.field()[1].display_name"

--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -61,9 +61,11 @@
                     data-attr-name="this.field()[0]"
                     data-attr-value="this.getFieldValue(this.field()[0])"
                     data-on-input="this.handleInput(event)"
+                    data-on-blur="this.validateInput(event)"
                     data-attr-type="this.field()[1].format === 'password' ? 'password' : 'text'"
                     data-attr-placeholder="this.field()[1].hint ? this.field()[1].hint : ''"
                     data-attr-required="this.field()[1].min_length > 0"
+                    data-attr-pattern="this.field()[1].pattern ? this.field()[1].pattern : ''"
                   />
                 </div>
                 <span class="description" data-text="this.field()[1].description"></span>
@@ -71,7 +73,12 @@
             </template>
           </div>
         </template>
-        <input class="button" type="submit" value="Generate & Save" />
+        <input
+          class="button"
+          type="submit"
+          value="Generate & Save"
+          data-attr-disabled="this.hasValidationErrors() === true ? true : false"
+        />
       </form>
     </main>
 
@@ -125,6 +132,9 @@
       .dropdown > * {
         width: 250px;
       }
+      input:disabled {
+        cursor: not-allowed;
+      }
       .dropdown {
         display: flex;
         flex-direction: column;
@@ -143,6 +153,11 @@
         color: var(--vscode-descriptionForeground);
         font-weight: 700;
         font-style: italic;
+      }
+
+      .error {
+        color: var(--vscode-errorForeground);
+        border: 1px solid var(--vscode-errorForeground);
       }
     </style>
   </body>

--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -10,15 +10,16 @@
     <link rel="stylesheet" type="text/css" nonce="${nonce}" href="${path('main.css')}" />
   </head>
   <body>
-    <main class="container">
-      <h1 data-text="'Set up ' + this.displayName()"></h1>
-      <h2 data-text="this.description()"></h2>
-      <p>
-        Take the first steps in creating a fully functional application by providing the options
-        below. You can always change them later in the project file.
-      </p>
-      <hr class="hr" />
-      <form data-on-submit="this.handleSubmit(event)">
+    <main class="container webview-form">
+      <div class="section">
+        <h1 class="heading" data-text="this.displayName()"></h1>
+        <p class="form-description" data-text="this.description()"></p>
+        <p class="form-description">
+          Take the first steps in creating a fully functional application by providing the options
+          below. You can always change them later in the project file.
+        </p>
+      </div>
+      <form class="section" data-on-submit="this.handleSubmit(event)">
         <template data-if="this.noOptions()">
           <p class="info">
             There are no configurable options for this template. Click Generate & Save to continue.
@@ -27,48 +28,53 @@
         <template data-for="field of this.options()">
           <div class="content-wrapper">
             <template data-if="this.isEnumField(this.field())">
-              <div class="input-container">
-                <div class="dropdown">
-                  <label data-text="this.field()[1].display_name"> </label>
-                  <vscode-dropdown
-                    data-attr-name="this.field()[0]"
-                    data-prop-value="this.field()[1].initial_value"
-                  >
-                    <template data-for="option of this.field()[1]._enum"
-                      ><vscode-option
-                        data-attr-value="this.option()"
-                        data-text="this.option()"
-                        data-attr-selected="this.option() === this.field()[1].initial_value"
-                      ></vscode-option>
-                    </template>
-                  </vscode-dropdown>
+              <div class="input-container dropdown">
+                <label class="label" data-text="this.field()[1].display_name"> </label>
+                <vscode-dropdown
+                  data-attr-name="this.field()[0]"
+                  data-prop-value="this.field()[1].initial_value"
+                >
+                  <template data-for="option of this.field()[1].enum"
+                    ><vscode-option
+                      data-attr-value="this.option()"
+                      data-text="this.option()"
+                      data-attr-selected="this.option() === this.field()[1].initial_value"
+                    ></vscode-option>
+                  </template>
+                </vscode-dropdown>
+                <div class="help-text">
+                  <span class="description" data-text="this.field()[1].description"></span>
                 </div>
-                <span class="description" data-text="this.field()[1].description"></span>
               </div>
             </template>
             <template data-if="!this.isEnumField(this.field())">
-              <div class="input-container">
-                <div>
-                  <label
-                    data-text="this.field()[1].display_name"
-                    data-attr-for="this.field()[0]"
-                    data-attr-class="this.field()[1].min_length > 0 ? 'label required' : 'label'"
-                  ></label>
-                  <input
-                    class="input"
-                    data-text="this.field()[1].display_name"
+              <div class="input-container" data-attr-id="'input_' + this.field()[0]">
+                <label
+                  data-text="this.field()[1].display_name"
+                  data-attr-for="this.field()[0]"
+                  data-attr-class="this.field()[1].min_length > 0 ? 'label required' : 'label'"
+                ></label>
+                <input
+                  class="input"
+                  data-text="this.field()[1].display_name"
+                  data-attr-id="this.field()[0]"
+                  data-attr-name="this.field()[0]"
+                  data-attr-value="this.getFieldValue(this.field()[0])"
+                  data-on-input="this.handleInput(event)"
+                  data-on-blur="this.validateInput(event)"
+                  data-attr-type="this.field()[1].format === 'password' ? 'password' : 'text'"
+                  data-attr-placeholder="this.field()[1].hint ? this.field()[1].hint : ''"
+                  data-attr-required="this.field()[1].min_length > 0"
+                  data-attr-pattern="this.field()[1].pattern ? this.field()[1].pattern : ''"
+                />
+                <div class="help-text">
+                  <span class="description" data-text="this.field()[1].description"></span
+                  >&nbsp;<span
+                    class="pattern"
                     data-attr-id="this.field()[0]"
-                    data-attr-name="this.field()[0]"
-                    data-attr-value="this.getFieldValue(this.field()[0])"
-                    data-on-input="this.handleInput(event)"
-                    data-on-blur="this.validateInput(event)"
-                    data-attr-type="this.field()[1].format === 'password' ? 'password' : 'text'"
-                    data-attr-placeholder="this.field()[1].hint ? this.field()[1].hint : ''"
-                    data-attr-required="this.field()[1].min_length > 0"
-                    data-attr-pattern="this.field()[1].pattern ? this.field()[1].pattern : ''"
-                  />
+                    data-text="this.field()[1].pattern ? 'Must match pattern: ' + this.field()[1].pattern : ''"
+                  ></span>
                 </div>
-                <span class="description" data-text="this.field()[1].description"></span>
               </div>
             </template>
           </div>
@@ -86,65 +92,55 @@
     <script type="module" nonce="${nonce}" src="${path('scaffold-form.js')}"></script>
     <style nonce="${nonce}">
       body {
-        max-width: 1000px;
+        margin: 0 auto;
         font-size: 14px;
       }
       .content-wrapper {
         display: contents;
       }
       .container {
-        padding: 60px 80px;
+        max-width: 960px;
+        padding: 64px 96px;
         display: flex;
         flex-direction: column;
-        gap: 16px;
+        gap: 24px;
       }
-      .container > * {
+      @media screen and (max-width: 760px) {
+        .container {
+          padding: 24px;
+        }
+      }
+      .section > * {
         margin: unset;
       }
-      h1 {
-        font-size: 26px;
-      }
-      h2 {
-        font-size: 16px;
-      }
-      form {
+      .section {
         display: flex;
         flex-direction: column;
         align-items: start;
-        gap: 20px;
-        margin-top: 26px;
+        gap: 16px;
       }
       .input-container {
         display: flex;
-        align-items: center;
-        gap: 16px;
+        flex-direction: column;
+        align-items: start;
+        gap: 2px;
         width: 100%;
-        font-weight: 500;
       }
-      @media screen and (max-width: 1000px) {
-        .input-container {
-          flex-wrap: wrap;
-          gap: 8px;
-          padding-bottom: 5px;
-        }
+      .input-container > .input {
+        width: 100%;
       }
-      input:not([type="submit"]),
-      .dropdown > * {
-        width: 250px;
-      }
+
       input:disabled {
         cursor: not-allowed;
       }
-      .dropdown {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-        align-items: start;
+      .button[type="submit"] {
+        margin-top: 24px;
       }
-      .description {
-        font-weight: 700;
+
+      .help-text {
+        font-weight: 500;
         color: var(--vscode-descriptionForeground);
-        font-size: 12px;
+        font-size: 11px;
       }
       .dropdown > label > vscode-dropdown {
         width: 100%;
@@ -154,9 +150,11 @@
         font-weight: 700;
         font-style: italic;
       }
-
-      .error {
+      .input-container.error .pattern {
         color: var(--vscode-errorForeground);
+      }
+      .input-container.error .input,
+      input:user-invalid {
         border: 1px solid var(--vscode-errorForeground);
       }
     </style>

--- a/src/webview/scaffold-form.spec.ts
+++ b/src/webview/scaffold-form.spec.ts
@@ -124,17 +124,6 @@ test("empty form submission works", async ({ execute, page }) => {
     window.dispatchEvent(new Event("DOMContentLoaded"));
   });
 
-  // await page.focus("[name=cc_bootstrap_server]");
-  // await page.keyboard.type("cc_bootstrap_server");
-  // await page.focus("[name=api_key]");
-  // await page.keyboard.type("api_key");
-  // await page.focus("[name=api_secret]");
-  // await page.keyboard.type("api_secret");
-  // await page.focus("[name=cc_topic]");
-  // await page.keyboard.type("cc_topic");
-  // await page.focus("[name=group_id]");
-  // await page.keyboard.type("group_id");
-
   await page.click("input[type=submit]");
 
   const specCallHandle = await sendWebviewMessage.evaluateHandle((stub) => stub.getCall(0).args);

--- a/src/webview/scaffold-form.spec.ts
+++ b/src/webview/scaffold-form.spec.ts
@@ -8,6 +8,7 @@ import esbuild from "rollup-plugin-esbuild";
 import { test } from "rollwright";
 import { SinonStub } from "sinon";
 import { ScaffoldV1TemplateSpec } from "../clients/scaffoldingService";
+import { ScaffoldV1TemplateSpecAlt } from "./scaffold-form";
 
 const template = readFileSync(new URL("scaffold-form.html", import.meta.url), "utf8");
 function render(template: string, variables: Record<string, any>) {
@@ -50,7 +51,7 @@ test("dummy form submission", async ({ execute, page }) => {
   });
 
   await execute(async (stub) => {
-    const dummy: ScaffoldV1TemplateSpec = {
+    const dummy: ScaffoldV1TemplateSpecAlt = {
       version: "0.0.1",
       name: "go-consumer",
       display_name: "Go Consumer Application",
@@ -93,7 +94,7 @@ test("dummy form submission", async ({ execute, page }) => {
           display_name: "Begin Consuming From",
           description:
             "What to do when there is no initial offset in the Kafka topic or if the current offset does not exist any more on the server (e.g. because that data has been deleted).",
-          _enum: ["earliest", "latest"],
+          enum: ["earliest", "latest"],
           initial_value: "earliest",
         },
       },

--- a/src/webview/scaffold-form.spec.ts
+++ b/src/webview/scaffold-form.spec.ts
@@ -11,6 +11,7 @@ import { ScaffoldV1TemplateSpec } from "../clients/scaffoldingService";
 import { ScaffoldV1TemplateSpecAlt } from "./scaffold-form";
 
 const template = readFileSync(new URL("scaffold-form.html", import.meta.url), "utf8");
+
 function render(template: string, variables: Record<string, any>) {
   return template
     .replace(/\$\{([^}]+)\}/g, (_, v) => variables[v])
@@ -44,7 +45,7 @@ test.use({
   ],
 });
 
-test("dummy form submission", async ({ execute, page }) => {
+test("empty form submission works", async ({ execute, page }) => {
   const sendWebviewMessage = await execute(async () => {
     const { sendWebviewMessage } = await import("./comms/comms");
     return sendWebviewMessage as SinonStub;
@@ -123,16 +124,16 @@ test("dummy form submission", async ({ execute, page }) => {
     window.dispatchEvent(new Event("DOMContentLoaded"));
   });
 
-  await page.focus("[name=cc_bootstrap_server]");
-  await page.keyboard.type("cc_bootstrap_server");
-  await page.focus("[name=api_key]");
-  await page.keyboard.type("api_key");
-  await page.focus("[name=api_secret]");
-  await page.keyboard.type("api_secret");
-  await page.focus("[name=cc_topic]");
-  await page.keyboard.type("cc_topic");
-  await page.focus("[name=group_id]");
-  await page.keyboard.type("group_id");
+  // await page.focus("[name=cc_bootstrap_server]");
+  // await page.keyboard.type("cc_bootstrap_server");
+  // await page.focus("[name=api_key]");
+  // await page.keyboard.type("api_key");
+  // await page.focus("[name=api_secret]");
+  // await page.keyboard.type("api_secret");
+  // await page.focus("[name=cc_topic]");
+  // await page.keyboard.type("cc_topic");
+  // await page.focus("[name=group_id]");
+  // await page.keyboard.type("group_id");
 
   await page.click("input[type=submit]");
 
@@ -150,11 +151,134 @@ test("dummy form submission", async ({ execute, page }) => {
   // @ts-expect-error we already checked for undefined
   expect(submitCall[1]).toEqual({
     data: {
-      cc_bootstrap_server: "cc_bootstrap_server",
-      api_key: "api_key",
-      api_secret: "api_secret",
-      cc_topic: "cc_topic",
-      group_id: "group_id",
+      cc_bootstrap_server: "",
+      api_key: "",
+      api_secret: "",
+      cc_topic: "",
+      group_id: "",
+      auto_offset_reset: "earliest",
+    },
+  });
+});
+
+test("form prevents invalid submissions", async ({ execute, page }) => {
+  const sendWebviewMessage = await execute(async () => {
+    const { sendWebviewMessage } = await import("./comms/comms");
+    return sendWebviewMessage as SinonStub;
+  });
+
+  await execute(async (stub) => {
+    const dummy: ScaffoldV1TemplateSpecAlt = {
+      version: "0.0.1",
+      name: "go-consumer",
+      display_name: "Go Consumer Application",
+      description:
+        "A simple Go project that reads messages from a topic in Confluent Cloud. Ideal for developers new to Kafka who want to learn about stream processing with Kafka.\n",
+      language: "Go",
+      tags: ["consumer", "getting started", "go"],
+      options: {
+        cc_bootstrap_server: {
+          display_name: "Kafka Bootstrap Server",
+          description:
+            "One or more comma-separated host and port pairs that are the addresses where Kafka brokers accept client bootstrap requests.",
+          pattern:
+            "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-.]{0,61}[a-zA-Z0-9])[:]([0-9]{2,8}))(,([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-.]{0,61}[a-zA-Z0-9])[:]([0-9]{2,8}))*$",
+          initial_value: "",
+        },
+        api_key: {
+          display_name: "Kafka Cluster API Key",
+          description: "The API key for accessing the Kafka cluster in Confluent Cloud.",
+          pattern: "^[A-Z0-7=]{16}$",
+        },
+        api_secret: {
+          display_name: "Kafka Cluster API Secret",
+          description: "The API secret for accessing the Kafka cluster in Confluent Cloud.",
+          format: "password",
+          pattern: "^[A-Z0-7=]{64,72}$",
+        },
+        cc_topic: {
+          display_name: "Topic Name",
+          description: "The name of the Kafka topic to consume.",
+          pattern: "^([a-zA-Z0-9._-]{1,255})$",
+        },
+        group_id: {
+          display_name: "Consumer Group",
+          description:
+            "A unique string that identifies the consumer group this consumer belongs to. This property is required if the consumer subscribes to a topic or uses the Kafka-based offset management strategy.",
+          pattern: "^([a-zA-Z0-9._-]{1,255})$",
+        },
+        auto_offset_reset: {
+          display_name: "Begin Consuming From",
+          description:
+            "What to do when there is no initial offset in the Kafka topic or if the current offset does not exist any more on the server (e.g. because that data has been deleted).",
+          enum: ["earliest", "latest"],
+          initial_value: "earliest",
+        },
+      },
+    };
+    const transformedOptions =
+      dummy.options !== undefined
+        ? Object.entries(dummy.options).reduce(
+            (acc, [key, value]) => {
+              acc[key] = value.initial_value || "";
+              return acc;
+            },
+            {} as Record<string, string>,
+          )
+        : {};
+    stub.withArgs("GetOptionValues").resolves(transformedOptions);
+    stub.withArgs("SetOptionValue").resolves(null);
+    stub.withArgs("GetTemplateSpec").resolves(dummy satisfies ScaffoldV1TemplateSpec);
+    stub.withArgs("Submit").resolves(null);
+  }, sendWebviewMessage);
+
+  await execute(async () => {
+    await import("./main");
+    await import("./scaffold-form");
+    // redispatching because the page already exists for some time
+    // before we actually import the view model application
+    window.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  const submitBtn = page.locator("input[type=submit]");
+  // try to use invalid value
+  await page.focus("[name=api_key]");
+  await page.keyboard.type("not a key");
+  await page.focus("[name=cc_bootstrap_server]"); // blur to invoke validation
+  expect(
+    await page.locator("[name=api_key]").evaluate((el) => el.matches(":invalid")),
+  ).toBeTruthy();
+  expect(submitBtn).toBeDisabled();
+
+  // Delete value and submit
+  await page.focus("[name=api_key]");
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.keyboard.press("Backspace");
+  await page.keyboard.type("MUSTBE16CHARACTE");
+
+  await page.focus("[name=cc_bootstrap_server]"); // blur to invoke validation
+  expect(await page.locator("[name=api_key]").evaluate((el) => el.matches(":invalid"))).toBeFalsy();
+  await submitBtn.click();
+
+  const specCallHandle = await sendWebviewMessage.evaluateHandle((stub) => stub.getCall(0).args);
+  const specCall = await specCallHandle.jsonValue();
+  expect(specCall[0]).toBe("GetTemplateSpec");
+
+  const submitCallHandle = await sendWebviewMessage.evaluateHandle(
+    (stub) => stub.getCalls().find((call) => call?.args[0] === "Submit")?.args,
+  );
+  const submitCall = await submitCallHandle?.jsonValue();
+  expect(submitCall).not.toBeUndefined();
+  // @ts-expect-error we already checked for undefined
+  expect(submitCall[0]).toBe("Submit");
+  // @ts-expect-error we already checked for undefined
+  expect(submitCall[1]).toEqual({
+    data: {
+      cc_bootstrap_server: "",
+      api_key: "MUSTBE16CHARACTE",
+      api_secret: "",
+      cc_topic: "",
+      group_id: "",
       auto_offset_reset: "earliest",
     },
   });

--- a/src/webview/scaffold-form.ts
+++ b/src/webview/scaffold-form.ts
@@ -41,9 +41,8 @@ class ScaffoldFormViewModel extends ViewModel {
     return true;
   });
 
-  // Updated on blur in validateInput, based on inputs with class "error".
-  // Initially set to true to prevent form submission without touching fields
-  hasValidationErrors = this.signal(true);
+  // Updated in validateInput & submit handler checks
+  hasValidationErrors = this.signal(false);
 
   isEnumField(field: [string, ScaffoldV1TemplateOption]) {
     return field[1]._enum;
@@ -65,24 +64,27 @@ class ScaffoldFormViewModel extends ViewModel {
     const minLength = this.spec()?.options?.[key]?.min_length;
     const required = minLength !== undefined && minLength > 0;
     const pattern = this.spec()?.options?.[key]?.pattern;
+    const inputContainer = input.closest(".input-container");
     if (required && value.length < minLength) {
       console.log(input.name, "not long enough");
-      input.classList.add("error");
+      inputContainer?.classList.add("error");
     } else if (value !== "" && pattern && !new RegExp(pattern).test(value)) {
       console.log(input.name, "not valid");
-      input.classList.add("error");
+      inputContainer?.classList.add("error");
     } else {
       console.log(input.name, "ok");
-      input.classList.remove("error");
+      inputContainer?.classList.remove("error");
     }
-    this.hasValidationErrors(document.querySelectorAll(".input.error").length > 0);
+    this.hasValidationErrors(document.querySelectorAll(".input-container.error").length > 0);
   }
 
   handleSubmit(event: Event) {
     event.preventDefault();
-    this.hasValidationErrors(document.querySelectorAll(".input.error").length > 0);
-    if (this.hasValidationErrors()) return;
     const form = event.target as HTMLFormElement;
+    this.hasValidationErrors(
+      document.querySelectorAll(".input-container.error").length > 0 || !form.checkValidity(),
+    );
+    if (this.hasValidationErrors()) return;
     const formData = new FormData(form);
     const data = Object.fromEntries(formData.entries());
     post("Submit", { data });

--- a/src/webview/scaffold-form.ts
+++ b/src/webview/scaffold-form.ts
@@ -11,7 +11,7 @@ addEventListener("DOMContentLoaded", () => {
   applyBindings(ui, os, vm);
 });
 
-/** In the Scaffolding Service, `enum` is not a reserved word, but in Typescript it is.
+/** In the Scaffolding Service (golang), `enum` is not a reserved word, but here in Typescript it is.
  * Our OpenAPI generator converts it to `_enum` instead, but we get the Template Options with the original underscore-less version.
  * These two type interfaces are combining those types, which allows us to check for either spelling
  * in getEnumField() when we use the option to generate a <select> element in the form.

--- a/src/webview/scaffold-form.ts
+++ b/src/webview/scaffold-form.ts
@@ -11,6 +11,19 @@ addEventListener("DOMContentLoaded", () => {
   applyBindings(ui, os, vm);
 });
 
+/** In the Scaffolding Service, `enum` is not a reserved word, but in Typescript it is.
+ * Our OpenAPI generator converts it to `_enum` instead, but we get the Template Options with the original underscore-less version.
+ * These two type interfaces are combining those types, which allows us to check for either spelling
+ * in getEnumField() when we use the option to generate a <select> element in the form.
+ */
+export interface ScaffoldV1TemplateOptionAlt extends ScaffoldV1TemplateOption {
+  enum?: string[];
+  _enum?: string[];
+}
+export interface ScaffoldV1TemplateSpecAlt extends ScaffoldV1TemplateSpec {
+  options: Record<string, ScaffoldV1TemplateOptionAlt>;
+}
+
 class ScaffoldFormViewModel extends ViewModel {
   spec = this.resolve(async () => {
     return await post("GetTemplateSpec", {});
@@ -44,8 +57,8 @@ class ScaffoldFormViewModel extends ViewModel {
   // Updated in validateInput & submit handler checks
   hasValidationErrors = this.signal(false);
 
-  isEnumField(field: [string, ScaffoldV1TemplateOption]) {
-    return field[1]._enum;
+  getEnumField(field: [string, ScaffoldV1TemplateOptionAlt]) {
+    return field[1].enum ?? field[1]._enum;
   }
 
   handleInput(event: Event) {

--- a/src/webview/scaffold-form.ts
+++ b/src/webview/scaffold-form.ts
@@ -11,10 +11,10 @@ addEventListener("DOMContentLoaded", () => {
   applyBindings(ui, os, vm);
 });
 
-/** In the Scaffolding Service (golang), `enum` is not a reserved word, but here in Typescript it is.
- * Our OpenAPI generator converts it to `_enum` instead, but we get the Template Options with the original underscore-less version.
- * These two type interfaces are combining those types, which allows us to check for either spelling
- * in getEnumField() when we use the option to generate a <select> element in the form.
+/** XXXX: We uncovered an issue in the way our OpenAPI spec is generated in the Scaffold Service
+ * and it means the reserved word in our options templates no longer gets converted from `enum` to `_enum`,
+ * causing a TypeScript error. To workaround it *temporarily* we have this special type interface for the form.
+ * TODO we should either patch the OpenAPI generator or push for template spec changes.
  */
 export interface ScaffoldV1TemplateOptionAlt extends ScaffoldV1TemplateOption {
   enum?: string[];
@@ -54,8 +54,7 @@ class ScaffoldFormViewModel extends ViewModel {
     return true;
   });
 
-  // Updated in validateInput & submit handler checks
-  hasValidationErrors = this.signal(false);
+  hasValidationErrors = this.signal(false); // updated in validateInput & submit handler checks
   success = this.signal(true); // only false if submission fails
   message = this.signal("");
 

--- a/src/webview/uikit/uikit.css
+++ b/src/webview/uikit/uikit.css
@@ -120,10 +120,6 @@
   line-height: normal;
   margin-bottom: 5px;
 }
-.label.required::after {
-  content: "*";
-  color: var(--vscode-inputValidation-errorBorder);
-}
 
 .hr {
   height: 1px;
@@ -173,6 +169,10 @@
 .input[type="submit"]:hover:not(:disabled),
 .button:hover:not(:disabled) {
   background-color: var(--vscode-button-hoverBackground);
+}
+.input[type="submit"]:disabled,
+.button:disabled {
+  opacity: 0.4;
 }
 .button.secondary {
   color: var(--vscode-button-secondaryForeground);

--- a/src/webview/uikit/uikit.css
+++ b/src/webview/uikit/uikit.css
@@ -49,6 +49,20 @@
   color: var(--vscode-list-activeSelectionForeground, #ffffff);
 }
 
+.webview-form .heading {
+  font-size: 26px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+}
+
+.webview-form .form-description {
+  color: var(--vscode-sideBarSectionHeader-foreground);
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
 /**
  * <label class="checkbox">
  *   <input type="checkbox" />
@@ -119,6 +133,12 @@
   font-size: var(--cflt-base-font-size);
   line-height: normal;
   margin-bottom: 5px;
+  font-style: normal;
+  font-weight: 500;
+}
+.label.required::after {
+  content: "*";
+  color: var(--vscode-inputValidation-errorBorder);
 }
 
 .hr {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
### Adds client-side form validation to the Project Generation Form for *required* and *invalid* options. 
We switched to use the new Scaffold Service to generate projects, which will check all fields and return an error message if they are not valid. With this PR we avoid the round trip by attempting to validate client-side first, and show any error response from the API in the form for users. 
- Closes #907 
- If the input value is non-empty & it has a `pattern`, we validate against the pattern on blur and show a red border if invalid. 
- Form submit is disabled if invalid fields are present.
- Extends the Submit function to return a `PostMessage` type instead of null, similar to Direct Connect form.
- If we still get an error response on submit, the form shows a message by the Save button (per recent design mocks for our forms. See additional details below.) 

| Other errors on submit show up like this: | 
| -- |
| <img width="784" alt="res-error" src="https://github.com/user-attachments/assets/3dfe5082-228d-4983-94c9-5afb4da90f46" /> | 


| New Blank Form |
| -- | 
| <img width="1305" alt="Screenshot 2025-01-24 at 1 38 20 PM" src="https://github.com/user-attachments/assets/a3ea8a3f-8af5-4168-b733-92380bdb2b3b" /> |
|  New invalid styles | 
| <img width="1319" alt="invalid" src="https://github.com/user-attachments/assets/56ebdf99-5bce-4628-bf4d-e3b72b44208f" /> |

## Any additional details or context that should be provided?

- We uncovered an issue in the way our OpenAPI spec is generated in the Scaffold Service that means our options templates no longer get converted from `enum` to `_enum`, causing a TypeScript error. To workaround it *temporarily* we have a special type interface for the form. In the near future we will either patch the OpenAPI generator or push for template spec changes. 
- We now have `pattern_description`, `order`, and other exciting things coming for templates. Plus, more styling is needed to pull it in line with our new form mocks from Design team. Expect clean up and updates in PRs coming soon! 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
