### PR TITLE
use input validation warning instead of secondary input for new schema subject creation

### DIFF
--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -241,7 +241,7 @@ export function validateNewSubject(
 ): vscode.InputBoxValidationMessage | undefined {
   if (!userInput.endsWith("-key") && !userInput.endsWith("-value")) {
     return {
-      message: `Subjects not ending in "-key" or "-value" will not match the [TopicNameStrategy](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#overview) and will not automatically associate with Kafka topics. ('Enter' to continue, 'Esc' to cancel)`,
+      message: `Subjects not ending in "-key" or "-value" will not match the [TopicNameStrategy](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#overview) and will not automatically associate with Kafka topics. (Press 'Enter' to confirm 'Escape' to cancel)`,
       severity: vscode.InputBoxValidationSeverity.Warning,
     };
   }

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -241,7 +241,7 @@ export function validateNewSubject(
 ): vscode.InputBoxValidationMessage | undefined {
   if (!userInput.endsWith("-key") && !userInput.endsWith("-value")) {
     return {
-      message: `Subjects not ending in "-key" or "-value" will not match the [TopicNameStrategy](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#overview) and will not automatically associate with Kafka topics. (Press 'Enter' to confirm 'Escape' to cancel)`,
+      message: `Subjects not ending in "-key" or "-value" will not match the [TopicNameStrategy](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#overview) and will not automatically associate with Kafka topics. (Press 'Enter' to confirm or 'Escape' to cancel)`,
       severity: vscode.InputBoxValidationSeverity.Warning,
     };
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Reduces the quickpick/input flow during schema upload and new-subject-creation to validate the new subject value and show a warning, rather than show a follow-on confirmation input.

| | |
|--------|--------|
| Before | <img width="717" alt="image" src="https://github.com/user-attachments/assets/a4c840a1-61cb-4b92-8208-5de6d1456053" /> <img width="713" alt="image" src="https://github.com/user-attachments/assets/7f176908-8e2f-4ac1-acbb-c247b0e87c81" /> |
| After | <img width="717" alt="image" src="https://github.com/user-attachments/assets/0cab2e69-7827-40b8-9bcd-31ae2b896527" /> | 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
