### PR TITLE
Telemetry event when uploading schemas, includes hashes of subject name and schema body

### DIFF
--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -14,6 +14,7 @@ import { SchemaRegistry } from "../models/schemaRegistry";
 import { schemaSubjectQuickPick, schemaTypeQuickPick } from "../quickpicks/schemas";
 import { loadDocumentContent, LoadedDocumentContent, uriQuickpick } from "../quickpicks/uris";
 import { getSidecar } from "../sidecar";
+import { hashed, logUsage, UserEvent } from "../telemetry/events";
 import { getSchemasViewProvider, SchemasViewProvider } from "../viewProviders/schemas";
 
 const logger = new Logger("commands.schemaUpload");
@@ -141,6 +142,18 @@ async function uploadSchema(
     const normalize = true;
 
     maybeNewId = await registerSchema(schemaSubjectsApi, subject, schemaType, content, normalize);
+
+    logUsage(UserEvent.SchemaAction, {
+      action: "upload",
+      connection_id: registry.connectionId,
+      connection_type: registry.connectionType,
+      environment_id: registry.environmentId,
+
+      schema_registry_id: registry.id,
+      schema_type: schemaType,
+      subject_hash: hashed(subject),
+      schema_hash: hashed(content),
+    });
 
     logger.info(
       `Schema registered successfully as subject "${subject}" in registry "${registry.id}" as schema id ${maybeNewId}`,

--- a/src/commands/schemaUpload.ts
+++ b/src/commands/schemaUpload.ts
@@ -156,7 +156,7 @@ async function uploadSchema(
   // Telemetry log the schema upload event + overall success or failure.
   logUsage(UserEvent.SchemaAction, {
     action: "upload",
-    status: success ? "success" : "failure",
+    status: success ? "succeeded" : "failed",
 
     connection_id: registry.connectionId,
     connection_type: registry.connectionType,

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -18,6 +18,7 @@ export enum UserEvent {
   ProjectScaffoldingAction = "Project Scaffolding Action",
   CCloudAuthentication = "CCloud Authentication",
   ViewSearchAction = "View Search Action",
+  SchemaAction = "Schema Action",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- New telemetry event family for "Schema Action"s , first being for  schema uploads attempts, be they successful (accepted by the SR) or not as indicated by "status": "succeeded" or "failed".
- Includes metadata about the schema registry, the schema document language, and the SHA256s of the subject name and the schema document body.

Slightly stale screenshots:

Successful upload, `status: "success"`
<img width="1295" alt="Screenshot 2025-03-13 at 4 55 08 PM" src="https://github.com/user-attachments/assets/8ebd86b3-734b-4fee-b49c-2bb7cc20690b" />

Syntax error within the document failure example,`status: "failure"`.
<img width="1288" alt="Screenshot 2025-03-13 at 4 57 58 PM" src="https://github.com/user-attachments/assets/f71a47a1-2aef-49ff-a85e-2f3d24cb5632" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1207

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
