### PR TITLE
Send the vscode uriScheme to segment as "productName"

### DIFF
--- a/src/telemetry/telemetryLogger.test.ts
+++ b/src/telemetry/telemetryLogger.test.ts
@@ -1,0 +1,52 @@
+import * as assert from "assert";
+import * as ideSidecar from "ide-sidecar";
+import Sinon from "sinon";
+import * as vscode from "vscode";
+import { preparePropertiesForTrack } from "./telemetryLogger";
+
+describe("preparePropertiesForTrack", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should remove identify and user from data", () => {
+    const data = {
+      user: {
+        id: "123",
+        email: "foo@bar.com",
+      },
+      identify: true,
+      foo: "bar",
+    };
+
+    const result = preparePropertiesForTrack(data);
+
+    // user and identify should be removed
+    assert.strictEqual(result.user, undefined);
+    assert.strictEqual(result.identify, undefined);
+    // Other properties should be kept
+    assert.strictEqual(result.foo, "bar");
+  });
+
+  it("should include vscode.env.uriScheme as productName", () => {
+    const vscodeEnvUriSchemeStub = sandbox.stub(vscode.env, "uriScheme");
+    for (const uriScheme of ["vscode", "vscode-insiders", "vscode-test"]) {
+      vscodeEnvUriSchemeStub.value(uriScheme);
+      const result = preparePropertiesForTrack(undefined);
+      assert.strictEqual(result.productName, uriScheme);
+    }
+  });
+
+  it("should include ide-sidecar version as currentSidecarVersion", () => {
+    const version = "1.2.3";
+    sandbox.stub(ideSidecar, "version").value(version);
+    const result = preparePropertiesForTrack(undefined);
+    assert.strictEqual(result.currentSidecarVersion, version);
+  });
+});

--- a/src/telemetry/telemetryLogger.test.ts
+++ b/src/telemetry/telemetryLogger.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as ideSidecar from "ide-sidecar";
-import Sinon from "sinon";
+import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { preparePropertiesForTrack } from "./telemetryLogger";
 
@@ -8,7 +8,7 @@ describe("preparePropertiesForTrack", () => {
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
-    sandbox = Sinon.createSandbox();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
@@ -27,10 +27,10 @@ describe("preparePropertiesForTrack", () => {
 
     const result = preparePropertiesForTrack(data);
 
-    // user and identify should be removed
+    // user and identify should be removed,
     assert.strictEqual(result.user, undefined);
     assert.strictEqual(result.identify, undefined);
-    // Other properties should be kept
+    // ... but other call-provided properties should remain.
     assert.strictEqual(result.foo, "bar");
   });
 

--- a/src/telemetry/telemetryLogger.ts
+++ b/src/telemetry/telemetryLogger.ts
@@ -102,9 +102,11 @@ export function getTelemetryLogger(): vscode.TelemetryLogger {
 export function preparePropertiesForTrack(
   data: Record<string, any> | undefined,
 ): Record<string, any> {
-  // We never want to send the user traits or identify property to track call.
-  delete data?.identify;
-  delete data?.user;
+  if (data) {
+    // We never want to send the user traits or identify property to track() call.
+    delete data.identify;
+    delete data.user;
+  }
 
   return {
     productName: vscode.env.uriScheme, // "vscode", "vscode-insiders", etc.

--- a/src/telemetry/telemetryLogger.ts
+++ b/src/telemetry/telemetryLogger.ts
@@ -1,6 +1,6 @@
 import { Analytics } from "@segment/analytics-node";
 import { randomUUID } from "crypto";
-import { version as currentSidecarVersion } from "ide-sidecar";
+import * as ideSidecar from "ide-sidecar";
 import * as vscode from "vscode";
 import { Logger } from "../logging";
 // TEMP keep this import here to make sure the production bundle doesn't split chunks
@@ -64,8 +64,6 @@ export function getTelemetryLogger(): vscode.TelemetryLogger {
 
   telemetryLogger = vscode.env.createTelemetryLogger({
     sendEventData: (eventName, data) => {
-      // Remove the prefix that vscode adds to event names
-      const cleanEventName = eventName.replace(/^confluentinc\.vscode-confluent\//, "");
       // Extract & save the user id if was sent
       if (data?.user?.id) userId = data.user.id;
       if (data?.identify && data?.user) {
@@ -74,15 +72,16 @@ export function getTelemetryLogger(): vscode.TelemetryLogger {
           anonymousId: segmentAnonId,
           traits: { ...data.user },
         });
-        // We don't want to send the user traits or identify prop in the following Track call
-        delete data.identify;
-        delete data.user;
       }
+
+      // Remove the prefix that vscode adds to event names
+      const cleanEventName = eventName.replace(/^confluentinc\.vscode-confluent\//, "");
+
       analytics?.track({
         userId,
         anonymousId: segmentAnonId,
         event: cleanEventName,
-        properties: { currentSidecarVersion, ...data }, // VSCode Common properties in data includes the extension version
+        properties: preparePropertiesForTrack(data),
       });
     },
     sendErrorData: (exception, data) => {
@@ -94,4 +93,22 @@ export function getTelemetryLogger(): vscode.TelemetryLogger {
   });
 
   return telemetryLogger;
+}
+
+/**
+ * Augment (and clean up) caller-provided data to telemetryLogger.sendEventData()
+ * before sending it to Segment.
+ */
+export function preparePropertiesForTrack(
+  data: Record<string, any> | undefined,
+): Record<string, any> {
+  // We never want to send the user traits or identify property to track call.
+  delete data?.identify;
+  delete data?.user;
+
+  return {
+    productName: vscode.env.uriScheme, // "vscode", "vscode-insiders", etc.
+    currentSidecarVersion: ideSidecar.version,
+    ...data, // VSCode Common properties in data includes the extension version
+  };
 }


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Refactor `telemetryLogger.sendEventData()` to do the preparation of the `properties` sent up in the track() call in an new external function, `preparePropertiesForTrack().`
- Have `preparePropertiesForTrack()` include the current vscode.env.uriScheme ("vscode", "vscode-insiders", etc.) as `productName`.
- Write tests.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1008 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
