### PR TITLE
MINOR: fix `gulp clicktest` publisher ID

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -843,8 +843,8 @@ export function install(done) {
     return done(1);
   }
   // uninstall any existing extension first
-  // (may holler about "Extension 'confluent.vscode-confluent' is not installed.", but that's fine)
-  spawnSync("code", ["--uninstall-extension", "confluent.vscode-confluent"], {
+  // (may holler about "Extension 'confluentinc.vscode-confluent' is not installed.", but that's fine)
+  spawnSync("code", ["--uninstall-extension", "confluentinc.vscode-confluent"], {
     stdio: "inherit",
     shell: IS_WINDOWS,
   });


### PR DESCRIPTION
Full extension ID needs to match our publisher + extension name:
https://github.com/confluentinc/vscode/blob/a193db13417024a7a6b7f3dd3c70d11182b65fa7/package.json#L9