### PR TITLE
cleanup: wrap `ResponseError`s for Sentry

### DIFF
--- a/src/clients/sidecar/apis/ConnectionsResourceApi.ts
+++ b/src/clients/sidecar/apis/ConnectionsResourceApi.ts
@@ -269,7 +269,7 @@ export class ConnectionsResourceApi extends runtime.BaseAPI {
 
     const response = await this.request(
       {
-        path: `/gateway/v1/TEST_MISSING_PATH`,
+        path: `/gateway/v1/connections`,
         method: "POST",
         headers: headerParameters,
         query: queryParameters,

--- a/src/clients/sidecar/apis/ConnectionsResourceApi.ts
+++ b/src/clients/sidecar/apis/ConnectionsResourceApi.ts
@@ -12,18 +12,9 @@
  * Do not edit the class manually.
  */
 
+import type { Connection, ConnectionSpec, ConnectionsList } from "../models/index";
+import { ConnectionFromJSON, ConnectionSpecToJSON, ConnectionsListFromJSON } from "../models/index";
 import * as runtime from "../runtime";
-import type { Connection, ConnectionSpec, ConnectionsList, Failure } from "../models/index";
-import {
-  ConnectionFromJSON,
-  ConnectionToJSON,
-  ConnectionSpecFromJSON,
-  ConnectionSpecToJSON,
-  ConnectionsListFromJSON,
-  ConnectionsListToJSON,
-  FailureFromJSON,
-  FailureToJSON,
-} from "../models/index";
 
 export interface GatewayV1ConnectionsIdDeleteRequest {
   id: string;
@@ -278,7 +269,7 @@ export class ConnectionsResourceApi extends runtime.BaseAPI {
 
     const response = await this.request(
       {
-        path: `/gateway/v1/connections`,
+        path: `/gateway/v1/TEST_MISSING_PATH`,
         method: "POST",
         headers: headerParameters,
         query: queryParameters,

--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -1,7 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { env, workspace } from "vscode";
 import { observabilityContext } from "../context/observability";
-import { extractErrorInformation } from "../errors";
 
 /** Helper function to make sure the user has Telemetry ON before sending Sentry error events */
 export function checkTelemetrySettings(event: Sentry.Event) {
@@ -17,13 +16,4 @@ export function checkTelemetrySettings(event: Sentry.Event) {
 export function includeObservabilityContext(event: Sentry.Event): Sentry.Event {
   event.extra = { ...event.extra, ...observabilityContext.toRecord() };
   return event;
-}
-
-export async function handleError(event: Sentry.Event): Sentry.Event | null {
-  if (event.exception) {
-    const errorInfo = await extractErrorInformation(event.exception);
-    if (errorInfo) {
-      event.exception = errorInfo.e;
-    }
-  }
 }

--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { env, workspace } from "vscode";
 import { observabilityContext } from "../context/observability";
+import { extractErrorInformation } from "../errors";
 
 /** Helper function to make sure the user has Telemetry ON before sending Sentry error events */
 export function checkTelemetrySettings(event: Sentry.Event) {
@@ -16,4 +17,13 @@ export function checkTelemetrySettings(event: Sentry.Event) {
 export function includeObservabilityContext(event: Sentry.Event): Sentry.Event {
   event.extra = { ...event.extra, ...observabilityContext.toRecord() };
   return event;
+}
+
+export async function handleError(event: Sentry.Event): Sentry.Event | null {
+  if (event.exception) {
+    const errorInfo = await extractErrorInformation(event.exception);
+    if (errorInfo) {
+      event.exception = errorInfo.e;
+    }
+  }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
