### PR TITLE
docs: Add missing support for snappy compression to known limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
 - Searching for schemas in the Topics and Schemas views is limited to the `subject` field only.
   Searching by other fields, such as `id` and `version`, is not supported due to cost and
   performance considerations.
+- The Message Viewer can't consume records that were compressed with `snappy` except for Confluent
+  Cloud connections.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
 - Searching for schemas in the Topics and Schemas views is limited to the `subject` field only.
   Searching by other fields, such as `id` and `version`, is not supported due to cost and
   performance considerations.
-- The Message Viewer can't consume records that were compressed with `snappy` except for Confluent
-  Cloud connections.
+- The Message Viewer does not support consuming records that were compressed with `snappy`
+  except for Confluent Cloud connections.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
   Searching by other fields, such as `id` and `version`, is not supported due to cost and
   performance considerations.
 - The Message Viewer does not support consuming records that were compressed with `snappy`
-  except for Confluent Cloud connections.
+  except for Confluent Cloud connections ([confluentinc/ide-sidecar#304](https://github.com/confluentinc/ide-sidecar/issues/304)).
 
 ## Support
 


### PR DESCRIPTION
## Summary of Changes

State that the Message Viewer doesn't support consuming records that were compressed with `snappy` except for Confluent Cloud connections.
## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
