### PR TITLE
fix: don't use the "value" subject icon for subjects that don't end in `-value`

### DIFF
--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -211,18 +211,22 @@ describe("SubjectTreeItem", () => {
     assert.equal(subjectWithSchemasTreeItem.description, "AVRO (2)");
   });
 
-  it("Test subject icon determination", () => {
-    for (const [name, expected] of [
-      ["test-key", IconNames.KEY_SUBJECT],
-      ["test-value", IconNames.VALUE_SUBJECT],
-      // Should default to value subject even if doesn't smell like it.
-      ["test-other", IconNames.VALUE_SUBJECT],
-    ]) {
-      const subject = new Subject(name, CCLOUD_CONNECTION_ID, "envId" as EnvironmentId, "srId", [
-        TEST_CCLOUD_SCHEMA,
-      ]);
+  for (const [subjectName, iconName, strategy] of [
+    ["test-key", IconNames.KEY_SUBJECT, "TopicNameStrategy"],
+    ["test-value", IconNames.VALUE_SUBJECT, "TopicNameStrategy"],
+    ["test-other", IconNames.OTHER_SUBJECT, "**NOT** TopicNameStrategy"],
+  ]) {
+    it(`subject "${subjectName}" should use the "${iconName}" icon (${strategy})`, () => {
+      const subject = new Subject(
+        subjectName,
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+        [TEST_CCLOUD_SCHEMA],
+      );
       const subjectTreeItem = new SubjectTreeItem(subject);
-      assert.deepEqual((subjectTreeItem.iconPath as vscode.ThemeIcon).id, expected);
-    }
-  });
+
+      assert.deepEqual((subjectTreeItem.iconPath as vscode.ThemeIcon).id, iconName);
+    });
+  }
 });

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -85,9 +85,7 @@ export class Subject implements IResourceBase, ISearchable {
   }
 }
 
-/**
- *
- */
+/** Base class representing a single version of a schema. */
 export class Schema extends Data implements IResourceBase {
   connectionId!: Enforced<ConnectionId>;
   connectionType!: Enforced<ConnectionType>;
@@ -165,9 +163,7 @@ export class SubjectTreeItem extends vscode.TreeItem {
 
     this.id = subject.name;
 
-    // If we have schema bindings, then err on the side of showing the value icon
-    const errOnValueSubject: boolean = subject.schemas != null;
-    this.iconPath = getSubjectIcon(subject.name, errOnValueSubject);
+    this.iconPath = getSubjectIcon(subject.name);
 
     const propertyParts: string[] = new Array<string>();
     if (subject.schemas) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #1130.

There's some weird behavior on `main` that updates a Subject on expansion that converts the "other" icon to the "value" icon (for subjects using the `TopicRecordNameStrategy`/`RecordNameStrategy`) once schemas are loaded that this PR fixes:

| Before | After |
|--------|--------|
| <img width="363" alt="image" src="https://github.com/user-attachments/assets/1cf7f075-8b9b-42b0-b979-cc51b7dd278f" /> | <img width="399" alt="image" src="https://github.com/user-attachments/assets/47e3beed-27b0-4a1f-925e-796f6a1c17d4" /> | 

Subjects following the `TopicNameStrategy` that end in `-key`/`-value` still show the correct icons.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
