### PR TITLE
New extract() function to simplify executeInWorkerPool() results hand…

### DIFF
--- a/src/loaders/loaderUtils.ts
+++ b/src/loaders/loaderUtils.ts
@@ -11,7 +11,7 @@ import { Schema, SchemaType, subjectMatchesTopicName } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
 import { getSidecar } from "../sidecar";
-import { executeInWorkerPool, isSuccessResult } from "../utils/workerPool";
+import { executeInWorkerPool, extract } from "../utils/workerPool";
 
 const logger = new Logger("resourceLoader");
 
@@ -205,17 +205,7 @@ export async function fetchSchemaSubjectGroup(
 
   // Filter the executeInWorkerPool() return for successful results and return the schemas.
   // If any single request failed, fail the whole operation.
-  const schemas: Schema[] = new Array(concurrentFetchResults.length);
-  concurrentFetchResults.forEach((result, index) => {
-    if (isSuccessResult(result)) {
-      schemas[index] = result.result;
-    } else {
-      // If any single request failed, fail the whole operation for now.
-      throw result.error;
-    }
-  });
-
-  return schemas;
+  return extract(concurrentFetchResults);
 }
 
 /** Interface describing a bundle of params needed for call to {@link fetchSchemaVersion} */

--- a/src/utils/workerPool.test.ts
+++ b/src/utils/workerPool.test.ts
@@ -159,6 +159,27 @@ describe("utils/workerPool.ts executeInWorkerPool()", () => {
       [0, 1, 2, 3],
     );
   });
+
+  it("If callback throws non-Error exception, it gets wrapped properly", async () => {
+    const items = [1, 2, 3];
+    const callable = async (num: number) => {
+      if (num === 2) throw "test error";
+      return num;
+    };
+
+    const results = await executeInWorkerPool(callable, items, { maxWorkers: 3 });
+
+    assert.strictEqual(results.length, 3);
+    assert.strictEqual(isSuccessResult(results[0]), true);
+    assert.strictEqual(isErrorResult(results[1]), true);
+    assert.ok(results[1].error instanceof Error);
+    assert.strictEqual(
+      results[1].error.message,
+      "executeInWorkerPool(): Non-Error encountered when dispatching index 1",
+    );
+    assert.strictEqual(results[1].error.cause, "test error");
+    assert.strictEqual(isSuccessResult(results[2]), true);
+  });
 });
 
 describe("utils/workerPool.ts type guards", () => {
@@ -172,11 +193,11 @@ describe("utils/workerPool.ts type guards", () => {
     assert.strictEqual(isErrorResult({ result: 123 }), false);
   });
 
-  it("isSuccessResult() should handle undefined input", () => {
+  it("isSuccessResult() should handle undefined input by returning false", () => {
     assert.strictEqual(isSuccessResult(undefined), false);
   });
 
-  it("isErrorResult() should handle undefined input", () => {
+  it("isErrorResult() should handle undefined input by returning false", () => {
     assert.strictEqual(isErrorResult(undefined), false);
   });
 });

--- a/src/utils/workerPool.ts
+++ b/src/utils/workerPool.ts
@@ -145,3 +145,24 @@ export async function executeInWorkerPool<T, R>(
 
   return results;
 }
+
+/**
+ * Extracts all the underlying `results` from an {@link ExecutionResult[]} if they are {@link SuccessResult},
+ * returns as an array. If any {@link ErrorResult} is encountered, throws the encountered error.
+ *
+ * Makes {@link executeInWorkerPool} error handling more like `Promise.all()` when the caller
+ * desires all-or-none semantics.
+ */
+export function extract<R>(results: ExecutionResult<R>[]): R[] {
+  const goodResults: R[] = new Array<R>(results.length);
+  let i = 0;
+  for (const result of results) {
+    if (isSuccessResult(result)) {
+      goodResults[i++] = result.result;
+    } else {
+      throw result.error;
+    }
+  }
+
+  return goodResults;
+}


### PR DESCRIPTION
…ling when expecting all to have succeeded.

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- `extract()` results post-processor giving `executeInWorkerPool()` similar semantics to `Promise.all()` if the use-case desires: It unpacks the actual results from the `ExecutionResult<R>` wrappers into an `R[]`. If an `ErrorResult` is encountered, it immediately throws it.
- Use to replace equivalent code inlined within the tail of `fetchSchemaSubjectGroup()`. Existing tests over it continue to prove that if any single version fetch failed, the whole block fails.
- While in here, fix edge case in executeInWorkerPool(), which would leave result array values undefined if the callback raised a non-Error. Fix that by noticing and wrapping with a definite Error.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
