### PR TITLE
SSL form follow-up and bug fixes

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -215,7 +215,7 @@
               data-attr-value="this.kafkaSslEnabled()"
               data-on-change="this.updateValue(event)"
               data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
-            /><span>SSL enabled</span></label
+            /><span>SSL/TLS enabled</span></label
           >
           <template data-if="this.kafkaSslEnabled()">
             <ssl-config
@@ -349,7 +349,7 @@
               data-on-change="this.updateValue(event)"
               data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
             />
-            <span>SSL enabled</span>
+            <span>SSL/TLS enabled</span>
           </label>
           <template data-if="this.schemaSslEnabled()">
             <ssl-config

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -125,50 +125,45 @@ test("renders form with existing connection spec values for edit", async ({ exec
   const specCallHandle = await sendWebviewMessage.evaluateHandle((stub) => stub.getCall(0).args);
   const specCall = await specCallHandle.jsonValue();
   expect(specCall[0]).toBe("GetConnectionSpec");
+
   const form = page.locator("form");
   await expect(form).toBeVisible();
 
   // Check that the form fields are populated with the connection spec values
   const nameInput = page.locator("input[name='name']");
-  await expect(await nameInput?.getAttribute("value")).toBe(SPEC_SAMPLE.name);
+  await expect(nameInput).toHaveValue(SPEC_SAMPLE.name);
 
   const bootstrapServersInput = page.locator("input[name='kafka_cluster.bootstrap_servers']");
-  await expect(await bootstrapServersInput?.getAttribute("value")).toBe(
-    SPEC_SAMPLE.kafka_cluster.bootstrap_servers,
-  );
+  await expect(bootstrapServersInput).toHaveValue(SPEC_SAMPLE.kafka_cluster.bootstrap_servers);
 
   const uriInput = page.locator("input[name='schema_registry.uri']");
-  await expect(await uriInput?.getAttribute("value")).toBe(SPEC_SAMPLE.schema_registry.uri);
+  await expect(uriInput).toHaveValue(SPEC_SAMPLE.schema_registry.uri);
 
   const kafkaSslCheckbox = page.locator("input[type='checkbox'][name='kafka_cluster.ssl.enabled']");
   await expect(await kafkaSslCheckbox?.isChecked()).toBe(true);
 
   const keystorePathInput = page.locator("input[name='kafka_cluster.ssl.keystore.path']");
-  await expect(await keystorePathInput?.getAttribute("value")).toBe(
-    SPEC_SAMPLE.kafka_cluster.ssl.keystore.path,
-  );
+  await expect(keystorePathInput).toHaveValue(SPEC_SAMPLE.kafka_cluster.ssl.keystore.path);
 
   const keystorePasswordInput = page.locator("input[name='kafka_cluster.ssl.keystore.password']");
-  await expect(await keystorePasswordInput?.getAttribute("value")).toBe(
-    SPEC_SAMPLE.kafka_cluster.ssl.keystore.password,
-  );
+  await expect(keystorePasswordInput).toHaveValue(SPEC_SAMPLE.kafka_cluster.ssl.keystore.password);
 
   const keystoreKeyPasswordInput = page.locator(
     "input[name='kafka_cluster.ssl.keystore.key_password']",
   );
-  await expect(await keystoreKeyPasswordInput?.getAttribute("value")).toBe(
+  await expect(keystoreKeyPasswordInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.keystore.key_password,
   );
 
   const truststorePathInput = page.locator("input[name='kafka_cluster.ssl.truststore.path']");
-  await expect(await truststorePathInput?.getAttribute("value")).toBe(
+  await expect(await truststorePathInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.truststore.path,
   );
 
   const truststorePasswordInput = page.locator(
     "input[name='kafka_cluster.ssl.truststore.password']",
   );
-  await expect(await truststorePasswordInput?.getAttribute("value")).toBe(
+  await expect(await truststorePasswordInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.truststore.password,
   );
 });
@@ -352,10 +347,10 @@ test("adds only edited ssl fields to form data", async ({ execute, page }) => {
 
   // Check that the form fields are populated with the connection spec values
   const nameInput = page.locator("input[name='name']");
-  await expect(await nameInput?.getAttribute("value")).toBe(SPEC_SAMPLE.name);
+  await expect(await nameInput).toHaveValue(SPEC_SAMPLE.name);
 
   const bootstrapServersInput = page.locator("input[name='kafka_cluster.bootstrap_servers']");
-  await expect(await bootstrapServersInput?.getAttribute("value")).toBe(
+  await expect(await bootstrapServersInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.bootstrap_servers,
   );
 
@@ -363,31 +358,29 @@ test("adds only edited ssl fields to form data", async ({ execute, page }) => {
   await expect(await kafkaSslCheckbox?.isChecked()).toBe(true);
 
   const keystorePathInput = page.locator("input[name='kafka_cluster.ssl.keystore.path']");
-  await expect(await keystorePathInput?.getAttribute("value")).toBe(
-    SPEC_SAMPLE.kafka_cluster.ssl.keystore.path,
-  );
+  await expect(await keystorePathInput).toHaveValue(SPEC_SAMPLE.kafka_cluster.ssl.keystore.path);
 
   const keystorePasswordInput = page.locator("input[name='kafka_cluster.ssl.keystore.password']");
-  await expect(await keystorePasswordInput?.getAttribute("value")).toBe(
+  await expect(await keystorePasswordInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.keystore.password,
   );
 
   const keystoreKeyPasswordInput = page.locator(
     "input[name='kafka_cluster.ssl.keystore.key_password']",
   );
-  await expect(await keystoreKeyPasswordInput?.getAttribute("value")).toBe(
+  await expect(await keystoreKeyPasswordInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.keystore.key_password,
   );
 
   const truststorePathInput = page.locator("input[name='kafka_cluster.ssl.truststore.path']");
-  await expect(await truststorePathInput?.getAttribute("value")).toBe(
+  await expect(await truststorePathInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.truststore.path,
   );
 
   const truststorePasswordInput = page.locator(
     "input[name='kafka_cluster.ssl.truststore.password']",
   );
-  await expect(await truststorePasswordInput?.getAttribute("value")).toBe(
+  await expect(await truststorePasswordInput).toHaveValue(
     SPEC_SAMPLE.kafka_cluster.ssl.truststore.password,
   );
 

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -242,8 +242,6 @@ test("submits the form with empty trust/key stores as defaults when ssl enabled"
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
   await page.fill("input[name='schema_registry.uri']", "http://localhost:8081");
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
-  const verify = page.locator("input[type=checkbox][name='kafka_cluster.ssl.verify_hostname']");
-  await expect(verify).toBeChecked();
 
   // Submit and check the form data
   await page.click("input[type=submit][value='Save']");
@@ -292,7 +290,7 @@ test("submits the form with namespaced ssl advanced config fields when filled", 
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
   // Click to show the advanced settings, then fill them in
-  await page.click("p:has-text('Advanced SSL Configuration')");
+  await page.click("p:has-text('Advanced SSL/TLS Configuration')");
   await page.selectOption("select[name='kafka_cluster.ssl.truststore.type']", "PEM");
   await page.fill("input[name='kafka_cluster.ssl.truststore.path']", "/path/to/truststore");
   await page.fill("input[name='kafka_cluster.ssl.truststore.password']", "truststore-password");
@@ -448,13 +446,13 @@ test("adds advanced ssl fields even if section is collapsed", async ({ execute, 
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
   // Click to show the advanced settings, then fill them in
-  await page.click("p:has-text('Advanced SSL Configuration')");
+  await page.click("p:has-text('Advanced SSL/TLS Configuration')");
   await page.selectOption("select[name='kafka_cluster.ssl.truststore.type']", "PEM");
   await page.fill("input[name='kafka_cluster.ssl.truststore.path']", "/path/to/truststore");
   await page.fill("input[name='kafka_cluster.ssl.truststore.password']", "truststore-password");
 
   // Click to hide the advanced settings, then submit the form
-  await page.click("p:has-text('Advanced SSL Configuration')");
+  await page.click("p:has-text('Advanced SSL/TLS Configuration')");
   await expect(page.locator("input[name='kafka_cluster.ssl.truststore.path']")).not.toBeVisible();
   await page.click("input[type=submit][value='Save']");
   const submitCallHandle = await sendWebviewMessage.evaluateHandle(

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -169,7 +169,7 @@ class DirectConnectFormViewModel extends ViewModel {
     if (input.name !== "kafka_cluster.auth_type" && input.name !== "schema_registry.auth_type") {
       await post("UpdateSpecValue", { inputName: input.name, inputValue: value });
     }
-
+    // The switch statement performs local side effects for certain inputs
     switch (input.name) {
       case "formconnectiontype":
         this.platformType(input.value as FormConnectionType);
@@ -180,15 +180,6 @@ class DirectConnectFormViewModel extends ViewModel {
           this.schemaSslEnabled(true);
         }
         break;
-      // case "other-platform":
-      //   this.otherPlatformType(input.value);
-      //   break;
-      // case "name":
-      //   this.name(input.value);
-      //   break;
-      // case "kafka_cluster.bootstrap_servers":
-      //   this.kafkaBootstrapServers(input.value);
-      //   break;
       case "kafka_cluster.auth_type":
         this.kafkaAuthType(input.value as SupportedAuthTypes);
         this.clearKafkaCreds();
@@ -197,21 +188,6 @@ class DirectConnectFormViewModel extends ViewModel {
         this.schemaAuthType(input.value as SupportedAuthTypes);
         this.clearSchemaCreds();
         break;
-      // case "schema_registry.uri":
-      //   this.schemaUri(input.value);
-      //   break;
-      // case "kafka_cluster.credentials.username":
-      //   this.kafkaUsername(input.value);
-      //   break;
-      // case "kafka_api_key":
-      //   this.kafkaApiKey(input.value);
-      //   break;
-      // case "schema_username":
-      //   this.schemaUsername(input.value);
-      //   break;
-      // case "schema_api_key":
-      //   this.schemaApiKey(input.value);
-      //   break;
       case "kafka_cluster.ssl.enabled":
         this.kafkaSslEnabled(input.checked);
         break;
@@ -219,7 +195,7 @@ class DirectConnectFormViewModel extends ViewModel {
         this.schemaSslEnabled(input.checked);
         break;
       default:
-        console.log(`Unhandled input update: ${input.name}`);
+        console.info(`No side effects for input update: ${input.name}`);
     }
   }
 

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -146,7 +146,7 @@ export class SslConfig extends HTMLElement {
           </label>
         </div>
         <div class="input-container">
-          <label class="label">KeyStore Configuration</label>
+          <label class="label">Key Store Configuration</label>
           <div class="input-row">
             <div class="input-container" style="flex: 1">
               <label data-attr-for="this.getInputId('keystore.type')" class="info">Type</label>
@@ -216,7 +216,7 @@ export class SslConfig extends HTMLElement {
           </div>
         </div>
         <div class="input-container">
-          <label class="label">TrustStore Configuration</label>
+          <label class="label">Trust Store Configuration</label>
           <div class="input-row">
             <div class="input-container" style="flex: 1">
               <label data-attr-for="this.getInputId('truststore.type')" class="info">Type</label>

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -62,19 +62,11 @@ export class SslConfig extends HTMLElement {
   }
 
   handleFileSelection(inputId: string) {
-    const fileGot: boolean = this.dispatchEvent(
+    this.dispatchEvent(
       new CustomEvent("getfile", {
         detail: { inputId },
       }),
     );
-
-    if (fileGot) {
-      // this makes sure we get the latest file path,
-      // it also collapses then expands the section in background
-      const config = { ...this.configObj() };
-      // @ts-expect-error typescript is complaining because some values can be undefined
-      this.configObj(config); // Update the source signal
-    }
   }
   /** Update the host form data so it contains all the changed values on submit
    * and dispatch a change event to the host for other actions
@@ -161,7 +153,7 @@ export class SslConfig extends HTMLElement {
                 class="input dropdown"
                 data-attr-id="this.getInputId('keystore.type')"
                 data-attr-name="this.getInputId('keystore.type')"
-                data-attr-value="this.keystoreType()"
+                data-value="this.keystoreType()"
                 data-on-change="this.updateValue(event)"
               >
                 <option value="JKS" data-attr-selected="this.keystoreType() === 'JKS'">JKS</option>
@@ -188,7 +180,7 @@ export class SslConfig extends HTMLElement {
                 data-attr-name="this.getInputId('keystore.path')"
                 type="text"
                 placeholder="/path/to/keystore"
-                data-attr-value="this.keystorePath()"
+                data-value="this.keystorePath()"
                 data-on-change="this.updateValue(event)"
               />
             </div>
@@ -203,7 +195,7 @@ export class SslConfig extends HTMLElement {
                 data-attr-id="this.getInputId('keystore.password')"
                 data-attr-name="this.getInputId('keystore.password')"
                 type="password"
-                data-attr-value="this.keystorePassword()"
+                data-value="this.keystorePassword()"
                 data-on-change="this.updateValue(event)"
               />
             </div>
@@ -216,7 +208,7 @@ export class SslConfig extends HTMLElement {
                 data-attr-id="this.getInputId('keystore.key_password')"
                 data-attr-name="this.getInputId('keystore.key_password')"
                 type="password"
-                data-attr-value="this.keystoreKeyPassword()"
+                data-value="this.keystoreKeyPassword()"
                 data-on-change="this.updateValue(event)"
               />
             </div>
@@ -231,7 +223,7 @@ export class SslConfig extends HTMLElement {
                 class="input dropdown"
                 data-attr-id="this.getInputId('truststore.type')"
                 data-attr-name="this.getInputId('truststore.type')"
-                data-attr-value="this.truststoreType()"
+                data-value="this.truststoreType()"
                 data-on-change="this.updateValue(event)"
               >
                 <option value="JKS" data-attr-selected="this.truststoreType() === 'JKS'">
@@ -262,7 +254,7 @@ export class SslConfig extends HTMLElement {
                 data-attr-name="this.getInputId('truststore.path')"
                 type="text"
                 placeholder="/path/to/truststore"
-                data-attr-value="this.truststorePath()"
+                data-value="this.truststorePath()"
                 data-on-change="this.updateValue(event)"
               />
             </div>
@@ -275,7 +267,7 @@ export class SslConfig extends HTMLElement {
                 data-attr-id="this.getInputId('truststore.password')"
                 data-attr-name="this.getInputId('truststore.password')"
                 type="password"
-                data-attr-value="this.truststorePassword()"
+                data-value="this.truststorePassword()"
                 data-on-change="this.updateValue(event)"
               />
             </div>

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -30,26 +30,25 @@ export class SslConfig extends HTMLElement {
     else return true;
   });
   truststorePath = this.os.derive(() => {
-    return this.configObj()?.truststore?.path || null;
+    return this.configObj()?.truststore?.path ?? null;
   });
   truststorePassword = this.os.derive(() => {
-    return this.configObj()?.truststore?.password || null;
+    return this.configObj()?.truststore?.password ?? null;
   });
   truststoreType = this.os.derive(() => {
     return this.configObj()?.truststore?.type;
   });
   keystorePath = this.os.derive(() => {
-    console.log("keystorePath", this.configObj()?.keystore?.path);
-    return this.configObj()?.keystore?.path || null;
+    return this.configObj()?.keystore?.path ?? null;
   });
   keystorePassword = this.os.derive(() => {
-    return this.configObj()?.keystore?.password || null;
+    return this.configObj()?.keystore?.password ?? null;
   });
   keystoreType = this.os.derive(() => {
     return this.configObj()?.keystore?.type;
   });
   keystoreKeyPassword = this.os.derive(() => {
-    return this.configObj()?.keystore?.key_password || null;
+    return this.configObj()?.keystore?.key_password ?? null;
   });
   getInputId(name: string) {
     return this.identifier() + ".ssl." + name;

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -62,11 +62,19 @@ export class SslConfig extends HTMLElement {
   }
 
   handleFileSelection(inputId: string) {
-    this.dispatchEvent(
+    const fileGot: boolean = this.dispatchEvent(
       new CustomEvent("getfile", {
         detail: { inputId },
       }),
     );
+
+    if (fileGot) {
+      // this makes sure we get the latest file path,
+      // it also collapses then expands the section in background
+      const config = { ...this.configObj() };
+      // @ts-expect-error typescript is complaining because some values can be undefined
+      this.configObj(config); // Update the source signal
+    }
   }
   /** Update the host form data so it contains all the changed values on submit
    * and dispatch a change event to the host for other actions

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -30,25 +30,26 @@ export class SslConfig extends HTMLElement {
     else return true;
   });
   truststorePath = this.os.derive(() => {
-    return this.configObj()?.truststore?.path;
+    return this.configObj()?.truststore?.path || null;
   });
   truststorePassword = this.os.derive(() => {
-    return this.configObj()?.truststore?.password;
+    return this.configObj()?.truststore?.password || null;
   });
   truststoreType = this.os.derive(() => {
     return this.configObj()?.truststore?.type;
   });
   keystorePath = this.os.derive(() => {
-    return this.configObj()?.keystore?.path;
+    console.log("keystorePath", this.configObj()?.keystore?.path);
+    return this.configObj()?.keystore?.path || null;
   });
   keystorePassword = this.os.derive(() => {
-    return this.configObj()?.keystore?.password;
+    return this.configObj()?.keystore?.password || null;
   });
   keystoreType = this.os.derive(() => {
     return this.configObj()?.keystore?.type;
   });
   keystoreKeyPassword = this.os.derive(() => {
-    return this.configObj()?.keystore?.key_password;
+    return this.configObj()?.keystore?.key_password || null;
   });
   getInputId(name: string) {
     return this.identifier() + ".ssl." + name;

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -146,10 +146,10 @@ export class SslConfig extends HTMLElement {
         class="heading clickable"
       >
         <span data-text="this.showTLS() ? '-' : '+'"></span>
-        Advanced SSL Configuration
+        Advanced SSL/TLS Configuration
       </p>
       <template data-if="this.showTLS()">
-        <p class="info">Optional settings for advanced SSL configuration</p>
+        <p class="info">Optional settings for advanced SSL/TLS configuration</p>
         <div class="input-container">
           <label class="label">TrustStore Configuration</label>
           <div class="input-row">

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -128,17 +128,6 @@ export class SslConfig extends HTMLElement {
 
   // Template for the component
   template = html`
-    <label class="checkbox" data-attr-for="this.getInputId('verify_hostname')">
-      <input
-        type="checkbox"
-        data-attr-id="this.getInputId('verify_hostname')"
-        data-attr-name="this.getInputId('verify_hostname')"
-        data-attr-checked="this.verifyHostname()"
-        data-on-change="this.updateValue(event);"
-        data-attr-value="this.verifyHostname()"
-      />
-      <span>Verify Server Hostname</span>
-    </label>
     <div class="input-sub-group">
       <p
         data-on-click="this.showTLS(!this.showTLS())"
@@ -151,63 +140,17 @@ export class SslConfig extends HTMLElement {
       <template data-if="this.showTLS()">
         <p class="info">Optional settings for advanced SSL/TLS configuration</p>
         <div class="input-container">
-          <label class="label">TrustStore Configuration</label>
-          <div class="input-row">
-            <div class="input-container" style="flex: 1">
-              <label data-attr-for="this.getInputId('truststore.type')" class="info">Type</label>
-              <select
-                class="input dropdown"
-                data-attr-id="this.getInputId('truststore.type')"
-                data-attr-name="this.getInputId('truststore.type')"
-                data-attr-value="this.truststoreType()"
-                data-on-change="this.updateValue(event)"
-              >
-                <option value="JKS" data-attr-selected="this.truststoreType() === 'JKS'">
-                  JKS
-                </option>
-                <option value="PKCS12" data-attr-selected="this.truststoreType() === 'PKCS12'">
-                  PKCS12
-                </option>
-                <option value="PEM" data-attr-selected="this.truststoreType() === 'PEM'">
-                  PEM
-                </option>
-              </select>
-            </div>
-            <div class="input-container">
-              <label data-attr-for="this.getInputId('truststore.path')" class="info"
-                >Path
-                <span
-                  class="button secondary"
-                  data-attr-id="this.getInputId('truststore.path')"
-                  data-attr-name="this.getInputId('truststore.path')"
-                  data-on-click="this.handleFileSelection(this.getInputId('truststore.path'))"
-                  >Choose file</span
-                ></label
-              >
-              <input
-                class="input"
-                data-attr-id="this.getInputId('truststore.path')"
-                data-attr-name="this.getInputId('truststore.path')"
-                type="text"
-                placeholder="/path/to/truststore"
-                data-attr-value="this.truststorePath()"
-                data-on-change="this.updateValue(event)"
-              />
-            </div>
-            <div class="input-container">
-              <label data-attr-for="this.getInputId('truststore.password')" class="info"
-                >Password</label
-              >
-              <input
-                class="input"
-                data-attr-id="this.getInputId('truststore.password')"
-                data-attr-name="this.getInputId('truststore.password')"
-                type="password"
-                data-attr-value="this.truststorePassword()"
-                data-on-change="this.updateValue(event)"
-              />
-            </div>
-          </div>
+          <label class="checkbox" data-attr-for="this.getInputId('verify_hostname')">
+            <input
+              type="checkbox"
+              data-attr-id="this.getInputId('verify_hostname')"
+              data-attr-name="this.getInputId('verify_hostname')"
+              data-attr-checked="this.verifyHostname()"
+              data-on-change="this.updateValue(event);"
+              data-attr-value="this.verifyHostname()"
+            />
+            <span>Verify Server Hostname</span>
+          </label>
         </div>
         <div class="input-container">
           <label class="label">KeyStore Configuration</label>
@@ -274,6 +217,65 @@ export class SslConfig extends HTMLElement {
                 data-attr-name="this.getInputId('keystore.key_password')"
                 type="password"
                 data-attr-value="this.keystoreKeyPassword()"
+                data-on-change="this.updateValue(event)"
+              />
+            </div>
+          </div>
+        </div>
+        <div class="input-container">
+          <label class="label">TrustStore Configuration</label>
+          <div class="input-row">
+            <div class="input-container" style="flex: 1">
+              <label data-attr-for="this.getInputId('truststore.type')" class="info">Type</label>
+              <select
+                class="input dropdown"
+                data-attr-id="this.getInputId('truststore.type')"
+                data-attr-name="this.getInputId('truststore.type')"
+                data-attr-value="this.truststoreType()"
+                data-on-change="this.updateValue(event)"
+              >
+                <option value="JKS" data-attr-selected="this.truststoreType() === 'JKS'">
+                  JKS
+                </option>
+                <option value="PKCS12" data-attr-selected="this.truststoreType() === 'PKCS12'">
+                  PKCS12
+                </option>
+                <option value="PEM" data-attr-selected="this.truststoreType() === 'PEM'">
+                  PEM
+                </option>
+              </select>
+            </div>
+            <div class="input-container">
+              <label data-attr-for="this.getInputId('truststore.path')" class="info"
+                >Path
+                <span
+                  class="button secondary"
+                  data-attr-id="this.getInputId('truststore.path')"
+                  data-attr-name="this.getInputId('truststore.path')"
+                  data-on-click="this.handleFileSelection(this.getInputId('truststore.path'))"
+                  >Choose file</span
+                ></label
+              >
+              <input
+                class="input"
+                data-attr-id="this.getInputId('truststore.path')"
+                data-attr-name="this.getInputId('truststore.path')"
+                type="text"
+                placeholder="/path/to/truststore"
+                data-attr-value="this.truststorePath()"
+                data-on-change="this.updateValue(event)"
+              />
+            </div>
+            <div class="input-container">
+              <label data-attr-for="this.getInputId('truststore.password')" class="info"
+                >Password</label
+              >
+              <input
+                class="input"
+                data-attr-id="this.getInputId('truststore.password')"
+                data-attr-name="this.getInputId('truststore.password')"
+                type="password"
+                data-attr-value="this.truststorePassword()"
                 data-on-change="this.updateValue(event)"
               />
             </div>


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
A few bug fixes and clean up items on the SSL Config form fields
- make sure these values are stored locally so they are in the form even after collapse/expand, tab away
- use the right binding for text and select input values - it's `data-value` not `data-attr-value` to ensure signals update
- rearrange some fields (key store first) and add "tls" to wording so it's accurate
- minor comment and clean up things (delete unused commented lines, etc)

## Any additional details or context that should be provided?
- ⚠️ Not done: adding tooltip info/descriptions to these fields, and updating the layout of path button+input per suggestions. I will follow up when higher-priority things are done. 

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
Update UI: 
<img width="948" alt="Screenshot 2025-03-04 at 11 30 30 AM" src="https://github.com/user-attachments/assets/eff3f82f-362c-4fbf-8100-6c4e15369118" />

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
