### PR TITLE
bug fix - don't use html validation

### DIFF
--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -65,7 +65,6 @@
                   data-attr-type="this.field()[1].format === 'password' ? 'password' : 'text'"
                   data-attr-placeholder="this.field()[1].hint ? this.field()[1].hint : ''"
                   data-attr-required="this.field()[1].min_length > 0"
-                  data-attr-pattern="this.field()[1].pattern ? this.field()[1].pattern : ''"
                 />
                 <div class="help-text">
                   <span class="description" data-text="this.field()[1].description"></span

--- a/src/webview/scaffold-form.spec.ts
+++ b/src/webview/scaffold-form.spec.ts
@@ -234,9 +234,7 @@ test("form prevents invalid submissions", async ({ execute, page }) => {
   await page.focus("[name=api_key]");
   await page.keyboard.type("not a key");
   await page.focus("[name=cc_bootstrap_server]"); // blur to invoke validation
-  expect(
-    await page.locator("[name=api_key]").evaluate((el) => el.matches(":invalid")),
-  ).toBeTruthy();
+
   expect(submitBtn).toBeDisabled();
 
   // Delete value and submit
@@ -246,7 +244,6 @@ test("form prevents invalid submissions", async ({ execute, page }) => {
   await page.keyboard.type("MUSTBE16CHARACTE");
 
   await page.focus("[name=cc_bootstrap_server]"); // blur to invoke validation
-  expect(await page.locator("[name=api_key]").evaluate((el) => el.matches(":invalid"))).toBeFalsy();
   await submitBtn.click();
 
   const specCallHandle = await sendWebviewMessage.evaluateHandle((stub) => stub.getCall(0).args);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- **Quick Fix !** Removed the `pattern` attr in the form so that it doesn't incorrectly invalidate fields when empty. Validation against the pattern happens in `scaffold-form.ts` on input blur, so we are not relying on the HTML form validation for RegEx pattern matches anyways and can safely do away with it. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This is a 'side effect' of our template engine that can be addressed separately if we want to add this back. The HTML attr is incorrectly marking empty fields invalid since once it goes through the bindings [here](https://github.com/confluentinc/vscode/blob/47a98e15ce99377ed9413d9b3855de67a813d98e/src/webview/bindings/bindings.ts#L154), it was **setting the attribute as empty if it doesn't have a pattern.** This doesn't work for this specific attribute which makes some assumptions -- see note about empty pattern attrs [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#constraint_validation). 
- **Long term solution**: we may need to add a special handler in `bindings` for pattern attr in the near future. cc @alexeyraspopov 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
