### PR TITLE
Try to harden sidecar starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this extension will be documented in this file.
   step of migrating away from use of the `GET /schemas` schema registry route, not implemented by
   all schema registries.
 
+### Fixed
+
+- Give the sidecar more time to start up, log more sidecar startup errors into sentry.
+
 ## 0.24.2
 
 ### Added

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -424,7 +424,7 @@ export class SidecarManager {
             );
 
             resolve(accessToken);
-            break;
+            return;
           } catch (e) {
             // We expect ECONNREFUSED while the sidecar is coming up, but log + rethrow other unexpected errors.
             if (!wasConnRefused(e)) {
@@ -442,9 +442,9 @@ export class SidecarManager {
               // loops back to the top, pauses, tries again.
             }
           }
-        }
+        } // the doHandshake() loop.
 
-        // Didn't resolve in the loop, so reject.
+        // Didn't resolve and return within the loop, so reject.
         reject(
           new Error(
             `${logPrefix}: Failed to handshake with sidecar after ${max_handshake_attempts} attempts`,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- To attempt to gain insight why we have lingering sidecar start issues in Sentry:
  - Bump up startup and handshake loops from 10 to 20 attempts (theory: fork/spawning the Graalvm native executable is pain for some?) (there will be 500ms pauses between iterations).
  - Log more intermediate unexpected errors into Sentry via `logErrror(..., true)` instead of just `logger.error()`, because it seems that the people suffering this are not making more formal complaints and submitting their logs.
  - Improve some log message phrasing.
  - Make `startSidecar()` definitely end with `reject()` if the loop over `doHandshake()` didn't succeed.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
