### PR TITLE
Pull respelling of schema registry ccloud urls into main (PR #1085)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this extension will be documented in this file.
 - Improved logging in the "Confluent (Sidecar)" output channel by implementing the
   `LogOutputChannel` API. When using VS Code 1.97 or higher, these logs can now be combined with the
   "Confluent" output channel for unified log viewing.
+- Updated the URL templates for viewing schemas and schema registries in CCloud (now under "stream-governance/schema-registry/data-contracts")
 
 ### Fixed
 

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -98,7 +98,7 @@ describe("Schema model methods", () => {
     // ccloud schemas have a ccloud url.
     assert.equal(
       TEST_CCLOUD_SCHEMA.ccloudUrl,
-      `https://confluent.cloud/environments/${TEST_CCLOUD_SCHEMA.environmentId}/schema-registry/schemas/${TEST_CCLOUD_SCHEMA.subject}`,
+      `https://confluent.cloud/environments/${TEST_CCLOUD_SCHEMA.environmentId}/stream-governance/schema-registry/data-contracts/${TEST_CCLOUD_SCHEMA.subject}`,
     );
 
     // Non-ccloud schemas do not

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -75,7 +75,7 @@ export class Schema extends Data implements IResourceBase {
 
   get ccloudUrl(): string {
     if (isCCloud(this)) {
-      return `https://confluent.cloud/environments/${this.environmentId}/schema-registry/schemas/${this.subject}`;
+      return `https://confluent.cloud/environments/${this.environmentId}/stream-governance/schema-registry/data-contracts/${this.subject}`;
     }
     return "";
   }

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -29,7 +29,7 @@ export class CCloudSchemaRegistry extends SchemaRegistry {
   region!: Enforced<string>;
 
   get ccloudUrl(): string {
-    return `https://confluent.cloud/environments/${this.environmentId}/schema-registry/schemas`;
+    return `https://confluent.cloud/environments/${this.environmentId}/stream-governance/schema-registry/data-contracts`;
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Bring https://github.com/confluentinc/vscode/pull/1085 forward into main.

