### PR TITLE
update telemetry for success+failed direct connections

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -1,28 +1,15 @@
 import { randomUUID } from "crypto";
 import { Uri, ViewColumn, window } from "vscode";
-import {
-  AuthErrors,
-  ConnectedState,
-  Connection,
-  ConnectionType,
-  instanceOfApiKeyAndSecret,
-  instanceOfBasicCredentials,
-  instanceOfKerberosCredentials,
-  instanceOfOAuthCredentials,
-  instanceOfScramCredentials,
-} from "./clients/sidecar";
+import { AuthErrors, ConnectedState, Connection, ConnectionType } from "./clients/sidecar";
+import { getCredentialsType } from "./directConnections/credentials";
+import { SupportedAuthTypes } from "./directConnections/types";
 import { DirectConnectionManager } from "./directConnectManager";
+import { ConnectionId } from "./models/resource";
+import { CustomConnectionSpec } from "./storage/resourceManager";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
-import {
-  post,
-  PostResponse,
-  SupportedAuthTypes,
-  TestResponse,
-} from "./webview/direct-connect-form";
+import { post, PostResponse, TestResponse } from "./webview/direct-connect-form";
 import connectionFormTemplate from "./webview/direct-connect-form.html";
-import { CustomConnectionSpec } from "./storage/resourceManager";
-import { ConnectionId } from "./models/resource";
 
 type MessageSender = OverloadUnion<typeof post>;
 type MessageResponse<MessageType extends string> = Awaited<
