### PR TITLE
chore(telemetry): show total item count in view search filtering and add usage events

### DIFF
--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -13,6 +13,7 @@ export enum UserEvent {
   NotificationButtonClicked = "Notification Button Clicked",
   ProjectScaffoldingAction = "Project Scaffolding Action",
   SignedIn = "Signed In",
+  ViewSearchAction = "View Search Action",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -475,7 +475,13 @@ describe("ResourceViewProvider search behavior", () => {
 
     await provider.getChildren(container);
 
-    assert.strictEqual(provider["treeView"].message, `Showing 1 result for "${searchStr}"`);
+    // fresh provider for this test, only tracked 1 item returned for its totalItemCount
+    assert.strictEqual(provider.searchMatches.size, 1);
+    assert.strictEqual(provider.totalItemCount, 1);
+    assert.strictEqual(
+      provider["treeView"].message,
+      `Showing 1 of ${provider.totalItemCount} result for "${searchStr}"`,
+    );
   });
 
   it("getChildren() should clear tree view message when search is cleared", async () => {

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -52,6 +52,7 @@ import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { updateLocalConnection } from "../sidecar/connections/local";
 import { ConnectionStateWatcher } from "../sidecar/connections/watcher";
 import { DirectConnectionsById, getResourceManager } from "../storage/resourceManager";
+import { logUsage, UserEvent } from "../telemetry/events";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
 
@@ -103,6 +104,8 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
   itemSearchString: string | null = null;
   /** Items directly matching the {@linkcode itemSearchString}, if provided. */
   searchMatches: Set<ResourceViewProviderData> = new Set();
+  /** Count of all items returned from `getChildren()`. */
+  totalItemCount: number = 0;
 
   refresh(forceDeepRefresh: boolean = false): void {
     this.forceDeepRefresh = forceDeepRefresh;
@@ -241,6 +244,7 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
       }
     }
 
+    this.totalItemCount += children.length;
     if (this.itemSearchString) {
       // if the parent item matches the search string, return all children so the user can expand
       // and see them all, even if just the parent item matched and shows the highlight(s)
@@ -261,13 +265,19 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
       // update the tree view message to show how many results were found to match the search string
       // NOTE: this can't be done in `getTreeItem()` because if we don't return children here, it
       // will never be called and the message won't update
-      const plural = this.searchMatches.size > 1 ? "s" : "";
+      const plural = this.totalItemCount > 1 ? "s" : "";
       if (this.searchMatches.size > 0) {
-        this.treeView.message = `Showing ${this.searchMatches.size} result${plural} for "${this.itemSearchString}"`;
+        this.treeView.message = `Showing ${this.searchMatches.size} of ${this.totalItemCount} result${plural} for "${this.itemSearchString}"`;
       } else {
         // let empty state take over
         this.treeView.message = undefined;
       }
+      logUsage(UserEvent.ViewSearchAction, {
+        status: "view results filtered",
+        view: "Resources",
+        filteredItemCount: this.searchMatches.size,
+        totalItemCount: this.totalItemCount,
+      });
     } else {
       this.treeView.message = undefined;
     }
@@ -321,10 +331,13 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
     const resourceSearchSetSub: vscode.Disposable = resourceSearchSet.event(
       (searchString: string | null) => {
         logger.debug("resourceSearchSet event fired, refreshing", { searchString });
-        // set/unset the filter and call into getChildren() to update the tree view
-        this.itemSearchString = searchString;
-        // clear from any previous search filter
-        this.searchMatches = new Set();
+        logUsage(UserEvent.ViewSearchAction, {
+          status: `search string ${searchString ? "set" : "cleared"}`,
+          view: "Resources",
+          filteredItemCount: this.searchMatches.size,
+          totalItemCount: this.totalItemCount,
+        });
+        this.setSearch(searchString);
         this.refresh();
       },
     );
@@ -438,6 +451,17 @@ export class ResourceViewProvider implements vscode.TreeDataProvider<ResourceVie
         this.environmentsMap.delete(id);
       }
     });
+  }
+
+  /** Update internal state when the search string is set or unset. */
+  setSearch(searchString: string | null): void {
+    // set/unset the filter so any calls to getChildren() will filter appropriately
+    this.itemSearchString = searchString;
+    // set context value to toggle between "search" and "clear search" actions
+    setContextValue(ContextValues.resourceSearchApplied, searchString !== null);
+    // clear from any previous search filter
+    this.searchMatches = new Set();
+    this.totalItemCount = 0;
   }
 }
 

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -47,6 +47,8 @@ describe("SchemasViewProvider search behavior", () => {
     subject: "bar-key",
     id: "100456",
   });
