### PR TITLE
SASL/SCRAM credentials in direct connection form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this extension will be documented in this file.
   keystore and truststore settings
 - Ability to export and import connection details as JSON files, for easier connection creation and
   sharing
+- SASL/SCRAM authentication type is now supported for Kafka Cluster connections that are added via
+  the connections form
 
 ## 0.25.0
 

--- a/src/directConnect.test.ts
+++ b/src/directConnect.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { parseTestResult, getConnectionSpecFromFormData, cleanSpec } from "./directConnect";
 import { TEST_DIRECT_CONNECTION } from "../tests/unit/testResources/connection";
-import { ConnectedState, Status } from "./clients/sidecar";
+import { ConnectedState, HashAlgorithm, Status } from "./clients/sidecar";
 import { ConnectionId } from "./models/resource";
 import { FormConnectionType } from "./webview/direct-connect-form";
 
@@ -290,6 +290,23 @@ describe("directConnect.ts", () => {
     });
   });
   describe("cleanSpec", () => {
+    it("should not modify the spec if no credentials are present", () => {
+      const spec = {
+        id: "123" as ConnectionId,
+        formConnectionType: "Apache Kafka" as FormConnectionType,
+        name: "Test Connection",
+        kafka_cluster: {
+          bootstrap_servers: "localhost:9092",
+        },
+        schema_registry: {
+          uri: "http://localhost:8081",
+        },
+      };
+      const result = cleanSpec(spec);
+      assert.strictEqual(result.name, "Test Connection");
+      assert.strictEqual(result.kafka_cluster?.bootstrap_servers, "localhost:9092");
+      assert.strictEqual(result.schema_registry?.uri, "http://localhost:8081");
+    });
     it("should replace password fields in Basic credentials with `fakeplaceholdersecrethere` text", () => {
       const spec = {
         id: "123" as ConnectionId,
@@ -401,6 +418,31 @@ describe("directConnect.ts", () => {
       );
       assert.strictEqual(
         result.kafka_cluster?.ssl?.keystore?.key_password,
+        "fakeplaceholdersecrethere",
+      );
+    });
+    it("should replace password fields in SCRAM credentials with `fakeplaceholdersecrethere` text", () => {
+      const spec = {
+        id: "123" as ConnectionId,
+        formConnectionType: "Apache Kafka" as FormConnectionType,
+        name: "Test Scram Connection",
+        kafka_cluster: {
+          bootstrap_servers: "localhost:9092",
+          credentials: {
+            hash_algorithm: "SCRAM_SHA_512" as HashAlgorithm,
+            scram_username: "user",
+            scram_password: "password",
+          },
+        },
+        schema_registry: {
+          uri: "http://localhost:8081",
+        },
+      };
+      const result = cleanSpec(spec);
+      assert.strictEqual(result.name, "Test Scram Connection");
+      assert.strictEqual(
+        // @ts-expect-error - could be api but we're using password here
+        result.kafka_cluster?.credentials?.scram_password,
         "fakeplaceholdersecrethere",
       );
     });

--- a/src/directConnect.test.ts
+++ b/src/directConnect.test.ts
@@ -107,6 +107,34 @@ describe("directConnect.ts", () => {
       // @ts-expect-error - incomplete types from OpenAPI
       assert.strictEqual(spec.schema_registry?.credentials?.api_secret, "secret");
     });
+    it("should return a valid CustomConnectionSpec with SCRAM credentials", () => {
+      const formData = {
+        name: "Test Connection",
+        formconnectiontype: "Kafka",
+        "kafka_cluster.bootstrap_servers": "localhost:9092",
+        "kafka_cluster.auth_type": "SCRAM",
+        "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_512",
+        "kafka_cluster.credentials.scram_username": "user",
+        "kafka_cluster.credentials.scram_password": "pass",
+        "schema_registry.uri": "http://localhost:8081",
+        "schema_registry.auth_type": "None",
+      };
+      const spec = getConnectionSpecFromFormData(formData);
+      assert.strictEqual(spec.name, "Test Connection");
+      assert.ok(spec.kafka_cluster);
+      assert.strictEqual(spec.kafka_cluster.bootstrap_servers, "localhost:9092");
+      assert.ok(spec.kafka_cluster.credentials);
+      // @ts-expect-error - incomplete types from OpenAPI
+      assert.strictEqual(spec.kafka_cluster?.credentials?.hash_algorithm, "SCRAM_SHA_512");
+      // @ts-expect-error - incomplete types from OpenAPI
+      assert.strictEqual(spec.kafka_cluster?.credentials?.scram_username, "user");
+      // @ts-expect-error - incomplete types from OpenAPI
+      assert.strictEqual(spec.kafka_cluster?.credentials?.scram_password, "pass");
+      assert.ok(spec.schema_registry);
+      assert.ok(spec.schema_registry.uri);
+      assert.strictEqual(spec.schema_registry.uri, "http://localhost:8081");
+      assert.strictEqual(spec.schema_registry.credentials, undefined);
+    });
     it("should not include credentials if the auth type is None", () => {
       const formData = {
         name: "Test Connection",

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -7,6 +7,7 @@ import {
   ConnectionType,
   instanceOfApiKeyAndSecret,
   instanceOfBasicCredentials,
+  instanceOfScramCredentials,
 } from "./clients/sidecar";
 import { DirectConnectionManager, mergeSecrets } from "./directConnectManager";
 import { WebviewPanelCache } from "./webview-cache";
@@ -324,6 +325,9 @@ export function cleanSpec(connection: CustomConnectionSpec): CustomConnectionSpe
     }
     if (instanceOfApiKeyAndSecret(clean.kafka_cluster.credentials)) {
       clean.kafka_cluster.credentials.api_secret = "fakeplaceholdersecrethere";
+    }
+    if (instanceOfScramCredentials(clean.kafka_cluster.credentials)) {
+      clean.kafka_cluster.credentials.scram_password = "fakeplaceholdersecrethere";
     }
   }
   if (clean.kafka_cluster?.ssl?.truststore?.password) {

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -220,6 +220,12 @@ export function getConnectionSpecFromFormData(
         api_key: formData["kafka_cluster.credentials.api_key"],
         api_secret: formData["kafka_cluster.credentials.api_secret"],
       };
+    } else if (formData["kafka_cluster.auth_type"] === "SCRAM") {
+      spec.kafka_cluster.credentials = {
+        hash_algorithm: formData["kafka_cluster.credentials.hash_algorithm"],
+        scram_username: formData["kafka_cluster.credentials.scram_username"],
+        scram_password: formData["kafka_cluster.credentials.scram_password"],
+      };
     }
   }
 

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -8,6 +8,7 @@ import {
   ConnectionType,
   instanceOfApiKeyAndSecret,
   instanceOfBasicCredentials,
+  instanceOfScramCredentials,
   ResponseError,
 } from "./clients/sidecar";
 import { getExtensionContext } from "./context/extension";
@@ -342,6 +343,11 @@ export function mergeSecrets(
       if (incomingKafkaCreds.api_secret === "fakeplaceholdersecrethere") {
         if (currentKafkaCreds && instanceOfApiKeyAndSecret(currentKafkaCreds))
           incomingKafkaCreds.api_secret = currentKafkaCreds.api_secret;
+      }
+    } else if (instanceOfScramCredentials(incomingKafkaCreds)) {
+      if (incomingKafkaCreds.scram_password === "fakeplaceholdersecrethere") {
+        if (currentKafkaCreds && instanceOfScramCredentials(currentKafkaCreds))
+          incomingKafkaCreds.scram_password = currentKafkaCreds.scram_password;
       }
     }
   }

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -170,20 +170,46 @@
               >
                 <option
                   value="SCRAM_SHA_256"
-                  data-attr-selected="this.kafkaHash() === 'SCRAM_SHA_256'"
+                  data-attr-selected="this.kafkaHash() === 'SCRAM_SHA_256' ? true : false"
                 >
-                  SCRAM-SHA-256
+                  SCRAM_SHA_256
                 </option>
                 <option
                   value="SCRAM_SHA_512"
-                  data-attr-selected="this.kafkaHash() === 'SCRAM_SHA_512'"
+                  data-attr-selected="this.kafkaHash() === 'SCRAM_SHA_512' ? true : false"
                 >
-                  SCRAM-SHA-512
+                  SCRAM_SHA_512
                 </option>
               </select>
             </div>
+            <div class="input-row">
+              <div class="input-container">
+                <label for="kafka_cluster.credentials.scram_username" class="label">Username</label>
+                <input
+                  class="input"
+                  id="kafka_cluster.credentials.scram_username"
+                  name="kafka_cluster.credentials.scram_username"
+                  type="text"
+                  data-value="this.kafkaScramUsername()"
+                  data-on-change="this.updateValue(event)"
+                  required
+                />
+              </div>
+              <div class="input-container">
+                <label for="kafka_cluster.credentials.scram_password" class="label">Password</label>
+                <input
+                  class="input"
+                  id="kafka_cluster.credentials.scram_password"
+                  name="kafka_cluster.credentials.scram_password"
+                  type="password"
+                  data-value="this.kafkaSecret()"
+                  required
+                  data-on-change="this.updateValue(event)"
+                />
+              </div>
+            </div>
           </template>
-          <template data-if="this.kafkaAuthType() === 'Basic' || this.kafkaAuthType() === 'SCRAM'">
+          <template data-if="this.kafkaAuthType() === 'Basic'">
             <div class="input-row">
               <div class="input-container">
                 <label for="kafka_cluster.credentials.username" class="label">Username</label>

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -127,6 +127,7 @@
               id="kafka_cluster.auth_type"
               name="kafka_cluster.auth_type"
               data-on-change="this.updateValue(event)"
+              data-value="this.kafkaAuthType()"
               data-attr-disabled="this.platformType() === 'Confluent Cloud' ? true : false"
             >
               <option
@@ -139,17 +140,50 @@
                 value="Basic"
                 data-attr-selected="this.kafkaAuthType() === 'Basic' ? true : false"
               >
-                Username & Password
+                Username & Password (SASL/PLAIN)
               </option>
               <option
                 value="API"
                 data-attr-selected="this.kafkaAuthType() === 'API' ? true : false"
               >
-                API Credentials
+                API Credentials (SASL/PLAIN)
+              </option>
+              <option
+                value="SCRAM"
+                data-attr-selected="this.kafkaAuthType() === 'SCRAM' ? true : false"
+              >
+                SASL/SCRAM
               </option>
             </select>
           </div>
-          <template data-if="this.kafkaAuthType() === 'Basic'">
+          <template data-if="this.kafkaAuthType() === 'SCRAM'">
+            <div class="input-container">
+              <label for="kafka_cluster.credentials.hash_algorithm" class="label"
+                >Hash Algorithm</label
+              >
+              <select
+                class="input dropdown"
+                id="kafka_cluster.credentials.hash_algorithm"
+                name="kafka_cluster.credentials.hash_algorithm"
+                data-value="this.kafkaHash()"
+                data-on-change="this.updateValue(event)"
+              >
+                <option
+                  value="SCRAM_SHA_256"
+                  data-attr-selected="this.kafkaHash() === 'SCRAM_SHA_256'"
+                >
+                  SCRAM-SHA-256
+                </option>
+                <option
+                  value="SCRAM_SHA_512"
+                  data-attr-selected="this.kafkaHash() === 'SCRAM_SHA_512'"
+                >
+                  SCRAM-SHA-512
+                </option>
+              </select>
+            </div>
+          </template>
+          <template data-if="this.kafkaAuthType() === 'Basic' || this.kafkaAuthType() === 'SCRAM'">
             <div class="input-row">
               <div class="input-container">
                 <label for="kafka_cluster.credentials.username" class="label">Username</label>

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -491,14 +491,17 @@ test("submits values for SASL/SCRAM auth type when filled in", async ({ execute,
   await page.fill("input[name=name]", "Test Connection");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
   await page.selectOption("select[name='kafka_cluster.auth_type']", "SCRAM");
-  await page.selectOption("select[name='kafka_cluster.credentials.hash_algorithm']", {
-    value: "SCRAM_SHA_512",
-  });
+  await page.selectOption(
+    "select[name='kafka_cluster.credentials.hash_algorithm']",
+    "SCRAM_SHA_256",
+  );
   await page.fill("input[name='kafka_cluster.credentials.scram_username']", "user");
   await page.fill("input[name='kafka_cluster.credentials.scram_password']", "password");
 
   // Submit the form
   await page.click("input[type=submit][value='Save']");
+  await page.waitForTimeout(100); // Wait briefly to ensure the submission completes
+
   const submitCallHandle = await sendWebviewMessage.evaluateHandle(
     (stub) => stub.getCalls().find((call) => call?.args[0] === "Submit")?.args,
   );
@@ -514,13 +517,13 @@ test("submits values for SASL/SCRAM auth type when filled in", async ({ execute,
     "kafka_cluster.ssl.enabled": "true",
     "kafka_cluster.credentials.scram_username": "user",
     "kafka_cluster.credentials.scram_password": "password",
-    "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_512", //FIXME this value is flaky in test!?
+    "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_256",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
     "schema_registry.uri": "",
   });
 });
-//TODO NC maybe a fixture that is the form default values
+
 test("populates values for SASL/SCRAM auth type when they're in the spec", async ({
   execute,
   page,

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -60,6 +60,10 @@ class DirectConnectFormViewModel extends ViewModel {
     // @ts-expect-error the types don't know which credentials are present
     return this.kafkaCreds()?.api_key || "";
   });
+  kafkaScramUsername = this.derive(() => {
+    // @ts-expect-error the types don't know which credentials are present
+    return this.kafkaCreds()?.scram_username ?? null;
+  });
   kafkaSecret = this.derive(() => {
     // if credentials are there it means there is a secret. We handle the secrets in directConnect.ts
     return this.kafkaCreds() ? "fakeplaceholdersecrethere" : "";
@@ -73,7 +77,7 @@ class DirectConnectFormViewModel extends ViewModel {
   });
   kafkaHash = this.derive(() => {
     // @ts-expect-error the types don't know which credentials are present
-    return this.spec()?.kafka_cluster?.credentials?.hash_algorithm ?? "SCRAM_SHA_256";
+    return this.kafkaCreds()?.hash_algorithm ?? "SCRAM_SHA_256";
   });
 
   /** Schema Registry */

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -6,6 +6,7 @@ import {
   ConnectedState,
   instanceOfApiKeyAndSecret,
   instanceOfBasicCredentials,
+  instanceOfScramCredentials,
 } from "../clients/sidecar";
 import { CustomConnectionSpec } from "../storage/resourceManager";
 import { SslConfig } from "./ssl-config-inputs";
@@ -69,6 +70,10 @@ class DirectConnectFormViewModel extends ViewModel {
   });
   kafkaSslConfig = this.derive(() => {
     return this.spec()?.kafka_cluster?.ssl || {};
+  });
+  kafkaHash = this.derive(() => {
+    // @ts-expect-error the types don't know which credentials are present
+    return this.spec()?.kafka_cluster?.credentials?.hash_algorithm ?? "SCRAM_SHA_256";
   });
 
   /** Schema Registry */
@@ -146,6 +151,7 @@ class DirectConnectFormViewModel extends ViewModel {
     if (!creds || typeof creds !== "object") return "None";
     if (instanceOfBasicCredentials(creds)) return "Basic";
     if (instanceOfApiKeyAndSecret(creds)) return "API";
+    if (instanceOfScramCredentials(creds)) return "SCRAM";
     return "None";
   }
   resetTestResults() {
@@ -288,4 +294,4 @@ export type FormConnectionType =
   | "Confluent Platform"
   | "Other";
 
-type SupportedAuthTypes = "None" | "Basic" | "API";
+type SupportedAuthTypes = "None" | "Basic" | "API" | "SCRAM";


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Adds new form fields to the direct connection form to support SASL/SCRAM authentication for Kafka Clusters. 
- Test by adding a connection with SASL/SCRAM auth selected and make sure it saves correctly (you can "export" the connection and check the json, or re-import to verify it's the same). 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Follows the same code paths as other credential types. Tests added for cleaning & merging secrets, and for "translating" the form data to the spec type. New functional tests added to verify the new data is submitted correctly with the form.
- I hope I have time to refactor this a bit in the near future and move auth creds into a separate component like SSL Config

<img width="774" alt="Screenshot 2025-03-05 at 3 14 33 PM" src="https://github.com/user-attachments/assets/c981a1a9-034f-4275-9401-920635748368" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [X] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [X] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
