### PR TITLE
security: update `openapi-generator-cli` for `axios` CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "devDependencies": {
         "@0no-co/graphqlsp": "^1.12.8",
         "@eslint/js": "^9.4.0",
-        "@openapitools/openapi-generator-cli": "^2.13.5",
+        "@openapitools/openapi-generator-cli": "^2.18.2",
         "@playwright/test": "^1.45.0",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^26.0.1",
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@openapitools/openapi-generator-cli": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.17.0.tgz",
-      "integrity": "sha512-gOgSEPD08okBn/EvlsNF/eM9vQOnLZRJJeu5KA7bBJdgXmeiu/lVhTMmb+BPanMXqMRtuaRua0UBqWkDw9VaXQ==",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.18.2.tgz",
+      "integrity": "sha512-aUZQfCTuKqVxnyhQboJhe5pfbtxLcCJHB6joH+jdJeaKTIWASn30/IPOeMobeNYC3rdlD8ysFoW+bOfHQByTMA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1739,7 +1739,7 @@
         "@nestjs/common": "10.4.15",
         "@nestjs/core": "10.4.15",
         "@nuxtjs/opencollective": "0.3.2",
-        "axios": "1.7.9",
+        "axios": "1.8.3",
         "chalk": "4.1.2",
         "commander": "8.3.0",
         "compare-versions": "4.1.4",
@@ -1750,7 +1750,7 @@
         "inquirer": "8.2.6",
         "lodash": "4.17.21",
         "proxy-agent": "6.5.0",
-        "reflect-metadata": "0.1.13",
+        "reflect-metadata": "0.2.2",
         "rxjs": "7.8.1",
         "tslib": "2.8.1"
       },
@@ -4958,9 +4958,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -11716,9 +11716,9 @@
       }
     },
     "node_modules/reflect-metadata": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "dev": true
     },
     "node_modules/regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -1188,7 +1188,7 @@
   "devDependencies": {
     "@0no-co/graphqlsp": "^1.12.8",
     "@eslint/js": "^9.4.0",
-    "@openapitools/openapi-generator-cli": "^2.13.5",
+    "@openapitools/openapi-generator-cli": "^2.18.2",
     "@playwright/test": "^1.45.0",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
Resolves https://github.com/confluentinc/vscode/security/dependabot/16

https://github.com/confluentinc/vscode/blob/b4803a0fc66c0e25d2947212115d7fe1dc0027b3/package-lock.json#L4960-L4962

Re-running `gulp apigen` didn't behave any differently and yields no changes in client code.