### PR TITLE
Have all telemetry events from message viewer include topic/cluster/environment metadata.

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -41,11 +41,13 @@ import { topicQuickPick } from "./quickpicks/topics";
 import { scheduler } from "./scheduler";
 import { getSidecar, type SidecarHandle } from "./sidecar";
 import { BitSet, includesSubstring, Stream } from "./stream/stream";
-import { logUsage, UserEvent } from "./telemetry/events";
+import { hashed, logUsage, UserEvent } from "./telemetry/events";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { type post } from "./webview/message-viewer";
 import messageViewerTemplate from "./webview/message-viewer.html";
+
+const logger = new Logger("consume");
 
 export function activateMessageViewer(context: ExtensionContext) {
   /* All active message viewer instances share the same scheduler to perform API
@@ -830,9 +832,38 @@ function messageViewerStartPollingCommand(
     handler.dispose();
     os.dispose();
   });
-}
 
-const logger = new Logger("consume");
+  type TrackAction = {
+    action: string;
+  };
+
+  /** Send a telemetry event. Will implicily include information about the topic/cluster. */
+  function track(details: TrackAction) {
+    const augmentedDetails = {
+      action: details.action,
+      connection_type: topic.connectionType,
+      connection_id: topic.connectionId,
+      environment_id: topic.environmentId,
+      cluster_id: topic.clusterId,
+      topic_hash: hashed(topic.name),
+    };
+
+    logUsage(UserEvent.MessageViewerAction, augmentedDetails);
+  }
+
+  let debounceTimer: ReturnType<typeof setTimeout>;
+
+  /** 200ms debounced sending a telemetry event. */
+  function debouncedTrack(details: TrackAction) {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(track, 200, details);
+  }
+
+  // End of new message viewer setup. Send a telemetry event when the message viewer is opened!
+  track({
+    action: "message-viewer-open",
+  });
+}
 
 /** Define basic consume params based on desired consume mode. */
 function getParams(
@@ -1026,14 +1057,4 @@ class Timer extends Data {
   reset(this: Timer) {
     return this.copy({ start: Date.now(), offset: 0 });
   }
-}
-
-function track(details: object) {
-  logUsage(UserEvent.MessageViewerAction, details);
-}
-
-let timer: ReturnType<typeof setTimeout>;
-function debouncedTrack(details: object) {
-  clearTimeout(timer);
-  timer = setTimeout(track, 200, details);
 }

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -861,7 +861,7 @@ function messageViewerStartPollingCommand(
 
   // End of new message viewer setup. Send a telemetry event when the message viewer is opened!
   track({
-    action: "message-viewer-open",
+    action: "opened",
   });
 }
 

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { TelemetryTrustedValue } from "vscode";
 import { Logger } from "../logging";
 import { getTelemetryLogger } from "./telemetryLogger";
@@ -25,4 +26,9 @@ export function logUsage(event: UserEvent, data?: Record<string, any | Telemetry
 
   // May or may send to Segment based on user settings. See checkTelemetrySettings().
   getTelemetryLogger().logUsage(event, data);
+}
+
+/** Compute a hex-encoded SHA-256 hash of a client-side string to accompany telemetry data. */
+export function hashed(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Refactor message-viewer telemetry logging to be able to include metadata about the connection/environment/cluster.
- Include the SHA256 -> hex encoding of the topic name.
- New augmented sub-event for exactly when message viewer is opened.

<img width="732" alt="image" src="https://github.com/user-attachments/assets/96e6b44c-b226-47bf-aa27-1f03483e9fff" />



## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1045

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
