### PR TITLE
Dregs from comments from https://github.com/confluentinc/vscode/pull/1163

### DIFF
--- a/src/sidecar/connections/watcherUtils.test.ts
+++ b/src/sidecar/connections/watcherUtils.test.ts
@@ -105,15 +105,11 @@ describe("connectionEventHandler", () => {
       connectionEventHandler(testConnectionEvent);
 
       // Assert
-      assert.strictEqual(connectionStableFireStub.calledOnce, true, "one");
+      assert.strictEqual(connectionStableFireStub.calledOnce, true);
       // called with the connection id
-      assert.strictEqual(
-        connectionStableFireStub.calledWith(TEST_DIRECT_CONNECTION.id),
-        true,
-        "two",
-      );
+      assert.strictEqual(connectionStableFireStub.calledWith(TEST_DIRECT_CONNECTION.id), true);
 
-      assert.strictEqual(environmentChangedFireStub.calledOnce, true, "three");
+      assert.strictEqual(environmentChangedFireStub.calledOnce, true);
 
       assert.strictEqual(
         environmentChangedFireStub.calledWith({
@@ -123,7 +119,6 @@ describe("connectionEventHandler", () => {
             action === ConnectionEventAction.DISCONNECTED,
         }),
         true,
-        "four",
       );
     });
   }

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -12,7 +12,7 @@ import {
   TEST_LOCAL_KAFKA_CLUSTER,
   TEST_LOCAL_SCHEMA,
 } from "../../tests/unit/testResources";
-import { getTestExtensionContext, pause } from "../../tests/unit/testUtils";
+import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { environmentChanged, topicSearchSet } from "../emitters";
 import { CCloudResourceLoader } from "../loaders";
 import { SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
@@ -198,6 +198,7 @@ describe("TopicViewProvider search behavior", () => {
 describe("TopicViewProvider environmentChanged handler", () => {
   let provider: TopicViewProvider;
   let sandbox: sinon.SinonSandbox;
+  let clock: sinon.SinonFakeTimers;
 
   before(async () => {
     await getTestExtensionContext();
@@ -206,6 +207,7 @@ describe("TopicViewProvider environmentChanged handler", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    clock = sandbox.useFakeTimers(Date.now());
   });
 
   afterEach(() => {
@@ -240,7 +242,7 @@ describe("TopicViewProvider environmentChanged handler", () => {
     environmentChanged.fire({ id: TEST_LOCAL_ENVIRONMENT_ID, wasDeleted: false });
 
     // Need to pause an iota to get the refresh to be called, is after first await in the block.
-    await pause(100);
+    await clock.tickAsync(100);
 
     assert.ok(resetFake.notCalled);
     assert.ok(updateTreeViewDescriptionFake.calledOnce);

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -102,7 +102,3 @@ export function createTestSubject(schemaRegistry: SchemaRegistry, name: string):
     schemaRegistry.id,
   );
 }
-
-export async function pause(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
Automerge fired too soon.

* Address a couple more things from comments on https://github.com/confluentinc/vscode/pull/1163
* Remove redundant spelling of tests. They were born in the wrong describe() block, then copy/paste into new block.

