### PR TITLE
chore(CI): build & test with VS Code Insiders

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,7 +57,7 @@ blocks:
   - name: "Build & Test (VS Code Insiders)"
     dependencies: []
     skip:
-      when: "branch_name != 'main' OR change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
+      when: "branch != 'main' OR change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
       jobs:
         - name: "Build & Test (VS Code Insiders)"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,7 @@ global_job_config:
         - make store-test-results-to-semaphore
 
 blocks:
-  - name: "Build & Test"
+  - name: "Build & Test (VS Code)"
     dependencies: []
     # Skip when:
     # - change in the release.svg file, signaling a `chore: none version bump vN.N.N` commit.
@@ -49,6 +49,17 @@ blocks:
         - name: "Build & Test"
           commands:
             - make test
+          # Not setting VSCODE_VERSION env var will default using the latest stable release version
+      epilogue:
+        always:
+          commands:
+            - make remove-test-env
+  - name: "Build & Test (VS Code Insiders)"
+    dependencies: []
+    skip:
+      when: "branch_name != 'main' || change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
+    task:
+      jobs:
         - name: "Build & Test (Insiders)"
           commands:
             - make test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,9 +49,6 @@ blocks:
         - name: "Build & Test"
           commands:
             - make test
-          env_vars:
-            - name: VSCODE_VERSION
-              value: 1.96.4
         - name: "Build & Test (Insiders)"
           commands:
             - make test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -46,7 +46,7 @@ blocks:
       when: "change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
       jobs:
-        - name: "Build & Test"
+        - name: "Build & Test (VS Code)"
           commands:
             - make test
           # Not setting VSCODE_VERSION env var will default using the latest stable release version
@@ -60,7 +60,7 @@ blocks:
       when: "branch_name != 'main' || change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
       jobs:
-        - name: "Build & Test (Insiders)"
+        - name: "Build & Test (VS Code Insiders)"
           commands:
             - make test
           env_vars:
@@ -72,7 +72,7 @@ blocks:
             - make remove-test-env
 
   - name: "Bump microversion"
-    dependencies: ["Build & Test"]
+    dependencies: ["Build & Test (VS Code)"]
     skip:
       # For main branch:    Always bump microversion on every commit (except those that bump next.txt
       #                       to set the next version under development)
@@ -90,7 +90,7 @@ blocks:
             - make bump-microversion
 
   - name: "Set next version under development"
-    dependencies: ["Build & Test"]
+    dependencies: ["Build & Test (VS Code)"]
     run:
       when: "branch = 'main' and change_in('/.versions/next.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,7 +57,7 @@ blocks:
   - name: "Build & Test (VS Code Insiders)"
     dependencies: []
     skip:
-      when: "branch != 'main' OR change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
+      when: "branch != 'main' AND change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
       jobs:
         - name: "Build & Test (VS Code Insiders)"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,6 +49,15 @@ blocks:
         - name: "Build & Test"
           commands:
             - make test
+          env_vars:
+            - name: VSCODE_VERSION
+              value: 1.96.4
+        - name: "Build & Test (Insiders)"
+          commands:
+            - make test
+          env_vars:
+            - name: VSCODE_VERSION
+              value: insiders
       epilogue:
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -57,7 +57,7 @@ blocks:
   - name: "Build & Test (VS Code Insiders)"
     dependencies: []
     skip:
-      when: "branch_name != 'main' || change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
+      when: "branch_name != 'main' OR change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
       jobs:
         - name: "Build & Test (VS Code Insiders)"

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -596,6 +596,7 @@ export async function testRun() {
   // argv array is something like ['gulp', 'test', '-t', 'something'], we look for the one after -t
   const testFilter = process.argv.find((v, i, a) => i > 0 && a[i - 1] === "-t");
   await runTests({
+    version: process.env.VSCODE_VERSION,
     extensionDevelopmentPath: resolve(DESTINATION),
     extensionTestsPath: resolve(DESTINATION + "/src/testing.js"),
     extensionTestsEnv: {


### PR DESCRIPTION
Closes #209 

Should be a decent smoketest to get us ahead of breaking changes. Tested by pinning `1.96.4` to the normal test run, with Insiders build `1.98.0`:
<img width="261" alt="image" src="https://github.com/user-attachments/assets/0cb696c9-6c4a-4b17-b004-135f8e7a7bca" />

Updated from the above screenshot: this is run as its own block, and will only run on PRs to `main` since we don't want to block releases or release patches if there's an issue with testing on Insiders.

| VS Code | VS Code Insiders |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/e116aba3-f9c0-4bfb-a0ff-c1f115b40477) | ![image](https://github.com/user-attachments/assets/51cbd05b-1a1b-41bc-9a4e-793bb833c731) | 