### PR TITLE
remove message-produce preview setting and enable functionality by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this extension will be documented in this file.
 - Updated icons for opening Message Viewer and producing messages to a topic.
 - Producing messages to a topic now offers options to include schema information through a series of
   quickpicks based on user settings.
+- The `confluent.preview.enableProduceMessages` setting has been removed, making message-produce
+  functionality on Kafka topics available by default.
 
 ## 0.25.0
 

--- a/package.json
+++ b/package.json
@@ -471,14 +471,6 @@
           "default": "latest",
           "markdownDescription": "Docker image tag to use when starting a local Schema Registry container. (By default, this will use the [`confluentinc/cp-schema-registry`](https://hub.docker.com/r/confluentinc/cp-schema-registry/tags) image.)"
         },
-        "confluent.preview.enableProduceMessages": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable message production for Kafka topics.",
-          "tags": [
-            "preview"
-          ]
-        },
         "confluent.topic.produceMessages.schemas.useTopicNameStrategy": {
           "type": "boolean",
           "default": true,
@@ -973,7 +965,7 @@
         },
         {
           "command": "confluent.topic.produce.fromDocument",
-          "when": "view == confluent-topics && viewItem =~ /.*-topic.*-authzWRITE.*/ && confluent.produceMessagesEnabled",
+          "when": "view == confluent-topics && viewItem =~ /.*-topic.*-authzWRITE.*/",
           "group": "inline@2"
         },
         {

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -64,9 +64,4 @@ export enum ContextValues {
   topicSearchApplied = "confluent.topicSearchApplied",
   /** The user applied a search string to the Schemas view. */
   schemaSearchApplied = "confluent.schemaSearchApplied",
-  /**
-   * PREVIEW: Is the "produce message" functionality enabled at all?
-   * (This should go away once the `confluent.preview.enableProduceMessages` setting is removed.)
-   */
-  produceMessagesEnabled = "confluent.produceMessagesEnabled",
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,11 +68,7 @@ import { MessageDocumentProvider } from "./documentProviders/message";
 import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { constructResourceLoaderSingletons } from "./loaders";
 import { Logger, outputChannel } from "./logging";
-import {
-  ENABLE_PRODUCE_MESSAGES,
-  SSL_PEM_PATHS,
-  SSL_VERIFY_SERVER_CERT_DISABLED,
-} from "./preferences/constants";
+import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
 import { registerProjectGenerationCommand } from "./scaffold";
@@ -253,12 +249,6 @@ async function _activateExtension(
 
 /** Configure any starting contextValues to use for view/menu controls during activation. */
 async function setupContextValues() {
-  // PREVIEW: set default values for enabling the direct connection and message-produce features
-  const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-  const produceMessagesEnabled = setContextValue(
-    ContextValues.produceMessagesEnabled,
-    config.get(ENABLE_PRODUCE_MESSAGES, false),
-  );
   // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
   const kafkaClusterSelected = setContextValue(ContextValues.kafkaClusterSelected, false);
   const schemaRegistrySelected = setContextValue(ContextValues.schemaRegistrySelected, false);
@@ -301,7 +291,6 @@ async function setupContextValues() {
     "direct-schema-registry",
   ]);
   await Promise.all([
-    produceMessagesEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,
     openInCCloudResources,

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -32,5 +32,3 @@ export const USE_TOPIC_NAME_STRATEGY =
 /** Whether to allow selecting older (than latest) schema versions when producing messages to a topic. */
 export const ALLOW_OLDER_SCHEMA_VERSIONS =
   prefix + "topic.produceMessages.schemas.allowOlderVersions";
-
-export const ENABLE_PRODUCE_MESSAGES = prefix + "preview.enableProduceMessages";

--- a/src/preferences/listener.test.ts
+++ b/src/preferences/listener.test.ts
@@ -2,12 +2,7 @@ import * as assert from "assert";
 import sinon from "sinon";
 import { ConfigurationChangeEvent, workspace } from "vscode";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
-import * as contextValues from "../context/values";
-import {
-  ENABLE_PRODUCE_MESSAGES,
-  SSL_PEM_PATHS,
-  SSL_VERIFY_SERVER_CERT_DISABLED,
-} from "./constants";
+import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
 import { createConfigChangeListener } from "./listener";
 import * as updates from "./updates";
 
@@ -15,7 +10,6 @@ describe("preferences/listener", function () {
   let sandbox: sinon.SinonSandbox;
   let getConfigurationStub: sinon.SinonStub;
   let onDidChangeConfigurationStub: sinon.SinonStub;
-  let setContextValueStub: sinon.SinonStub;
 
   before(async () => {
     // ResourceViewProvider interactions require the extension context to be set (used during changes
@@ -28,7 +22,6 @@ describe("preferences/listener", function () {
     // stub the WorkspaceConfiguration and onDidChangeConfiguration emitter
     getConfigurationStub = sandbox.stub(workspace, "getConfiguration");
     onDidChangeConfigurationStub = sandbox.stub(workspace, "onDidChangeConfiguration");
-    setContextValueStub = sandbox.stub(contextValues, "setContextValue");
   });
 
   afterEach(function () {
@@ -85,25 +78,26 @@ describe("preferences/listener", function () {
     assert.ok(updatePreferencesStub.notCalled);
   });
 
-  for (const [previewSetting, previewContextValue] of [
-    [ENABLE_PRODUCE_MESSAGES, contextValues.ContextValues.produceMessagesEnabled],
-  ]) {
-    for (const enabled of [true, false]) {
-      it(`should update the "${previewContextValue}" context value when the "${previewSetting}" setting is changed to ${enabled} (REMOVE ONCE PREVIEW SETTING IS NO LONGER USED)`, async () => {
-        getConfigurationStub.returns({
-          get: sandbox.stub().withArgs(previewSetting).returns(enabled),
-        });
-        const mockEvent = {
-          affectsConfiguration: (config: string) => config === previewSetting,
-        } as ConfigurationChangeEvent;
-        onDidChangeConfigurationStub.yields(mockEvent);
+  // TODO: uncomment this when we have preview/experimental settings again
+  // for (const [previewSetting, previewContextValue] of [
+  //   // [SETTING_CONST, contextValues.ContextValues.valueHere],
+  // ]) {
+  //   for (const enabled of [true, false]) {
+  //     it(`should update the "${previewContextValue}" context value when the "${previewSetting}" setting is changed to ${enabled} (REMOVE ONCE PREVIEW SETTING IS NO LONGER USED)`, async () => {
+  //       getConfigurationStub.returns({
+  //         get: sandbox.stub().withArgs(previewSetting).returns(enabled),
+  //       });
+  //       const mockEvent = {
+  //         affectsConfiguration: (config: string) => config === previewSetting,
+  //       } as ConfigurationChangeEvent;
+  //       onDidChangeConfigurationStub.yields(mockEvent);
 
-        createConfigChangeListener();
-        // simulate the setting being changed by the user
-        await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
+  //       createConfigChangeListener();
+  //       // simulate the setting being changed by the user
+  //       await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
 
-        assert.ok(setContextValueStub.calledWith(previewContextValue, enabled));
-      });
-    }
-  }
+  //       assert.ok(setContextValueStub.calledWith(previewContextValue, enabled));
+  //     });
+  //   }
+  // }
 });

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,11 +1,6 @@
 import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration } from "vscode";
-import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
-import {
-  ENABLE_PRODUCE_MESSAGES,
-  SSL_PEM_PATHS,
-  SSL_VERIFY_SERVER_CERT_DISABLED,
-} from "./constants";
+import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
 import { updatePreferences } from "./updates";
 
 const logger = new Logger("preferences.listener");
@@ -40,15 +35,6 @@ export function createConfigChangeListener(): Disposable {
       // --- PREVIEW SETTINGS --
       // Remove the sections below once the behavior is enabled by default and a setting is no
       // longer needed to opt-in to the feature.
-
-      if (event.affectsConfiguration(ENABLE_PRODUCE_MESSAGES)) {
-        // user toggled the "Enable Produce Messages" preview setting
-        const enabled = configs.get(ENABLE_PRODUCE_MESSAGES, false);
-        logger.debug(`"${ENABLE_PRODUCE_MESSAGES}" config changed`, { enabled });
-        setContextValue(ContextValues.produceMessagesEnabled, enabled);
-        // no need to refresh the Topics view here since no items are being changed; VS Code will
-        // handle updating the UI to toggle any actions' visibility/enablement
-      }
     },
   );
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #1157.

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/8c4bcf32-6894-41e9-92b4-15ca40ad3f28" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
