### PR TITLE
fix: don't set MessageViewerConfig `textFilter` when produce-message key is an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ All notable changes to this extension will be documented in this file.
 
 - Any "direct" connections with a failing configuration will now show a red "warning" icon (⚠️)
   instead of the red "error" icon.
-
-### Changed
-
 - Schema registry subjects are now cached, reducing round trips to a schema registry. Use the
   'reload' button in the Schemas view to force refresh.
+
+### Fixed
+
+- Clicking "View Message(s)" after producing to a topic will no longer attempt to stringify
+  non-primitive values in the message payload.
 
 ## 0.26.1
 

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -400,9 +400,10 @@ async function produceMessages(
         uniquePartitions.add(result.response.partition_id);
       }
     });
-    // if there was only one message, we can also filter by key (if it exists)
+    // if there was only one message, we can also filter by key (if it exists) as long as it's a
+    // primitive type and can be easily converted to a string
     let textFilter: string | undefined;
-    if (successResults.length === 1 && contents[0].key) {
+    if (successResults.length === 1 && contents[0].key && typeof contents[0].key !== "object") {
       textFilter = String(contents[0].key);
     }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #1184.

Mostly testing updates, actual fix is here where we now guard against objects and arrays:
https://github.com/confluentinc/vscode/blob/cb82c9d6f1d853c7faa6f3eee312b1e22e2290ec/src/commands/topics.ts#L403-L408

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
