### PR TITLE
chore(CI): use `test-results gen-pipeline-report` for unified test report in Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -133,6 +133,13 @@ blocks:
           - export GIT_BRANCH=$SEMAPHORE_GIT_BRANCH
           - make validate-bump
 
+after_pipeline:
+  task:
+    jobs:
+      - name: Publish Test Results to Semaphore
+        commands:
+          - test-results gen-pipeline-report || echo "Could not publish pipeline test result report due to probably no test results to publish"
+
 promotions:
   - name: Multi-Arch VSIX Packaging and Upload
     pipeline_file: multi-arch-packaging.yml


### PR DESCRIPTION
Same as the sidecar:
https://github.com/confluentinc/ide-sidecar/blob/0eb5a1cbe1562ffbc3e7ef90e8ce70674a54f8cd/.semaphore/semaphore.yml#L70C1-L75C144

Should hopefully make it easier to compare results between VS Code (stable) and VS Code Insiders tests if there are any failures
https://docs.semaphoreci.com/using-semaphore/tests/test-reports