### PR TITLE
Wean schema subject quickpick off of `GET /schemas` route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this extension will be documented in this file.
 - Matching topics to schemas now based on the result of the `GET /subjects` route results. First
   step of migrating away from use of the `GET /schemas` schema registry route, not implemented by
   all schema registries.
+- Quickpick for schema registry subject names (i.e. when uploading a new schema) now based off of `GET /subjects` route results.
 
 ## 0.24.2
 

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -98,11 +98,15 @@ export async function uploadSchemaFromFile(registry?: SchemaRegistry, subject?: 
     return;
   }
 
-  subject = subject ? subject : await chooseSubject(registry, schemaType);
+  subject = subject ? subject : await chooseSubject(registry);
   if (!subject) {
     logger.error("Could not determine schema subject");
     return;
   }
+
+  // TODO after #951: grab the subject group and / or the most recent schema binding
+  // to the subject to ensure is the right type. Error out if not. This error
+  // will be more clear than the one that the schema registry will give us.
 
   await uploadSchema(registry, subject, schemaType, docContent.content);
 }
@@ -212,12 +216,11 @@ async function documentHasErrors(uri: vscode.Uri): Promise<boolean> {
  */
 async function chooseSubject(
   registry: SchemaRegistry,
-  schemaType: SchemaType,
   defaultSubject: string | undefined = undefined,
 ): Promise<string | undefined> {
   // Ask the user to choose a subject to bind the schema to. Shows subjects with schemas
   // using the given schema type. Will return "" if they want to create a new subject.
-  let subject = await schemaSubjectQuickPick(registry, schemaType, defaultSubject);
+  let subject = await schemaSubjectQuickPick(registry, defaultSubject);
 
   if (subject === "") {
     // User chose the 'create a new subject' quickpick item. Prompt for the new name.

--- a/src/loaders/loaderUtils.test.ts
+++ b/src/loaders/loaderUtils.test.ts
@@ -1,8 +1,13 @@
 import assert from "assert";
-import { TEST_LOCAL_KAFKA_CLUSTER } from "../../tests/unit/testResources";
+import * as sinon from "sinon";
+import {
+  TEST_LOCAL_KAFKA_CLUSTER,
+  TEST_LOCAL_SCHEMA_REGISTRY,
+} from "../../tests/unit/testResources";
 import { createTestTopicData } from "../../tests/unit/testUtils";
 import { TopicData } from "../clients/kafkaRest/models";
 import * as loaderUtils from "../loaders/loaderUtils";
+import * as sidecar from "../sidecar";
 
 // as from fetchTopics() result.
 export const topicsResponseData: TopicData[] = [
@@ -12,7 +17,7 @@ export const topicsResponseData: TopicData[] = [
   createTestTopicData(TEST_LOCAL_KAFKA_CLUSTER.id, "topic4", ["READ", "WRITE"]),
 ];
 
-describe("correlateTopicsWithSchemaSubjects() test", () => {
+describe("loaderUtils correlateTopicsWithSchemaSubjects() test", () => {
   it("should correlate topics with schema subjects as strings", () => {
     // topic 1-3 will be correlated with schema subjects, topic 4 will not.
     const subjects: string[] = ["topic1-value", "topic2-key", "topic3-Foo"];
@@ -27,5 +32,45 @@ describe("correlateTopicsWithSchemaSubjects() test", () => {
     assert.ok(results[1].hasSchema);
     assert.ok(results[2].hasSchema);
     assert.ok(!results[3].hasSchema);
+  });
+});
+
+describe("loaderUtils fetchSubjects() tests", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  let listSubjectsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    listSubjectsStub = sandbox.stub();
+
+    const mockSubjectsV1Api = {
+      list: listSubjectsStub,
+    };
+
+    let getSidecarStub: sinon.SinonStub;
+    getSidecarStub = sandbox.stub(sidecar, "getSidecar");
+
+    const mockHandle = {
+      getSubjectsV1Api: () => {
+        return mockSubjectsV1Api;
+      },
+    };
+    getSidecarStub.resolves(mockHandle);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return subjects sorted", async () => {
+    const subjectsRaw = ["subject2", "subject3", "subject1"];
+    listSubjectsStub.resolves(subjectsRaw);
+
+    const subjects = await loaderUtils.fetchSubjects(TEST_LOCAL_SCHEMA_REGISTRY);
+
+    // be sure to test against a wholly separate array, 'cause .sort() is in-place.
+    assert.deepStrictEqual(subjects, ["subject1", "subject2", "subject3"]);
   });
 });

--- a/src/loaders/loaderUtils.ts
+++ b/src/loaders/loaderUtils.ts
@@ -145,7 +145,7 @@ export async function fetchSchemas(schemaRegistry: SchemaRegistry): Promise<Sche
 }
 
 /**
- * Fetch all of the subjects in the schema registry and return them as an array of strings.
+ * Fetch all of the subjects in the schema registry and return them as an array of sorted strings.
  * Does not store into the resource manager.
  */
 export async function fetchSubjects(schemaRegistry: SchemaRegistry): Promise<string[]> {
@@ -155,5 +155,5 @@ export async function fetchSubjects(schemaRegistry: SchemaRegistry): Promise<str
     schemaRegistry.connectionId,
   );
 
-  return await client.list();
+  return (await client.list()).sort();
 }

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -19,13 +19,14 @@ import { ResourceLoader } from "./resourceLoader";
 describe("ResourceLoader::getSubjects()", () => {
   let loaderInstance: ResourceLoader;
   let sandbox: sinon.SinonSandbox;
+
   let getSchemaRegistryForEnvironmentIdStub: sinon.SinonStub;
+  let fetchSubjectsStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
-    const fetchSubjectsStub: sinon.SinonStub = sandbox.stub(loaderUtils, "fetchSubjects");
-    fetchSubjectsStub.resolves(["subject1", "subject2"]);
+    fetchSubjectsStub = sandbox.stub(loaderUtils, "fetchSubjects");
 
     loaderInstance = LocalResourceLoader.getInstance();
 
@@ -58,13 +59,16 @@ describe("ResourceLoader::getSubjects()", () => {
   });
 
   it("Returns subjects when called with right schema registry or env id", async () => {
+    const fetchSubjectsStubReturns = ["subject1", "subject2", "subject3"];
+    fetchSubjectsStub.resolves(fetchSubjectsStubReturns);
+
     for (const inputParam of [
       TEST_LOCAL_SCHEMA_REGISTRY,
       TEST_LOCAL_SCHEMA_REGISTRY.environmentId,
     ]) {
       const subjects = await loaderInstance.getSubjects(inputParam);
 
-      assert.deepStrictEqual(subjects, ["subject1", "subject2"]);
+      assert.deepStrictEqual(subjects, fetchSubjectsStubReturns);
     }
   });
 });

--- a/src/quickpicks/schemas.ts
+++ b/src/quickpicks/schemas.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { ResourceLoader } from "../loaders/";
 import { getConnectionLabel } from "../models/resource";
-import { getSubjectIcon, Schema, SchemaType } from "../models/schema";
+import { getSubjectIcon, SchemaType } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 
 /** Quickpick returning a string for what to use as a schema subject out of the preexisting options.
@@ -12,35 +12,11 @@ import { SchemaRegistry } from "../models/schemaRegistry";
  */
 export async function schemaSubjectQuickPick(
   schemaRegistry: SchemaRegistry,
-  onlyType: SchemaType | undefined = undefined,
   defaultSubject: string | undefined = undefined,
 ): Promise<string | undefined> {
   const loader = ResourceLoader.getInstance(schemaRegistry.connectionId);
-  const schemas = await loader.getSchemasForRegistry(schemaRegistry);
 
-  let schemaSubjects: string[] | undefined;
-
-  const latestVersionSchemaBySubject = new Map<string, Schema>();
-  if (schemas) {
-    // Crunch down to map of subject -> latest version'd Schema for said subject
-    for (const schema of schemas) {
-      // Skip if the caller asked for only a specific type of schema and this one doesn't match.
-      if (onlyType && schema.type !== onlyType) {
-        continue;
-      }
-      const latestVersionSchema = latestVersionSchemaBySubject.get(schema.subject);
-      if (!latestVersionSchema || schema.version > latestVersionSchema.version) {
-        latestVersionSchemaBySubject.set(schema.subject, schema);
-      }
-    }
-
-    schemaSubjects = Array.from(latestVersionSchemaBySubject.keys());
-    schemaSubjects.sort();
-  }
-
-  if (schemas === undefined) {
-    schemaSubjects = [];
-  }
+  const schemaSubjects = await loader.getSubjects(schemaRegistry);
 
   // Convert to quickpick items, first entry to create a new schema / subject followed by a separator
   const newSchemaLabel = "Create new schema / subject";
@@ -58,13 +34,10 @@ export async function schemaSubjectQuickPick(
 
   // Wire up all of the exsting schema registry subjects as items
   // with the description as the subject name for easy return value.
-  for (const subject of schemaSubjects!) {
-    const latestVersionSchema = latestVersionSchemaBySubject.get(subject);
-
+  for (const subject of schemaSubjects) {
     subjectItems.push({
       label: subject,
       iconPath: getSubjectIcon(subject),
-      description: `v${latestVersionSchema?.version}`,
       alwaysShow: subject === defaultSubject,
     });
   }


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- `schemaSubjectQuickPick()`, the quickpick for schema registry subject names (i.e. when uploading a new schema) now based off of `GET /subjects` route results.
- Alas, being based only on subject names means we cannot pre-filter based on schema type anymore, so we lose an ounce of functionality when being driven by the 'evolve schema' codepath. If the user picks, say, a preexisting AVRO subject when trying to upload a protobuf schema, now we'll expose the schema registry-produced error message, whereas before we would never let them pick an existing AVRO subject when the upload contents smelled protobuf, and so on.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #997 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
