### PR TITLE
MINOR: remove `primitive-square` schema icon

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,6 @@ export enum IconNames {
   KAFKA_CLUSTER = "confluent-kafka-cluster",
   LOCAL_RESOURCE_GROUP = "device-desktop",
   SCHEMA_REGISTRY = "confluent-schema-registry",
-  SCHEMA = "primitive-square",
   KEY_SUBJECT = "key",
   VALUE_SUBJECT = "symbol-object",
   OTHER_SUBJECT = "question",

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -89,7 +89,6 @@ export class Subject implements IResourceBase, ISearchable {
 export class Schema extends Data implements IResourceBase {
   connectionId!: Enforced<ConnectionId>;
   connectionType!: Enforced<ConnectionType>;
-  iconName: IconNames.SCHEMA = IconNames.SCHEMA;
 
   id!: Enforced<string>;
   subject!: Enforced<string>;
@@ -198,7 +197,6 @@ export class SchemaTreeItem extends vscode.TreeItem {
 
     // user-facing properties
     this.description = resource.id.toString();
-    this.iconPath = new vscode.ThemeIcon(IconNames.SCHEMA);
     this.tooltip = createSchemaTooltip(this.resource);
 
     this.command = {
@@ -211,7 +209,7 @@ export class SchemaTreeItem extends vscode.TreeItem {
 
 function createSchemaTooltip(resource: Schema): vscode.MarkdownString {
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${resource.iconName}) Schema`)
+    .appendMarkdown("#### Schema")
     .appendMarkdown("\n\n---")
     .appendMarkdown(`\n\nID: \`${resource.id}\``)
     .appendMarkdown(`\n\nSubject: \`${resource.subject}\``)


### PR DESCRIPTION
Looks too much like the "missing icon" icon. We can replace it with something more schema-like in the future.

Before:
<img width="287" alt="image" src="https://github.com/user-attachments/assets/973ba58f-8259-4fed-b8e1-6c0796fa6a14" />


After:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/54bb52c5-c912-41e8-9f04-c706701fb634" />


Closes #1182.