### PR TITLE
minor: make sure empty message appears under options header

### DIFF
--- a/src/webview/scaffold-form.html
+++ b/src/webview/scaffold-form.html
@@ -20,13 +20,14 @@
         </p>
       </div>
       <form class="form-container" data-on-submit="this.handleSubmit(event)">
-        <template data-if="this.noOptions()">
-          <p class="form-description">
-            There are no configurable options for this template. Click Generate & Save to continue.
-          </p>
-        </template>
         <div class="form-section">
           <h2 class="form-section-heading">Options</h2>
+          <template data-if="this.noOptions()">
+            <p class="form-description">
+              There are no configurable options for this template. Click Generate & Save to
+              continue.
+            </p>
+          </template>
           <template data-for="field of this.options()">
             <div class="content-wrapper">
               <template data-if="this.getEnumField(this.field())">


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Just a little fix @Cerchie and I noticed when testing new templates (UDF has no options for example) - the message about no options should appear under the "Options" heading, not above it !

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-
<img width="1096" alt="Screenshot 2025-02-24 at 3 06 04 PM" src="https://github.com/user-attachments/assets/13d1b835-09c8-4e73-8dfe-fb5f823cd382" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
