### PR TITLE
Wean topicQuickPick() off of getSchemasForEnvironmentId().

### DIFF
--- a/src/quickpicks/topics.ts
+++ b/src/quickpicks/topics.ts
@@ -1,11 +1,8 @@
 import { ProgressOptions, ThemeColor, ThemeIcon, window } from "vscode";
 import { IconNames } from "../constants";
 import { ResourceLoader } from "../loaders";
-import { Logger } from "../logging";
 import { KafkaCluster } from "../models/kafkaCluster";
 import { KafkaTopic } from "../models/topic";
-
-const logger = new Logger("quickpicks.topics");
 
 export async function topicQuickPick(
   cluster: KafkaCluster,
@@ -18,27 +15,12 @@ export async function topicQuickPick(
   return window.withProgress(options, async () => {
     const loader = ResourceLoader.getInstance(cluster.connectionId);
 
-    const [subjects, topics]: [string[], KafkaTopic[]] = await Promise.all([
-      loader.getSubjects(cluster.environmentId!, forceRefresh),
-      loader.getTopicsForCluster(cluster, forceRefresh),
-    ]);
-
-    logger.debug(
-      `Loaded ${subjects.length} subjects and ${topics.length} topics for cluster ${cluster.name}`,
-    );
-
-    // Poor person's subject -> topic name mapping, matching only via TopicNameStrategy.
-    const subjectSet = new Set(subjects.map((subject) => subject.replace(/-key$|-value$/, "")));
+    const topics: KafkaTopic[] = await loader.getTopicsForCluster(cluster, forceRefresh);
 
     const choices = topics.map((topic) => {
-      const hasSchema = subjectSet.has(topic.name);
-      if (hasSchema) {
-        // Found a schema for this topic, remove it from the set to speed up future lookups
-        subjectSet.delete(topic.name);
-      }
       return {
         label: topic.name,
-        iconPath: hasSchema
+        iconPath: topic.hasSchema
           ? new ThemeIcon(IconNames.TOPIC)
           : new ThemeIcon(
               IconNames.TOPIC_WITHOUT_SCHEMA,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Simple small branch.
- topicQuickPick() is only used by the command invocation to start up message browser from command palate.
- No need to call `loader.getSchemas()` (or new `loader.getSubjects()`) at all , because the equivalent topic -> subject matching has already been happening within `loader.getTopicsForCluster()` for some time now. Just need to realize to pivot off of the `KafkaTopic` model's `hasSchema` property. 

<img width="919" alt="image" src="https://github.com/user-attachments/assets/e3b7ef75-e627-4735-9dd9-d4a0e7f3a405" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes https://github.com/confluentinc/vscode/issues/1006

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
