### PR TITLE
Additional model tests as indicated by coverage report.

### DIFF
--- a/src/models/kafkaCluster.test.ts
+++ b/src/models/kafkaCluster.test.ts
@@ -1,0 +1,36 @@
+import * as assert from "assert";
+import {
+  TEST_CCLOUD_KAFKA_CLUSTER,
+  TEST_LOCAL_KAFKA_CLUSTER,
+} from "../../tests/unit/testResources/kafkaCluster";
+import { createKafkaClusterTooltip, LocalKafkaCluster } from "./kafkaCluster";
+
+describe("createKafkaClusterTooltip()", () => {
+  it("should return the correct tooltip for a Confluent Cloud Kafka cluster", () => {
+    const tooltipString = createKafkaClusterTooltip(TEST_CCLOUD_KAFKA_CLUSTER).value;
+    assert.ok(tooltipString.includes(`Name: \`${TEST_CCLOUD_KAFKA_CLUSTER.name}\``));
+    assert.ok(tooltipString.includes("Open in Confluent Cloud"));
+    assert.ok(tooltipString.includes("URI:"));
+  });
+
+  it("Should handle nameless cluster (??)", () => {
+    const cluster = LocalKafkaCluster.create({
+      ...TEST_LOCAL_KAFKA_CLUSTER,
+      id: "local-kafka-cluster-abc123",
+      name: "",
+    });
+
+    const tooltipString = createKafkaClusterTooltip(cluster).value;
+    assert.ok(!tooltipString.includes("Name:"));
+  });
+
+  it("Should handle URI-less cluster (??)", () => {
+    const cluster = LocalKafkaCluster.create({
+      ...TEST_LOCAL_KAFKA_CLUSTER,
+      uri: undefined,
+    });
+
+    const tooltipString = createKafkaClusterTooltip(cluster).value;
+    assert.ok(!tooltipString.includes("URI:"));
+  });
+});

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -93,7 +93,7 @@ export class KafkaClusterTreeItem extends TreeItem {
 }
 
 // todo make this a method of KafkaCluster family.
-function createKafkaClusterTooltip(resource: KafkaCluster): MarkdownString {
+export function createKafkaClusterTooltip(resource: KafkaCluster): MarkdownString {
   const tooltip = new CustomMarkdownString()
     .appendMarkdown(`#### $(${resource.iconName}) Kafka Cluster`)
     .appendMarkdown("\n\n---");


### PR DESCRIPTION
Tests over branches of `createKafkaClusterTooltip()` not already exercised.