+  // three sample schema versions across three subjects
+  const schemas = [TEST_CCLOUD_SCHEMA, TEST_CCLOUD_SCHEMA2, TEST_CCLOUD_SCHEMA3];
 
   before(async () => {
     await getTestExtensionContext();
@@ -57,10 +59,7 @@ describe("SchemasViewProvider search behavior", () => {
 
     // stub loader method for fetching schemas
     ccloudLoader = CCloudResourceLoader.getInstance();
-    sandbox
-      .stub(ccloudLoader, "getSchemasForRegistry")
-      // three sample schema versions across three subjects
-      .resolves([TEST_CCLOUD_SCHEMA, TEST_CCLOUD_SCHEMA2, TEST_CCLOUD_SCHEMA3]);
+    sandbox.stub(ccloudLoader, "getSchemasForRegistry").resolves(schemas);
 
     provider = SchemasViewProvider.getInstance();
     provider.schemaRegistry = TEST_CCLOUD_SCHEMA_REGISTRY;
@@ -107,13 +106,18 @@ describe("SchemasViewProvider search behavior", () => {
   });
 
   it("getChildren() should show correct count in tree view message when items match search", async () => {
-    // Search matching two subjects
     const searchStr = "-value";
     schemaSearchSet.fire("-value");
 
     await provider.getChildren();
 
-    assert.strictEqual(provider["treeView"].message, `Showing 2 results for "${searchStr}"`);
+    // Search matching two subjects
+    assert.strictEqual(provider.searchMatches.size, 2);
+    assert.strictEqual(provider.totalItemCount, schemas.length);
+    assert.strictEqual(
+      provider["treeView"].message,
+      `Showing ${provider.searchMatches.size} of ${schemas.length} results for "${searchStr}"`,
+    );
   });
 
   it("getChildren() should clear tree view message when search is cleared", async () => {

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -188,14 +188,22 @@ describe("TopicViewProvider search behavior", () => {
   });
 
   it("getChildren() should show correct count in tree view message when items match search", async () => {
-    getTopicsForClusterStub.resolves([TEST_CCLOUD_KAFKA_TOPIC]);
-    // Topic name matches the search string
+    getTopicsForClusterStub.resolves([
+      TEST_CCLOUD_KAFKA_TOPIC,
+      KafkaTopic.create({ ...TEST_CCLOUD_KAFKA_TOPIC, name: "other-topic" }),
+    ]);
+    // Topic name matches the search string of one topic
     const searchStr = TEST_CCLOUD_KAFKA_TOPIC.name;
     topicSearchSet.fire(searchStr);
 
     await provider.getChildren();
 
-    assert.strictEqual(provider["treeView"].message, `Showing 1 result for "${searchStr}"`);
+    assert.strictEqual(provider.searchMatches.size, 1);
+    assert.strictEqual(provider.totalItemCount, 2);
+    assert.strictEqual(
+      provider["treeView"].message,
+      `Showing ${provider.searchMatches.size} of ${provider.totalItemCount} results for "${searchStr}"`,
+    );
   });
 
   it("getChildren() should clear tree view message when search is cleared", async () => {

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -18,6 +18,7 @@ import { ContainerTreeItem } from "../models/main";
 import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { generateSchemaSubjectGroups, Schema, SchemaTreeItem } from "../models/schema";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
+import { logUsage, UserEvent } from "../telemetry/events";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
 
@@ -66,6 +67,8 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
   itemSearchString: string | null = null;
   /** Items directly matching the {@linkcode itemSearchString}, if provided. */
   searchMatches: Set<TopicViewProviderData> = new Set();
+  /** Count of all items returned from `getChildren()`. */
+  totalItemCount: number = 0;
 
   private static instance: TopicViewProvider | null = null;
   private constructor() {
@@ -147,6 +150,7 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
       }
     }
 
+    this.totalItemCount += children.length;
     // filter the children based on the search string, if provided
     if (this.itemSearchString) {
       // if the parent item matches the search string, return all children so the user can expand
@@ -168,9 +172,15 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
       // update the tree view message to show how many results were found to match the search string
       // NOTE: this can't be done in `getTreeItem()` because if we don't return children here, it
       // will never be called and the message won't update
-      const plural = this.searchMatches.size > 1 ? "s" : "";
+      const plural = this.totalItemCount > 1 ? "s" : "";
       if (this.searchMatches.size > 0) {
-        this.treeView.message = `Showing ${this.searchMatches.size} result${plural} for "${this.itemSearchString}"`;
+        this.treeView.message = `Showing ${this.searchMatches.size} of ${this.totalItemCount} result${plural} for "${this.itemSearchString}"`;
+        logUsage(UserEvent.ViewSearchAction, {
+          status: "view results filtered",
+          view: "Topics",
+          filteredItemCount: this.searchMatches.size,
+          totalItemCount: this.totalItemCount,
+        });
       } else {
         // let empty state take over
         this.treeView.message = undefined;
@@ -246,6 +256,12 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
     const topicSearchSetSub: vscode.Disposable = topicSearchSet.event(
       (searchString: string | null) => {
         logger.debug("topicSearchSet event fired, refreshing", { searchString });
+        logUsage(UserEvent.ViewSearchAction, {
+          status: `search string ${searchString ? "set" : "cleared"}`,
+          view: "Topics",
+          filteredItemCount: this.searchMatches.size,
+          totalItemCount: this.totalItemCount,
+        });
         this.setSearch(searchString);
         this.refresh();
       },
@@ -289,6 +305,7 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
     setContextValue(ContextValues.topicSearchApplied, searchString !== null);
     // clear from any previous search filter
     this.searchMatches = new Set();
+    this.totalItemCount = 0;
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Two main things done in this PR:
- Added a new "view search action" event for telemetry
- Added basic counting of (unfiltered) items returned from `getChildren()` to then show in the view message (and send with telemetry)
<img width="409" alt="image" src="https://github.com/user-attachments/assets/262866c8-823b-4733-97d5-fef4900eccf6" />



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
