### PR TITLE
fix: use `ConnectionSpecToJSON` to ensure we use `schema-registry-uri` for patching connections

### DIFF
--- a/src/sidecar/connections/index.ts
+++ b/src/sidecar/connections/index.ts
@@ -2,6 +2,7 @@ import { getSidecar } from "..";
 import {
   Connection,
   ConnectionSpec,
+  ConnectionSpecToJSON,
   ConnectionsResourceApi,
   ResponseError,
 } from "../../clients/sidecar";
@@ -69,7 +70,7 @@ export async function tryToUpdateConnection(spec: ConnectionSpec): Promise<Conne
   try {
     connection = await client.gatewayV1ConnectionsIdPatch({
       id: spec.id!,
-      body: spec,
+      body: ConnectionSpecToJSON(spec),
     });
     logger.debug("updated connection:", { id: connection.id });
     return connection;

--- a/src/sidecar/connections/local.ts
+++ b/src/sidecar/connections/local.ts
@@ -5,7 +5,7 @@ import {
   tryToUpdateConnection,
 } from ".";
 import { ContainerListRequest, ContainerSummary, Port } from "../../clients/docker";
-import { Connection, ConnectionSpec, LocalConfigToJSON } from "../../clients/sidecar";
+import { Connection, ConnectionSpec } from "../../clients/sidecar";
 import { LOCAL_CONNECTION_ID, LOCAL_CONNECTION_SPEC } from "../../constants";
 import {
   getLocalSchemaRegistryImageName,
@@ -42,10 +42,10 @@ export async function updateLocalConnection(schemaRegistryUri?: string): Promise
   if (schemaRegistryUri) {
     spec = {
       ...LOCAL_CONNECTION_SPEC,
-      local_config: LocalConfigToJSON({
+      local_config: {
         ...LOCAL_CONNECTION_SPEC.local_config,
         schema_registry_uri: schemaRegistryUri,
-      }),
+      },
     };
   }
 

--- a/src/sidecar/connections/local.ts
+++ b/src/sidecar/connections/local.ts
@@ -5,7 +5,7 @@ import {
   tryToUpdateConnection,
 } from ".";
 import { ContainerListRequest, ContainerSummary, Port } from "../../clients/docker";
-import { Connection, ConnectionSpec } from "../../clients/sidecar";
+import { Connection, ConnectionSpec, LocalConfigToJSON } from "../../clients/sidecar";
 import { LOCAL_CONNECTION_ID, LOCAL_CONNECTION_SPEC } from "../../constants";
 import {
   getLocalSchemaRegistryImageName,
@@ -42,10 +42,10 @@ export async function updateLocalConnection(schemaRegistryUri?: string): Promise
   if (schemaRegistryUri) {
     spec = {
       ...LOCAL_CONNECTION_SPEC,
-      local_config: {
+      local_config: LocalConfigToJSON({
         ...LOCAL_CONNECTION_SPEC.local_config,
         schema_registry_uri: schemaRegistryUri,
-      },
+      }),
     };
   }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Ensures we pass the correctly typed `LocalConfig` through our update-local-connection flow since our client code uses `schema_registry_uri` but the sidecar spec shows `schema-registry-uri`, so we have to use this:
https://github.com/confluentinc/vscode/blob/a35be57b123b27ae3d37686d2dd17418bd6ce182/src/clients/sidecar/models/LocalConfig.ts#L55-L66

But the proper fix is to just make sure that the `PATCH` request method uses `ConnectionSpecToJSON` all the time so we don't have to revisit this for some other connection type / field.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
