### PR TITLE
MINOR: change failing direct connection icon in the Resources view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ All notable changes to this extension will be documented in this file.
 
 ### Changed
 
+- Any "direct" connections with a failing configuration will now show a red "warning" icon (⚠️)
+  instead of the red "error" icon.
+
+### Changed
+
 - Schema registry subjects are now cached, reducing round trips to a schema registry. Use the
-'reload' button in the Schemas view to force refresh.
+  'reload' button in the Schemas view to force refresh.
 
 ## 0.26.1
 

--- a/src/models/environment.test.ts
+++ b/src/models/environment.test.ts
@@ -62,7 +62,7 @@ describe("EnvironmentTreeItem", () => {
       if (missingKafka || missingSR) {
         assert.deepStrictEqual(
           treeItem.iconPath,
-          new ThemeIcon("error", new ThemeColor("problemsErrorIcon.foreground")),
+          new ThemeIcon("warning", new ThemeColor("problemsErrorIcon.foreground")),
         );
       } else {
         assert.deepStrictEqual(treeItem.iconPath, new ThemeIcon(env.iconName));

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -231,7 +231,7 @@ export class EnvironmentTreeItem extends TreeItem {
     } else if (isDirect(resource)) {
       const { missingKafka, missingSR } = checkForMissingResources(resource);
       if (missingKafka || missingSR) {
-        this.iconPath = new ThemeIcon("error", new ThemeColor("problemsErrorIcon.foreground"));
+        this.iconPath = new ThemeIcon("warning", new ThemeColor("problemsErrorIcon.foreground"));
       }
     }
     this.tooltip = createEnvironmentTooltip(this.resource);


### PR DESCRIPTION
| | |
|--------|--------|
| Before | <img width="308" alt="image" src="https://github.com/user-attachments/assets/ab60bc33-6088-4922-b578-2f139e7fcd51" /> |
| After | <img width="307" alt="image" src="https://github.com/user-attachments/assets/ec6334ca-6cd5-4f86-a7d2-3db2ad841c88" /> | 

Closes #1181.