### PR TITLE
Lowest level enforced websocket message higher-level field decoding

### DIFF
--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -1,12 +1,7 @@
 import { commands, EventEmitter } from "vscode";
-import {
-  Connection,
-  ConnectionFromJSON,
-  ConnectionType,
-  instanceOfConnection,
-} from "../../clients/sidecar";
+import { Connection, ConnectionType } from "../../clients/sidecar";
 import { connectionStable, environmentChanged } from "../../emitters";
-import { logResponseError, showErrorNotificationWithButtons } from "../../errors";
+import { showErrorNotificationWithButtons } from "../../errors";
 import { Logger } from "../../logging";
 import { ConnectionId, connectionIdToType, EnvironmentId } from "../../models/resource";
 import {
@@ -299,29 +294,6 @@ export class ConnectionStateWatcher {
     logger.debug(
       `ConnectionStateWatcher: received ${message.body.action} event for connection id ${connectionId}`,
     );
-
-    // ensure Connection structure is coerced to the expected types (e.g. `requires_authentication_at`
-    // as a Date and not a string) for any callers that need to work with it
-    try {
-      if (!instanceOfConnection(connectionEvent.connection)) {
-        throw new Error(
-          `WebSocket message contained a non-Connection object: ${JSON.stringify(connectionEvent)}`,
-        );
-      }
-      connectionEvent.connection = ConnectionFromJSON(connectionEvent.connection);
-    } catch (e) {
-      // log the error and send to Sentry if we managed to get an error parsing the Connection
-      logResponseError(
-        e,
-        "handleConnectionUpdateEvent parsing",
-        {
-          connectionId,
-          event: JSON.stringify(connectionEvent, null, 2),
-        },
-        true,
-      );
-      return;
-    }
 
     let singleConnectionState = this.connectionStates.get(connectionId);
     if (!singleConnectionState) {

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -2,8 +2,9 @@ import { Disposable, EventEmitter as VscodeEventEmitter, window } from "vscode";
 // our message callback routing internally using node's EventEmitter for .once() support + per-event-type callbacks, lacking in VSCode's EventEmitter implementation
 import { EventEmitter as NodeEventEmitter } from "node:events";
 import WebSocket from "ws";
+import { logResponseError } from "../errors";
 import { Logger } from "../logging";
-import { Message, MessageType, validateMessageBody } from "../ws/messageTypes";
+import { Message, MessageBodyDecoders, MessageType, validateMessageBody } from "../ws/messageTypes";
 
 const logger = new Logger("websocketManager");
 
@@ -256,8 +257,7 @@ export class WebsocketManager implements Disposable {
     this.disposables = [];
   }
 
-  /** Parse a message recieved from websocket into a Message<T> or die trying *
-   */
+  /** Parse/deserialize a message recieved from websocket into a Message<T> or die trying **/
   static parseMessage(data: WebSocket.Data): Message<MessageType> {
     const strMessage = data.toString();
     const message = JSON.parse(strMessage) as Message<MessageType>;
@@ -291,8 +291,31 @@ export class WebsocketManager implements Disposable {
       throw new Error("Message body must be an object: " + strMessage);
     }
 
+    const messageType = message.headers.message_type;
+
     // Validate the body against the message type
-    validateMessageBody(message.headers.message_type, body);
+    validateMessageBody(messageType, body);
+
+    // If needed for the message type, perform any higher-level body deserialization, say, promoting Dates encoded as
+    // strings up to Date instances.
+    const additionalDeserializer = MessageBodyDecoders[messageType];
+    if (additionalDeserializer) {
+      try {
+        message.body = additionalDeserializer(body);
+      } catch (e) {
+        logResponseError(
+          e,
+          "Websocket message body higher-level body deserialization error",
+          {
+            message: strMessage,
+          },
+          true,
+        );
+
+        // rethrow the error
+        throw e;
+      }
+    }
 
     return message;
   }

--- a/src/ws/messageTypes.ts
+++ b/src/ws/messageTypes.ts
@@ -50,22 +50,13 @@ export interface MessageHeaders {
   message_id: string;
 }
 
-export interface ReplyMessageHeaders extends MessageHeaders {
-  /** Used to correlate responses to requests. Holds message_id value of the message being replied to. */
-  response_to_id: string;
-}
-
-/** Construct and return either a MessageHeaders or ReplyMessageHeaders given the message type and possible response_to_id value. */
-export function newMessageHeaders<T extends MessageType>(
-  message_type: T,
-  response_to_id?: string,
-): MessageHeaderMap[T] {
+/** Construct and return a MessageHeaders given the message type, providing the `originator` and `message_id` fields. */
+export function newMessageHeaders<T extends MessageType>(message_type: T): MessageHeaders {
   return {
     message_type,
     originator: process.pid.toString(),
     message_id: randomUUID().toString(),
-    ...(response_to_id ? { response_to_id } : {}),
-  } as MessageHeaderMap[T];
+  };
 }
 
 /**
@@ -73,13 +64,8 @@ export function newMessageHeaders<T extends MessageType>(
  * is determined by the message type.
  **/
 export interface Message<T extends MessageType> {
-  headers: MessageHeaderMap[T];
+  headers: MessageHeaders;
   body: MessageBodyMap[T];
-}
-
-/** A message whose headers carry field "response_to_id", indicating is a response message. */
-export interface ResponseMessage<T extends MessageType> extends Message<T> {
-  headers: ReplyMessageHeaders;
 }
 
 /**
@@ -131,17 +117,6 @@ export type MessageBodyMap = {
   [MessageType.WORKSPACE_COUNT_CHANGED]: WorkspacesChangedBody;
   [MessageType.CONNECTION_EVENT]: ConnectionEventBody;
   [MessageType.PROTOCOL_ERROR]: ProtocolErrorBody;
-};
-
-/**
- * Type mapping of message type -> corresponding headers type.
- * Dictates which messages whose headers should have `response_to_id` field.`
- */
-type MessageHeaderMap = {
-  [MessageType.WORKSPACE_HELLO]: MessageHeaders;
-  [MessageType.WORKSPACE_COUNT_CHANGED]: MessageHeaders;
-  [MessageType.CONNECTION_EVENT]: MessageHeaders;
-  [MessageType.PROTOCOL_ERROR]: ReplyMessageHeaders;
 };
 
 /**

--- a/tests/unit/testResources/websocketMessages.ts
+++ b/tests/unit/testResources/websocketMessages.ts
@@ -1,0 +1,66 @@
+/** Sample test suite spellings of complex websocket messages */
+
+import { ConnectionEventAction, Message, MessageType } from "../../../src/ws/messageTypes";
+
+export const GOOD_CCLOUD_CONNECTION_EVENT_MESSAGE: Message<MessageType.CONNECTION_EVENT> = {
+  headers: {
+    message_type: MessageType.CONNECTION_EVENT,
+    originator: "sidecar",
+    message_id: "1",
+  },
+  body: {
+    action: ConnectionEventAction.CONNECTED,
+    connection: {
+      api_version: "gateway/v1",
+      kind: "Connection",
+      id: "vscode-confluent-cloud-connection",
+      metadata: {
+        resource_name: undefined,
+        self: "http://localhost:26636/gateway/v1/connections/vscode-confluent-cloud-connection",
+        sign_in_uri: "https://login.confluent.io/oauth/authorize?...",
+      },
+      spec: {
+        id: "vscode-confluent-cloud-connection",
+        name: "Confluent Cloud",
+        type: "CCLOUD",
+        ccloud_config: {
+          organization_id: undefined,
+          ide_auth_callback_uri: "vscode://confluentinc.vscode-confluent/authCallback",
+        },
+        kafka_cluster: undefined,
+        local_config: undefined,
+        schema_registry: undefined,
+      },
+      status: {
+        authentication: {
+          status: "VALID_TOKEN",
+          user: {
+            id: "u-n9dv06",
+            username: "foo@bar.com",
+            first_name: "Foo",
+            last_name: "Bar",
+            social_connection: "",
+            auth_type: "AUTH_TYPE_LOCAL",
+          },
+          requires_authentication_at: new Date("2025-01-24T04:25:01.242072Z"),
+          errors: undefined,
+        },
+        ccloud: {
+          state: "SUCCESS",
+          user: {
+            id: "u-n3234",
+            username: "foo@bar.com",
+            first_name: "Foo",
+            last_name: "Bar",
+            social_connection: "",
+            auth_type: "AUTH_TYPE_LOCAL",
+          },
+          requires_authentication_at: new Date("2025-01-24T04:25:01.242072Z"),
+          errors: undefined,
+        },
+        kafka_cluster: undefined,
+        schema_registry: undefined,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Push the good fix from https://github.com/confluentinc/vscode/pull/955, apply higher-level decoding beyond mere de-JSON-ing, down a few layers to happen for all websocket message types right at websocket message reception time, so that the message object delivered to any registered callbacks will have been fully deserialized and decoded already. The issue was that `JSON.parse()` isn't sufficient for many things, such as the case of timestamps-encoded-as-strings.
- Do so through making a mapping of message type -> body decoder within `ws/messageTypes.ts`, requiring every message type to declare a (possibly null-valued) entry. At this time, we only need an entry for `MessageType.CONNECTION_EVENT` message bodies, decoding the dates-as-strings up to date instances. But if/when we have new message types with deser needs above and beyond `JSON.parse()`, we now have the appropriate hook and force the dev to consider the lifecycle need.
- Therefore, registered websocket event listeners will only ever be called with completely deserialized and decoded messages. Invalid messages will be logged. No need for special handling at a higher level in the codebase just for `Message<MessageType.CONNECTION_EVENT>` messages within `ConnectionStateWatcher`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- While here, simplify an aspect of  `ws/messageTypes.ts`, removing modeling of message headers that carry a `reply_to_id` field, and the required mapping of message type to message header type. We do not use this functionality at all at this time.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
