### PR TITLE
update description for CCloud use

### DIFF
--- a/package.json
+++ b/package.json
@@ -446,7 +446,7 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Path(s) to `.pem` file(s) to use for SSL/TLS connections when making requests to Confluent/Kafka resources. (You can also use the [\"Add SSL/TLS PEM Path\" command](command:confluent.connections.addSSLPemPath).)"
+          "markdownDescription": "Path(s) to `.pem` file(s) to use for SSL/TLS connections when making requests to Confluent Cloud. (You can also use the [\"Add SSL/TLS PEM Path\" command](command:confluent.connections.addSSLPemPath).)\n\n_NOTE: This is only used for the main Confluent Cloud connection, and does not apply to custom/'direct' connections._"
         },
         "confluent.localDocker.socketPath": {
           "type": "string",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Updates the description of the `confluent.ssl.pemPaths` setting to be CCloud specific and help users avoid using it for direct connections (or otherwise).

| Before | After |
|--------|--------|
| <img width="536" alt="image" src="https://github.com/user-attachments/assets/28c55b74-7f24-457e-943d-324bf946b9bf" /> | <img width="541" alt="image" src="https://github.com/user-attachments/assets/66a8e979-9a55-4c01-bb35-852cfc99b3db" /> | 

We may want to update the id/name of this as well to be more CCloud-focused, but that should probably come with a migration to get users' existing settings swapped over to it and include a `deprecationMessage` on the current setting id.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
