### PR TITLE
[v0.24.x] add handling for `FetchError`s

### DIFF
--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -5,7 +5,7 @@ import { getExtensionContext } from "../context/extension";
 import { observabilityContext } from "../context/observability";
 import { ContextValues, setContextValue } from "../context/values";
 import { ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
-import { ExtensionContextNotSetError, logResponseError } from "../errors";
+import { ExtensionContextNotSetError, logError } from "../errors";
 import { Logger } from "../logging";
 import { fetchPreferences } from "../preferences/updates";
 import {
@@ -137,7 +137,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
         vscode.window.showErrorMessage(
           `Error during Confluent Cloud sign-in process: ${e.message}`,
         );
-        logResponseError(
+        logError(
           e,
           "browser sign-in flow",
           {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logResponseError, showErrorNotificationWithButtons } from "../errors";
+import { logError, showErrorNotificationWithButtons } from "../errors";
 import { UserEvent, logUsage } from "../telemetry/events";
 
 export function registerCommandWithLogging(
@@ -14,7 +14,7 @@ export function registerCommandWithLogging(
       if (e instanceof Error) {
         // gather more (possibly-ResponseError) context and send to Sentry (only enabled in
         // production builds)
-        logResponseError(e, `${commandName}`, { command: commandName }, true);
+        logError(e, `${commandName}`, { command: commandName }, true);
         // also show error notification to the user with default buttons
         showErrorNotificationWithButtons(`Error invoking command "${commandName}": ${e}`);
       }

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -12,7 +12,7 @@ import {
 } from "../clients/kafkaRest";
 import { MessageViewerConfig } from "../consume";
 import { MESSAGE_URI_SCHEME } from "../documentProviders/message";
-import { logResponseError, showErrorNotificationWithButtons } from "../errors";
+import { logError, showErrorNotificationWithButtons } from "../errors";
 import { Logger } from "../logging";
 import { KafkaCluster } from "../models/kafkaCluster";
 import { isCCloud, isDirect } from "../models/resource";
@@ -379,7 +379,7 @@ export async function produceMessage(content: any, topic: KafkaTopic): Promise<P
     }
     timestamp = response.timestamp ? new Date(response.timestamp) : timestamp;
   } catch (error) {
-    logResponseError(error, "topic message produce", { connectionId: topic.connectionId }, true);
+    logError(error, "topic message produce", { connectionId: topic.connectionId }, true);
     if (error instanceof ResponseError) {
       const body = await error.response.clone().text();
       errorBody = `${error.response.status} ${error.response.statusText} ${body}`;

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -5,7 +5,7 @@ import { join, normalize } from "path";
 import { Agent, RequestInit as UndiciRequestInit } from "undici";
 import { commands, env, Uri, window, workspace, WorkspaceConfiguration } from "vscode";
 import { ResponseError, SystemApi } from "../clients/docker";
-import { logResponseError } from "../errors";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import {
   LOCAL_DOCKER_SOCKET_PATH,
@@ -167,7 +167,7 @@ export async function isDockerAvailable(showNotification: boolean = false): Prom
     // either float this as an `error` log if it's a ResponseError or was an explicit action that
     // warrants notifying the user that something is wrong
     if (error instanceof ResponseError || showNotification) {
-      logResponseError(error, "docker ping");
+      logError(error, "docker ping");
     } else {
       // likely FetchError->TypeError: connect ENOENT <socket path> but not a lot else we can do here
       logger.debug("docker ping error:", error);

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -1,5 +1,5 @@
 import { graphql } from "gql.tada";
-import { logResponseError, showErrorNotificationWithButtons } from "../errors";
+import { logError, showErrorNotificationWithButtons } from "../errors";
 import { DirectEnvironment } from "../models/environment";
 import { DirectKafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId } from "../models/resource";
@@ -38,7 +38,7 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
   try {
     response = await sidecar.query(query);
   } catch (error) {
-    logResponseError(error, "direct connection resources", {}, true);
+    logError(error, "direct connection resources", {}, true);
     showErrorNotificationWithButtons(
       `Failed to fetch resources for direct Kafka / Schema Registry connection(s): ${error}`,
     );

--- a/src/graphql/environments.ts
+++ b/src/graphql/environments.ts
@@ -1,6 +1,6 @@
 import { graphql } from "gql.tada";
 import { CCLOUD_CONNECTION_ID } from "../constants";
-import { logResponseError, showErrorNotificationWithButtons } from "../errors";
+import { logError, showErrorNotificationWithButtons } from "../errors";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
@@ -44,7 +44,7 @@ export async function getEnvironments(): Promise<CCloudEnvironment[]> {
   try {
     response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
   } catch (error) {
-    logResponseError(error, "CCloud environments", { connectionId: CCLOUD_CONNECTION_ID }, true);
+    logError(error, "CCloud environments", { connectionId: CCLOUD_CONNECTION_ID }, true);
     showErrorNotificationWithButtons(`Failed to fetch CCloud resources: ${error}`);
     return envs;
   }

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -1,6 +1,6 @@
 import { graphql } from "gql.tada";
 import { LOCAL_CONNECTION_ID, LOCAL_ENVIRONMENT_NAME } from "../constants";
-import { logResponseError, showErrorNotificationWithButtons } from "../errors";
+import { logError, showErrorNotificationWithButtons } from "../errors";
 import { LocalEnvironment } from "../models/environment";
 import { LocalKafkaCluster } from "../models/kafkaCluster";
 import { LocalSchemaRegistry } from "../models/schemaRegistry";
@@ -45,7 +45,7 @@ export async function getLocalResources(): Promise<LocalEnvironment[]> {
   try {
     response = await sidecar.query(query, LOCAL_CONNECTION_ID);
   } catch (error) {
-    logResponseError(error, "local resources", { connectionId: LOCAL_CONNECTION_ID }, true);
+    logError(error, "local resources", { connectionId: LOCAL_CONNECTION_ID }, true);
     showErrorNotificationWithButtons(`Failed to fetch local resources: ${error}`);
     return envs;
   }

--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -1,6 +1,6 @@
 import { graphql } from "gql.tada";
 import { CCLOUD_CONNECTION_ID } from "../constants";
-import { logResponseError, showErrorNotificationWithButtons } from "../errors";
+import { logError, showErrorNotificationWithButtons } from "../errors";
 import { Logger } from "../logging";
 import { CCloudOrganization } from "../models/organization";
 import { getSidecar } from "../sidecar";
@@ -27,7 +27,7 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   try {
     response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
   } catch (error) {
-    logResponseError(error, "CCloud organizations", { connectionId: CCLOUD_CONNECTION_ID }, true);
+    logError(error, "CCloud organizations", { connectionId: CCLOUD_CONNECTION_ID }, true);
     showErrorNotificationWithButtons(`Failed to fetch CCloud organizations: ${error}`);
     return orgs;
   }

--- a/src/preferences/updates.ts
+++ b/src/preferences/updates.ts
@@ -1,5 +1,5 @@
 import { Preferences, PreferencesResourceApi, PreferencesSpec } from "../clients/sidecar";
-import { logResponseError } from "../errors";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import { getSidecar } from "../sidecar";
 
@@ -11,7 +11,7 @@ export async function fetchPreferences(): Promise<Preferences> {
   try {
     return await client.gatewayV1PreferencesGet();
   } catch (error) {
-    logResponseError(error, "fetching preferences", {}, true);
+    logError(error, "fetching preferences", {}, true);
     throw error;
   }
 }
@@ -45,7 +45,7 @@ export async function updatePreferences(updates: Partial<Record<keyof Preference
     });
     logger.debug("Successfully updated preferences: ", { resp });
   } catch (error) {
-    logResponseError(
+    logError(
       error,
       "updating preferences",
       {

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -13,14 +13,14 @@ import {
 import { getSidecar } from "./sidecar";
 
 import { ExtensionContext, ViewColumn } from "vscode";
+import { ResponseError } from "./clients/sidecar";
 import { registerCommandWithLogging } from "./commands";
-import { logResponseError } from "./errors";
+import { logError } from "./errors";
 import { UserEvent, logUsage } from "./telemetry/events";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { PostResponse, type post } from "./webview/scaffold-form";
 import scaffoldFormTemplate from "./webview/scaffold-form.html";
-import { ResponseError } from "./clients/sidecar";
 type MessageSender = OverloadUnion<typeof post>;
 type MessageResponse<MessageType extends string> = Awaited<
   ReturnType<Extract<MessageSender, (type: MessageType, body: any) => any>>
@@ -45,7 +45,7 @@ export const scaffoldProjectRequest = async () => {
       (template) => template.spec!.display_name === pickedItem?.label,
     );
   } catch (err) {
-    logResponseError(err, "template listing", {}, true);
+    logError(err, "template listing", {}, true);
     vscode.window.showErrorMessage("Failed to retrieve template list");
     return;
   }
@@ -187,7 +187,7 @@ async function applyTemplate(
     }
     return { success: true, message: "Project generated successfully." };
   } catch (e) {
-    logResponseError(e, "applying template", { templateName: pickedTemplate.spec!.name! }, true);
+    logError(e, "applying template", { templateName: pickedTemplate.spec!.name! }, true);
     let message = "Failed to generate template. An unknown error occurred.";
     if (e instanceof Error) {
       message = e.message;

--- a/src/sidecar/connections/index.ts
+++ b/src/sidecar/connections/index.ts
@@ -5,7 +5,7 @@ import {
   ConnectionsResourceApi,
   ResponseError,
 } from "../../clients/sidecar";
-import { logResponseError } from "../../errors";
+import { logError } from "../../errors";
 import { Logger } from "../../logging";
 import { ConnectionId } from "../../models/resource";
 import { ConnectionStateWatcher } from "./watcher";
@@ -30,7 +30,7 @@ export async function tryToCreateConnection(
     });
     return connection;
   } catch (error) {
-    logResponseError(
+    logError(
       error,
       `${dryRun ? "testing" : "creating"} new connection:`,
       { connectionId: spec.id! },
@@ -52,7 +52,7 @@ export async function tryToGetConnection(id: string): Promise<Connection | null>
       logger.debug("No connection found", { connectionId: id });
     } else {
       // only log the non-404 errors, since we expect a 404 if the connection doesn't exist
-      logResponseError(error, "fetching connection", { connectionId: id }, true);
+      logError(error, "fetching connection", { connectionId: id }, true);
     }
   }
   return connection;
@@ -74,7 +74,7 @@ export async function tryToUpdateConnection(spec: ConnectionSpec): Promise<Conne
     logger.debug("updated connection:", { id: connection.id });
     return connection;
   } catch (error) {
-    logResponseError(error, "updating connection", { connectionId: spec.id! }, true);
+    logError(error, "updating connection", { connectionId: spec.id! }, true);
     throw error;
   }
 }
@@ -90,7 +90,7 @@ export async function tryToDeleteConnection(id: string): Promise<void> {
       logger.debug("no connection found to delete:", { id });
       return;
     }
-    logResponseError(error, "deleting connection", { connectionId: id }, true);
+    logError(error, "deleting connection", { connectionId: id }, true);
     throw error;
   }
 }

--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -38,7 +38,7 @@ import * as watcherUtils from "./watcherUtils";
 describe("sidecar/connections/watcher.ts ConnectionStateWatcher handleConnectionUpdateEvent()", () => {
   let sandbox: sinon.SinonSandbox;
   let connectionEventHandlerStub: sinon.SinonStub;
-  let logResponseErrorStub: sinon.SinonStub;
+  let logErrorStub: sinon.SinonStub;
 
   let connectionStateWatcher: ConnectionStateWatcher;
 
@@ -46,7 +46,7 @@ describe("sidecar/connections/watcher.ts ConnectionStateWatcher handleConnection
     sandbox = sinon.createSandbox();
     connectionStateWatcher = ConnectionStateWatcher.getInstance();
     connectionEventHandlerStub = sandbox.stub(watcherUtils, "connectionEventHandler").returns();
-    logResponseErrorStub = sandbox.stub(errors, "logResponseError").resolves();
+    logErrorStub = sandbox.stub(errors, "logError").resolves();
   });
 
   afterEach(() => {
@@ -66,7 +66,7 @@ describe("sidecar/connections/watcher.ts ConnectionStateWatcher handleConnection
     await connectionStateWatcher.handleConnectionUpdateEvent(message);
 
     assert.ok(connectionEventHandlerStub.calledOnce);
-    assert.ok(logResponseErrorStub.notCalled);
+    assert.ok(logErrorStub.notCalled);
     const cachedEvent = connectionStateWatcher.getLatestConnectionEvent(
       TEST_AUTHENTICATED_CCLOUD_CONNECTION.id as ConnectionId,
     );

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -2,7 +2,7 @@ import { Disposable, EventEmitter as VscodeEventEmitter, window } from "vscode";
 // our message callback routing internally using node's EventEmitter for .once() support + per-event-type callbacks, lacking in VSCode's EventEmitter implementation
 import { EventEmitter as NodeEventEmitter } from "node:events";
 import WebSocket from "ws";
-import { logResponseError } from "../errors";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import { Message, MessageBodyDecoders, MessageType, validateMessageBody } from "../ws/messageTypes";
 
@@ -303,7 +303,7 @@ export class WebsocketManager implements Disposable {
       try {
         message.body = additionalDeserializer(body);
       } catch (e) {
-        logResponseError(
+        logError(
           e,
           "Websocket message body higher-level body deserialization error",
           {

--- a/src/storage/resourceLoader.ts
+++ b/src/storage/resourceLoader.ts
@@ -3,6 +3,7 @@ import { toKafkaTopicOperations } from "../authz/types";
 import { ResponseError, TopicData, TopicDataList, TopicV3Api } from "../clients/kafkaRest";
 import { Schema as ResponseSchema, SchemasV1Api } from "../clients/schemaRegistryRest";
 import { ConnectionType } from "../clients/sidecar";
+import { Logger } from "../logging";
 import { Environment } from "../models/environment";
 import { KafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId, IResourceBase } from "../models/resource";
@@ -10,6 +11,8 @@ import { Schema, SchemaType } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
 import { getSidecar } from "../sidecar";
+
+const logger = new Logger("resourceLoader");
 
 /**
  * Class family for dealing with loading (and perhaps caching) information
@@ -155,6 +158,8 @@ export class TopicFetchError extends Error {
  * Deep read and return of all topics in a Kafka cluster.
  */
 export async function fetchTopics(cluster: KafkaCluster): Promise<TopicData[]> {
+  logger.debug(`fetching topics for ${cluster.connectionType} Kafka cluster ${cluster.id}`);
+
   const sidecar = await getSidecar();
   const client: TopicV3Api = sidecar.getTopicV3Api(cluster.id, cluster.connectionId);
   let topicsResp: TopicDataList;
@@ -164,6 +169,9 @@ export async function fetchTopics(cluster: KafkaCluster): Promise<TopicData[]> {
       cluster_id: cluster.id,
       includeAuthorizedOperations: true,
     });
+    logger.debug(
+      `fetched ${topicsResp.data.length} topic(s) for ${cluster.connectionType} Kafka cluster ${cluster.id}`,
+    );
   } catch (error) {
     if (error instanceof ResponseError) {
       // XXX todo improve this, raise a more specific error type.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Our generated client code (`src/clients/*`) will throw `FetchError`s when it encounters any kind of error that doesn't fall into the `ResponseError` category:
https://github.com/confluentinc/vscode/blob/b9f9f8213c2c529d73e4fc7ec997e3eaf5c0c59e/src/clients/schemaRegistryRest/runtime.ts#L231-L236

These [`FetchError`s include a `cause`*](https://github.com/confluentinc/vscode/blob/b9f9f8213c2c529d73e4fc7ec997e3eaf5c0c59e/src/clients/schemaRegistryRest/runtime.ts#L286-L294) which is a nested `Error` type, but we weren't generally handling these well**, and the main reason for this PR is the fact that some users are getting these `FetchError`s when attempting to list topics (but the request to get schemas is causing the issue).


*`cause` isn't strictly used with `FetchError`s though. We've seen it before with `TypeError`s and it's generally supported as an optional property for `Error`s: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause

**Logging would only show things like `Error while preloading CCloud schemas {"error":{"cause":{},"name":"FetchError"}}`

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
