### PR TITLE
Use `schema_registry` instead of `local_config` for SR URI

### DIFF
--- a/src/sidecar/connections/local.ts
+++ b/src/sidecar/connections/local.ts
@@ -45,6 +45,8 @@ export async function updateLocalConnection(schemaRegistryUri?: string): Promise
       schema_registry: {
         ...LOCAL_CONNECTION_SPEC.schema_registry,
         uri: schemaRegistryUri,
+        // disable SSL for local connections
+        ssl: { enabled: false },
       },
     };
   }

--- a/src/sidecar/connections/local.ts
+++ b/src/sidecar/connections/local.ts
@@ -42,9 +42,9 @@ export async function updateLocalConnection(schemaRegistryUri?: string): Promise
   if (schemaRegistryUri) {
     spec = {
       ...LOCAL_CONNECTION_SPEC,
-      local_config: {
-        ...LOCAL_CONNECTION_SPEC.local_config,
-        schema_registry_uri: schemaRegistryUri,
+      schema_registry: {
+        ...LOCAL_CONNECTION_SPEC.schema_registry,
+        uri: schemaRegistryUri,
       },
     };
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The sidecar has always supported using `schema_registry.uri` to set the SR URI for local connections. Use it.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
