### PR TITLE
Fix signing out of ccloud with ccloud sr focused doesnt wipe the schemas view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this extension will be documented in this file.
 - SASL/SCRAM authentication type is now supported for Kafka Cluster connections that are added via
   the connections form
 
+### Fixed
+- Logging out of CCloud resets the Topics and/or Schema Registry views if and only if they were focused on CCloud-based broker or schema registry.
+
 ### Changed
 - No longer calls the semi-documented Schema Registry route `GET /schemas`. Subject and schema fetching done through `GET /subjects`, `GET /subjects/<subject>/versions`, and `GET /subjects/{subject}/versions/{version}` routes. Should now be compatible with WarpStream schema registry.
 

--- a/src/sidecar/connections/ccloud.ts
+++ b/src/sidecar/connections/ccloud.ts
@@ -5,6 +5,8 @@ import { ContextValues, getContextValue } from "../../context/values";
 import { currentKafkaClusterChanged, currentSchemaRegistryChanged } from "../../emitters";
 import { Logger } from "../../logging";
 import { getResourceManager } from "../../storage/resourceManager";
+import { SchemasViewProvider } from "../../viewProviders/schemas";
+import { TopicViewProvider } from "../../viewProviders/topics";
 
 const logger = new Logger("sidecar.connections.ccloud");
 
@@ -30,8 +32,18 @@ export async function clearCurrentCCloudResources() {
   // - fire events to update things like the Topics view, Schemas view, etc.
   logger.warn("clearing current CCloud resources from extension state");
   await getResourceManager().deleteCCloudResources();
-  currentKafkaClusterChanged.fire(null);
-  currentSchemaRegistryChanged.fire(null);
+
+  // If we are looking at a CCloud cluster in the Topics view, we need to clear the current cluster.
+  const topicViewProvider = TopicViewProvider.getInstance();
+  if (topicViewProvider.isFocusedOnCCloud()) {
+    currentKafkaClusterChanged.fire(null);
+  }
+
+  // Likewise for the Schema Registry view.
+  const schemasViewProvider = SchemasViewProvider.getInstance();
+  if (schemasViewProvider.isFocusedOnCCloud()) {
+    currentSchemaRegistryChanged.fire(null);
+  }
 }
 
 /** Do we currently have a ccloud connection? */

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -5,6 +5,7 @@ import {
   TEST_CCLOUD_SCHEMA_REGISTRY,
   TEST_CCLOUD_SUBJECT,
   TEST_CCLOUD_SUBJECT_WITH_SCHEMAS,
+  TEST_LOCAL_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { schemaSearchSet } from "../emitters";
@@ -139,5 +140,22 @@ describe("SchemasViewProvider search behavior", () => {
     assert.ok(setSearchSpy.calledWith("foo"));
 
     assert.ok(refreshSpy.calledOnce);
+  });
+
+  it("Test isFocusedOnCCloud() returns true when the current schema registry is a CCloud one", () => {
+    const isFocused = provider.isFocusedOnCCloud();
+    assert.strictEqual(isFocused, true);
+  });
+
+  it("Test isFocusedOnCCloud() returns false when the current schema registry is not ccloud", () => {
+    provider.schemaRegistry = TEST_LOCAL_SCHEMA_REGISTRY;
+    const isFocused = provider.isFocusedOnCCloud();
+    assert.strictEqual(isFocused, false);
+  });
+
+  it("Test isFocusedOnCCloud() returns false when the current schema registry is null", () => {
+    provider.schemaRegistry = null;
+    const isFocused = provider.isFocusedOnCCloud();
+    assert.strictEqual(isFocused, false);
   });
 });

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -7,6 +7,7 @@ import {
   TEST_CCLOUD_SCHEMA,
   TEST_CCLOUD_SUBJECT,
   TEST_CCLOUD_SUBJECT_WITH_SCHEMAS,
+  TEST_LOCAL_KAFKA_CLUSTER,
   TEST_LOCAL_SCHEMA,
 } from "../../tests/unit/testResources";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
@@ -38,6 +39,21 @@ describe("TopicViewProvider methods", () => {
   it("getTreeItem() should return a SubjectTreeItem when given a Subject", () => {
     const treeItem = provider.getTreeItem(TEST_CCLOUD_SUBJECT_WITH_SCHEMAS);
     assert.ok(treeItem instanceof SubjectTreeItem);
+  });
+
+  it("Test isFocusedOnCCloud() returns true when the cluster is a CCloud one", () => {
+    provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
+    assert.strictEqual(provider.isFocusedOnCCloud(), true);
+  });
+
+  it("Test isFocusedOnCCloud() returns false when the cluster is not a CCloud one", () => {
+    provider.kafkaCluster = TEST_LOCAL_KAFKA_CLUSTER;
+    assert.strictEqual(provider.isFocusedOnCCloud(), false);
+  });
+
+  it("Test isFocusedOnCCloud() returns false when the cluster is null", () => {
+    provider.kafkaCluster = null;
+    assert.strictEqual(provider.isFocusedOnCCloud(), false);
   });
 });
 

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -319,6 +319,11 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
     this.searchMatches = new Set();
     this.totalItemCount = 0;
   }
+
+  /** Are we currently viewing a CCloud-based Kafka cluster? */
+  isFocusedOnCCloud(): boolean {
+    return this.kafkaCluster !== null && isCCloud(this.kafkaCluster);
+  }
 }
 
 /** Get the singleton instance of the {@link TopicViewProvider} */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix CCloud logout side effects on view controllers :
  - SHOULD clear topics or schema registry view if currently viewing CCloud-based resources.
  - SHOULD NOT clear topics or schema registry view if NOT currently viewing CCloud-based resources.

While in here:
  - If user clicks on the same SR they were already focused on, short circuit do nothing. Do not reload the SR's subjects. That effect is reserved for the 'reload' icon.
  
## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1137.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
