### PR TITLE
fix: make ConnectionStateWatcher.handleConnectionUpdateEvent use parsed `Connection` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this extension will be documented in this file.
 ### Fixed
 
 - Extension/sidecar logs and the support zip can now be saved as expected on Windows.
+- CCloud auth sessions will now show the pre-expiration warning and post-expiration error
+  notifications as expected.
 
 ## 0.23.3
 

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -9,6 +9,7 @@ import { getTestExtensionContext } from "../tests/unit/testUtils";
 import {
   ConnectionsList,
   ConnectionSpec,
+  ConnectionSpecFromJSON,
   ConnectionsResourceApi,
   ResponseError,
 } from "./clients/sidecar";
@@ -283,7 +284,12 @@ describe("DirectConnectionManager behavior", () => {
 
     await DirectConnectionManager.getInstance().rehydrateConnections();
 
-    assert.ok(tryToCreateConnectionStub.calledOnceWith(TEST_DIRECT_CONNECTION_FORM_SPEC));
+    assert.ok(tryToCreateConnectionStub.calledOnce);
+    const args = tryToCreateConnectionStub.getCall(0).args;
+    assert.deepStrictEqual(
+      ConnectionSpecFromJSON(args[0]),
+      ConnectionSpecFromJSON(TEST_DIRECT_CONNECTION_FORM_SPEC),
+    );
   });
 
   it("rehydrateConnections() should not inform the sidecar of existing/tracked connections", async () => {

--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   ConnectedState,
   Connection,
+  ConnectionFromJSON,
   ConnectionToJSONTyped,
   ConnectionType,
   instanceOfConnection,
@@ -179,7 +180,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
     const testAuthStatus = { authentication: { status: Status.NoToken } };
 
     it(`${baseConnection.spec.type}: waitForConnectionToBeStable() should return the connection when it becomes usable`, async () => {
-      const testConnection: Connection = {
+      const testConnection: Connection = ConnectionFromJSON({
         ...baseConnection,
         status: {
           kafka_cluster: { state: usableKafkaClusterState },
@@ -187,7 +188,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
           ccloud: { state: usableCcloudState },
           ...testAuthStatus,
         },
-      };
+      });
 
       announceConnectionState(testConnection);
 
@@ -200,7 +201,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
       // use fake timers so we can control the time and "time out" quickly
       clock = sandbox.useFakeTimers(Date.now());
 
-      const testConnection: Connection = {
+      const testConnection: Connection = ConnectionFromJSON({
         ...baseConnection,
         status: {
           kafka_cluster: { state: pendingState },
@@ -208,7 +209,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
           ccloud: { state: pendingState },
           ...testAuthStatus,
         },
-      };
+      });
       announceConnectionState(testConnection);
 
       // set a short timeout, even though we're using fake timers
@@ -227,7 +228,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
     });
 
     it(`${baseConnection.spec.type}: waitForConnectionToBeStable() should wait for websocket event if the connection is not found initially`, async () => {
-      const testConnection = {
+      const testConnection = ConnectionFromJSON({
         ...baseConnection,
         status: {
           kafka_cluster: { state: usableKafkaClusterState },
@@ -235,7 +236,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
           ccloud: { state: usableCcloudState },
           ...testAuthStatus,
         },
-      };
+      });
 
       // wrap a spy around isConnectionStable so we can check when it's called
       const isConnectionStableSpy = sandbox.spy(watcherUtils, "isConnectionStable");

--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -1,12 +1,20 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import {
+  TEST_AUTHENTICATED_CCLOUD_CONNECTION,
   TEST_CCLOUD_CONNECTION,
   TEST_DIRECT_CONNECTION,
   TEST_DIRECT_CONNECTION_ID,
   TEST_LOCAL_CONNECTION,
 } from "../../../tests/unit/testResources/connection";
-import { ConnectedState, Connection, ConnectionType, Status } from "../../clients/sidecar";
+import {
+  ConnectedState,
+  Connection,
+  ConnectionToJSONTyped,
+  ConnectionType,
+  instanceOfConnection,
+  Status,
+} from "../../clients/sidecar";
 import { connectionStable } from "../../emitters";
 import { ConnectionId } from "../../models/resource";
 import {
@@ -17,6 +25,7 @@ import {
   newMessageHeaders,
 } from "../../ws/messageTypes";
 
+import { CCLOUD_CONNECTION_ID } from "../../constants";
 import * as errors from "../../errors";
 import {
   ConnectionStateWatcher,
@@ -25,6 +34,78 @@ import {
   waitForConnectionToBeStable,
 } from "./watcher";
 import * as watcherUtils from "./watcherUtils";
+
+describe("sidecar/connections/watcher.ts ConnectionStateWatcher handleConnectionUpdateEvent()", () => {
+  let sandbox: sinon.SinonSandbox;
+  let connectionEventHandlerStub: sinon.SinonStub;
+  let logResponseErrorStub: sinon.SinonStub;
+
+  let connectionStateWatcher: ConnectionStateWatcher;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    connectionStateWatcher = ConnectionStateWatcher.getInstance();
+    connectionEventHandlerStub = sandbox.stub(watcherUtils, "connectionEventHandler").returns();
+    logResponseErrorStub = sandbox.stub(errors, "logResponseError").resolves();
+  });
+
+  afterEach(() => {
+    connectionStateWatcher.purgeCachedConnectionState(CCLOUD_CONNECTION_ID);
+    sandbox.restore();
+  });
+
+  it("should parse valid Connection-like JSON objects correctly", async () => {
+    // since websockets don't go through the same client code as the (HTTP) REST API, we need to
+    // test that the watcher can coerce the JSON object into a Connection object correctly
+    const connectionObj = ConnectionToJSONTyped(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+    assert.equal(
+      // not Date
+      typeof connectionObj["status"]["authentication"]["requires_authentication_at"],
+      "string",
+    );
+
+    const message: Message<MessageType.CONNECTION_EVENT> = {
+      headers: newMessageHeaders(MessageType.CONNECTION_EVENT),
+      body: {
+        action: ConnectionEventAction.UPDATED,
+        connection: connectionObj,
+      },
+    };
+
+    await connectionStateWatcher.handleConnectionUpdateEvent(message);
+
+    assert.ok(connectionEventHandlerStub.calledOnce);
+    assert.ok(logResponseErrorStub.notCalled);
+    const cachedEvent = connectionStateWatcher.getLatestConnectionEvent(
+      TEST_AUTHENTICATED_CCLOUD_CONNECTION.id as ConnectionId,
+    );
+    assert.ok(cachedEvent);
+    assert.ok(instanceOfConnection(cachedEvent.connection));
+    assert.ok(
+      cachedEvent.connection.status.authentication.requires_authentication_at instanceof Date,
+    );
+  });
+
+  it("should handle invalid Connection JSON objects gracefully", async () => {
+    const connectionString = "{error: 'this is not a Connection object'}";
+
+    const message: Message<MessageType.CONNECTION_EVENT> = {
+      headers: newMessageHeaders(MessageType.CONNECTION_EVENT),
+      body: {
+        action: ConnectionEventAction.UPDATED,
+        connection: connectionString as any,
+      },
+    };
+
+    await connectionStateWatcher.handleConnectionUpdateEvent(message);
+
+    assert.ok(connectionEventHandlerStub.notCalled);
+    assert.ok(logResponseErrorStub.calledOnce);
+    const cachedEvent = connectionStateWatcher.getLatestConnectionEvent(CCLOUD_CONNECTION_ID);
+    // we shouldn't have set the connection to anything since the JSON was invalid
+    assert.strictEqual(cachedEvent, null);
+  });
+});
 
 describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
   const connectionStateWatcher = ConnectionStateWatcher.getInstance();

--- a/src/sidecar/connections/watcherUtils.test.ts
+++ b/src/sidecar/connections/watcherUtils.test.ts
@@ -43,10 +43,9 @@ describe("connectionEventHandler", () => {
       // upon reciept of a connection event for the CCloud connection.
 
       // Arrange
-      const reactToCCloudAuthStateStub = sandbox.stub(
-        ccloudStateHandling,
-        "reactToCCloudAuthState",
-      );
+      const reactToCCloudAuthStateStub = sandbox
+        .stub(ccloudStateHandling, "reactToCCloudAuthState")
+        .resolves();
 
       const testConnectionEvent: ConnectionEventBody = {
         action: action,
@@ -65,14 +64,16 @@ describe("connectionEventHandler", () => {
 
       assert.ok(
         reactToCCloudAuthStateStub.calledWith(TEST_CCLOUD_CONNECTION),
-        "called with test ccloud connection",
+        `reactToCCloudAuthState called with ${reactToCCloudAuthStateStub.getCall(0).args[0]}`,
       );
     });
   }
 
   it("CCloud connection DELETED event should not call ccloudStateHandling.reactToCCloudAuthState", () => {
     // Arrange
-    const reactToCCloudAuthStateStub = sandbox.stub(ccloudStateHandling, "reactToCCloudAuthState");
+    const reactToCCloudAuthStateStub = sandbox
+      .stub(ccloudStateHandling, "reactToCCloudAuthState")
+      .resolves();
 
     const testConnectionEvent: ConnectionEventBody = {
       action: ConnectionEventAction.DELETED,

--- a/src/sidecar/connections/watcherUtils.ts
+++ b/src/sidecar/connections/watcherUtils.ts
@@ -70,7 +70,9 @@ export function connectionEventHandler(event: ConnectionEventBody) {
           logger.debug(
             "connectionEventHandler: ccloud connection update received, passing to reactToCCloudAuthState()",
           );
-          reactToCCloudAuthState(connection);
+          reactToCCloudAuthState(connection).catch((e) => {
+            logger.error(`connectionEventHandler: reactToCCloudAuthState() failed: ${e}`, e.stack);
+          });
           break;
         case "DELETED":
           // When a DELETED event comes, it will come with the prior (perhaps fully happy) spelling of the connection.

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -11,7 +11,7 @@ import {
   TEST_LOCAL_KAFKA_TOPIC,
 } from "../../tests/unit/testResources";
 import {
-  TEST_DIRECT_CONNECTION,
+  TEST_DIRECT_CONNECTION_FORM_SPEC,
   TEST_DIRECT_CONNECTION_ID,
 } from "../../tests/unit/testResources/connection";
 import { getTestExtensionContext, getTestStorageManager } from "../../tests/unit/testUtils";
@@ -26,6 +26,7 @@ import { UriMetadataKeys, WorkspaceStorageKeys } from "./constants";
 import {
   CCloudKafkaClustersByEnv,
   CCloudSchemaRegistryByEnv,
+  CustomConnectionSpec,
   DirectConnectionsById,
   getResourceManager,
   ResourceManager,
@@ -984,7 +985,7 @@ describe("ResourceManager direct connection methods", function () {
 
   it("addDirectConnection() should correctly store a direct connection spec", async () => {
     // preload one connection
-    const spec = TEST_DIRECT_CONNECTION.spec;
+    const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
     await rm.addDirectConnection(spec);
 
     // make sure it exists
@@ -993,7 +994,8 @@ describe("ResourceManager direct connection methods", function () {
     assert.deepStrictEqual(storedSpecs, new Map([[TEST_DIRECT_CONNECTION_ID, spec]]));
     assert.deepStrictEqual(storedSpecs.get(TEST_DIRECT_CONNECTION_ID), spec);
 
-    const storedSpec: ConnectionSpec | null =
+    // and that it also exists when fetched directly
+    const storedSpec: CustomConnectionSpec | null =
       await rm.getDirectConnection(TEST_DIRECT_CONNECTION_ID);
     assert.ok(storedSpec);
     assert.deepStrictEqual(storedSpec, spec);
@@ -1019,9 +1021,9 @@ describe("ResourceManager direct connection methods", function () {
     // preload two connections
     const connId1: ConnectionId = TEST_DIRECT_CONNECTION_ID;
     const connId2: ConnectionId = "other-id" as ConnectionId;
-    const specs: ConnectionSpec[] = [
-      TEST_DIRECT_CONNECTION.spec,
-      { ...TEST_DIRECT_CONNECTION.spec, id: connId2 },
+    const specs: CustomConnectionSpec[] = [
+      TEST_DIRECT_CONNECTION_FORM_SPEC,
+      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: connId2 },
     ];
     await Promise.all(specs.map((spec) => rm.addDirectConnection(spec)));
 
@@ -1043,10 +1045,10 @@ describe("ResourceManager direct connection methods", function () {
 
   it("deleteDirectConnections() should delete all direct connections", async () => {
     // preload multiple connections
-    const specs: ConnectionSpec[] = [
-      TEST_DIRECT_CONNECTION.spec,
-      { ...TEST_DIRECT_CONNECTION.spec, id: "other-id" },
-      { ...TEST_DIRECT_CONNECTION.spec, id: "another-id" },
+    const specs: CustomConnectionSpec[] = [
+      TEST_DIRECT_CONNECTION_FORM_SPEC,
+      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: "other-id" as ConnectionId },
+      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: "another-id" as ConnectionId },
     ];
     await Promise.all(specs.map((spec) => rm.addDirectConnection(spec)));
 

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "crypto";
-import { Connection, ConnectionType, UserInfo } from "../../../src/clients/sidecar";
+import {
+  Connection,
+  ConnectionFromJSON,
+  ConnectionSpecFromJSON,
+  ConnectionType,
+  UserInfo,
+} from "../../../src/clients/sidecar";
 import {
   CCLOUD_AUTH_CALLBACK_URI,
   CCLOUD_CONNECTION_ID,
@@ -23,7 +29,7 @@ export const TEST_CCLOUD_USER: UserInfo = {
 const TEST_AUTH_EXPIRATION = new Date(Date.now() + 4 * 60 * 60 * 1000);
 
 /** A basic CCloud {@link Connection} with `NO_TOKEN` auth status. */
-export const TEST_CCLOUD_CONNECTION: Connection = {
+export const TEST_CCLOUD_CONNECTION: Connection = ConnectionFromJSON({
   api_version: "gateway/v1",
   kind: "Connection",
   id: CCLOUD_CONNECTION_ID,
@@ -44,10 +50,10 @@ export const TEST_CCLOUD_CONNECTION: Connection = {
       status: "NO_TOKEN",
     },
   },
-};
+});
 
 /** A CCloud {@link Connection} with `VALID_TOKEN` auth status and user info. */
-export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = {
+export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = ConnectionFromJSON({
   ...TEST_CCLOUD_CONNECTION,
   status: {
     ...TEST_CCLOUD_CONNECTION.status,
@@ -57,9 +63,9 @@ export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = {
       requires_authentication_at: TEST_AUTH_EXPIRATION,
     },
   },
-};
+});
 
-export const TEST_LOCAL_CONNECTION: Connection = {
+export const TEST_LOCAL_CONNECTION: Connection = ConnectionFromJSON({
   api_version: "gateway/v1",
   kind: "Connection",
   id: LOCAL_CONNECTION_ID,
@@ -72,10 +78,10 @@ export const TEST_LOCAL_CONNECTION: Connection = {
       status: "NO_TOKEN",
     },
   },
-};
+});
 
 export const TEST_DIRECT_CONNECTION_ID = randomUUID() as ConnectionId;
-export const TEST_DIRECT_CONNECTION: Connection = {
+export const TEST_DIRECT_CONNECTION: Connection = ConnectionFromJSON({
   api_version: "gateway/v1",
   kind: "Connection",
   id: TEST_DIRECT_CONNECTION_ID,
@@ -92,11 +98,11 @@ export const TEST_DIRECT_CONNECTION: Connection = {
       status: "NO_TOKEN",
     },
   },
-};
+});
 
 /** Fake spec augmented with `formConnectionType` for test purposes. */
 export const TEST_DIRECT_CONNECTION_FORM_SPEC: CustomConnectionSpec = {
-  ...TEST_DIRECT_CONNECTION.spec,
+  ...ConnectionSpecFromJSON(TEST_DIRECT_CONNECTION.spec),
   id: TEST_DIRECT_CONNECTION_ID, // enforced ConnectionId type
   formConnectionType: "Apache Kafka",
 };


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes https://github.com/confluentinc/vscode/issues/940.

Using websockets to receive connection events, we don't go through the same middleware/parsing layers as we do for the sidecar REST (HTTP) API, so in order to use the "real"/typed objects, we need to convert them (and their nested structures) to the expected types.

The main fix is in https://github.com/confluentinc/vscode/blob/fb162e544273fb9ec4bd7b828e0221b149356fb2/src/sidecar/connections/watcher.ts#L306-L311
Which ultimately calls into https://github.com/confluentinc/vscode/blob/e900d8a3f114c05d6385cb0e8b3668c59117d01d/src/clients/sidecar/models/Authentication.ts#L86-L89

The fact that we were dealing with a `requires_authentication_at` string instead of `Date` was silently throwing an error here:
https://github.com/confluentinc/vscode/blob/e900d8a3f114c05d6385cb0e8b3668c59117d01d/src/authn/ccloudStateHandling.ts#L108

Also added a `.catch()` on the `reactToCCloudAuthState()` call since we don't `await` it but want to know if anything goes wrong.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

This new `<structure>ToJSON()` and `<structure>FromJSON()` usage broke a lot of previous assumptions regarding testing, so there were a lot more test changes included as well to ensure we weren't basing our tests on partial `Connection` objects.

It _also_ broke some assumptions around how we were handling stored `[Custom]ConnectionSpec` objects going in/out of SecretStorage, so some of the direct connection handling also had to be updated. 

> [!IMPORTANT]
> I also click-tested this against direct connections made on `main` to make sure we could still load/edit existing connections with these changes, and I didn't run into any issues. I do not think any kind of migration is needed here.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
