### PR TITLE
feat: add search functionality to Schemas view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this extension will be documented in this file.
   - Resources view: search by any label or description of visible environments, Kafka clusters, and
     Schema Registries
   - Topics view: search by topic name or schema subject (if applicable)
+  - Schemas view: search by schema subject
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
 - Preview links for non-default organizations work only after switching to the non-default
   organization in the Confluent Cloud UI in your browser.
 - When using multiple users on a single machine, only one user can run the extension at a time.
+- Searching by schema ID (in the Topics and Schemas views) is not supported due to cost and
+  performance considerations.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
 - Preview links for non-default organizations work only after switching to the non-default
   organization in the Confluent Cloud UI in your browser.
 - When using multiple users on a single machine, only one user can run the extension at a time.
-- Searching by schema ID (in the Topics and Schemas views) is not supported due to cost and
+- Searching for schemas in the Topics and Schemas views is limited to the `subject` field only.
+  Searching by other fields, such as `id` and `version`, is not supported due to cost and
   performance considerations.
 
 ## Support

--- a/package.json
+++ b/package.json
@@ -280,6 +280,17 @@
         "category": "Confluent: Schemas"
       },
       {
+        "command": "confluent.schemas.search",
+        "icon": "$(search)",
+        "title": "Search",
+        "category": "Confluent: Schemas View"
+      },
+      {
+        "command": "confluent.schemas.search.clear",
+        "title": "Clear Search",
+        "category": "Confluent: Schemas View"
+      },
+      {
         "command": "confluent.showOutputChannel",
         "title": "Show Output Channel",
         "icon": "$(output)",
@@ -490,6 +501,12 @@
         "key": "ctrl+f",
         "mac": "cmd+f",
         "when": "focusedView == confluent-topics"
+      },
+      {
+        "command": "confluent.schemas.search",
+        "key": "ctrl+f",
+        "mac": "cmd+f",
+        "when": "focusedView == confluent-schemas"
       }
     ],
     "viewsContainers": {
@@ -649,11 +666,7 @@
           "when": "false"
         },
         {
-          "command": "confluent.schemas.upload",
-          "when": "false"
-        },
-        {
-          "command": "confluent.schemas.uploadForSubject",
+          "command": "confluent.schemas.copySchemaRegistryId",
           "when": "false"
         },
         {
@@ -669,7 +682,15 @@
           "when": "false"
         },
         {
-          "command": "confluent.schemas.copySchemaRegistryId",
+          "command": "confluent.schemas.search.clear",
+          "when": "confluent.schemaSearchApplied"
+        },
+        {
+          "command": "confluent.schemas.upload",
+          "when": "false"
+        },
+        {
+          "command": "confluent.schemas.uploadForSubject",
           "when": "false"
         },
         {
@@ -789,6 +810,16 @@
           "command": "confluent.resources.kafka-cluster.select",
           "when": "view == confluent-topics && (confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)",
           "group": "navigation@3"
+        },
+        {
+          "command": "confluent.schemas.search",
+          "when": "view == confluent-schemas && !confluent.schemaSearchApplied",
+          "group": "navigation@1"
+        },
+        {
+          "command": "confluent.schemas.search.clear",
+          "when": "view == confluent-schemas && confluent.schemaSearchApplied",
+          "group": "navigation@1"
         },
         {
           "command": "confluent.topics.refresh",

--- a/package.json
+++ b/package.json
@@ -809,16 +809,6 @@
           "command": "confluent.topics.copyKafkaClusterBootstrapServers",
           "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "2_copy@3"
-        },
-        {
-          "command": "confluent.topics.search",
-          "when": "view == confluent-topics && !confluent.topicSearchApplied",
-          "group": "navigation@1"
-        },
-        {
-          "command": "confluent.topics.search.clear",
-          "when": "view == confluent-topics && confluent.topicSearchApplied",
-          "group": "navigation@1"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -553,7 +553,7 @@
       },
       {
         "view": "confluent-schemas",
-        "contents": "No connections available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)\nAlternatively, [start Schema Registry locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
+        "contents": "No Schema Registries available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)\nAlternatively, [start Schema Registry locally](command:confluent.docker.startLocalResources) with Docker or [connect directly](command:confluent.connections.direct) to a Schema Registry instance.",
         "when": "!(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)"
       },
       {
@@ -564,7 +564,12 @@
       {
         "view": "confluent-schemas",
         "contents": "No schemas found.\n[Create Schema](command:confluent.schemas.create)",
-        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable) && confluent.schemaRegistrySelected"
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable) && confluent.schemaRegistrySelected && !confluent.schemaSearchApplied"
+      },
+      {
+        "view": "confluent-schemas",
+        "contents": "No schemas match search string. [Clear search](command:confluent.schemas.search.clear) or [try a new search](command:confluent.schemas.search).",
+        "when": "(confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable) && confluent.schemaRegistrySelected && confluent.schemaSearchApplied"
       },
       {
         "view": "confluent-topics",

--- a/package.json
+++ b/package.json
@@ -772,24 +772,34 @@
           "group": "navigation@3"
         },
         {
+          "command": "confluent.schemas.search",
+          "when": "view == confluent-schemas && !confluent.schemaSearchApplied",
+          "group": "navigation@1"
+        },
+        {
+          "command": "confluent.schemas.search.clear",
+          "when": "view == confluent-schemas && confluent.schemaSearchApplied",
+          "group": "navigation@1"
+        },
+        {
           "command": "confluent.schemas.create",
           "when": "view == confluent-schemas",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "confluent.schemas.upload",
           "when": "view == confluent-schemas && confluent.schemaRegistrySelected",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "confluent.resources.schema-registry.select",
           "when": "view == confluent-schemas && (confluent.ccloudConnectionAvailable || confluent.localSchemaRegistryAvailable || confluent.directSchemaRegistryAvailable)",
-          "group": "navigation@3"
+          "group": "navigation@4"
         },
         {
           "command": "confluent.schemas.refresh",
           "when": "view == confluent-schemas",
-          "group": "navigation@4"
+          "group": "navigation@5"
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",
@@ -815,16 +825,6 @@
           "command": "confluent.resources.kafka-cluster.select",
           "when": "view == confluent-topics && (confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)",
           "group": "navigation@3"
-        },
-        {
-          "command": "confluent.schemas.search",
-          "when": "view == confluent-schemas && !confluent.schemaSearchApplied",
-          "group": "navigation@1"
-        },
-        {
-          "command": "confluent.schemas.search.clear",
-          "when": "view == confluent-schemas && confluent.schemaSearchApplied",
-          "group": "navigation@1"
         },
         {
           "command": "confluent.topics.refresh",

--- a/package.json
+++ b/package.json
@@ -809,6 +809,16 @@
           "command": "confluent.topics.copyKafkaClusterBootstrapServers",
           "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "2_copy@3"
+        },
+        {
+          "command": "confluent.topics.search",
+          "when": "view == confluent-topics && !confluent.topicSearchApplied",
+          "group": "navigation@1"
+        },
+        {
+          "command": "confluent.topics.search.clear",
+          "when": "view == confluent-topics && confluent.topicSearchApplied",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [

--- a/src/commands/extra.ts
+++ b/src/commands/extra.ts
@@ -1,7 +1,7 @@
 import { Disposable, env, Uri, window } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
-import { resourceSearchSet, topicSearchSet } from "../emitters";
+import { resourceSearchSet, schemaSearchSet, topicSearchSet } from "../emitters";
 import { Logger } from "../logging";
 
 const logger = new Logger("commands.extra");
@@ -83,6 +83,25 @@ async function clearTopicSearch() {
   topicSearchSet.fire(null);
 }
 
+async function searchSchemas() {
+  const searchString = await window.showInputBox({
+    title: "Search items in the Schemas view",
+    ignoreFocusOut: true,
+  });
+  if (!searchString) {
+    return;
+  }
+  await setContextValue(ContextValues.schemaSearchApplied, true);
+  logger.debug("Searching schemas");
+  schemaSearchSet.fire(searchString);
+}
+
+async function clearSchemaSearch() {
+  logger.debug("Clearing schema search");
+  await setContextValue(ContextValues.schemaSearchApplied, false);
+  schemaSearchSet.fire(null);
+}
+
 export function registerExtraCommands(): Disposable[] {
   return [
     registerCommandWithLogging("confluent.openCCloudLink", openCCloudLink),
@@ -93,5 +112,7 @@ export function registerExtraCommands(): Disposable[] {
     registerCommandWithLogging("confluent.resources.search.clear", clearResourceSearch),
     registerCommandWithLogging("confluent.topics.search", searchTopics),
     registerCommandWithLogging("confluent.topics.search.clear", clearTopicSearch),
+    registerCommandWithLogging("confluent.schemas.search", searchSchemas),
+    registerCommandWithLogging("confluent.schemas.search.clear", clearSchemaSearch),
   ];
 }

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -62,6 +62,8 @@ export enum ContextValues {
   resourceSearchApplied = "confluent.resourceSearchApplied",
   /** The user applied a search string to the Topics view. */
   topicSearchApplied = "confluent.topicSearchApplied",
+  /** The user applied a search string to the Schemas view. */
+  schemaSearchApplied = "confluent.schemaSearchApplied",
   /**
    * PREVIEW: Is the "produce message" functionality enabled at all?
    * (This should go away once the `confluent.preview.enableProduceMessages` setting is removed.)

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -44,3 +44,5 @@ export const connectionStable = new vscode.EventEmitter<ConnectionId>();
 export const resourceSearchSet = new vscode.EventEmitter<string | null>();
 /** The user set/unset a filter for the Topics view. */
 export const topicSearchSet = new vscode.EventEmitter<string | null>();
+/** The user set/unset a filter for the Schemas view. */
+export const schemaSearchSet = new vscode.EventEmitter<string | null>();

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -23,6 +23,8 @@ export class ContainerTreeItem<T extends IdItem & ISearchable>
     children: T[],
   ) {
     super(label, collapsibleState);
+    // set id to the label so it isn't `undefined`; can be overwritten by the caller if needed
+    this.id = label.toString();
 
     // set id to the label so it isn't `undefined`; can be overwritten by the caller if needed
     this.id = label.toString();

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -26,8 +26,6 @@ export class ContainerTreeItem<T extends IdItem & ISearchable>
     // set id to the label so it isn't `undefined`; can be overwritten by the caller if needed
     this.id = label.toString();
 
-    // set id to the label so it isn't `undefined`; can be overwritten by the caller if needed
-    this.id = label.toString();
     this.description = `(${children.length})`;
 
     this.children = children;

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -23,9 +23,9 @@ export class ContainerTreeItem<T extends IdItem & ISearchable>
     children: T[],
   ) {
     super(label, collapsibleState);
+
     // set id to the label so it isn't `undefined`; can be overwritten by the caller if needed
     this.id = label.toString();
-
     this.description = `(${children.length})`;
 
     this.children = children;

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -92,7 +92,7 @@ export class Schema extends Data implements IResourceBase {
     // NOTE: based on the availability of schema-specific data at the time of SchemasViewProvider
     // loading, the Subject containers won't actually have any Schema children, so we can't offer
     // any searchability on them.
-    return this.id;
+    return "";
   }
 }
 

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { IconNames } from "../constants";
 import { ContainerTreeItem, CustomMarkdownString } from "./main";
-import { ConnectionId, EnvironmentId, IResourceBase, isCCloud, ISearchable } from "./resource";
+import { ConnectionId, EnvironmentId, IResourceBase, isCCloud } from "./resource";
 
 export enum SchemaType {
   Avro = "AVRO",
@@ -29,7 +29,7 @@ export function getLanguageTypes(schemaType: SchemaType): string[] {
 
 // Main class representing CCloud Schema Registry schemas, matching key/value pairs returned
 // by the `confluent schema-registry schema list` command.
-export class Schema extends Data implements IResourceBase, ISearchable {
+export class Schema extends Data implements IResourceBase {
   connectionId!: Enforced<ConnectionId>;
   connectionType!: Enforced<ConnectionType>;
   iconName: IconNames.SCHEMA = IconNames.SCHEMA;
@@ -89,6 +89,9 @@ export class Schema extends Data implements IResourceBase, ISearchable {
   }
 
   searchableText(): string {
+    // NOTE: based on the availability of schema-specific data at the time of SchemasViewProvider
+    // loading, the Subject containers won't actually have any Schema children, so we can't offer
+    // any searchability on them.
     return this.id;
   }
 }

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -1,9 +1,14 @@
 import * as assert from "assert";
-import * as vscode from "vscode";
-import { TEST_CCLOUD_SCHEMA } from "../../tests/unit/testResources";
+import * as sinon from "sinon";
+import { TreeItemCollapsibleState } from "vscode";
+import { TEST_CCLOUD_SCHEMA, TEST_CCLOUD_SCHEMA_REGISTRY } from "../../tests/unit/testResources";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
+import { schemaSearchSet } from "../emitters";
+import { CCloudResourceLoader } from "../loaders";
 import { ContainerTreeItem } from "../models/main";
 import { Schema, SchemaTreeItem } from "../models/schema";
 import { SchemasViewProvider } from "./schemas";
+import { SEARCH_DECORATION_URI_SCHEME } from "./search";
 
 describe("SchemasViewProvider methods", () => {
   let provider: SchemasViewProvider;
@@ -18,12 +23,134 @@ describe("SchemasViewProvider methods", () => {
   });
 
   it("getTreeItem() should pass ContainerTreeItems through directly", () => {
+    const container = new ContainerTreeItem<Schema>("test", TreeItemCollapsibleState.Collapsed, [
+      TEST_CCLOUD_SCHEMA,
+    ]);
+    const treeItem = provider.getTreeItem(container);
+    assert.deepStrictEqual(treeItem, container);
+  });
+});
+
+describe("SchemasViewProvider search behavior", () => {
+  let provider: SchemasViewProvider;
+  let ccloudLoader: CCloudResourceLoader;
+
+  let sandbox: sinon.SinonSandbox;
+
+  const TEST_CCLOUD_SCHEMA2 = Schema.create({
+    ...TEST_CCLOUD_SCHEMA,
+    subject: "foo-value",
+    id: "100123",
+  });
+  const TEST_CCLOUD_SCHEMA3 = Schema.create({
+    ...TEST_CCLOUD_SCHEMA,
+    subject: "bar-key",
+    id: "100456",
+  });
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // stub loader method for fetching schemas
+    ccloudLoader = CCloudResourceLoader.getInstance();
+    sandbox
+      .stub(ccloudLoader, "getSchemasForRegistry")
+      // three sample schema versions across three subjects
+      .resolves([TEST_CCLOUD_SCHEMA, TEST_CCLOUD_SCHEMA2, TEST_CCLOUD_SCHEMA3]);
+
+    provider = SchemasViewProvider.getInstance();
+    provider.schemaRegistry = TEST_CCLOUD_SCHEMA_REGISTRY;
+  });
+
+  afterEach(() => {
+    SchemasViewProvider["instance"] = null;
+    sandbox.restore();
+  });
+
+  it("getChildren() should filter root-level subjects based on search string", async () => {
+    // First schema subject matches search
+    schemaSearchSet.fire(TEST_CCLOUD_SCHEMA.subject);
+
+    const rootElements = await provider.getChildren();
+
+    assert.strictEqual(rootElements.length, 1);
+    assert.ok(rootElements[0] instanceof ContainerTreeItem);
+    assert.strictEqual(
+      (rootElements[0] as ContainerTreeItem<Schema>).label,
+      TEST_CCLOUD_SCHEMA.subject,
+    );
+  });
+
+  it("getChildren() should return all schemas if parent subject matches search", async () => {
+    // Parent subject matches search
+    schemaSearchSet.fire(TEST_CCLOUD_SCHEMA.subject);
+
+    const rootElements = await provider.getChildren();
+
+    assert.strictEqual(rootElements.length, 1);
+    assert.ok(rootElements[0] instanceof ContainerTreeItem);
+    assert.strictEqual(
+      (rootElements[0] as ContainerTreeItem<Schema>).label,
+      TEST_CCLOUD_SCHEMA.subject,
+    );
+
+    // expand subject container to get child schemas
+    const children = await provider.getChildren(rootElements[0]);
+
+    assert.strictEqual(children.length, 1);
+    assert.ok(children[0] instanceof Schema);
+    assert.strictEqual(children[0].subject, TEST_CCLOUD_SCHEMA.subject);
+  });
+
+  it("getChildren() should show correct count in tree view message when items match search", async () => {
+    // Search matching two subjects
+    const searchStr = "-value";
+    schemaSearchSet.fire("-value");
+
+    await provider.getChildren();
+
+    assert.strictEqual(provider["treeView"].message, `Showing 2 results for "${searchStr}"`);
+  });
+
+  it("getChildren() should clear tree view message when search is cleared", async () => {
+    // Search cleared
+    schemaSearchSet.fire(null);
+
+    await provider.getChildren();
+
+    assert.strictEqual(provider["treeView"].message, undefined);
+  });
+
+  it("getTreeItem() should set the resourceUri of subject containers that match the search string", async () => {
+    // First schema subject matches search
+    schemaSearchSet.fire(TEST_CCLOUD_SCHEMA.subject);
+
     const container = new ContainerTreeItem<Schema>(
-      "test",
-      vscode.TreeItemCollapsibleState.Collapsed,
+      TEST_CCLOUD_SCHEMA.subject,
+      TreeItemCollapsibleState.Collapsed,
       [TEST_CCLOUD_SCHEMA],
     );
     const treeItem = provider.getTreeItem(container);
-    assert.deepStrictEqual(treeItem, container);
+
+    assert.ok(treeItem.resourceUri);
+    assert.strictEqual(treeItem.resourceUri?.scheme, SEARCH_DECORATION_URI_SCHEME);
+  });
+
+  it("getTreeItem() should collapse items when children exist but don't match search", async () => {
+    // Search for non-matching string
+    schemaSearchSet.fire("non-matching-search");
+
+    const container = new ContainerTreeItem<Schema>(
+      TEST_CCLOUD_SCHEMA.subject,
+      TreeItemCollapsibleState.Expanded,
+      [TEST_CCLOUD_SCHEMA],
+    );
+    const treeItem = provider.getTreeItem(container);
+
+    assert.strictEqual(treeItem.collapsibleState, TreeItemCollapsibleState.Collapsed);
   });
 });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Continuation of #996 and #1010. Closes #1003.

This is a much smaller search PR than the previous two, mainly because we can only realistically support searching by **subject** rather than any visible data associated with the schema items themselves.


https://github.com/user-attachments/assets/c5a559df-41a7-4aec-a871-8fb8ad3ab627


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Unfortunately, because we're still using `ContainerTreeItem<Schema>`, that means that `Schema`s had to be "searchable" -- (since ContainerTreeItem children types must also [implement `ISearchable`](https://github.com/confluentinc/vscode/blob/main/src/models/main.ts#L14)) -- despite not functionally being searchable.

Once https://github.com/confluentinc/vscode/issues/1021 is done, this should be less confusing.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
