### PR TITLE
[v0.26.x] watch for issues during sidecar process start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Additional logging and telemetry for any issues with the sidecar process starting up to help
+  diagnose issues with the extension.
+
 ## 0.26.0
 
 ### Added

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -9,7 +9,6 @@ import * as vscode from "vscode";
 import { Configuration, HandshakeResourceApi, SidecarVersionResponse } from "../clients/sidecar";
 import { Logger, OUTPUT_CHANNEL } from "../logging";
 import { getStorageManager } from "../storage";
-import { checkSidecarOsAndArch } from "./checkArchitecture";
 import {
   SIDECAR_BASE_URL,
   SIDECAR_LOGFILE_PATH,
@@ -26,6 +25,7 @@ import { EXTENSION_VERSION, SIDECAR_OUTPUT_CHANNEL } from "../constants";
 import { observabilityContext } from "../context/observability";
 import { logError, showErrorNotificationWithButtons } from "../errors";
 import { SecretStorageKeys } from "../storage/constants";
+import { checkSidecarOsAndArch } from "./checkArchitecture";
 
 /** Header name for the workspace's PID in the request headers. */
 const WORKSPACE_PROCESS_ID_HEADER: string = "x-workspace-process-id";
@@ -433,6 +433,10 @@ export class SidecarManager {
                   const err = new SidecarFatalError(`${logPrefix}: sidecar process is not running`);
                   logError(err, "sidecar process check", {}, true);
                   reject(err);
+                  // show a notification to the user to Open Logs or File Issue
+                  showErrorNotificationWithButtons(
+                    `Sidecar process ${sidecarPid} failed to start. Please check the logs for more details.`,
+                  );
                   return;
                 }
               } catch (e) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

If the extension fails to handshake with the sidecar 20 times in a row, something is _very wrong_ and the sidecar process likely exited immediately after starting (unrelated to platform/arch compatibility). This PR tries to capture any stderr to a file, and after a couple seconds from the process spawn, check the process to see if it's still running while logging any stderr/log output. If the process isn't running by the time that check happens, we report it to Sentry with the stderr and log output to expedite debugging so we can get a proper fix merged.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
