### PR TITLE
chore(CI): Migrate to Ubuntu 24.04 from soon-to-be EoL Ubuntu 20.04

### DIFF
--- a/.semaphore/multi-arch-packaging.yml
+++ b/.semaphore/multi-arch-packaging.yml
@@ -79,7 +79,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-amd64-1
+          type: s1-prod-ubuntu24-04-amd64-1
       env_vars:
         - name: TARGET
           value: linux-x64
@@ -94,7 +94,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-ubuntu20-04-arm64-1
+          type: s1-prod-ubuntu24-04-arm64-1
       env_vars:
         - name: TARGET
           value: linux-arm64


### PR DESCRIPTION
Closes #1047 

Works fine with manual promotion
<img width="237" alt="image" src="https://github.com/user-attachments/assets/fc860049-a42e-4978-87a4-afa6cac6255d" />
