### PR TITLE
cleanup: extension logfile handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this extension will be documented in this file.
   focused on CCloud-based broker or schema registry.
 - Stopping a local Schema Registry container with a custom image tag will now use the correct tag
   instead of "latest".
+- Extension log file rotation is now implemented, with a cleanup process to remove older log files
+  that haven't been modified in 3+ days.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "graphql": "^16.8.2",
         "inertial": "^0.4.1",
         "opentelemetry-instrumentation-fetch-node": "^1.2.3",
+        "rotating-file-stream": "^3.2.6",
         "tail": "^2.2.6",
         "undici": "^6.19.8",
         "unzipit": "^1.4.3",
@@ -12117,6 +12118,17 @@
       "peerDependencies": {
         "@playwright/test": "^1.42.1",
         "rollup": "^4.14.0"
+      }
+    },
+    "node_modules/rotating-file-stream": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-3.2.6.tgz",
+      "integrity": "sha512-r8yShzMWUvWXkRzbOXDM1fEaMpc3qo2PzK7bBH/0p0Nl/uz8Mud/Y+0XTQxe3kbSnDF7qBH2tSe83WDKA7o3ww==",
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "url": "https://www.blockchain.com/btc/address/12p1p5q7sK75tPyuesZmssiMYr4TKzpSCN"
       }
     },
     "node_modules/run-async": {

--- a/package.json
+++ b/package.json
@@ -1248,6 +1248,7 @@
     "graphql": "^16.8.2",
     "inertial": "^0.4.1",
     "opentelemetry-instrumentation-fetch-node": "^1.2.3",
+    "rotating-file-stream": "^3.2.6",
     "tail": "^2.2.6",
     "undici": "^6.19.8",
     "unzipit": "^1.4.3",

--- a/src/commands/debugtools.ts
+++ b/src/commands/debugtools.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { SIDECAR_OUTPUT_CHANNEL } from "../constants";
-import { outputChannel } from "../logging";
+import { OUTPUT_CHANNEL } from "../logging";
 
 async function showOutputChannelCommand() {
   // make sure the Output panel is visible first
   await vscode.commands.executeCommand("workbench.panel.output.focus");
-  outputChannel.show();
+  OUTPUT_CHANNEL.show();
 }
 
 async function showSidecarOutputChannelCommand() {

--- a/src/commands/support.test.ts
+++ b/src/commands/support.test.ts
@@ -1,0 +1,53 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { Uri } from "vscode";
+import * as logging from "../logging";
+import { SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
+import { extensionLogFileUris, sidecarLogFileUri } from "./support";
+
+describe("commands/support.ts", function () {
+  let sandbox: sinon.SinonSandbox;
+
+  const currentLogfile = "vscode-confluent-123.log";
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+
+    sandbox.stub(logging, "CURRENT_LOGFILE_NAME").value(currentLogfile);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("extensionLogFileUris() should return URIs for all log files without duplicates", function () {
+    const rotatedLogFiles = [currentLogfile, "vscode-confluent-456.log"];
+    sandbox.stub(logging, "ROTATED_LOGFILE_NAMES").value(rotatedLogFiles);
+
+    const logFileUris: Uri[] = extensionLogFileUris();
+
+    // two results since the current log file is included in the rotated log files
+    assert.strictEqual(logFileUris.length, rotatedLogFiles.length);
+    assert.strictEqual(logFileUris[0].path.includes(logging.CURRENT_LOGFILE_NAME), true);
+    assert.strictEqual(logFileUris[1].path.includes(rotatedLogFiles[1]), true);
+  });
+
+  it("extensionLogFileUris() should return the correct URIs when CURRENT_LOGFILE_NAME isn't in ROTATED_LOGFILE_NAMES", function () {
+    const rotatedLogFiles = ["vscode-confluent-456.log", "vscode-confluent-789.log"];
+    sandbox.stub(logging, "ROTATED_LOGFILE_NAMES").value(rotatedLogFiles);
+
+    const logFileUris: Uri[] = extensionLogFileUris();
+
+    // three results since the current log file isn't included in the rotated log files
+    assert.strictEqual(logFileUris.length, rotatedLogFiles.length + 1);
+    assert.strictEqual(logFileUris[0].path.includes(logging.CURRENT_LOGFILE_NAME), true);
+    assert.strictEqual(logFileUris[1].path.includes(rotatedLogFiles[0]), true);
+    assert.strictEqual(logFileUris[2].path.includes(rotatedLogFiles[1]), true);
+  });
+
+  it("sidecarLogFileUri() should return the correct URI for the sidecar log file", function () {
+    const logFileUri: Uri = sidecarLogFileUri();
+
+    assert.strictEqual(logFileUri.path, SIDECAR_LOGFILE_PATH);
+  });
+});

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -58,7 +58,7 @@ function openSettings() {
 
 /** Return the file URIs for the extension's currently-active log file and any rotated log files for
  * this extension instance, normalized for the user's OS. */
-function extensionLogFileUris(): Uri[] {
+export function extensionLogFileUris(): Uri[] {
   const uris: Uri[] = [];
   // early on, CURRENT_LOGFILE_NAME will be included in ROTATED_LOGFILE_NAMES, but after a few
   // rotations, it will be removed from the array so we need to make sure we include it here
@@ -73,7 +73,7 @@ function extensionLogFileUris(): Uri[] {
 }
 
 /** Return the file URI for the sidecar's log file, normalized for the user's OS. */
-function sidecarLogFileUri(): Uri {
+export function sidecarLogFileUri(): Uri {
   return Uri.file(normalize(SIDECAR_LOGFILE_PATH));
 }
 

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -7,7 +7,7 @@ import { commands, Disposable, env, Uri, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
-import { LOGFILE_NAME, LOGFILE_PATH, Logger } from "../logging";
+import { LOGFILE_DIR, LOGFILE_NAME, Logger } from "../logging";
 import { SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
 
 const logger = new Logger("commands.support");
@@ -59,7 +59,7 @@ function openSettings() {
 
 /** Return the file URI for the extension's log file, normalized for the user's OS. */
 function extensionLogFileUri(): Uri {
-  return Uri.file(normalize(LOGFILE_PATH));
+  return Uri.joinPath(Uri.file(LOGFILE_DIR), LOGFILE_NAME);
 }
 
 /** Return the file URI for the sidecar's log file, normalized for the user's OS. */

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -60,8 +60,6 @@ function openSettings() {
  * this extension instance, normalized for the user's OS. */
 export function extensionLogFileUris(): Uri[] {
   const uris: Uri[] = [];
-  // early on, CURRENT_LOGFILE_NAME will be included in ROTATED_LOGFILE_NAMES, but after a few
-  // rotations, it will be removed from the array so we need to make sure we include it here
   const filenames: string[] = [CURRENT_LOGFILE_NAME, ...ROTATED_LOGFILE_NAMES];
   for (const filename of filenames) {
     const uri = Uri.file(normalize(join(LOGFILE_DIR, filename)));

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -1,5 +1,3 @@
-import archiver from "archiver";
-import { createWriteStream } from "fs";
 import { homedir } from "os";
 import { join, normalize } from "path";
 
@@ -7,8 +5,9 @@ import { commands, Disposable, env, Uri, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
-import { CURRENT_LOGFILE_NAME, LOGFILE_DIR, Logger } from "../logging";
+import { CURRENT_LOGFILE_NAME, LOGFILE_DIR, Logger, ROTATED_LOGFILE_NAMES } from "../logging";
 import { SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
+import { createZipFile, ZipContentEntry, ZipFileEntry } from "./utils/zipFiles";
 
 const logger = new Logger("commands.support");
 
@@ -57,9 +56,20 @@ function openSettings() {
   commands.executeCommand("workbench.action.openSettings", "@ext:confluentinc.vscode-confluent");
 }
 
-/** Return the file URI for the extension's log file, normalized for the user's OS. */
-function extensionLogFileUri(): Uri {
-  return Uri.joinPath(Uri.file(LOGFILE_DIR), CURRENT_LOGFILE_NAME);
+/** Return the file URIs for the extension's currently-active log file and any rotated log files for
+ * this extension instance, normalized for the user's OS. */
+function extensionLogFileUris(): Uri[] {
+  const uris: Uri[] = [];
+  // early on, CURRENT_LOGFILE_NAME will be included in ROTATED_LOGFILE_NAMES, but after a few
+  // rotations, it will be removed from the array so we need to make sure we include it here
+  const filenames: string[] = [CURRENT_LOGFILE_NAME, ...ROTATED_LOGFILE_NAMES];
+  for (const filename of filenames) {
+    const uri = Uri.file(normalize(join(LOGFILE_DIR, filename)));
+    if (!uris.some((existingUri) => existingUri.fsPath === uri.fsPath)) {
+      uris.push(uri);
+    }
+  }
+  return uris;
 }
 
 /** Return the file URI for the sidecar's log file, normalized for the user's OS. */
@@ -68,22 +78,42 @@ function sidecarLogFileUri(): Uri {
 }
 
 /**
- * Save the extension log file to the user's local file system, prompting for a save location.
- * The default parent directory is the user's home directory.
+ * Save extension log files to the user's local file system.
+ * If multiple files exist, they'll be saved as a zip.
  */
 async function saveExtensionLogFile() {
-  // prompt where to save the file, using the home directory as the default
-  const defaultPath = join(homedir(), CURRENT_LOGFILE_NAME);
-  const saveUri = await window.showSaveDialog({
-    defaultUri: Uri.file(defaultPath),
-    filters: {
-      "Log files": ["log"],
-    },
-    title: "Save Confluent Extension Log",
-  });
-  if (saveUri) {
-    await handleLogFileSave(extensionLogFileUri(), saveUri, true);
+  const logUris: Uri[] = extensionLogFileUris();
+
+  // one file: save it directly
+  if (logUris.length === 1) {
+    const defaultPath: string = join(homedir(), CURRENT_LOGFILE_NAME);
+    const saveUri: Uri | undefined = await window.showSaveDialog({
+      defaultUri: Uri.file(defaultPath),
+      filters: { "Log files": ["log"] },
+      title: "Save Confluent Extension Log",
+    });
+    if (!saveUri) return;
+
+    await handleLogFileSave(logUris[0], saveUri);
+    return;
   }
+
+  // multiple files: save as a zip
+  const dateTimeString: string = new Date().toISOString().replace(/[-:T]/g, "").slice(0, -5);
+  const defaultPath: string = join(homedir(), `vscode-confluent-logs-${dateTimeString}.zip`);
+  const saveUri: Uri | undefined = await window.showSaveDialog({
+    defaultUri: Uri.file(defaultPath),
+    filters: { "ZIP files": ["zip"] },
+    title: "Save Confluent Extension Logs",
+  });
+  if (!saveUri) return;
+
+  const fileEntries: ZipFileEntry[] = logUris.map((uri) => ({
+    sourceUri: uri,
+    zipPath: uri.path.split("/").pop() || "vscode-confluent.log",
+  }));
+
+  await createZipFile(saveUri, fileEntries, [], "Confluent extension logs saved successfully.");
 }
 
 /**
@@ -160,45 +190,31 @@ async function saveSupportZip() {
     return;
   }
 
-  const output = createWriteStream(writeUri.fsPath);
-  const archive = archiver("zip", {
-    zlib: { level: 9 },
-  });
-
-  // set up event listeners for write errors & close/finalize
-  const closeListener = output.on("close", () => {
-    const openButton = "Open";
-    window
-      .showInformationMessage("Confluent extension support .zip saved successfully.", openButton)
-      .then((value) => {
-        if (value === openButton) {
-          // show in OS file explorer, don't try to open it in VS Code
-          commands.executeCommand("revealFileInOS", writeUri);
-        }
-      });
-    closeListener.destroy();
-  });
-  const errorListener = archive.on("error", (err) => {
-    window.showErrorMessage(`Error creating zip: ${err.message}`);
-    errorListener.destroy();
-  });
-
-  archive.pipe(output);
-
   // add extension+sidecar log files
   // NOTE: this will not include other workspaces' logs, only the current workspace
-  const extensionLog = await workspace.fs.readFile(extensionLogFileUri());
-  archive.append(Buffer.from(extensionLog), { name: "vscode-confluent.log" });
-  const sidecarLog = await workspace.fs.readFile(sidecarLogFileUri());
-  archive.append(Buffer.from(sidecarLog), { name: "vscode-confluent-sidecar.log" });
-
-  // add observability context
-  archive.append(Buffer.from(JSON.stringify(observabilityContext.toRecord())), {
-    name: "observability-context.json",
+  const fileEntries: ZipFileEntry[] = extensionLogFileUris().map((uri) => ({
+    sourceUri: uri,
+    zipPath: `${uri.path.split("/").pop() || "vscode-confluent.log"}`,
+  }));
+  fileEntries.push({
+    sourceUri: sidecarLogFileUri(),
+    zipPath: `${sidecarLogFileUri().path.split("/").pop() || "vscode-confluent-sidecar.log"}`,
   });
 
-  // create the .zip and trigger the onClose event
-  await archive.finalize();
+  // add the observability context as JSON content
+  const contentEntries: ZipContentEntry[] = [
+    {
+      content: JSON.stringify(observabilityContext.toRecord(), null, 2),
+      zipPath: "observability-context.json",
+    },
+  ];
+
+  await createZipFile(
+    writeUri,
+    fileEntries,
+    contentEntries,
+    "Confluent extension support .zip saved successfully.",
+  );
 }
 
 export function registerSupportCommands(): Disposable[] {

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -6,7 +6,7 @@ import { registerCommandWithLogging } from ".";
 import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
 import { CURRENT_LOGFILE_NAME, LOGFILE_DIR, Logger, ROTATED_LOGFILE_NAMES } from "../logging";
-import { SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
+import { SIDECAR_LOGFILE_NAME, SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
 import { createZipFile, ZipContentEntry, ZipFileEntry } from "./utils/zipFiles";
 
 const logger = new Logger("commands.support");
@@ -198,7 +198,7 @@ async function saveSupportZip() {
   }));
   fileEntries.push({
     sourceUri: sidecarLogFileUri(),
-    zipPath: `${sidecarLogFileUri().path.split("/").pop() || "vscode-confluent-sidecar.log"}`,
+    zipPath: SIDECAR_LOGFILE_NAME,
   });
 
   // add the observability context as JSON content

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -7,7 +7,7 @@ import { commands, Disposable, env, Uri, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
-import { LOGFILE_DIR, LOGFILE_NAME, Logger } from "../logging";
+import { CURRENT_LOGFILE_NAME, LOGFILE_DIR, Logger } from "../logging";
 import { SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
 
 const logger = new Logger("commands.support");
@@ -59,7 +59,7 @@ function openSettings() {
 
 /** Return the file URI for the extension's log file, normalized for the user's OS. */
 function extensionLogFileUri(): Uri {
-  return Uri.joinPath(Uri.file(LOGFILE_DIR), LOGFILE_NAME);
+  return Uri.joinPath(Uri.file(LOGFILE_DIR), CURRENT_LOGFILE_NAME);
 }
 
 /** Return the file URI for the sidecar's log file, normalized for the user's OS. */
@@ -73,7 +73,7 @@ function sidecarLogFileUri(): Uri {
  */
 async function saveExtensionLogFile() {
   // prompt where to save the file, using the home directory as the default
-  const defaultPath = join(homedir(), LOGFILE_NAME);
+  const defaultPath = join(homedir(), CURRENT_LOGFILE_NAME);
   const saveUri = await window.showSaveDialog({
     defaultUri: Uri.file(defaultPath),
     filters: {

--- a/src/commands/utils/zipFiles.ts
+++ b/src/commands/utils/zipFiles.ts
@@ -1,0 +1,68 @@
+import archiver from "archiver";
+import { createWriteStream } from "fs";
+import { Uri, commands, window, workspace } from "vscode";
+import { Logger } from "../../logging";
+
+const logger = new Logger("commands.utils.zipFiles");
+
+/** File to include in a zip archive */
+export interface ZipFileEntry {
+  sourceUri: Uri;
+  zipPath: string;
+}
+
+/** Data to include directly in a zip archive */
+export interface ZipContentEntry {
+  content: string | Buffer;
+  zipPath: string;
+}
+
+/** * Creates a zip file from file(s) and/or string or Buffer content. */
+export async function createZipFile(
+  saveUri: Uri,
+  fileEntries: ZipFileEntry[] = [],
+  contentEntries: ZipContentEntry[] = [],
+  successMessage: string = "File saved successfully.",
+): Promise<void> {
+  const output = createWriteStream(saveUri.fsPath);
+  const archive = archiver("zip", { zlib: { level: 9 } });
+
+  // set up event listeners for write errors & close/finalize
+  const closeListener = output.on("close", () => {
+    const openButton = "Open";
+    window.showInformationMessage(successMessage, openButton).then((value) => {
+      if (value === openButton) {
+        // show in OS file explorer, don't try to open it in VS Code
+        commands.executeCommand("revealFileInOS", saveUri);
+      }
+    });
+    closeListener.destroy();
+  });
+
+  const errorListener = archive.on("error", (err) => {
+    window.showErrorMessage(`Error creating zip: ${err.message}`);
+    errorListener.destroy();
+  });
+
+  archive.pipe(output);
+
+  // add content entries
+  for (const contentEntry of contentEntries) {
+    archive.append(contentEntry.content, { name: contentEntry.zipPath });
+  }
+
+  // add file entries
+  try {
+    for (const fileEntry of fileEntries) {
+      try {
+        const fileData = await workspace.fs.readFile(fileEntry.sourceUri);
+        archive.append(Buffer.from(fileData), { name: fileEntry.zipPath });
+      } catch (error) {
+        logger.error(`Could not read file ${fileEntry.sourceUri.fsPath}`, error);
+      }
+    }
+    await archive.finalize();
+  } catch (err) {
+    logger.error("Error processing files for zip", err);
+  }
+}

--- a/src/docker/configs.ts
+++ b/src/docker/configs.ts
@@ -38,7 +38,6 @@ export function getSocketPath(): string {
   } else {
     path = path ? path : DEFAULT_UNIX_SOCKET_PATH;
   }
-  logger.trace("using docker socket path:", { socketPath: path });
 
   return path;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,7 @@ import { MessageDocumentProvider } from "./documentProviders/message";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { logError } from "./errors";
 import { constructResourceLoaderSingletons } from "./loaders";
-import { getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
+import { cleanupOldLogFiles, getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
 import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
@@ -243,6 +243,9 @@ async function _activateExtension(
   context.subscriptions.push(
     vscode.window.registerFileDecorationProvider(SEARCH_DECORATION_PROVIDER),
   );
+
+  // one-time cleanup of old log files from before the rotating log file stream was implemented
+  cleanupOldLogFiles();
 
   // XXX: used for testing; do not remove
   return context;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,7 @@ import { registerLocalResourceWorkflows } from "./docker/workflows/workflowIniti
 import { MessageDocumentProvider } from "./documentProviders/message";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { constructResourceLoaderSingletons } from "./loaders";
-import { Logger, outputChannel } from "./logging";
+import { Logger, OUTPUT_CHANNEL } from "./logging";
 import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
@@ -135,7 +135,7 @@ async function _activateExtension(
 
   // register the log output channels and debugging commands before anything else, in case we need
   // to reset global/workspace state or there's a problem further down with extension activation
-  context.subscriptions.push(outputChannel, SIDECAR_OUTPUT_CHANNEL, ...registerDebugCommands());
+  context.subscriptions.push(OUTPUT_CHANNEL, SIDECAR_OUTPUT_CHANNEL, ...registerDebugCommands());
   // automatically display and focus the Confluent extension output channel in development mode
   // to avoid needing to keep the main window & Debug Console tab open alongside the extension dev
   // host window during debugging

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,8 +66,9 @@ import { EventListener } from "./docker/eventListener";
 import { registerLocalResourceWorkflows } from "./docker/workflows/workflowInitialization";
 import { MessageDocumentProvider } from "./documentProviders/message";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
+import { logError } from "./errors";
 import { constructResourceLoaderSingletons } from "./loaders";
-import { Logger, OUTPUT_CHANNEL } from "./logging";
+import { getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
 import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
@@ -384,9 +385,20 @@ function setupDocumentProviders(): vscode.Disposable[] {
   return disposables;
 }
 
-// This method is called when your extension is deactivated or when VSCode is shutting down
 export function deactivate() {
-  getTelemetryLogger().dispose();
+  // dispose of the telemetry logger
+  try {
+    getTelemetryLogger().dispose();
+  } catch (e) {
+    const msg = "Error disposing telemetry logger during extension deactivation";
+    logError(new Error(msg, { cause: e }), msg, {}, true);
+  }
+
+  // close the file stream used with OUTPUT_CHANNEL
+  const logStream = getLogFileStream();
+  if (logStream) {
+    logStream.end();
+  }
 
   logger.info("Extension deactivated");
 }

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import {
+  CURRENT_LOGFILE_NAME,
   Logger,
   MAX_LOGFILES,
   OUTPUT_CHANNEL,
@@ -91,23 +92,33 @@ describe("logging.ts Logger methods", function () {
 });
 
 describe("logging.ts rotatingFilenameGenerator", function () {
-  it("should generate a new filename with a different index", function () {
+  it("should leave ROTATED_LOGFILE_NAMES empty before any rotations", function () {
     const fileName: string = rotatingFilenameGenerator(new Date(), 0);
 
     assert.strictEqual(fileName, `vscode-confluent-${process.pid}.log`);
+    // no rotations yet
+    assert.strictEqual(ROTATED_LOGFILE_NAMES.length, 0);
+    assert.strictEqual(CURRENT_LOGFILE_NAME, `vscode-confluent-${process.pid}.log`);
   });
 
   it("should generate a new filename with a higher index", function () {
     const fileName: string = rotatingFilenameGenerator(new Date(), 1);
 
     assert.strictEqual(fileName, `vscode-confluent-${process.pid}.1.log`);
+    // one rotated file, current left alone
+    assert.strictEqual(ROTATED_LOGFILE_NAMES.length, 1);
+    assert.strictEqual(ROTATED_LOGFILE_NAMES[0], `vscode-confluent-${process.pid}.1.log`);
+    assert.strictEqual(CURRENT_LOGFILE_NAME, `vscode-confluent-${process.pid}.log`);
   });
 
   it(`should only keep the last ${MAX_LOGFILES} log files in ROTATED_LOGFILE_NAMES`, function () {
-    for (let i = 0; i < MAX_LOGFILES + 1; i++) {
-      rotatingFilenameGenerator(new Date(), i);
+    // start at 1 since 0 is the current log file index
+    for (let i = 1; i <= MAX_LOGFILES; i++) {
+      const fileName = rotatingFilenameGenerator(new Date(), i);
+      assert.strictEqual(fileName, `vscode-confluent-${process.pid}.${i}.log`);
     }
 
     assert.strictEqual(ROTATED_LOGFILE_NAMES.length, MAX_LOGFILES);
+    assert.strictEqual(CURRENT_LOGFILE_NAME, `vscode-confluent-${process.pid}.log`);
   });
 });

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -1,0 +1,113 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import {
+  Logger,
+  MAX_LOGFILES,
+  OUTPUT_CHANNEL,
+  ROTATED_LOGFILE_NAMES,
+  rotatingFilenameGenerator,
+} from "./logging";
+
+describe("logging.ts Logger methods", function () {
+  let sandbox: sinon.SinonSandbox;
+
+  let traceStub: sinon.SinonStub;
+  let debugStub: sinon.SinonStub;
+  let infoStub: sinon.SinonStub;
+  let warnStub: sinon.SinonStub;
+  let errorStub: sinon.SinonStub;
+
+  let logger: Logger;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+
+    // stub output channel methods
+    traceStub = sandbox.stub(OUTPUT_CHANNEL, "trace");
+    debugStub = sandbox.stub(OUTPUT_CHANNEL, "debug");
+    infoStub = sandbox.stub(OUTPUT_CHANNEL, "info");
+    warnStub = sandbox.stub(OUTPUT_CHANNEL, "warn");
+    errorStub = sandbox.stub(OUTPUT_CHANNEL, "error");
+
+    // create a new logger instance for each test
+    logger = new Logger("test");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should call OUTPUT_CHANNEL.trace when .trace() is called", function () {
+    logger.trace("test message");
+
+    assert.strictEqual(traceStub.calledOnce, true);
+    assert.strictEqual(traceStub.firstCall.args[0], "[test] test message");
+  });
+
+  it("should call OUTPUT_CHANNEL.debug when .debug() is called", function () {
+    logger.debug("test message");
+
+    assert.strictEqual(debugStub.calledOnce, true);
+    assert.strictEqual(debugStub.firstCall.args[0], "[test] test message");
+  });
+
+  it("should call OUTPUT_CHANNEL.info when .log() is called", function () {
+    logger.log("test message");
+
+    assert.strictEqual(infoStub.calledOnce, true);
+    assert.strictEqual(infoStub.firstCall.args[0], "[test] test message");
+  });
+
+  it("should call OUTPUT_CHANNEL.info when .info() is called", function () {
+    logger.info("test message");
+
+    assert.strictEqual(infoStub.calledOnce, true);
+    assert.strictEqual(infoStub.firstCall.args[0], "[test] test message");
+  });
+
+  it("should call OUTPUT_CHANNEL.warn when .warn() is called", function () {
+    logger.warn("test message");
+
+    assert.strictEqual(warnStub.calledOnce, true);
+    assert.strictEqual(warnStub.firstCall.args[0], "[test] test message");
+  });
+
+  it("should call OUTPUT_CHANNEL.error when .error() is called", function () {
+    logger.error("test message");
+
+    assert.strictEqual(errorStub.calledOnce, true);
+    assert.strictEqual(errorStub.firstCall.args[0], "[test] test message");
+  });
+
+  it("should create a new logger with callpoint when withCallpoint is used", function () {
+    const boundLogger = logger.withCallpoint("testpoint");
+
+    // call a method on the bound logger to check the modified prefix
+    boundLogger.info("test message");
+
+    assert.strictEqual(infoStub.calledOnce, true);
+    assert.strictEqual(infoStub.firstCall.args[0].includes("[test[testpoint.0]]"), true);
+  });
+});
+
+describe("logging.ts rotatingFilenameGenerator", function () {
+  it("should generate a new filename with a different index", function () {
+    const fileName: string = rotatingFilenameGenerator(new Date(), 0);
+
+    assert.strictEqual(fileName, `vscode-confluent-${process.pid}.log`);
+  });
+
+  it("should generate a new filename with a higher index", function () {
+    const fileName: string = rotatingFilenameGenerator(new Date(), 1);
+
+    assert.strictEqual(fileName, `vscode-confluent-${process.pid}.1.log`);
+  });
+
+  it(`should only keep the last ${MAX_LOGFILES} log files in ROTATED_LOGFILE_NAMES`, function () {
+    for (let i = 0; i < MAX_LOGFILES + 1; i++) {
+      rotatingFilenameGenerator(new Date(), i);
+    }
+
+    assert.strictEqual(ROTATED_LOGFILE_NAMES.length, MAX_LOGFILES);
+  });
+});

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -2,7 +2,6 @@ import { tmpdir } from "os";
 import { createStream, Generator, RotatingFileStream } from "rotating-file-stream";
 import { LogOutputChannel, window } from "vscode";
 
-export const LOGFILE_NAME = `vscode-confluent-${process.pid}.log`;
 /**
  * Default path to store downloadable log files for this extension instance.
  *
@@ -13,13 +12,15 @@ export const LOGFILE_DIR = tmpdir();
 
 /** Max size of any log file written to disk.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#size */
-const MAX_LOG_FILE_SIZE = "20K"; // 10MB max file size
+const MAX_LOGFILE_SIZE = "15K"; // 10MB max file size
+
 /** Number of log files to keep.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#maxfiles */
-const MAX_LOG_FILES = 3; // only keep 3 log files at a time
-/** How often log files should rotate if they don't exceed {@link MAX_LOG_FILE_SIZE}.
+const MAX_LOGFILES = 3; // only keep 3 log files at a time
+
+/** How often log files should rotate if they don't exceed {@link MAX_LOGFILE_SIZE}.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#interval */
-const LOG_ROTATION_INTERVAL = "1d"; // rotate log files daily
+const LOGFILE_ROTATION_INTERVAL = "1d"; // rotate log files daily
 
 /**
  * Main "Confluent" output channel.
@@ -153,13 +154,14 @@ export class Logger {
 /** Single stream to allow rotating-file-stream to keep track of file sizes and rotation timing. */
 let logFileStream: RotatingFileStream | undefined;
 
+/** Creates a new rotating log file stream if it doesn't already exist. */
 export function getLogFileStream(): RotatingFileStream {
   if (!logFileStream) {
     logFileStream = createStream(rotatingFilenameGenerator, {
-      size: MAX_LOG_FILE_SIZE,
-      maxSize: MAX_LOG_FILE_SIZE,
-      maxFiles: MAX_LOG_FILES,
-      interval: LOG_ROTATION_INTERVAL,
+      size: MAX_LOGFILE_SIZE,
+      maxSize: MAX_LOGFILE_SIZE,
+      maxFiles: MAX_LOGFILES,
+      interval: LOGFILE_ROTATION_INTERVAL,
       path: LOGFILE_DIR,
       encoding: "utf-8",
     });
@@ -167,20 +169,40 @@ export function getLogFileStream(): RotatingFileStream {
   return logFileStream;
 }
 
-function pad(num: number) {
+/**
+ * Pads a number with leading zero if it's less than 10.
+ * @param num - The number to pad.
+ * @returns The padded number as a string.
+ */
+function pad(num: number): string {
   return (num > 9 ? "" : "0") + num;
 }
 
+/** Set of log file names that have already been created for this extension instance. */
+const ROTATED_LOGFILE_NAMES = new Set<string>();
+
+/** The name of the currently active log file, including time/index prefixing. */
+export let CURRENT_LOGFILE_NAME: string;
+
+/** The name of the log file, without any time/index prefixing. */
+const LOGFILE_NAME = `vscode-confluent-${process.pid}.log`;
+
+/**
+ * Generates a rotating filename based on the current date and time, with an optional index.
+ * The format is `YYYYMMDD-HHMM-index-logfile.log`.
+ * @param time - The date/time to use for the filename. If not provided, defaults to the current date/time.
+ * @param index - An optional index to append to the filename.
+ * @returns The generated filename.
+ */
 const rotatingFilenameGenerator: Generator = (time: number | Date, index?: number): string => {
-  if (!time) return LOGFILE_NAME;
-
-  if (!(time instanceof Date)) {
-    time = new Date(time);
-  }
-  const month = time.getFullYear() + "" + pad(time.getMonth() + 1);
-  const day = pad(time.getDate());
-  const hour = pad(time.getHours());
-  const minute = pad(time.getMinutes());
-
-  return `${month}/${month}${day}-${hour}${minute}-${index}-${LOGFILE_NAME}`;
+  const currentTime = new Date();
+  const year = currentTime.getFullYear();
+  const month = pad(currentTime.getMonth() + 1);
+  const day = pad(currentTime.getDate());
+  const hour = pad(currentTime.getHours());
+  const minute = pad(currentTime.getMinutes());
+  const newFileName = `${year}-${month}-${day}-${hour}${minute}-${index ?? 0}-${LOGFILE_NAME}`;
+  ROTATED_LOGFILE_NAMES.add(newFileName);
+  CURRENT_LOGFILE_NAME = newFileName;
+  return newFileName;
 };

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -207,12 +207,20 @@ function rotatingFilenameGenerator(time: number | Date, index?: number): string 
   const maybefileIndex = index !== undefined ? `.${index}` : "";
   // use process.pid to keep the log file names unique across multiple extension instances
   const newFileName = `vscode-confluent-${process.pid}${maybefileIndex}.log`;
-  ROTATED_LOGFILE_NAMES.push(newFileName);
+
+  // this function will be called multiple times by RotatingFileStream as it handles rotations, so
+  // we need to guard against adding the same file name multiple times
+  // (we could use a Set, but we would end up calling Array.from() on it over and over)
+  if (!ROTATED_LOGFILE_NAMES.includes(newFileName)) {
+    ROTATED_LOGFILE_NAMES.push(newFileName);
+  }
+
   if (ROTATED_LOGFILE_NAMES.length > MAX_LOGFILES) {
     // remove the oldest log file from the array
     // (RotatingFileStream will handle the actual file deletion)
     ROTATED_LOGFILE_NAMES.shift();
   }
+
   CURRENT_LOGFILE_NAME = newFileName;
   return newFileName;
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -21,7 +21,7 @@ export const LOGFILE_PATH: string = join(tmpdir(), LOGFILE_NAME);
  * @remarks We're using a {@link LogOutputChannel} instead of a {@link OutputChannel}
  * because it includes timestamps and colored log levels in the output by default.
  */
-export const outputChannel = window.createOutputChannel("Confluent", { log: true });
+export const OUTPUT_CHANNEL = window.createOutputChannel("Confluent", { log: true });
 
 const callpointCounter = new Map<string, number>();
 
@@ -90,19 +90,19 @@ export class Logger {
     try {
       switch (level) {
         case "trace":
-          outputChannel.trace(fullMessage, ...args);
+          OUTPUT_CHANNEL.trace(fullMessage, ...args);
           break;
         case "debug":
-          outputChannel.debug(fullMessage, ...args);
+          OUTPUT_CHANNEL.debug(fullMessage, ...args);
           break;
         case "info":
-          outputChannel.info(fullMessage, ...args);
+          OUTPUT_CHANNEL.info(fullMessage, ...args);
           break;
         case "warn":
-          outputChannel.warn(fullMessage, ...args);
+          OUTPUT_CHANNEL.warn(fullMessage, ...args);
           break;
         case "error":
-          outputChannel.error(fullMessage, ...args);
+          OUTPUT_CHANNEL.error(fullMessage, ...args);
           break;
       }
       // don't write trace logs to the log file

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -145,7 +145,7 @@ export class Logger {
 export const LOGFILE_DIR = tmpdir();
 
 /** The name of the currently active log file, including time/index prefixing. */
-export let CURRENT_LOGFILE_NAME: string;
+export const CURRENT_LOGFILE_NAME: string = `vscode-confluent-${process.pid}.log`;
 
 /** Set of log file names that have already been created for this extension instance. */
 export const ROTATED_LOGFILE_NAMES: string[] = [];
@@ -191,13 +191,13 @@ export function getLogFileStream(): RotatingFileStream {
  *
  * Example for a max of 3 log files:
  * First set of rotations:
- * - `vscode-confluent-1234.0.log` (current log file)
+ * - `vscode-confluent-1234.log` (current log file)
  * - `vscode-confluent-1234.1.log` (oldest log file)
  * - `vscode-confluent-1234.2.log`
  * - `vscode-confluent-1234.3.log` (new log file)
  *
  * The next rotation will remove the oldest file and create a new one:
- * - `vscode-confluent-1234.0.log` (current log file)
+ * - `vscode-confluent-1234.log` (current log file)
  * - (`vscode-confluent-1234.1.log` is deleted)
  * - `vscode-confluent-1234.2.log`
  * - `vscode-confluent-1234.3.log`
@@ -212,7 +212,7 @@ export function rotatingFilenameGenerator(time: number | Date, index?: number): 
   // this function will be called multiple times by RotatingFileStream as it handles rotations, so
   // we need to guard against adding the same file name multiple times
   // (we could use a Set, but we would end up calling Array.from() on it over and over)
-  if (!ROTATED_LOGFILE_NAMES.includes(newFileName)) {
+  if (newFileName !== CURRENT_LOGFILE_NAME && !ROTATED_LOGFILE_NAMES.includes(newFileName)) {
     ROTATED_LOGFILE_NAMES.push(newFileName);
   }
 
@@ -222,7 +222,6 @@ export function rotatingFilenameGenerator(time: number | Date, index?: number): 
     ROTATED_LOGFILE_NAMES.shift();
   }
 
-  CURRENT_LOGFILE_NAME = newFileName;
   return newFileName;
 }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -152,7 +152,7 @@ export const ROTATED_LOGFILE_NAMES: string[] = [];
 
 /** Max size of any log file written to disk.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#size */
-const MAX_LOGFILE_SIZE = "10K"; // 10MB max file size
+const MAX_LOGFILE_SIZE = "10M"; // 10MB max file size
 
 /** Number of log files to keep.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#maxfiles */

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,10 +1,13 @@
-import { createWriteStream } from "fs";
+import { createWriteStream, existsSync, readdirSync, renameSync, statSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { LogOutputChannel, OutputChannel, window } from "vscode";
 
 export const LOGFILE_NAME = `vscode-confluent-${process.pid}.log`;
+const MAX_LOG_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB max file size
+const MAX_LOG_FILES = 3; // only keep 3 log files at a time
+
 /**
  * Default path to store downloadable log files for this extension instance.
  *
@@ -41,13 +44,13 @@ export class Logger {
   trace(message: string, ...args: any[]) {
     const prefix = this.logPrefix("trace");
     console.debug(prefix, message, ...args);
-    this.logToOutputChannelAndFile(outputChannel.trace, prefix, message, ...args);
+    this.logToOutputChannelAndFile("trace", prefix, message, ...args);
   }
 
   debug(message: string, ...args: any[]) {
     const prefix = this.logPrefix("debug");
     console.debug(prefix, message, ...args);
-    this.logToOutputChannelAndFile(outputChannel.debug, prefix, message, ...args);
+    this.logToOutputChannelAndFile("debug", prefix, message, ...args);
   }
 
   log(message: string, ...args: any[]) {
@@ -57,19 +60,19 @@ export class Logger {
   info(message: string, ...args: any[]) {
     const prefix = this.logPrefix("info");
     console.info(prefix, message, ...args);
-    this.logToOutputChannelAndFile(outputChannel.info, prefix, message, ...args);
+    this.logToOutputChannelAndFile("info", prefix, message, ...args);
   }
 
   warn(message: string, ...args: any[]) {
     const prefix = this.logPrefix("warning");
     console.warn(prefix, message, ...args);
-    this.logToOutputChannelAndFile(outputChannel.warn, prefix, message, ...args);
+    this.logToOutputChannelAndFile("warn", prefix, message, ...args);
   }
 
   error(message: string, ...args: any[]) {
     const prefix = this.logPrefix("error");
     console.error(prefix, message, ...args);
-    this.logToOutputChannelAndFile(outputChannel.error, prefix, message, ...args);
+    this.logToOutputChannelAndFile("error", prefix, message, ...args);
   }
 
   private logPrefix(level: string): string {
@@ -78,15 +81,37 @@ export class Logger {
   }
 
   private logToOutputChannelAndFile(
-    func: (message: string, ...args: any[]) => void,
+    level: string,
     prefix: string,
     message: string,
     ...args: any[]
   ): void {
+    const fullMessage = `[${this.name}] ${message}`;
     try {
-      func(`[${this.name}] ${message}`, ...args);
-      // not awaiting this, as it's not critical to the operation
-      this.writeToLogFile(prefix, message, ...args);
+      switch (level) {
+        case "trace":
+          outputChannel.trace(fullMessage, ...args);
+          break;
+        case "debug":
+          outputChannel.debug(fullMessage, ...args);
+          break;
+        case "info":
+          outputChannel.info(fullMessage, ...args);
+          break;
+        case "warn":
+          outputChannel.warn(fullMessage, ...args);
+          break;
+        case "error":
+          outputChannel.error(fullMessage, ...args);
+          break;
+      }
+      // don't write trace logs to the log file
+      if (level !== "trace") {
+        this.writeToLogFile(prefix, message, ...args).catch(() => {
+          // already logged, no need for additional handling. we still need this here so we don't
+          // get unhandled promise rejections bubbling up.
+        });
+      }
     } catch {
       // ignore if the channel is disposed or the log file write fails
     }
@@ -99,21 +124,84 @@ export class Logger {
     const formattedMessage = `${prefix} ${message} ${argString}\n`;
 
     return new Promise<void>((resolve, reject) => {
-      const logWriteStream = createWriteStream(LOGFILE_PATH, { flags: "a" });
-      logWriteStream.once("error", (error) => {
-        console.error("Error writing to log file:", error);
-        logWriteStream.end();
-        reject(error);
-      });
-      logWriteStream.write(Buffer.from(formattedMessage), (error) => {
-        if (error) {
+      try {
+        this.rotateLogFileIfNeeded();
+
+        const logWriteStream = createWriteStream(LOGFILE_PATH, { flags: "a" });
+        logWriteStream.once("error", (error) => {
           console.error("Error writing to log file:", error);
           logWriteStream.end();
           reject(error);
-        }
-        // waits for any remaining data to be written to the file before closing the stream
-        logWriteStream.end(() => resolve());
-      });
+        });
+        logWriteStream.write(Buffer.from(formattedMessage), (error) => {
+          if (error) {
+            console.error("Error writing to log file:", error);
+            logWriteStream.end();
+            reject(error);
+          }
+          // waits for any remaining data to be written to the file before closing the stream
+          logWriteStream.end(() => resolve());
+        });
+      } catch (error) {
+        console.error("Unexpected error during log file operations:", error);
+        resolve();
+      }
     });
+  }
+
+  /** Check if the current log file exceeds size limit and rotate if needed */
+  private rotateLogFileIfNeeded(): void {
+    try {
+      // no need to rotate if the file doesn't exist or it's under the size limit
+      if (!existsSync(LOGFILE_PATH)) {
+        return;
+      }
+      const stats = statSync(LOGFILE_PATH);
+      if (stats.size < MAX_LOG_FILE_SIZE_BYTES) {
+        return;
+      }
+
+      this.rotateLogFiles();
+    } catch (error) {
+      console.error("Error checking log file size:", error);
+    }
+  }
+
+  /** Handle the log file rotation */
+  private rotateLogFiles(): void {
+    try {
+      const logDir: string = tmpdir();
+      const logFilePrefix: string = LOGFILE_NAME.split("-")[0]; // "vscode-confluent"
+      const logFiles: string[] = readdirSync(logDir)
+        .filter(
+          (file) =>
+            file.startsWith(logFilePrefix) && file.endsWith(".log") && file !== LOGFILE_NAME,
+        )
+        .map((file) => join(logDir, file))
+        .sort(); // sort by name (including timestamp) to get oldest first
+
+      // remove oldest log file(s) if we have more than the max number
+      while (logFiles.length >= MAX_LOG_FILES) {
+        const oldestFile = logFiles.shift();
+        if (oldestFile) {
+          unlinkSync(oldestFile);
+        }
+      }
+
+      // create new log file with timestamp
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const newLogPath = join(tmpdir(), `${logFilePrefix}-${timestamp}-${process.pid}.log`);
+
+      // rename current file to archived name (or just delete if renaming fails)
+      try {
+        createWriteStream(newLogPath).close();
+        renameSync(LOGFILE_PATH, newLogPath);
+      } catch {
+        // if rename fails, just delete the old file
+        unlinkSync(LOGFILE_PATH);
+      }
+    } catch (error) {
+      console.error("Error rotating log files:", error);
+    }
   }
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,5 +1,5 @@
 import { tmpdir } from "os";
-import { createStream, Generator, RotatingFileStream } from "rotating-file-stream";
+import { createStream, RotatingFileStream } from "rotating-file-stream";
 import { LogOutputChannel, window } from "vscode";
 
 /**
@@ -194,7 +194,7 @@ const LOGFILE_NAME = `vscode-confluent-${process.pid}.log`;
  * @param index - An optional index to append to the filename.
  * @returns The generated filename.
  */
-const rotatingFilenameGenerator: Generator = (time: number | Date, index?: number): string => {
+function rotatingFilenameGenerator(time: number | Date, index?: number): string {
   const currentTime = new Date();
   const year = currentTime.getFullYear();
   const month = pad(currentTime.getMonth() + 1);
@@ -205,4 +205,4 @@ const rotatingFilenameGenerator: Generator = (time: number | Date, index?: numbe
   ROTATED_LOGFILE_NAMES.add(newFileName);
   CURRENT_LOGFILE_NAME = newFileName;
   return newFileName;
-};
+}

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,12 +1,19 @@
-import { createWriteStream, existsSync, readdirSync, renameSync, statSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { LogOutputChannel, OutputChannel, window } from "vscode";
+import { createStream, RotatingFileStream } from "rotating-file-stream";
+import { LogOutputChannel, window } from "vscode";
 
 export const LOGFILE_NAME = `vscode-confluent-${process.pid}.log`;
-const MAX_LOG_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB max file size
+
+/** Max size of any log file written to disk.
+ * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#size */
+const MAX_LOG_FILE_SIZE = "100K"; // 10MB max file size
+/** Number of log files to keep.
+ * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#maxfiles */
 const MAX_LOG_FILES = 3; // only keep 3 log files at a time
+/** How often log files should rotate if they don't exceed {@link MAX_LOG_FILE_SIZE}.
+ * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#interval */
+const LOG_ROTATION_INTERVAL = "1d"; // rotate log files daily
 
 /**
  * Default path to store downloadable log files for this extension instance.
@@ -18,10 +25,12 @@ export const LOGFILE_PATH: string = join(tmpdir(), LOGFILE_NAME);
 
 /**
  * Main "Confluent" output channel.
- * @remarks We're using a {@link LogOutputChannel} instead of a {@link OutputChannel}
+ * @remarks We're using a {@link LogOutputChannel} instead of an `OutputChannel`
  * because it includes timestamps and colored log levels in the output by default.
  */
-export const OUTPUT_CHANNEL = window.createOutputChannel("Confluent", { log: true });
+export const OUTPUT_CHANNEL: LogOutputChannel = window.createOutputChannel("Confluent", {
+  log: true,
+});
 
 const callpointCounter = new Map<string, number>();
 
@@ -126,9 +135,11 @@ export class Logger {
 
     return new Promise<void>((resolve, reject) => {
       try {
-        this.rotateLogFileIfNeeded();
-
-        const logWriteStream = createWriteStream(LOGFILE_PATH, { flags: "a" });
+        const logWriteStream: RotatingFileStream = createStream(`${tmpdir()}/${LOGFILE_NAME}`, {
+          size: MAX_LOG_FILE_SIZE,
+          maxFiles: MAX_LOG_FILES,
+          interval: LOG_ROTATION_INTERVAL,
+        });
         logWriteStream.once("error", (error) => {
           console.error("Error writing to log file:", error);
           logWriteStream.end();
@@ -148,61 +159,5 @@ export class Logger {
         resolve();
       }
     });
-  }
-
-  /** Check if the current log file exceeds size limit and rotate if needed */
-  private rotateLogFileIfNeeded(): void {
-    try {
-      // no need to rotate if the file doesn't exist or it's under the size limit
-      if (!existsSync(LOGFILE_PATH)) {
-        return;
-      }
-      const stats = statSync(LOGFILE_PATH);
-      if (stats.size < MAX_LOG_FILE_SIZE_BYTES) {
-        return;
-      }
-
-      this.rotateLogFiles();
-    } catch (error) {
-      console.error("Error checking log file size:", error);
-    }
-  }
-
-  /** Handle the log file rotation */
-  private rotateLogFiles(): void {
-    try {
-      const logDir: string = tmpdir();
-      const logFilePrefix: string = LOGFILE_NAME.split("-")[0]; // "vscode-confluent"
-      const logFiles: string[] = readdirSync(logDir)
-        .filter(
-          (file) =>
-            file.startsWith(logFilePrefix) && file.endsWith(".log") && file !== LOGFILE_NAME,
-        )
-        .map((file) => join(logDir, file))
-        .sort(); // sort by name (including timestamp) to get oldest first
-
-      // remove oldest log file(s) if we have more than the max number
-      while (logFiles.length >= MAX_LOG_FILES) {
-        const oldestFile = logFiles.shift();
-        if (oldestFile) {
-          unlinkSync(oldestFile);
-        }
-      }
-
-      // create new log file with timestamp
-      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-      const newLogPath = join(tmpdir(), `${logFilePrefix}-${timestamp}-${process.pid}.log`);
-
-      // rename current file to archived name (or just delete if renaming fails)
-      try {
-        createWriteStream(newLogPath).close();
-        renameSync(LOGFILE_PATH, newLogPath);
-      } catch {
-        // if rename fails, just delete the old file
-        unlinkSync(LOGFILE_PATH);
-      }
-    } catch (error) {
-      console.error("Error rotating log files:", error);
-    }
   }
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -3,26 +3,6 @@ import { createStream, RotatingFileStream } from "rotating-file-stream";
 import { LogOutputChannel, window } from "vscode";
 
 /**
- * Default path to store downloadable log files for this extension instance.
- *
- * The main difference between this and the ExtensionContext.logUri (where LogOutputChannel lines
- * are written) is this will include ALL log levels, not just the ones enabled in the output channel.
- */
-export const LOGFILE_DIR = tmpdir();
-
-/** Max size of any log file written to disk.
- * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#size */
-const MAX_LOGFILE_SIZE = "15K"; // 10MB max file size
-
-/** Number of log files to keep.
- * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#maxfiles */
-const MAX_LOGFILES = 3; // only keep 3 log files at a time
-
-/** How often log files should rotate if they don't exceed {@link MAX_LOGFILE_SIZE}.
- * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#interval */
-const LOGFILE_ROTATION_INTERVAL = "1d"; // rotate log files daily
-
-/**
  * Main "Confluent" output channel.
  * @remarks We're using a {@link LogOutputChannel} instead of an `OutputChannel`
  * because it includes timestamps and colored log levels in the output by default.
@@ -134,7 +114,11 @@ export class Logger {
 
     return new Promise<void>((resolve, reject) => {
       try {
-        const stream = getLogFileStream();
+        const stream: RotatingFileStream = getLogFileStream();
+        if (stream.closed) {
+          resolve();
+          return;
+        }
         stream.write(formattedMessage, (error) => {
           if (error) {
             console.error("Error writing to log file:", error);
@@ -151,18 +135,46 @@ export class Logger {
   }
 }
 
+/**
+ * Default path to store downloadable log files for this extension instance.
+ *
+ * The main difference between this and the ExtensionContext.logUri (where LogOutputChannel lines
+ * are written) is this will include ALL log levels, not just the ones enabled in the output channel.
+ */
+export const LOGFILE_DIR = tmpdir();
+
+/** The name of the currently active log file, including time/index prefixing. */
+export let CURRENT_LOGFILE_NAME: string;
+
+/** Set of log file names that have already been created for this extension instance. */
+export const ROTATED_LOGFILE_NAMES: string[] = [];
+
+/** Max size of any log file written to disk.
+ * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#size */
+const MAX_LOGFILE_SIZE = "10K"; // 10MB max file size
+
+/** Number of log files to keep.
+ * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#maxfiles */
+const MAX_LOGFILES = 3; // only keep 3 **rotated** log files at a time for this extension instance
+
+/** How often log files should rotate if they don't exceed {@link MAX_LOGFILE_SIZE}.
+ * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#interval */
+const LOGFILE_ROTATION_INTERVAL = "1d"; // rotate log files daily
+
 /** Single stream to allow rotating-file-stream to keep track of file sizes and rotation timing. */
 let logFileStream: RotatingFileStream | undefined;
 
 /** Creates a new rotating log file stream if it doesn't already exist. */
 export function getLogFileStream(): RotatingFileStream {
   if (!logFileStream) {
+    // don't use the `maxSize` option since that will interfere with proper rotation and cleanup by
+    // immediately removing the created rotated log file
     logFileStream = createStream(rotatingFilenameGenerator, {
       size: MAX_LOGFILE_SIZE,
-      maxSize: MAX_LOGFILE_SIZE,
       maxFiles: MAX_LOGFILES,
       interval: LOGFILE_ROTATION_INTERVAL,
       path: LOGFILE_DIR,
+      history: `vscode-confluent-${process.pid}.history.log`,
       encoding: "utf-8",
     });
   }
@@ -170,39 +182,36 @@ export function getLogFileStream(): RotatingFileStream {
 }
 
 /**
- * Pads a number with leading zero if it's less than 10.
- * @param num - The number to pad.
- * @returns The padded number as a string.
- */
-function pad(num: number): string {
-  return (num > 9 ? "" : "0") + num;
-}
-
-/** Set of log file names that have already been created for this extension instance. */
-const ROTATED_LOGFILE_NAMES = new Set<string>();
-
-/** The name of the currently active log file, including time/index prefixing. */
-export let CURRENT_LOGFILE_NAME: string;
-
-/** The name of the log file, without any time/index prefixing. */
-const LOGFILE_NAME = `vscode-confluent-${process.pid}.log`;
-
-/**
- * Generates a rotating filename based on the current date and time, with an optional index.
- * The format is `YYYYMMDD-HHMM-index-logfile.log`.
- * @param time - The date/time to use for the filename. If not provided, defaults to the current date/time.
- * @param index - An optional index to append to the filename.
- * @returns The generated filename.
+ * Generates a rotating filename based on the index, to be used in the `RotatingFileStream`'s
+ * internal operations.
+ *
+ * The currently-active logfile will always end in `0.log`, and as new files are created, the older
+ * files will be removed until the max number of files is reached.
+ *
+ * Example for a max of 3 log files:
+ * First set of rotations:
+ * - `vscode-confluent-1234.0.log` (current log file)
+ * - `vscode-confluent-1234.1.log` (oldest log file)
+ * - `vscode-confluent-1234.2.log`
+ * - `vscode-confluent-1234.3.log` (new log file)
+ *
+ * The next rotation will remove the oldest file and create a new one:
+ * - `vscode-confluent-1234.0.log` (current log file)
+ * - (`vscode-confluent-1234.1.log` is deleted)
+ * - `vscode-confluent-1234.2.log`
+ * - `vscode-confluent-1234.3.log`
+ * - `vscode-confluent-1234.4.log` (new log file)
  */
 function rotatingFilenameGenerator(time: number | Date, index?: number): string {
-  const currentTime = new Date();
-  const year = currentTime.getFullYear();
-  const month = pad(currentTime.getMonth() + 1);
-  const day = pad(currentTime.getDate());
-  const hour = pad(currentTime.getHours());
-  const minute = pad(currentTime.getMinutes());
-  const newFileName = `${year}-${month}-${day}-${hour}${minute}-${index ?? 0}-${LOGFILE_NAME}`;
-  ROTATED_LOGFILE_NAMES.add(newFileName);
+  const maybefileIndex = index !== undefined ? `.${index}` : "";
+  // use process.pid to keep the log file names unique across multiple extension instances
+  const newFileName = `vscode-confluent-${process.pid}${maybefileIndex}.log`;
+  ROTATED_LOGFILE_NAMES.push(newFileName);
+  if (ROTATED_LOGFILE_NAMES.length > MAX_LOGFILES) {
+    // remove the oldest log file from the array
+    // (RotatingFileStream will handle the actual file deletion)
+    ROTATED_LOGFILE_NAMES.shift();
+  }
   CURRENT_LOGFILE_NAME = newFileName;
   return newFileName;
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -107,11 +107,12 @@ export class Logger {
       }
       // don't write trace logs to the log file
       if (level !== "trace") {
-        this.writeToLogFile(prefix, message, ...args).catch(() => {
-          // already logged, no need for additional handling. we still need this here so we don't
-          // get unhandled promise rejections bubbling up.
-        });
+        // TODO(shoup): move this.writeToLogFile() here after initial rotating file testing
       }
+      this.writeToLogFile(prefix, message, ...args).catch(() => {
+        // already logged, no need for additional handling. we still need this here so we don't
+        // get unhandled promise rejections bubbling up.
+      });
     } catch {
       // ignore if the channel is disposed or the log file write fails
     }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -156,7 +156,7 @@ const MAX_LOGFILE_SIZE = "10M"; // 10MB max file size
 
 /** Number of log files to keep.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#maxfiles */
-const MAX_LOGFILES = 3; // only keep 3 **rotated** log files at a time for this extension instance
+export const MAX_LOGFILES = 3; // only keep 3 **rotated** log files at a time for this extension instance
 
 /** How often log files should rotate if they don't exceed {@link MAX_LOGFILE_SIZE}.
  * @see https://github.com/iccicci/rotating-file-stream?tab=readme-ov-file#interval */
@@ -203,8 +203,9 @@ export function getLogFileStream(): RotatingFileStream {
  * - `vscode-confluent-1234.3.log`
  * - `vscode-confluent-1234.4.log` (new log file)
  */
-function rotatingFilenameGenerator(time: number | Date, index?: number): string {
-  const maybefileIndex = index !== undefined ? `.${index}` : "";
+export function rotatingFilenameGenerator(time: number | Date, index?: number): string {
+  // 0, undefined, null will drop any index suffix
+  const maybefileIndex = index ? `.${index}` : "";
   // use process.pid to keep the log file names unique across multiple extension instances
   const newFileName = `vscode-confluent-${process.pid}${maybefileIndex}.log`;
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -96,12 +96,11 @@ export class Logger {
       }
       // don't write trace logs to the log file
       if (level !== "trace") {
-        // TODO(shoup): move this.writeToLogFile() here after initial rotating file testing
+        this.writeToLogFile(prefix, message, ...args).catch(() => {
+          // already logged, no need for additional handling. we still need this here so we don't
+          // get unhandled promise rejections bubbling up.
+        });
       }
-      this.writeToLogFile(prefix, message, ...args).catch(() => {
-        // already logged, no need for additional handling. we still need this here so we don't
-        // get unhandled promise rejections bubbling up.
-      });
     } catch {
       // ignore if the channel is disposed or the log file write fails
     }

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,6 +1,10 @@
 import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration } from "vscode";
 import { Logger } from "../logging";
-import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
+import {
+  LOCAL_DOCKER_SOCKET_PATH,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 import { updatePreferences } from "./updates";
 
 const logger = new Logger("preferences.listener");
@@ -29,6 +33,15 @@ export function createConfigChangeListener(): Disposable {
         // if the user disables server cert verification, trust all certs
         const trustAllCerts: boolean = configs.get(SSL_VERIFY_SERVER_CERT_DISABLED, false);
         await updatePreferences({ trust_all_certificates: trustAllCerts });
+        return;
+      }
+
+      if (event.affectsConfiguration(LOCAL_DOCKER_SOCKET_PATH)) {
+        // just log it so we don't have to log every time we use it
+        logger.debug(
+          `"${LOCAL_DOCKER_SOCKET_PATH}" changed:`,
+          configs.get(LOCAL_DOCKER_SOCKET_PATH),
+        );
         return;
       }
 

--- a/src/sidecar/constants.ts
+++ b/src/sidecar/constants.ts
@@ -19,5 +19,7 @@ export const ENABLE_REQUEST_RESPONSE_LOGGING: boolean =
 /** Header name for the sidecar's PID in the response headers. */
 export const SIDECAR_PROCESS_ID_HEADER = "x-sidecar-pid";
 
+export const SIDECAR_LOGFILE_NAME = "vscode-confluent-sidecar.log";
+
 /** OS-independent path to the log file for the sidecar process. */
-export const SIDECAR_LOGFILE_PATH = join(tmpdir(), "vscode-confluent-sidecar.log");
+export const SIDECAR_LOGFILE_PATH = join(tmpdir(), SIDECAR_LOGFILE_NAME);

--- a/src/sidecar/sidecarManager.test.ts
+++ b/src/sidecar/sidecarManager.test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import "mocha";
 import * as sinon from "sinon";
 import { SIDECAR_OUTPUT_CHANNEL } from "../constants";
-import { outputChannel } from "../logging";
+import { OUTPUT_CHANNEL } from "../logging";
 import { SIDECAR_LOGFILE_PATH } from "./constants";
 import {
   appendSidecarLogToOutputChannel,
@@ -130,7 +130,7 @@ describe("appendSidecarLogToOutputChannel() tests", () => {
     errorStub = sandbox.stub(SIDECAR_OUTPUT_CHANNEL, "error");
     appendLineStub = sandbox.stub(SIDECAR_OUTPUT_CHANNEL, "appendLine");
 
-    mainOutputErrorStub = sandbox.stub(outputChannel, "error");
+    mainOutputErrorStub = sandbox.stub(OUTPUT_CHANNEL, "error");
   });
 
   afterEach(() => {

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -7,7 +7,7 @@ import sidecarExecutablePath, { version as currentSidecarVersion } from "ide-sid
 import * as vscode from "vscode";
 
 import { Configuration, HandshakeResourceApi, SidecarVersionResponse } from "../clients/sidecar";
-import { Logger, outputChannel } from "../logging";
+import { Logger, OUTPUT_CHANNEL } from "../logging";
 import { getStorageManager } from "../storage";
 import { checkSidecarOsAndArch } from "./checkArchitecture";
 import {
@@ -518,7 +518,7 @@ export class SidecarManager {
     });
 
     this.logTailer.on("error", (data: any) => {
-      outputChannel.error(`Error tailing sidecar log: ${data.toString()}`);
+      OUTPUT_CHANNEL.error(`Error tailing sidecar log: ${data.toString()}`);
     });
   }
 
@@ -680,7 +680,7 @@ export function appendSidecarLogToOutputChannel(line: string) {
     log = JSON.parse(line) as SidecarLogFormat;
   } catch (e) {
     if (e instanceof Error) {
-      outputChannel.error(`Failed to parse sidecar log line: ${e.message}\n\t${line}`);
+      OUTPUT_CHANNEL.error(`Failed to parse sidecar log line: ${e.message}\n\t${line}`);
     }
     return;
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #1100.

- Renames the global const `outputChannel` to `OUTPUT_CHANNEL` for consistency with `SIDECAR_OUTPUT_CHANNEL` (#1058).
- Adds the [`rotating-file-stream`](https://www.npmjs.com/package/rotating-file-stream) dependency so we can rotate log files based on max interval and size.

> [!TIP]
> To click-test this branch, update the following from `10M` to `10K`. Signing in and out of CCloud (multiple times) will help push the logs past the 10K file limit faster to see the rotation in action. https://github.com/confluentinc/vscode/blob/a2ae3b19b30a55a5a26b01683207d11023d33f55/src/logging.ts#L153-L155

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Unfortunately, now that we're handling multiple logs per workspace/window, this means the support commands needed some updating as well:
- "Support: Save Logs" will now either save an individual log file (if we haven't hit the 10MB file size limit and had to rotate), or save a .zip of the current-workspace's files
- "Support: Save Support File (.zip)" will include any/all logs from the current workspace

There is also a new **cleanup** function run on extension activation that will look for any (non-sidecar) log files in `$TMPDIR` and attempt deleting any log files modified more than three days ago. We should be able to get rid of this once most folks are on the new rotating-log setup.
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/82fed229-d06f-4ade-8327-f06b626e75ed" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
