### PR TITLE
Make environmentChanged events more informative

### DIFF
--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -28,6 +28,7 @@ export type EnvironmentChangeEvent = {
   /** Was it that the env has been deleted? */
   wasDeleted: boolean;
 };
+
 /**
  * Fired whenever a property of an {@link Environment} has changed. (Mainly to affect watchers in
  * the Topics/Schemas views, or similar.)

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -21,9 +21,18 @@ export const directConnectionsChanged = new vscode.EventEmitter<void>();
 export const localKafkaConnected = new vscode.EventEmitter<boolean>();
 export const localSchemaRegistryConnected = new vscode.EventEmitter<boolean>();
 
-/** Fired whenever a property of an {@link Environment} has changed. (Mainly to affect watchers in
- * the Topics/Schemas views, or similar.) */
-export const environmentChanged = new vscode.EventEmitter<EnvironmentId>();
+/** Event type used by {@link environmentChanged} */
+export type EnvironmentChangeEvent = {
+  /** The environment that changed. */
+  id: EnvironmentId;
+  /** Was it that the env has been deleted? */
+  wasDeleted: boolean;
+};
+/**
+ * Fired whenever a property of an {@link Environment} has changed. (Mainly to affect watchers in
+ * the Topics/Schemas views, or similar.)
+ **/
+export const environmentChanged = new vscode.EventEmitter<EnvironmentChangeEvent>();
 
 /**
  * Fired whenever a Kafka cluster is selected from the Resources view, chosen from the "Select Kafka

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -46,7 +46,7 @@ export async function waitForConnectionToBeStable(
     connectionStable.fire(id);
     // and trigger any kind of Topics/Schemas refresh to reenforce the error state / clear out any
     // old data
-    environmentChanged.fire(id as unknown as EnvironmentId);
+    environmentChanged.fire({ id: id as unknown as EnvironmentId, wasDeleted: false });
     const lastConnectionEvent = connectionStateWatcher.getLatestConnectionEvent(id);
     if (lastConnectionEvent) {
       showErrorNotificationWithButtons(

--- a/src/sidecar/connections/watcherUtils.test.ts
+++ b/src/sidecar/connections/watcherUtils.test.ts
@@ -105,13 +105,26 @@ describe("connectionEventHandler", () => {
       connectionEventHandler(testConnectionEvent);
 
       // Assert
-      assert.strictEqual(connectionStableFireStub.calledOnce, true);
+      assert.strictEqual(connectionStableFireStub.calledOnce, true, "one");
       // called with the connection id
-      assert.strictEqual(connectionStableFireStub.calledWith(TEST_DIRECT_CONNECTION.id), true);
+      assert.strictEqual(
+        connectionStableFireStub.calledWith(TEST_DIRECT_CONNECTION.id),
+        true,
+        "two",
+      );
 
-      assert.strictEqual(environmentChangedFireStub.calledOnce, true);
-      // called with the connection id cast as environment id
-      assert.strictEqual(environmentChangedFireStub.calledWith(TEST_DIRECT_CONNECTION.id), true);
+      assert.strictEqual(environmentChangedFireStub.calledOnce, true, "three");
+
+      assert.strictEqual(
+        environmentChangedFireStub.calledWith({
+          id: TEST_DIRECT_CONNECTION.id,
+          wasDeleted:
+            action === ConnectionEventAction.DELETED ||
+            action === ConnectionEventAction.DISCONNECTED,
+        }),
+        true,
+        "four",
+      );
     });
   }
 

--- a/src/sidecar/connections/watcherUtils.ts
+++ b/src/sidecar/connections/watcherUtils.ts
@@ -37,7 +37,7 @@ export function connectionEventHandler(event: ConnectionEventBody) {
             connectionStable.fire(id);
             // notify subscribers that the "environment" has changed since direct connections are treated
             // as environment-specific resources
-            environmentChanged.fire(environmentId);
+            environmentChanged.fire({ id: environmentId, wasDeleted: false });
           } else {
             logger.info(
               `connectionEventHandler: direct connection ${event.action} ${connection.id} not stable, not firing side-effects.`,
@@ -53,7 +53,7 @@ export function connectionEventHandler(event: ConnectionEventBody) {
           // Stop any loading spinny...
           connectionStable.fire(id);
           // ???
-          environmentChanged.fire(environmentId);
+          environmentChanged.fire({ id: environmentId, wasDeleted: true });
           break;
         default:
           logger.warn(`connectionEventHandler: unhandled ccloud connection action ${event.action}`);

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -361,7 +361,7 @@ describe("SchemasViewProvider environmentChanged handler", () => {
   });
 
   for (const currentRegistry of [TEST_LOCAL_SCHEMA_REGISTRY, null]) {
-    it("Firing environmentChanged when SR not germane should do nothing", () => {
+    it(`Firing environmentChanged when SR set a ${currentRegistry?.environmentId} environment SR and event is for other env should do nothing`, () => {
       const resetFake = sandbox.fake();
       const updateTreeViewDescriptionFake = sandbox.fake();
       const refreshFake = sandbox.fake();

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -1,15 +1,17 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import {
+  TEST_CCLOUD_ENVIRONMENT_ID,
   TEST_CCLOUD_SCHEMA,
   TEST_CCLOUD_SCHEMA_REGISTRY,
   TEST_CCLOUD_SUBJECT,
   TEST_CCLOUD_SUBJECT_WITH_SCHEMAS,
+  TEST_LOCAL_ENVIRONMENT_ID,
   TEST_LOCAL_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
-import { getTestExtensionContext } from "../../tests/unit/testUtils";
+import { getTestExtensionContext, pause } from "../../tests/unit/testUtils";
 import { ContextValues, getContextValue } from "../context/values";
-import { currentSchemaRegistryChanged, schemaSearchSet } from "../emitters";
+import { currentSchemaRegistryChanged, environmentChanged, schemaSearchSet } from "../emitters";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { SchemasViewProvider } from "./schemas";
 import { SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -120,6 +122,67 @@ describe("SchemasViewProvider setSchemaRegistry()", () => {
       assert.ok(setSchemaRegistryFake.calledWith(newRegistry));
     }
   });
+
+  it("Firing environmentChanged + deleted should call reset()", async () => {
+    const resetFake = sandbox.fake();
+    sandbox.replace(provider, "reset", resetFake);
+
+    // Be set to a SR within the environment being deleted
+    provider.schemaRegistry = TEST_LOCAL_SCHEMA_REGISTRY;
+    // fire the event
+    environmentChanged.fire({ id: TEST_LOCAL_ENVIRONMENT_ID, wasDeleted: true });
+
+    // Should have called .reset()
+    assert.ok(resetFake.calledOnce);
+  });
+
+  it("Firing environmentChanged + misc change should not call reset(), should call updateTreeViewDescription + refresh", async () => {
+    const resetFake = sandbox.fake();
+    const updateTreeViewDescriptionFake = sandbox.fake();
+    const refreshFake = sandbox.fake();
+
+    sandbox.replace(provider, "reset", resetFake);
+    sandbox.replace(provider, "updateTreeViewDescription", updateTreeViewDescriptionFake);
+    sandbox.replace(provider, "refresh", refreshFake);
+
+    // Be set to a SR within the environment being deleted
+    provider.schemaRegistry = TEST_LOCAL_SCHEMA_REGISTRY;
+    // fire the event
+    environmentChanged.fire({ id: TEST_LOCAL_ENVIRONMENT_ID, wasDeleted: false });
+
+    // Need to pause an iota to get the refresh to be called, is after first await in the block.
+    await pause(100);
+
+    assert.ok(resetFake.notCalled);
+    assert.ok(updateTreeViewDescriptionFake.calledOnce);
+    assert.ok(refreshFake.calledOnce);
+  });
+
+  for (const currentRegistry of [TEST_LOCAL_SCHEMA_REGISTRY, null]) {
+    it("Firing environmentChanged when SR not germane should do nothing", () => {
+      const resetFake = sandbox.fake();
+      const updateTreeViewDescriptionFake = sandbox.fake();
+      const refreshFake = sandbox.fake();
+
+      sandbox.replace(provider, "reset", resetFake);
+      sandbox.replace(provider, "updateTreeViewDescription", updateTreeViewDescriptionFake);
+      sandbox.replace(provider, "refresh", refreshFake);
+
+      // Be set to a SR NOT within the environment being updated, or null.
+      provider.schemaRegistry = currentRegistry;
+
+      // fire the event against some other environment.
+      environmentChanged.fire({
+        id: TEST_CCLOUD_ENVIRONMENT_ID,
+        wasDeleted: false,
+      });
+
+      // Should not have called any of these
+      assert.ok(resetFake.notCalled);
+      assert.ok(updateTreeViewDescriptionFake.notCalled);
+      assert.ok(refreshFake.notCalled);
+    });
+  }
 });
 
 describe("SchemasViewProvider search behavior", () => {
@@ -243,4 +306,83 @@ describe("SchemasViewProvider search behavior", () => {
     const isFocused = provider.isFocusedOnCCloud();
     assert.strictEqual(isFocused, false);
   });
+});
+
+describe("SchemasViewProvider environmentChanged handler", () => {
+  let provider: SchemasViewProvider;
+  let sandbox: sinon.SinonSandbox;
+
+  before(async () => {
+    await getTestExtensionContext();
+    provider = SchemasViewProvider.getInstance();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Firing environmentChanged + deleted should call reset()", async () => {
+    const resetFake = sandbox.fake();
+    sandbox.replace(provider, "reset", resetFake);
+
+    // Be set to a SR within the environment being deleted
+    provider.schemaRegistry = TEST_LOCAL_SCHEMA_REGISTRY;
+    // fire the event
+    environmentChanged.fire({ id: TEST_LOCAL_ENVIRONMENT_ID, wasDeleted: true });
+
+    // Should have called .reset()
+    assert.ok(resetFake.calledOnce);
+  });
+
+  it("Firing environmentChanged + misc change should not call reset(), should call updateTreeViewDescription + refresh", async () => {
+    const resetFake = sandbox.fake();
+    const updateTreeViewDescriptionFake = sandbox.fake();
+    const refreshFake = sandbox.fake();
+
+    sandbox.replace(provider, "reset", resetFake);
+    sandbox.replace(provider, "updateTreeViewDescription", updateTreeViewDescriptionFake);
+    sandbox.replace(provider, "refresh", refreshFake);
+
+    // Be set to a SR within the environment being deleted
+    provider.schemaRegistry = TEST_LOCAL_SCHEMA_REGISTRY;
+    // fire the event
+    environmentChanged.fire({ id: TEST_LOCAL_ENVIRONMENT_ID, wasDeleted: false });
+
+    // Need to pause an iota to get the refresh to be called, is after first await in the block.
+    await pause(100);
+
+    assert.ok(resetFake.notCalled);
+    assert.ok(updateTreeViewDescriptionFake.calledOnce);
+    assert.ok(refreshFake.calledOnce);
+  });
+
+  for (const currentRegistry of [TEST_LOCAL_SCHEMA_REGISTRY, null]) {
+    it("Firing environmentChanged when SR not germane should do nothing", () => {
+      const resetFake = sandbox.fake();
+      const updateTreeViewDescriptionFake = sandbox.fake();
+      const refreshFake = sandbox.fake();
+
+      sandbox.replace(provider, "reset", resetFake);
+      sandbox.replace(provider, "updateTreeViewDescription", updateTreeViewDescriptionFake);
+      sandbox.replace(provider, "refresh", refreshFake);
+
+      // Be set to a SR NOT within the environment being updated, or null.
+      provider.schemaRegistry = currentRegistry;
+
+      // fire the event against some other environment.
+      environmentChanged.fire({
+        id: TEST_CCLOUD_ENVIRONMENT_ID,
+        wasDeleted: false,
+      });
+
+      // Should not have called any of these
+      assert.ok(resetFake.notCalled);
+      assert.ok(updateTreeViewDescriptionFake.notCalled);
+      assert.ok(refreshFake.notCalled);
+    });
+  }
 });

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -313,7 +313,7 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
               },
             );
             await this.updateTreeViewDescription();
-            this.refresh();
+            await this.refresh();
           } else {
             logger.debug(
               "environmentChanged deletion event fired with matching SR env ID, resetting view",

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -102,3 +102,7 @@ export function createTestSubject(schemaRegistry: SchemaRegistry, name: string):
     schemaRegistry.id,
   );
 }
+
+export async function pause(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Event emitter `environmentChanged` was born just carrying the env id which was changed, but information about what kind of change, specifically if the environment has just been _deleted_ was being discarded, leading to small UI issues including that if the topics or schemas views were set to a cluster within the now gone environment, the view description line would not be cleared properly.
- Fix through:
  - Extending the type carried by the event to be a pair: the env id, and boolean `wasDeleted`.
  - Having the event listeners pivot off of if `wasDeleted` was set, and opt to call `this.reset()` accordingly.
- Now with thorough test coverage over the two view controller event listeners.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1159 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
