### PR TITLE
[v0.24.x] always send `sourcemaps`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,7 +19,4 @@ service.yml
 sonar-project.properties
 *openapi.json
 *openapi.yaml
-bin/create_release.sh
-bin/download_deploy.sh
-releases/**
 openapitools.json

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -143,6 +143,8 @@ export function build(done) {
   const extOutput = {
     dir: DESTINATION,
     format: "cjs",
+    // this must be set to true for the sourcemaps to be uploaded to Sentry
+    // see: https://docs.sentry.io/platforms/javascript/guides/wasm/sourcemaps/uploading/rollup/
     sourcemap: true,
     sourcemapBaseUrl: `file://${process.cwd()}/${DESTINATION}/`,
     exports: "named",

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -118,6 +118,7 @@ export function build(done) {
               "NOTICE-vsix.txt",
               "THIRD_PARTY_NOTICES.txt",
               "THIRD_PARTY_NOTICES_IDE_SIDECAR.txt",
+              ".vscodeignore",
             ],
             dest: DESTINATION,
           },
@@ -142,7 +143,7 @@ export function build(done) {
   const extOutput = {
     dir: DESTINATION,
     format: "cjs",
-    sourcemap: !production,
+    sourcemap: true,
     sourcemapBaseUrl: `file://${process.cwd()}/${DESTINATION}/`,
     exports: "named",
   };


### PR DESCRIPTION
#901 adjusted sourcemap behavior to only include them when we weren't doing a production build (to reduce .vsix size), but the Sentry rollup plugin requires it to be set to `true` https://docs.sentry.io/platforms/javascript/guides/wasm/sourcemaps/uploading/rollup/

This PR sets it back to `true` but uses the `.vscodeignore` file to ensure those `*.js.map` files are excluded in the `vsce package` command (via `gulp pack`) and the .vsix still remains smaller