### PR TITLE
chore(telemetry): add `MessageProduceAction` events

### DIFF
--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -8,6 +8,7 @@ export enum UserEvent {
   ExtensionActivation = "Extension Activation",
   InputBoxFilled = "Input Box Filled",
   LocalDockerAction = "Local Docker Action",
+  MessageProduceAction = "Message Produce Action",
   MessageViewerAction = "Message Viewer Action",
   NotificationButtonClicked = "Notification Button Clicked",
   ProjectScaffoldingAction = "Project Scaffolding Action",


### PR DESCRIPTION
Telemetry updates around the produce-message flow. Only includes the URI scheme chosen (`file`, `untitled`, or the message-viewer URI) along with counts of original message(s) to be sent and resulting success/failure counts. No message or topic content is being sent.

Closes #896.

Associated PRs:
- https://github.com/confluentinc/vscode/pull/1028
  - https://github.com/confluentinc/vscode/pull/1042 👈 
    - https://github.com/confluentinc/vscode/pull/1044