### PR TITLE
Use `PATCH` endpoint for updating direct connections

### DIFF
--- a/src/sidecar/connections/index.test.ts
+++ b/src/sidecar/connections/index.test.ts
@@ -68,7 +68,7 @@ describe("sidecar/connections/index.ts", () => {
         ...testConnection,
         spec: { ...testConnection.spec, name: "updated-name" },
       };
-      stubConnectionsResourceApi.gatewayV1ConnectionsIdPut.resolves(updatedConnection);
+      stubConnectionsResourceApi.gatewayV1ConnectionsIdPatch.resolves(updatedConnection);
 
       const connection = await tryToUpdateConnection(updatedConnection);
 

--- a/src/sidecar/connections/index.ts
+++ b/src/sidecar/connections/index.ts
@@ -67,9 +67,9 @@ export async function tryToUpdateConnection(spec: ConnectionSpec): Promise<Conne
   let connection: Connection;
   const client: ConnectionsResourceApi = (await getSidecar()).getConnectionsResourceApi();
   try {
-    connection = await client.gatewayV1ConnectionsIdPut({
+    connection = await client.gatewayV1ConnectionsIdPatch({
       id: spec.id!,
-      ConnectionSpec: spec,
+      body: spec,
     });
     logger.debug("updated connection:", { id: connection.id });
     return connection;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Simple replace `PUT` -> `PATCH` since we now have that endpoint on the sidecar side.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- I originally hoped this would allow me to clean up a lot of the manipulation of the spec object for secrets, etc., but we **still must store/retrieve/manipulate the entire spec during updates** since we store the secrets & delete/replace the whole spec vscode-side when it's updated.
- I tried splitting the ID from connection spec and passing a partial spec from the form, but after playing with it a while I just couldn't justify _adding_ complexity with handling undefined pieces & tracking touched/changed items when it's ultimately not needed (since we're always using the spec as a whole in our update functions ^).
- So, I ripped out a bunch of the changes I had started and this ended up being a _very_ simple replacement for now. The endpoint is there if we need to send select parts of the spec in the future though! 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [NO] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
