### PR TITLE
chore(CI): set `testsuitesTitle`

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -4,6 +4,7 @@ import Mocha from "mocha";
 import { resolve } from "path";
 
 export async function run() {
+  const version = process.env.VSCODE_VERSION ?? "stable";
   const mocha = new Mocha({
     color: true,
     ui: "bdd",
@@ -12,6 +13,7 @@ export async function run() {
     reporterOptions: {
       reporterEnabled: "spec, mocha-junit-reporter",
       mochaJunitReporterReporterOptions: {
+        testsuitesTitle: `VS Code (${version}) Extension Tests: Mocha`,
         mochaFile: "TEST-result.xml",
       },
     },


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/vscode/pull/1165 since the test report was merging the test results between stable and insiders under one `Mocha Tests` result.

This splits the test results into two suites based on how we set up the environment variables in the [pipeline](https://github.com/confluentinc/vscode/blob/8af2dadd0cc7b67c34e3cc34adffee1dac13ce5f/.semaphore/semaphore.yml#L40-L68):
- "VS Code (stable) Extension Tests: Mocha"
- "VS Code (insiders) Extension Tests: Mocha"
<img width="781" alt="image" src="https://github.com/user-attachments/assets/ae550d37-0105-45bd-b469-53f800335906" />


https://www.npmjs.com/package/mocha-junit-reporter#:~:text=to%20%27Root%20Suite%27)-,testsuitesTitle,-Mocha%20Tests