@@ -141,15 +128,6 @@ export function openDirectConnectionForm(connection: CustomConnectionSpec | null
   let specUpdatedValues: Partial<CustomConnectionSpec> = {};
   function updateSpecValue(inputName: string, value: string) {
     setValueAtPath(specUpdatedValues, inputName, value);
-  }
-  function getCredentialsType(creds: any): SupportedAuthTypes {
-    if (!creds || typeof creds !== "object") return "None";
-    if (instanceOfBasicCredentials(creds)) return "Basic";
-    if (instanceOfApiKeyAndSecret(creds)) return "API";
-    if (instanceOfScramCredentials(creds)) return "SCRAM";
-    if (instanceOfOAuthCredentials(creds)) return "OAuth";
-    if (instanceOfKerberosCredentials(creds)) return "Kerberos";
-    return "None";
   }
   // Initialize auth type to whatever matches incoming connection
   let kafkaClusterAuthType = getCredentialsType(connection?.kafka_cluster?.credentials);

--- a/src/directConnections/credentials.ts
+++ b/src/directConnections/credentials.ts
@@ -1,0 +1,18 @@
+import {
+  instanceOfApiKeyAndSecret,
+  instanceOfBasicCredentials,
+  instanceOfKerberosCredentials,
+  instanceOfOAuthCredentials,
+  instanceOfScramCredentials,
+} from "../clients/sidecar";
+import { SupportedAuthTypes } from "./types";
+
+export function getCredentialsType(creds: any): SupportedAuthTypes {
+  if (!creds || typeof creds !== "object") return "None";
+  if (instanceOfBasicCredentials(creds)) return "Basic";
+  if (instanceOfApiKeyAndSecret(creds)) return "API";
+  if (instanceOfScramCredentials(creds)) return "SCRAM";
+  if (instanceOfOAuthCredentials(creds)) return "OAuth";
+  if (instanceOfKerberosCredentials(creds)) return "Kerberos";
+  return "None";
+}

--- a/src/directConnections/types.ts
+++ b/src/directConnections/types.ts
@@ -1,0 +1,8 @@
+/** Similar to {@link ConnectionType}, but only used for telemetry purposes. */
+export type FormConnectionType =
+  | "Apache Kafka"
+  | "Confluent Cloud"
+  | "Confluent Platform"
+  | "Other";
+
+export type SupportedAuthTypes = "None" | "Basic" | "API" | "SCRAM" | "OAuth" | "Kerberos";

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -14,7 +14,7 @@ import {
   LOCAL_ENVIRONMENT_NAME,
   UTM_SOURCE_VSCODE,
 } from "../constants";
-import { FormConnectionType } from "../webview/direct-connect-form";
+import { FormConnectionType } from "../directConnections/types";
 import {
   CCloudKafkaCluster,
   DirectKafkaCluster,

--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -25,10 +25,9 @@ import {
   newMessageHeaders,
 } from "../../ws/messageTypes";
 
+import { getTestExtensionContext } from "../../../tests/unit/testUtils";
 import { CCLOUD_CONNECTION_ID } from "../../constants";
 import * as errors from "../../errors";
-import * as telemetryEvents from "../../telemetry/events";
-import { UserEvent } from "../../telemetry/events";
 import {
   ConnectionStateWatcher,
   reportUsableState,
@@ -332,17 +331,19 @@ describe("sidecar/connections/watcher.ts SingleConnectionEntry", () => {
   });
 });
 
-describe.only("sidecar/connections/watcher.ts reportUsableState() notifications", () => {
+describe("sidecar/connections/watcher.ts reportUsableState() notifications", () => {
   let sandbox: sinon.SinonSandbox;
   let showErrorNotificationStub: sinon.SinonStub;
-  let logUsageStub: sinon.SinonStub;
 
   const fakeDirectConnectionButtonLabel = "View Connection Details";
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     showErrorNotificationStub = sandbox.stub(errors, "showErrorNotificationWithButtons");
-    logUsageStub = sandbox.stub(telemetryEvents, "logUsage").returns();
   });
 
   afterEach(() => {
@@ -362,7 +363,6 @@ describe.only("sidecar/connections/watcher.ts reportUsableState() notifications"
     await reportUsableState(connection);
 
     sinon.assert.notCalled(showErrorNotificationStub);
-    sinon.assert.calledWith(logUsageStub, UserEvent.DirectConnectionAction);
   });
 
   it("should show a notification if a DIRECT connection has a FAILED `kafka_cluster` state", async () => {

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -153,7 +153,7 @@ type ConfigType = "Kafka" | "Schema Registry" | "Confluent Cloud";
 
 /** Summary of a {@link Connection}'s {@link ConnectedState} and config, including additional fields
  * that may not be tracked by the sidecar (mainly for `DIRECT` connections). */
-interface ConnectionSummary {
+export interface ConnectionSummary {
   connectionType: ConnectionType;
   configType: ConfigType;
   connectedState: ConnectedState;

--- a/src/storage/migrations/v2.test.ts
+++ b/src/storage/migrations/v2.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../../../tests/unit/testResources";
 import { TEST_DIRECT_CONNECTION_FORM_SPEC } from "../../../tests/unit/testResources/connection";
 import { getTestExtensionContext } from "../../../tests/unit/testUtils";
+import { FormConnectionType } from "../../directConnections/types";
 import { ConnectionId } from "../../models/resource";
-import { FormConnectionType } from "../../webview/direct-connect-form";
 import { CustomConnectionSpec, DirectConnectionsById, mapToString } from "../resourceManager";
 import { MigrationV2 } from "./v2";
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -8,6 +8,7 @@ import {
   ConnectionType,
   Status,
 } from "../clients/sidecar";
+import { FormConnectionType } from "../directConnections/types";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
@@ -15,7 +16,6 @@ import { ConnectionId, isCCloud, isLocal } from "../models/resource";
 import { Schema, Subject } from "../models/schema";
 import { CCloudSchemaRegistry, SchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
-import { FormConnectionType } from "../webview/direct-connect-form";
 import { SecretStorageKeys, UriMetadataKeys, WorkspaceStorageKeys } from "./constants";
 
 const logger = new Logger("storage.resourceManager");

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -1,5 +1,4 @@
 import { ObservableScope } from "inertial";
-import { applyBindings, html } from "./bindings/bindings";
 import {
   type KerberosCredentials,
   type ApiKeyAndSecret,
@@ -7,7 +6,9 @@ import {
   type OAuthCredentials,
   type ScramCredentials,
 } from "../clients/sidecar";
-import { type SupportedAuthTypes, type FormConnectionType } from "./direct-connect-form";
+import { FormConnectionType, SupportedAuthTypes } from "../directConnections/types";
+import { applyBindings, html } from "./bindings/bindings";
+
 type SupportedCredentialTypes =
   | BasicCredentials
   | ApiKeyAndSecret

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -1,11 +1,12 @@
 import { ObservableScope } from "inertial";
+import { ConnectedState } from "../clients/sidecar";
+import { FormConnectionType, SupportedAuthTypes } from "../directConnections/types";
+import { CustomConnectionSpec } from "../storage/resourceManager";
+import { AuthCredentials } from "./auth-credentials";
 import { applyBindings } from "./bindings/bindings";
 import { ViewModel } from "./bindings/view-model";
 import { sendWebviewMessage } from "./comms/comms";
-import { ConnectedState } from "../clients/sidecar";
-import { CustomConnectionSpec } from "../storage/resourceManager";
 import { SslConfig } from "./ssl-config-inputs";
-import { AuthCredentials } from "./auth-credentials";
 // Register the custom element
 customElements.define("ssl-config", SslConfig);
 customElements.define("auth-credentials", AuthCredentials);
@@ -250,11 +251,3 @@ export function post(
 export function post(type: any, body: any): Promise<unknown> {
   return sendWebviewMessage(type, body);
 }
-
-/** Similar to {@link ConnectionType}, but only used for telemetry purposes. */
-export type FormConnectionType =
-  | "Apache Kafka"
-  | "Confluent Cloud"
-  | "Confluent Platform"
-  | "Other";
-export type SupportedAuthTypes = "None" | "Basic" | "API" | "SCRAM" | "OAuth" | "Kerberos";

--- a/tests/unit/testResources/authCredentials.ts
+++ b/tests/unit/testResources/authCredentials.ts
@@ -1,0 +1,60 @@
+import {
+  ApiKeyAndSecret,
+  ApiKeyAndSecretFromJSON,
+  BasicCredentials,
+  BasicCredentialsFromJSON,
+  KerberosCredentials,
+  KerberosCredentialsFromJSON,
+  OAuthCredentials,
+  OAuthCredentialsFromJSON,
+  ScramCredentials,
+  ScramCredentialsFromJSON,
+} from "../../../src/clients/sidecar";
+import { SupportedAuthTypes } from "../../../src/directConnections/types";
+
+type TEST_CRED_TYPES =
+  | ApiKeyAndSecret
+  | BasicCredentials
+  | KerberosCredentials
+  | OAuthCredentials
+  | ScramCredentials;
+
+export const TEST_APIKEYSECRET_CREDENTIALS: ApiKeyAndSecret = ApiKeyAndSecretFromJSON({
+  api_key: "your_api_key_here",
+  api_secret: "your_api_secret_here",
+} as ApiKeyAndSecret);
+
+export const TEST_BASIC_CREDENTIALS: BasicCredentials = BasicCredentialsFromJSON({
+  username: "your_username_here",
+  password: "your_password_here",
+} as BasicCredentials);
+
+export const TEST_KERBEROS_CREDENTIALS: KerberosCredentials = KerberosCredentialsFromJSON({
+  principal: "your_principal_here",
+  keytab_path: "your_keytab_path_here",
+  service_name: "your_service_name_here",
+} as KerberosCredentials);
+
+export const TEST_OAUTH_CREDENTIALS: OAuthCredentials = OAuthCredentialsFromJSON({
+  tokens_url: "https://your_tokens_url_here",
+  client_id: "your_client_id_here",
+  client_secret: "your_client_secret_here",
+  scope: "your_scope_here",
+  connect_timeout_millis: 5000,
+  ccloud_logical_cluster_id: "your_logical_cluster_id_here",
+  ccloud_identity_pool_id: "your_identity_pool_id_here",
+} as OAuthCredentials);
+
+export const TEST_SCRAM_CREDENTIALS: ScramCredentials = ScramCredentialsFromJSON({
+  hash_algorithm: "SCRAM_SHA_256",
+  scram_username: "your_scram_username_here",
+  scram_password: "your_scram_password_here",
+} as ScramCredentials);
+
+export const TEST_AUTHTYPES_AND_CREDS = new Map<SupportedAuthTypes, TEST_CRED_TYPES>([
+  ["API", TEST_APIKEYSECRET_CREDENTIALS],
+  ["Basic", TEST_BASIC_CREDENTIALS],
+  ["Kerberos", TEST_KERBEROS_CREDENTIALS],
+  ["OAuth", TEST_OAUTH_CREDENTIALS],
+  ["SCRAM", TEST_SCRAM_CREDENTIALS],
+]);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Refactors `notifyForFailedState()` into `reportUsableState()` and adds a general helper function to summarize the `ConnectedState` and `ConnectionSpec` along with additional properties we use based on the direct connection form:
https://github.com/confluentinc/vscode/blob/616139c5dfca2da868f76f5bc679f05330ea62f2/src/sidecar/connections/watcher.ts#L122-L141

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Some of these telemetry updates required some helper functions and types that were previously only used in the `webviews/` area, so this is the first PR to start using a `src/directConnections/` subdirectory. Follow-on PRs will break up `directConnectManager` and probably some others.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
