### PR TITLE
Bindings: remove attribute from node when null or undefined is given

### DIFF
--- a/src/webview/bindings/bindings.ts
+++ b/src/webview/bindings/bindings.ts
@@ -195,7 +195,11 @@ function nodeAttribute<T>(node: T, attr: string, expr: string, os: Scope, vm: an
       else node.removeAttribute(attr);
     });
   }
-  return os.watch(() => node.setAttribute(attr, get.call(vm)));
+  return os.watch(() => {
+    let value = get.call(vm);
+    if (value != null) node.setAttribute(attr, value);
+    else node.removeAttribute(attr);
+  });
 }
 
 function walk(root: Node) {


### PR DESCRIPTION
Addressing the issue raised in https://github.com/confluentinc/vscode/pull/967. When `data-attr-*` binding receives `null` or `undefined`, it is going to remove attribute from a node. This should make elements like `<input />` update their behavior accordingly.
