### PR TITLE
chore: move third party notices generation to Semaphore promotion

### DIFF
--- a/.semaphore/multi-arch-packaging.yml
+++ b/.semaphore/multi-arch-packaging.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: multi-arch-packaging
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 auto_cancel:
   running:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,7 +6,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 auto_cancel:
   running:
@@ -133,18 +133,12 @@ blocks:
           - export GIT_BRANCH=$SEMAPHORE_GIT_BRANCH
           - make validate-bump
 
-  - name: "Update third party notices PR"
-    dependencies: ["Bump microversion"]
-    run:
-      when: "branch =~ '.*' and change_in(['/package.json', '/NOTICE.txt', '/scripts/notices/NOTICE-vsix_PREAMBLE.txt'], {default_branch: 'main', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', pipeline_file: 'ignore'})"
-    task:
-      jobs:
-        - name: "Update Third Party Notices PR"
-          commands:
-            - make update-third-party-notices-pr
-
 promotions:
   - name: Multi-Arch VSIX Packaging and Upload
     pipeline_file: multi-arch-packaging.yml
     auto_promote:
       when: "result = 'passed' and branch =~ '.*' and change_in('/release.svg', {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
+  - name: Third Party Notices
+    pipeline_file: third-party-notices.yml
+    auto-promote:
+      when: "branch =~ '.*' and change_in(['/package.json', '/NOTICE.txt', '/scripts/notices/NOTICE-vsix_PREAMBLE.txt'], {default_branch: 'main', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', pipeline_file: 'ignore'})"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -140,5 +140,5 @@ promotions:
       when: "result = 'passed' and branch =~ '.*' and change_in('/release.svg', {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
   - name: Third Party Notices
     pipeline_file: third-party-notices.yml
-    auto-promote:
+    auto_promote:
       when: "branch =~ '.*' and change_in(['/package.json', '/NOTICE.txt', '/scripts/notices/NOTICE-vsix_PREAMBLE.txt'], {default_branch: 'main', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', pipeline_file: 'ignore'})"

--- a/.semaphore/third-party-notices.yml
+++ b/.semaphore/third-party-notices.yml
@@ -1,0 +1,40 @@
+version: v1.0
+name: third-party-notices
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+auto_cancel:
+  running:
+    when: "branch != 'main'"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'main'"
+    processing: parallel
+
+global_job_config:
+  env_vars:
+    - name: NODE_ENV
+      value: "production"
+
+blocks:
+  - name: "Update third party notices PR"
+    run:
+      when: "branch =~ '.*'"
+    task:
+      prologue:
+        commands:
+          - checkout
+          - sem-version java 21
+          - . vault-setup
+      jobs:
+      - name: "Update third party notices PR"
+        dependencies: []
+        task:
+          jobs:
+            - name: "Update Third Party Notices PR"
+              commands:
+                - make update-third-party-notices-pr

--- a/.semaphore/third-party-notices.yml
+++ b/.semaphore/third-party-notices.yml
@@ -28,8 +28,6 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version java 21
-          - . vault-setup
       jobs:
       - name: "Update third party notices PR"
         dependencies: []


### PR DESCRIPTION
## Summary of Changes

pulls out 3P notices to its own block 

also updates ubuntu version

-


## Pull request checklist

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
