### PR TITLE
add telemetry for failing-to-connect direct connections

### DIFF
--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -110,6 +110,8 @@ export function notifyIfFailedState(connection: Connection) {
     logUsage(UserEvent.DirectConnectionAction, {
       action: "failed",
       connectionType: type,
+      // only send the keys/fields used to indicate which auth type(s) are used so we can tell if this
+      // was for basic auth, oauth, SCRAM, etc. not sending any actual credentials
       kafkaConfigAuthType: connection.spec.kafka_cluster?.credentials
         ? Object.keys(connection.spec.kafka_cluster.credentials)
         : undefined,

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -76,16 +76,16 @@ export async function waitForConnectionToBeStable(
  * and provide buttons to open the logs or file an issue.
  */
 export function notifyIfFailedState(connection: Connection) {
-  let failedStatuses: string[] = [];
+  let failedConfigTypes: string[] = [];
   let notificationButtons: Record<string, () => void> | undefined;
 
   const type: ConnectionType = connection.spec.type!;
   switch (type) {
     case ConnectionType.Direct:
       {
-        if (connection.status.kafka_cluster?.state === "FAILED") failedStatuses.push("Kafka");
+        if (connection.status.kafka_cluster?.state === "FAILED") failedConfigTypes.push("Kafka");
         if (connection.status.schema_registry?.state === "FAILED")
-          failedStatuses.push("Schema Registry");
+          failedConfigTypes.push("Schema Registry");
         notificationButtons = {
           "View Connection Details": () =>
             commands.executeCommand("confluent.connections.direct.edit", connection.id),
@@ -93,16 +93,16 @@ export function notifyIfFailedState(connection: Connection) {
       }
       break;
     case ConnectionType.Ccloud: {
-      if (connection.status.ccloud?.state === "FAILED") failedStatuses.push("Confluent Cloud");
+      if (connection.status.ccloud?.state === "FAILED") failedConfigTypes.push("Confluent Cloud");
       // don't assign any buttons and allow the "Open Logs" + "File Issue" buttons to show by default
     }
   }
 
   // the notifications don't allow rich formatting here, so we'll just list out the failed resources
   // and then try to show the errors themselves in the item tooltips if possible
-  if (failedStatuses.length > 0) {
+  if (failedConfigTypes.length > 0) {
     showErrorNotificationWithButtons(
-      `Failed to establish connection to ${failedStatuses.join(" and ")} for "${connection.spec.name}".`,
+      `Failed to establish connection to ${failedConfigTypes.join(" and ")} for "${connection.spec.name}".`,
       notificationButtons,
     );
     // send an event for failed connections to help understand how often this happens, for which
@@ -119,13 +119,13 @@ export function notifyIfFailedState(connection: Connection) {
     const schemaRegistryConfigSslEnabled: boolean | undefined =
       connection.spec.schema_registry?.ssl?.enabled;
     logUsage(UserEvent.DirectConnectionAction, {
-      action: "failed",
+      action: "failed to connect",
       connectionType: type,
       kafkaConfigAuthFields,
       kafkaConfigSslEnabled,
       schemaRegistryConfigAuthFields,
       schemaRegistryConfigSslEnabled,
-      failedConfigTypes: failedStatuses.join(", "),
+      failedConfigTypes,
     });
   }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Adds the sending of a new telemetry event in the instance of "direct" connections that fail to connect.


Sample event data for:
- a connection using Kafka with basic auth and SSL/TLS disabled:
<img width="938" alt="image" src="https://github.com/user-attachments/assets/592f86dc-c717-40b2-a4a8-b184106b0cb6" />

- a connection using SR with username/password and SSL/TLS disabled:
<img width="944" alt="image" src="https://github.com/user-attachments/assets/49191736-b165-4bcb-b0c2-703f2104cca1" />

- a connection using Kafka with SCRAM and SSL/TLS enabled + SR with API key/secret and SSL/TLS enabled (where only the Kafka connection is failing):
<img width="962" alt="image" src="https://github.com/user-attachments/assets/5a6b5a63-25dd-4d81-b11c-4eb0e738e59f" />


Closes #1153 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
