### PR TITLE
cleanup(telemetry): consolidate user events

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -114,7 +114,8 @@ export async function runWorkflowWithProgress(
         });
 
         logger.debug(`running ${workflow.resourceKind} workflow`, { start });
-        workflow.sendTelemetryEvent(UserEvent.WorkflowInitiated, {
+        workflow.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+          status: "workflow initialized",
           start,
         });
         try {
@@ -124,13 +125,15 @@ export async function runWorkflowWithProgress(
             await workflow.stop(token, progress);
           }
           logger.debug(`finished ${workflow.resourceKind} workflow`, { start });
-          workflow.sendTelemetryEvent(UserEvent.WorkflowFinished, {
+          workflow.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+            status: "workflow completed",
             start,
           });
         } catch (error) {
           logger.error(`error running ${workflow.resourceKind} workflow`, error);
           if (error instanceof Error) {
-            workflow.sendTelemetryEvent(UserEvent.WorkflowErrored, {
+            workflow.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+              status: "workflow failed",
               start,
             });
             Sentry.captureException(error, {

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -174,7 +174,7 @@ export class DirectConnectionManager {
 
   async updateConnection(incomingSpec: CustomConnectionSpec): Promise<void> {
     // at this point incoming spec has placeholder secrets... look up the associated ConnectionSpec
-    const currentSpec: ConnectionSpec | null = await getResourceManager().getDirectConnection(
+    const currentSpec: CustomConnectionSpec | null = await getResourceManager().getDirectConnection(
       incomingSpec.id,
     );
     if (!currentSpec) {
@@ -190,6 +190,13 @@ export class DirectConnectionManager {
       );
       return;
     }
+
+    logUsage(UserEvent.DirectConnectionAction, {
+      type: currentSpec.formConnectionType,
+      action: "updated",
+      withKafka: !!updatedSpec.kafka_cluster,
+      withSchemaRegistry: !!updatedSpec.schema_registry,
+    });
 
     // combine the returned ConnectionSpec with the CustomConnectionSpec before storing
     // (spec comes first because the ConnectionSpec will try to override `id` as a string)

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -47,7 +47,8 @@ export async function pullImage(repo: string, tag: string): Promise<void> {
       status: resp.raw.status,
       statusText: resp.raw.statusText,
     });
-    logUsage(UserEvent.DockerImagePulled, {
+    logUsage(UserEvent.LocalDockerAction, {
+      status: "image pulled",
       dockerImage: repoTag,
     });
   } catch (error) {

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -237,7 +237,6 @@ export abstract class LocalResourceWorkflow {
   sendTelemetryEvent(eventName: UserEvent, properties: Record<string, any>) {
     logUsage(eventName, {
       dockerImage: this.imageRepoTag,
-      extensionUserFlow: "Local Resource Management",
       localResourceKind: this.resourceKind,
       ...properties,
     });

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -60,7 +60,8 @@ export abstract class LocalResourceWorkflow {
   ): Promise<ContainerInspectResponse | undefined> {
     try {
       await startContainer(container.id);
-      this.sendTelemetryEvent(UserEvent.DockerContainerStarted, {
+      this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+        status: "started",
         dockerContainerName: container.name,
       });
     } catch (error) {

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -61,7 +61,7 @@ export abstract class LocalResourceWorkflow {
     try {
       await startContainer(container.id);
       this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
-        status: "started",
+        status: "container started",
         dockerContainerName: container.name,
       });
     } catch (error) {
@@ -122,7 +122,7 @@ export abstract class LocalResourceWorkflow {
     if (existingContainer.State?.Status === "running") {
       await stopContainer(container.id);
       this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
-        status: "stopped",
+        status: "container stopped",
         dockerContainerName: container.name,
       });
     }

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -121,7 +121,8 @@ export abstract class LocalResourceWorkflow {
 
     if (existingContainer.State?.Status === "running") {
       await stopContainer(container.id);
-      this.sendTelemetryEvent(UserEvent.DockerContainerStopped, {
+      this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+        status: "stopped",
         dockerContainerName: container.name,
       });
     }

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -138,7 +138,8 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
         success = false;
         break;
       }
-      this.sendTelemetryEvent(UserEvent.DockerContainerCreated, {
+      this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+        status: "created",
         dockerContainerName: container.name,
       });
       // then start the container

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -139,7 +139,7 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
         break;
       }
       this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
-        status: "created",
+        status: "container created",
         dockerContainerName: container.name,
       });
       // then start the container

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -143,7 +143,7 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       return;
     }
     this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
-      status: "created",
+      status: "container created",
       dockerContainerName: container.name,
     });
     if (token.isCancellationRequested) return;

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -142,7 +142,8 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
       showErrorNotificationWithButtons(`Failed to create ${this.resourceKind} container.`);
       return;
     }
-    this.sendTelemetryEvent(UserEvent.DockerContainerCreated, {
+    this.sendTelemetryEvent(UserEvent.LocalDockerAction, {
+      status: "created",
       dockerContainerName: container.name,
     });
     if (token.isCancellationRequested) return;

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -51,7 +51,8 @@ export const scaffoldProjectRequest = async () => {
   }
 
   if (pickedTemplate !== undefined) {
-    logUsage(UserEvent.ScaffoldTemplatePicked, {
+    logUsage(UserEvent.ProjectScaffoldingAction, {
+      status: "template picked",
       templateName: pickedTemplate.spec!.display_name,
     });
   } else {
@@ -99,7 +100,8 @@ export const scaffoldProjectRequest = async () => {
         return null satisfies MessageResponse<"SetOptionValue">;
       }
       case "Submit": {
-        logUsage(UserEvent.ScaffoldFormSubmitted, {
+        logUsage(UserEvent.ProjectScaffoldingAction, {
+          status: "form submitted",
           templateName: templateSpec.display_name,
         });
         let res: PostResponse = { success: false, message: "Failed to apply template." };
@@ -150,7 +152,8 @@ async function applyTemplate(
 
     if (!fileUris || fileUris.length !== 1) {
       // This means the user cancelled @ save dialog. Show a message and return
-      logUsage(UserEvent.ScaffoldCancelled, {
+      logUsage(UserEvent.ProjectScaffoldingAction, {
+        status: "cancelled before save",
         templateName: pickedTemplate.spec!.display_name,
       });
       vscode.window.showInformationMessage("Project generation cancelled");
@@ -160,7 +163,8 @@ async function applyTemplate(
     const destination = await getNonConflictingDirPath(fileUris[0], pickedTemplate);
 
     await extractZipContents(arrayBuffer, destination);
-    logUsage(UserEvent.ScaffoldCompleted, {
+    logUsage(UserEvent.ProjectScaffoldingAction, {
+      status: "project generated",
       templateName: pickedTemplate.spec!.display_name,
     });
     // Notify the user that the project was generated successfully
@@ -175,7 +179,8 @@ async function applyTemplate(
       // if "true" is set in the `vscode.openFolder` command, it will open a new window instead of
       // reusing the current one
       const keepsExistingWindow = selection.title === "Open in New Window";
-      logUsage(UserEvent.ScaffoldFolderOpened, {
+      logUsage(UserEvent.ProjectScaffoldingAction, {
+        status: "project folder opened",
         templateName: pickedTemplate.spec!.display_name,
         keepsExistingWindow,
       });

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -11,7 +11,7 @@ export enum UserEvent {
   MessageViewerAction = "Message Viewer Action",
   NotificationButtonClicked = "Notification Button Clicked",
   ProjectScaffoldingAction = "Project Scaffolding Action",
-  SignedIn = "Signed In",
+  CCloudAuthentication = "CCloud Authentication",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -3,36 +3,15 @@ import { getTelemetryLogger } from "./telemetryLogger";
 
 /** The names of user events that can be logged when telemetry is enabled. */
 export enum UserEvent {
-  ActivatedWithSession = "Activated With Session",
-
   CommandInvoked = "Command Invoked",
-
   DirectConnectionAction = "Direct Connection Action",
-
-  DockerContainerCreated = "Docker Container Created",
-  DockerContainerStarted = "Docker Container Started",
-  DockerContainerStopped = "Docker Container Stopped",
-  DockerImagePulled = "Docker Image Pulled",
-
-  ExtensionActivated = "Extension Activated",
-
+  ExtensionActivation = "Extension Activation",
   InputBoxFilled = "Input Box Filled",
-
+  LocalDockerAction = "Local Docker Action",
   MessageViewerAction = "Message Viewer Action",
-
   NotificationButtonClicked = "Notification Button Clicked",
-
-  ScaffoldTemplatePicked = "Scaffold Template Picked",
-  ScaffoldFormSubmitted = "Scaffold Form Submitted",
-  ScaffoldCancelled = "Scaffold Cancelled",
-  ScaffoldCompleted = "Scaffold Completed",
-  ScaffoldFolderOpened = "Scaffold Folder Opened",
-
+  ProjectScaffoldingAction = "Project Scaffolding Action",
   SignedIn = "Signed In",
-
-  WorkflowInitiated = "Workflow Initiated",
-  WorkflowFinished = "Workflow Finished",
-  WorkflowErrored = "Workflow Errored",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */

--- a/src/telemetry/telemetry.test.ts
+++ b/src/telemetry/telemetry.test.ts
@@ -41,6 +41,7 @@ describe("sendTelemetryIdentifyEvent", () => {
     Sinon.assert.called(logUsageStub);
     Sinon.assert.calledWith(logUsageStub, testEvent, {
       identify: true,
+      status: "identify",
       user: {
         id: "user123",
         domain: "mycooldomain.com",
@@ -66,6 +67,7 @@ describe("sendTelemetryIdentifyEvent", () => {
     Sinon.assert.called(logUsageStub);
     Sinon.assert.calledWith(logUsageStub, testEvent, {
       identify: true,
+      status: "identify",
       user: {
         id: "session123",
         domain: "example.com",
@@ -105,6 +107,7 @@ describe("sendTelemetryIdentifyEvent", () => {
 
     Sinon.assert.calledWith(logUsageStub, testEvent, {
       identify: true,
+      status: "identify",
       user: {
         id: "user1",
         domain: undefined,

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -34,6 +34,7 @@ export function sendTelemetryIdentifyEvent({
   if (id) {
     logUsage(eventName, {
       identify: true,
+      status: "identify",
       user: { id, domain, social_connection },
     });
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

**No user-facing changes here.**

This PR consolidates a lot of the old telemetry events ([`src/telemetry/events.ts`](https://github.com/confluentinc/vscode/pull/1028/files#diff-83886f8a82ab31e0a5db17ae6db93a72f46caee5684835f80cd880805d25abbe)) and starts using more `status` fields to indicate different stages for a particular event.

| Before | After |
|--------|--------|
| `ActivatedWithSession` | `ExtensionActivation` with `status: "identify"` |
| `DockerContainerCreated` | `LocalDockerAction` with `status: "container created"` |
| `DockerContainerStarted` | `LocalDockerAction` with `status: "container started"` |
| `DockerContainerStopped` | `LocalDockerAction` with `status: "container stopped"` |
| `DockerImagePulled` | `LocalDockerAction` with `status: "image pulled"` |
| `ExtensionActivated` | `ExtensionActivation` with `status: "started" / "completed" / "failed"` (and the "identify" above) |
| `ScaffoldTemplatePicked` | `ProjectScaffoldingAction` with `status: "template picked"`|
| `ScaffoldFormSubmitted` | `ProjectScaffoldingAction` with `status: "form submitted"`|
| `ScaffoldCancelled` | `ProjectScaffoldingAction` with `status: "cancelled before save"`|
| `ScaffoldFolderOpened` | `ProjectScaffoldingAction` with `status: "project folder opened"`|
| `SignedIn` | `CCloudAuthentication` with `status: "signed in" / "identify" / "signed out"` |
| `WorkflowInitiated` | `LocalDockerAction ` with `status: "workflow initialized"`|
| `WorkflowFinished` | `LocalDockerAction ` with `status: "workflow completed"`|
| `WorkflowErrored` | `LocalDockerAction ` with `status: "workflow failed"`|

Also added a `DirectConnectionAction` event with `action: "updated"`(maybe we change these to `status: ___`?) after the "Edit Connection" flow.

Prep work for associated PRs:
- https://github.com/confluentinc/vscode/pull/1028 👈 
  - https://github.com/confluentinc/vscode/pull/1042
    - https://github.com/confluentinc/vscode/pull/1044

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
