### PR TITLE
use read-only document provider for "Open consumed messages as JSON"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this extension will be documented in this file.
   all schema registries.
 - Quickpick for schema registry subject names (i.e. when uploading a new schema) now based off of
   `GET /subjects` route results.
+- Message Viewer's "Open consumed messages as JSON" feature now opens messages in a read-only
+  document, which can be used to produce messages to other topics.
 
 ### Fixed
 

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -700,7 +700,8 @@ function messageViewerStartPollingCommand(
           }
         }
         // use a single-instance provider to display a read-only document buffer with the messages
-        const filename = `${topic.name}-messages.json`;
+        // at the given timestamp, so the document isn't reused across multiple previews
+        const filename = `${topic.name}-messages-${new Date().getTime()}.json`;
         const provider = new MessageDocumentProvider();
         MessageDocumentProvider.message = `[\n${records.join(",\n")}\n]`;
         // this is really only used for the filename:


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #931.
Continuation of #799, but this time for the multi-message view:
<img width="567" alt="image" src="https://github.com/user-attachments/assets/c32c032e-1738-4bdf-ab15-1c752e48e77e" />

Content is now passed to the `MessageDocumentProvider` in the same format it was shown as a workspace doc, but with an updated title. All content is now read-only, and can be used for the (still in preview) produce-message flow:
<img width="1802" alt="image" src="https://github.com/user-attachments/assets/4c59ef69-72e0-4658-8a85-2e563b39cfb7" />

Also supports VS Code document `preview` mode (when enabled in user settings) and will not show up as "dirty" / prompt for saving when closing the tab.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
