### PR TITLE
Gracefully handle case when environment has no schema registry.

### DIFF
--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -129,9 +129,21 @@ export abstract class ResourceLoader implements IResourceBase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     forceRefresh: boolean = false,
   ): Promise<string[]> {
-    const schemaRegistry = await this.resolveSchemaRegistry(registryOrEnvironmentId);
-
-    return await fetchSubjects(schemaRegistry);
+    try {
+      const schemaRegistry = await this.resolveSchemaRegistry(registryOrEnvironmentId);
+      return await fetchSubjects(schemaRegistry);
+    } catch (error) {
+      logger.error("Error fetching subjects", error);
+      if (
+        error instanceof Error &&
+        error.message.match(/No schema registry found for environment/)
+      ) {
+        // Expected error when no schema registry found for the environment.
+        // Act as if there are no subjects / schemas.
+        return [];
+      }
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix badness when an environment doesn't have a schema registry. Oops, my bad.
- Closes #1082 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Can be clicktested through starting up Docker, then only starting up local kafka -- no schema registry at all.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
