### PR TITLE
fix: support CCloud reset password flow

### DIFF
--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -22,6 +22,8 @@ import { logUsage, UserEvent } from "../telemetry/events";
 import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
 import { getUriHandler } from "../uriHandler";
 import { openExternal } from "./ccloudStateHandling";
+import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
+import { AuthCallbackEvent } from "./types";
 
 const logger = new Logger("authn.ccloudProvider");
 
@@ -71,8 +73,8 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     return this._onDidChangeSessions.event;
   }
 
-  // used to notify the extension when the user has completed the auth flow and resolve any promises
-  private _onAuthFlowCompletedSuccessfully = new vscode.EventEmitter<boolean>();
+  /** Notify the extension when the user has completed the auth flow and resolve any promises */
+  private _onAuthFlowCompletedSuccessfully = new vscode.EventEmitter<AuthCallbackEvent>();
 
   /** Used to check for changes in auth state between extension instance and sidecar. */
   private _session: vscode.AuthenticationSession | null = null;
@@ -130,13 +132,33 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     }
 
     // this will block until we handle the URI event or the user cancels
-    const success: boolean | undefined = await this.browserAuthFlow(signInUri);
-    if (success === undefined) {
+    const authCallback: AuthCallbackEvent | undefined = await this.browserAuthFlow(signInUri);
+
+    if (authCallback === undefined) {
       // user cancelled the operation
       logger.debug("createSession() user cancelled the operation");
       return Promise.reject(new Error("User cancelled the authentication flow."));
     }
-    if (!success) {
+
+    if (authCallback.resetPassword) {
+      // user reset their password, so we need to notify them to reauthenticate
+      logger.debug("createSession() user reset their password");
+      vscode.window
+        .showInformationMessage(
+          "Your password has been reset. Please sign in again to Confluent Cloud.",
+          CCLOUD_SIGN_IN_BUTTON_LABEL,
+        )
+        .then((selection) => {
+          if (selection === CCLOUD_SIGN_IN_BUTTON_LABEL) {
+            // this will trigger the `createSession()` method again, which will start the auth flow
+            // and create a new connection
+            this.createSession();
+          }
+        });
+      return Promise.reject(new Error("User reset their password."));
+    }
+
+    if (!authCallback.success) {
       const authFailedMsg = `Confluent Cloud authentication failed. See browser for details.`;
       vscode.window.showErrorMessage(authFailedMsg);
       logUsage(UserEvent.CCloudAuthentication, {
@@ -230,6 +252,8 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       await Promise.all([
         storageManager.deleteSecret(SecretStorageKeys.AUTH_SESSION_EXISTS),
         storageManager.deleteSecret(SecretStorageKeys.AUTH_COMPLETED),
+        // don't check this in the if block above since it changes with AUTH_COMPLETED
+        storageManager.deleteSecret(SecretStorageKeys.AUTH_PASSWORD_RESET),
         // we don't need to check for this up above, just clear it out if we don't have a connection
         storageManager.deleteSecret(SecretStorageKeys.CCLOUD_AUTH_STATUS),
       ]);
@@ -343,8 +367,11 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
             // (e.g they started the auth flow in one window and another handled the callback URI) --
             // so we need to notify any listeners in this extension instance that the auth flow has
             // completed to resolve any promises that may still be waiting
-            const success: boolean = await resourceManager.getAuthFlowCompleted();
-            this._onAuthFlowCompletedSuccessfully.fire(success);
+            const [success, resetPassword]: [boolean, boolean] = await Promise.all([
+              resourceManager.getAuthFlowCompleted(),
+              resourceManager.getAuthFlowPasswordReset(),
+            ]);
+            this._onAuthFlowCompletedSuccessfully.fire({ success, resetPassword });
 
             if (!success) {
               // fetch+log current sidecar preferences to help debug any auth issues
@@ -369,11 +396,12 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     const uriHandlerSub: vscode.Disposable = getUriHandler().event(async (uri: vscode.Uri) => {
       if (uri.path === "/authCallback") {
         const queryParams = new URLSearchParams(uri.query);
-        const success: boolean = queryParams.get("success") === "true";
-        logger.debug("handled authCallback URI; calling `setAuthFlowCompleted()`", {
-          success,
-        });
-        await resourceManager.setAuthFlowCompleted(success);
+        const callbackEvent: AuthCallbackEvent = {
+          success: queryParams.get("success") === "true",
+          resetPassword: queryParams.get("reset_password") === "true",
+        };
+        logger.debug("handled authCallback URI; calling `setAuthFlowCompleted()`", callbackEvent);
+        await resourceManager.setAuthFlowCompleted(callbackEvent);
       }
     });
 
@@ -401,26 +429,33 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
    * @returns A promise that resolves to a `boolean` indicating whether the authentication flow was
    * successful, or `undefined` if the user cancelled the operation.
    */
-  async browserAuthFlow(uri: string): Promise<boolean | undefined> {
+  async browserAuthFlow(uri: string): Promise<AuthCallbackEvent | undefined> {
     return await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
         title: `Signing in to [Confluent Cloud](${uri})...`,
         cancellable: true,
       },
-      async (_, token) => {
+      async (_, token): Promise<AuthCallbackEvent | undefined> => {
         await openExternal(vscode.Uri.parse(uri));
         // keep progress notification open until one of two things happens:
-        // - we handle the auth completion event and resolve with the `success` value
+        // - we handle the auth completion event and resolve with the callback query params
         // - user clicks the "Cancel" button from the notification
-        const [success, cancelled] = await Promise.race([
-          this.waitForUriHandling().then((success) => [success, false]),
-          this.waitForCancellationRequest(token).then(() => [false, true]),
+        const [authCallback, cancelled] = await Promise.race([
+          this.waitForUriHandling().then((authCallback): [AuthCallbackEvent, boolean] => [
+            authCallback,
+            false,
+          ]),
+          this.waitForCancellationRequest(token).then((): [AuthCallbackEvent, boolean] => [
+            { success: false, resetPassword: false } as AuthCallbackEvent,
+            true,
+          ]),
         ]);
         if (cancelled) return;
-        // user completed the auth flow, so we need to resolve the promise with the success value
-        logger.debug("browserAuthFlow() user completed the auth flow", { success });
-        return success;
+        // user completed the auth flow, so we need to resolve the promise with the callback
+        // query params
+        logger.debug("browserAuthFlow() user completed the auth flow", authCallback);
+        return authCallback;
       },
     );
   }
@@ -429,14 +464,14 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
    * Wait for the user to complete the authentication flow in the browser and resolve the promise,
    * whether triggered from this workspace or another.
    */
-  waitForUriHandling(): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
-      // this will only fire if the auth flow didn't initially start from the Accounts action, or
-      // if it was done in another window entirely -- see
-      const sub = this._onAuthFlowCompletedSuccessfully.event((success: boolean) => {
-        logger.debug("handling _onAuthFlowCompletedSuccessfully event", { success });
+  waitForUriHandling(): Promise<AuthCallbackEvent> {
+    return new Promise<AuthCallbackEvent>((resolve) => {
+      // this will only fire if the auth flow didn't initially start in another window entirely and
+      // we're just reacting to a change in secret state
+      const sub = this._onAuthFlowCompletedSuccessfully.event((event: AuthCallbackEvent) => {
+        logger.debug("handling _onAuthFlowCompletedSuccessfully event", event);
         sub.dispose();
-        resolve(success);
+        resolve(event);
       });
     });
   }
@@ -508,6 +543,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       await Promise.all([
         storageManager.deleteSecret(SecretStorageKeys.AUTH_SESSION_EXISTS),
         storageManager.deleteSecret(SecretStorageKeys.AUTH_COMPLETED),
+        storageManager.deleteSecret(SecretStorageKeys.AUTH_PASSWORD_RESET),
       ]);
     }
   }

--- a/src/authn/ccloudStateHandling.ts
+++ b/src/authn/ccloudStateHandling.ts
@@ -5,6 +5,7 @@ import { observabilityContext } from "../context/observability";
 import { ccloudAuthSessionInvalidated, nonInvalidTokenStatus } from "../emitters";
 import { Logger } from "../logging";
 import { getResourceManager } from "../storage/resourceManager";
+import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
 import { getCCloudAuthSession } from "./utils";
 
 const logger = new Logger("authn.ccloudStateHandling");
@@ -254,17 +255,19 @@ export function checkAuthErrors(connection: Connection) {
     return;
   }
 
-  let authButton: string = "Sign in to Confluent Cloud";
   // show an error message to the user to retry the auth flow
   tracker.authErrorPromptOpen = true;
   vscode.window
-    .showErrorMessage("Error authenticating with Confluent Cloud. Please try again.", authButton)
+    .showErrorMessage(
+      "Error authenticating with Confluent Cloud. Please try again.",
+      CCLOUD_SIGN_IN_BUTTON_LABEL,
+    )
     .then(async (response: string | undefined) => {
       // always reset the prompt tracker after the user interacts with the notification in any way,
       // since they will either dismiss it (and we re-prompt at the next iteration) or they re-
       // authenticate and we get a new status back (or another auth error at the next iteration)
       tracker.authErrorPromptOpen = false;
-      if (response === authButton) {
+      if (response === CCLOUD_SIGN_IN_BUTTON_LABEL) {
         // if we got to this point, we likely cleared out the existing connection via the
         // `ccloudAuthSessionInvalidated` emitter, so we need to create a new session to re-auth
         await getCCloudAuthSession(true);

--- a/src/authn/constants.ts
+++ b/src/authn/constants.ts
@@ -1,0 +1,1 @@
+export const CCLOUD_SIGN_IN_BUTTON_LABEL: string = "Sign in to Confluent Cloud";

--- a/src/authn/types.ts
+++ b/src/authn/types.ts
@@ -1,0 +1,5 @@
+/** Query parameters passed in the UriHandler's /authCallback path. */
+export interface AuthCallbackEvent {
+  success: boolean;
+  resetPassword: boolean;
+}

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -33,7 +33,8 @@ async function ccloudSignIn() {
       if (
         error.message === "User did not consent to login." ||
         error.message === "User cancelled the authentication flow." ||
-        error.message === "Confluent Cloud authentication failed. See browser for details."
+        error.message === "Confluent Cloud authentication failed. See browser for details." ||
+        error.message === "User reset their password."
       ) {
         return;
       }

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -1,4 +1,5 @@
 import { commands, QuickPickItem, QuickPickItemKind, ThemeIcon, window } from "vscode";
+import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "../authn/constants";
 import { IconNames } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
 import { ResourceLoader } from "../loaders";
@@ -63,7 +64,7 @@ export async function kafkaClusterQuickPick(): Promise<KafkaCluster | undefined>
     let login: string = "";
     let local: string = "";
     if (!getContextValue(ContextValues.ccloudConnectionAvailable)) {
-      login = "Sign in to Confluent Cloud";
+      login = CCLOUD_SIGN_IN_BUTTON_LABEL;
     }
     if (!getContextValue(ContextValues.localKafkaClusterAvailable)) {
       local = "Start Local Resources";

--- a/src/quickpicks/schemaRegistries.ts
+++ b/src/quickpicks/schemaRegistries.ts
@@ -1,4 +1,5 @@
 import { commands, QuickPickItem, QuickPickItemKind, ThemeIcon, window } from "vscode";
+import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "../authn/constants";
 import { IconNames } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
 import { ResourceLoader } from "../loaders";
@@ -67,7 +68,7 @@ export async function schemaRegistryQuickPick(
     let login: string = "";
     let local: string = "";
     if (!getContextValue(ContextValues.ccloudConnectionAvailable)) {
-      login = "Sign in to Confluent Cloud";
+      login = CCLOUD_SIGN_IN_BUTTON_LABEL;
     }
     if (!getContextValue(ContextValues.localSchemaRegistryAvailable)) {
       local = "Start Local Resources";

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -51,6 +51,10 @@ export enum SecretStorageKeys {
    * browser-based authentication flow to complete after handling a URI callback from the sidecar.
    */
   AUTH_COMPLETED = "authCompleted",
+
+  /** The user recently reset their password and needs to reauthenticate. */
+  AUTH_PASSWORD_RESET = "authPasswordReset",
+
   /** Only used as a way to kick off cross-workspace events for the authentication provider. Only
    * ever set to "true" or deleted. */
   AUTH_SESSION_EXISTS = "authSessionExists",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Paired with https://github.com/confluentinc/ide-sidecar/pull/348.

If the extension handles an `/authCallback` URI with the new `reset_password=true` params, it needs to prompt the user to reauthenticate with CCloud.

Closes #1204.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
