### PR TITLE
MINOR: use count of local Kafka clusters to set context value

### DIFF
--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -231,7 +231,7 @@ describe("ResourceViewProvider loading functions", () => {
     );
   });
 
-  it("loadLocalResources() should not fire context value updates when no local resources are found", async () => {
+  it("loadLocalResources() should not set context values to true when no local resources are found", async () => {
     // empty local environment
     sandbox.stub(local, "getLocalResources").resolves([TEST_LOCAL_ENVIRONMENT]);
 

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -132,6 +132,7 @@ describe("ResourceViewProvider methods", () => {
 
 describe("ResourceViewProvider loading functions", () => {
   let sandbox: sinon.SinonSandbox;
+  let setContextValueStub: sinon.SinonStub;
 
   before(async () => {
     // activate the extension once before this test suite runs
@@ -140,6 +141,7 @@ describe("ResourceViewProvider loading functions", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    setContextValueStub = sandbox.stub(contextValues, "setContextValue");
   });
 
   afterEach(() => {
@@ -193,6 +195,16 @@ describe("ResourceViewProvider loading functions", () => {
     assert.equal(result.collapsibleState, TreeItemCollapsibleState.Expanded);
     assert.equal(result.description, TEST_LOCAL_KAFKA_CLUSTER.uri);
     assert.deepStrictEqual(result.children, [TEST_LOCAL_KAFKA_CLUSTER, TEST_LOCAL_SCHEMA_REGISTRY]);
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.localKafkaClusterAvailable,
+      true,
+    );
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.localSchemaRegistryAvailable,
+      true,
+    );
   });
 
   it("loadLocalResources() should return a Local placeholder when no clusters are discoverable", async () => {
@@ -207,6 +219,34 @@ describe("ResourceViewProvider loading functions", () => {
     assert.equal(result.collapsibleState, TreeItemCollapsibleState.None);
     assert.equal(result.description, "(Not running)");
     assert.deepStrictEqual(result.children, []);
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.localKafkaClusterAvailable,
+      false,
+    );
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.localSchemaRegistryAvailable,
+      false,
+    );
+  });
+
+  it("loadLocalResources() should not fire context value updates when no local resources are found", async () => {
+    // empty local environment
+    sandbox.stub(local, "getLocalResources").resolves([TEST_LOCAL_ENVIRONMENT]);
+
+    await loadLocalResources();
+
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.localKafkaClusterAvailable,
+      false,
+    );
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.localSchemaRegistryAvailable,
+      false,
+    );
   });
 
   it("loadDirectResources() should return an empty array when no direct connections exist", async () => {

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -550,7 +550,7 @@ export async function loadLocalResources(): Promise<
     });
     // update the UI based on whether or not we have local resources available
     await Promise.all([
-      setContextValue(ContextValues.localKafkaClusterAvailable, localEnvs.length > 0),
+      setContextValue(ContextValues.localKafkaClusterAvailable, localKafkaClusters.length > 0),
       setContextValue(ContextValues.localSchemaRegistryAvailable, localSchemaRegistries.length > 0),
     ]);
     // XXX: adjust the ID to ensure the collapsible state is correctly updated in the UI

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -535,24 +535,20 @@ export async function loadLocalResources(): Promise<
 
   const localEnvs: LocalEnvironment[] = await getLocalResources();
   logger.debug(`got ${localEnvs.length} local environment(s) from GQL query`);
+
+  const localKafkaClusters: LocalKafkaCluster[] = [];
+  const localSchemaRegistries: LocalSchemaRegistry[] = [];
   if (localEnvs.length > 0) {
     const connectedId = "local-container-connected";
     // enable the "Stop Local Resources" action
     localContainerItem.contextValue = connectedId;
     // unpack the local resources to more easily update the UI elements
-    const localKafkaClusters: LocalKafkaCluster[] = [];
-    const localSchemaRegistries: LocalSchemaRegistry[] = [];
     localEnvs.forEach((env: LocalEnvironment) => {
       localKafkaClusters.push(...env.kafkaClusters);
       if (env.schemaRegistry) {
         localSchemaRegistries.push(env.schemaRegistry);
       }
     });
-    // update the UI based on whether or not we have local resources available
-    await Promise.all([
-      setContextValue(ContextValues.localKafkaClusterAvailable, localKafkaClusters.length > 0),
-      setContextValue(ContextValues.localSchemaRegistryAvailable, localSchemaRegistries.length > 0),
-    ]);
     // XXX: adjust the ID to ensure the collapsible state is correctly updated in the UI
     localContainerItem.id = `local-connected-${EXTENSION_VERSION}`;
     localContainerItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
@@ -563,6 +559,12 @@ export async function loadLocalResources(): Promise<
     getResourceManager().setLocalKafkaClusters(localKafkaClusters);
     localContainerItem.children = [...localKafkaClusters, ...localSchemaRegistries];
   }
+
+  // update the UI based on whether or not we have local resources available
+  await Promise.all([
+    setContextValue(ContextValues.localKafkaClusterAvailable, localKafkaClusters.length > 0),
+    setContextValue(ContextValues.localSchemaRegistryAvailable, localSchemaRegistries.length > 0),
+  ]);
 
   return localContainerItem;
 }


### PR DESCRIPTION
Avoids the edge case where we may have an childless `LocalEnvironment` that would incorrectly set `confluent.localKafkaClusterAvailable`. 