### PR TITLE
fix schema diffing

### DIFF
--- a/package.json
+++ b/package.json
@@ -875,12 +875,12 @@
         },
         {
           "command": "confluent.diff.selectForCompare",
-          "when": "view == confluent-schemas && viewItem =~ /.*-schema$/",
+          "when": "(view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*-schema$/",
           "group": "3_compare"
         },
         {
           "command": "confluent.diff.compareWithSelected",
-          "when": "confluent.resourceSelectedForCompare && view == confluent-schemas && viewItem =~ /.*-schema$/",
+          "when": "confluent.resourceSelectedForCompare && (view == confluent-schemas || view == confluent-topics) && viewItem =~ /.*-schema$/",
           "group": "3_compare"
         },
         {

--- a/src/commands/diffs.test.ts
+++ b/src/commands/diffs.test.ts
@@ -1,0 +1,110 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { TEST_LOCAL_SCHEMA } from "../../tests/unit/testResources";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
+import * as contextValues from "../context/values";
+import { SchemaDocumentProvider } from "../documentProviders/schema";
+import { Schema } from "../models/schema";
+import { getStorageManager } from "../storage";
+import { WorkspaceStorageKeys } from "../storage/constants";
+import * as diffs from "./diffs";
+
+describe("commands/diffs.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let executeCommandStub: sinon.SinonStub;
+  let setContextValueStub: sinon.SinonStub;
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    executeCommandStub = sandbox.stub(vscode.commands, "executeCommand");
+    setContextValueStub = sandbox.stub(contextValues, "setContextValue");
+  });
+
+  afterEach(async () => {
+    // clear stored URI between tests
+    await getStorageManager().deleteWorkspaceState(WorkspaceStorageKeys.DIFF_BASE_URI);
+    sandbox.restore();
+  });
+
+  it("selectForCompareCommand() should store schema URI in workspace state when schema is selected for compare", async () => {
+    const schema = TEST_LOCAL_SCHEMA;
+    const expectedUri = new SchemaDocumentProvider().resourceToUri(schema, schema.fileName());
+
+    await diffs.selectForCompareCommand(schema);
+
+    const storedUriString = await getStorageManager().getWorkspaceState(
+      WorkspaceStorageKeys.DIFF_BASE_URI,
+    );
+    assert.strictEqual(storedUriString, expectedUri.toString());
+    sinon.assert.calledWith(
+      setContextValueStub,
+      contextValues.ContextValues.resourceSelectedForCompare,
+      true,
+    );
+  });
+
+  it("selectForCompareCommand() should do nothing when no item is provided", async () => {
+    await diffs.selectForCompareCommand(undefined);
+
+    const storedUri = await getStorageManager().getWorkspaceState(
+      WorkspaceStorageKeys.DIFF_BASE_URI,
+    );
+    assert.strictEqual(storedUri, undefined);
+    sinon.assert.notCalled(setContextValueStub);
+  });
+
+  it("compareWithSelectedCommand() should execute the diff command with correct URIs when comparing two schemas", async () => {
+    // preload first schema URI
+    const schema1 = TEST_LOCAL_SCHEMA;
+    const uri1 = new SchemaDocumentProvider().resourceToUri(schema1, schema1.fileName());
+    await diffs.selectForCompareCommand(schema1);
+
+    // compare with second schema
+    const schema2 = Schema.create({ ...TEST_LOCAL_SCHEMA, id: "different-id" });
+    const uri2 = new SchemaDocumentProvider().resourceToUri(schema2, schema2.fileName());
+    await diffs.compareWithSelectedCommand(schema2);
+
+    assert.ok(executeCommandStub.calledOnce);
+    sinon.assert.calledWith(
+      executeCommandStub,
+      "vscode.diff",
+      // fsPath will show up as `null`, so just compare the scheme, path, and query
+      sinon.match((value) => {
+        return (
+          value.scheme === uri1.scheme && value.path === uri1.path && value.query === uri1.query
+        );
+      }),
+      sinon.match((value) => {
+        return (
+          value.scheme === uri2.scheme && value.path === uri2.path && value.query === uri2.query
+        );
+      }),
+      sinon.match.string, // for the title argument
+    );
+  });
+
+  it("compareWithSelectedCommand() should not execute the diff command when no previous selection exists", async () => {
+    const schema = TEST_LOCAL_SCHEMA;
+
+    // Clear any existing stored URI
+    await getStorageManager().setWorkspaceState(WorkspaceStorageKeys.DIFF_BASE_URI, undefined);
+
+    await diffs.compareWithSelectedCommand(schema);
+
+    assert.ok(executeCommandStub.notCalled);
+  });
+
+  it("compareWithSelectedCommand() should throw an error when trying to compare unsupported resource type", async () => {
+    const unsupportedItem = { type: "unsupported" };
+
+    await assert.rejects(
+      async () => await diffs.compareWithSelectedCommand(unsupportedItem),
+      /Unsupported resource type for comparison/,
+    );
+  });
+});

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -10,31 +10,33 @@ import { WorkspaceStorageKeys } from "../storage/constants";
 
 const logger = new Logger("commands.diffs");
 
-async function selectForCompareCommand(item: any) {
+export async function selectForCompareCommand(item: any) {
   if (!item) {
     return;
   }
   const uri: vscode.Uri = convertItemToUri(item);
   logger.debug("Selected item for compare", uri);
-  await getStorageManager().setWorkspaceState(WorkspaceStorageKeys.DIFF_BASE_URI, uri);
+  // convert to string before storing so we can Uri.parse it later since Uri is not serializable
+  await getStorageManager().setWorkspaceState(WorkspaceStorageKeys.DIFF_BASE_URI, uri.toString());
   // allows the "Compare with Selected" command to be used
   await setContextValue(ContextValues.resourceSelectedForCompare, true);
 }
 
-async function compareWithSelectedCommand(item: any) {
+export async function compareWithSelectedCommand(item: any) {
   if (!item) {
     return;
   }
   const uri2: vscode.Uri = convertItemToUri(item);
   logger.debug("Comparing with selected item", uri2);
-
-  const uri1: vscode.Uri | undefined = await getStorageManager().getWorkspaceState(
+  const uri1str: string | undefined = await getStorageManager().getWorkspaceState(
     WorkspaceStorageKeys.DIFF_BASE_URI,
   );
-  if (!uri1) {
+  if (!uri1str) {
     logger.error("No resource selected for compare; this shouldn't happen", uri2);
     return;
   }
+  // convert back to Uri
+  const uri1: vscode.Uri = vscode.Uri.parse(uri1str);
 
   // replace fsPaths with ~ if they contain $HOME
   const uri1Path = uri1.fsPath.replace(homedir(), "~");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Same situation as https://github.com/confluentinc/vscode/pull/1032 -- VS Code `Uri`s aren't natively serializable, so we need to stringify them and parse them when performing the actual "compare with selected" action.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
