### PR TITLE
Include vscode.version as "productVersion" in telemetry events.

### DIFF
--- a/src/telemetry/telemetryLogger.test.ts
+++ b/src/telemetry/telemetryLogger.test.ts
@@ -43,6 +43,12 @@ describe("preparePropertiesForTrack", () => {
     }
   });
 
+  it("should include vscode.version as productVersion", () => {
+    // vscode.version is unstubbable and read-only, so just go with expecting current value.
+    const result = preparePropertiesForTrack(undefined);
+    assert.strictEqual(result.productVersion, vscode.version);
+  });
+
   it("should include ide-sidecar version as currentSidecarVersion", () => {
     const version = "1.2.3";
     sandbox.stub(ideSidecar, "version").value(version);

--- a/src/telemetry/telemetryLogger.ts
+++ b/src/telemetry/telemetryLogger.ts
@@ -110,6 +110,7 @@ export function preparePropertiesForTrack(
 
   return {
     productName: vscode.env.uriScheme, // "vscode", "vscode-insiders", etc.
+    productVersion: vscode.version,
     currentSidecarVersion: ideSidecar.version,
     ...data, // VSCode Common properties in data includes the extension version
   };


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes https://github.com/confluentinc/vscode/issues/991


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
