### PR TITLE
Connection form - validation on required fields, add tests

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -341,7 +341,7 @@ function isValidCredentialForAuthType(path: string, authType: string): boolean {
   }
 }
 // Deep merging nested spec object, keeping existing values if they aren't in updated spec
-function deepMerge(current: any, updated: any): any {
+export function deepMerge(current: any, updated: any): any {
   const result = { ...current };
 
   for (const key in updated) {

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -86,7 +86,7 @@ export class AuthCredentials extends HTMLElement {
     }
   }
 
-  // updateValue called onInput
+  // updateValue called on input
   updateValue(event: Event) {
     const input = event.target as HTMLInputElement;
     const name = input.name;
@@ -423,7 +423,11 @@ export class AuthCredentials extends HTMLElement {
     shadow.adoptedStyleSheets = [sheet];
     shadow.innerHTML = this.template;
     applyBindings(shadow, this.os, this);
-
+    this.os.watch(() => {
+      this.authType();
+      // start with a clean slate when auth type changes
+      this._internals.setValidity({});
+    });
     // Before form submits, invoke validation checks
     if (this._internals.form) {
       this._internals.form.addEventListener(

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -383,7 +383,6 @@ export class AuthCredentials extends HTMLElement {
                 type="text"
                 placeholder="kafka"
                 data-value="this.creds()?.service_name ?? null"
-                required
                 data-on-input="this.updateValue(event)"
               />
             </div>
@@ -399,7 +398,6 @@ export class AuthCredentials extends HTMLElement {
                 type="text"
                 placeholder="/path/to/keytab"
                 data-value="this.creds()?.keytab_path ?? null"
-                required
                 data-on-input="this.updateValue(event)"
               />
             </div>

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -86,7 +86,7 @@ export class AuthCredentials extends HTMLElement {
     }
   }
 
-  // Update the updateValue method
+  // updateValue called onInput
   updateValue(event: Event) {
     const input = event.target as HTMLInputElement;
     const name = input.name;

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -56,14 +56,50 @@ export class AuthCredentials extends HTMLElement {
     return this.identifier() + ".credentials." + name;
   }
 
+  // Helper method to validate a single input
+  validateInput(input: HTMLInputElement): boolean {
+    if (!input.validity.valid) {
+      input.classList.add("error");
+      // Determine the specific validation error
+      if (input.validity.patternMismatch) {
+        this._internals.setValidity(
+          { patternMismatch: true },
+          "Value does not match expected pattern",
+          input,
+        );
+      } else if (input.validity.valueMissing) {
+        this._internals.setValidity({ valueMissing: true }, "This field is required", input);
+      } else if (input.validity.typeMismatch) {
+        this._internals.setValidity(
+          { typeMismatch: true },
+          `Please enter a valid ${input.type}`,
+          input,
+        );
+      } else {
+        this._internals.setValidity({ customError: true }, "Invalid input", input);
+      }
+      return false;
+    } else {
+      input.classList.remove("error");
+      this._internals.setValidity({});
+      return true;
+    }
+  }
+
+  // Update the updateValue method
   updateValue(event: Event) {
     const input = event.target as HTMLInputElement;
     const name = input.name;
     const value = input.value;
-    // This sets the value in the FormData object for the form submission
+
+    // Sets the value in the FormData object for the form submission
     this.entries.set(name, value.toString());
     this._internals.setFormValue(this.entries);
-    // This dispatches a change event to the parent html for other actions
+
+    // Validate the input
+    this.validateInput(input);
+
+    // Dispatch a change event to the parent html for other actions
     this.dispatchEvent(
       new CustomEvent("change", {
         detail: event,
@@ -71,8 +107,45 @@ export class AuthCredentials extends HTMLElement {
     );
   }
 
+  // Check validity of all inputs in this (auth) section
+  // Handles reporting validation to form before submit
+  checkValidity() {
+    const inputs: NodeListOf<HTMLInputElement> | undefined =
+      this.shadowRoot?.querySelectorAll("input");
+
+    // If no inputs are visible (e.g., auth type is "None"), consider it valid
+    if (!inputs || inputs.length === 0) return true;
+
+    let isValid = true;
+    let firstInvalidInput: HTMLElement | null = null;
+
+    inputs.forEach((input) => {
+      // Force check on required fields even if untouched
+      if (input.hasAttribute("required") && !input.value) {
+        input.classList.add("error");
+      }
+
+      if (!this.validateInput(input)) {
+        isValid = false;
+        if (!firstInvalidInput) firstInvalidInput = input;
+      }
+    });
+
+    if (!isValid) {
+      this._internals.setValidity(
+        { customError: true },
+        "Please fill out all required fields correctly",
+        firstInvalidInput || undefined,
+      );
+    } else {
+      this._internals.setValidity({});
+    }
+
+    return isValid;
+  }
+
   template = html`
-    <div class="auth-credentials">
+    <div class="auth-credentials" data-attr-name="this.identifier() + '.credentials'">
       <template data-if="this.authType() === 'Basic'">
         <div class="input-row">
           <div class="input-container">
@@ -85,7 +158,6 @@ export class AuthCredentials extends HTMLElement {
               type="text"
               data-value="this.creds()?.username ?? null"
               data-on-input="this.updateValue(event)"
-              required
             />
           </div>
           <div class="input-container">
@@ -97,7 +169,6 @@ export class AuthCredentials extends HTMLElement {
               data-attr-name="this.getInputId('password')"
               type="password"
               data-value="this.creds()?.password ?? null"
-              required
               data-on-input="this.updateValue(event)"
             />
           </div>
@@ -160,7 +231,6 @@ export class AuthCredentials extends HTMLElement {
                 type="text"
                 data-value="this.creds()?.scram_username ?? null"
                 data-on-input="this.updateValue(event)"
-                required
               />
             </div>
             <div class="input-container">
@@ -168,11 +238,10 @@ export class AuthCredentials extends HTMLElement {
               <input
                 class="input"
                 required
+                type="password"
                 data-attr-id="this.getInputId('scram_password')"
                 data-attr-name="this.getInputId('scram_password')"
-                type="password"
                 data-value="this.creds()?.scram_password ?? null"
-                required
                 data-on-input="this.updateValue(event)"
               />
             </div>
@@ -191,7 +260,6 @@ export class AuthCredentials extends HTMLElement {
                 type="url"
                 data-attr-id="this.getInputId('tokens_url')"
                 data-attr-name="this.getInputId('tokens_url')"
-                required
                 data-value="this.creds()?.tokens_url ?? null"
                 data-on-input="this.updateValue(event)"
                 title="The URL of the OAuth 2.0 identity provider's token endpoint. Must be a valid URL."
@@ -357,6 +425,22 @@ export class AuthCredentials extends HTMLElement {
     shadow.adoptedStyleSheets = [sheet];
     shadow.innerHTML = this.template;
     applyBindings(shadow, this.os, this);
+
+    // Before form submits, invoke validation checks
+    if (this._internals.form) {
+      this._internals.form.addEventListener(
+        "submit",
+        (event) => {
+          console.log("Form submitted:", event);
+          // Validate all inputs on form submission
+          if (!this.checkValidity()) {
+            // Don't prevent default. Since we send validation checks to _internals,
+            // the parent form will see element is invalid and prevent submission
+          }
+        },
+        { capture: true },
+      );
+    }
   }
 }
 

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -93,8 +93,9 @@
               name="kafka_cluster.bootstrap_servers"
               type="text"
               placeholder="host:port, host2:port2"
-              data-attr-value="this.kafkaBootstrapServers()"
+              data-value="this.kafkaBootstrapServers()"
               data-on-change="this.updateValue(event)"
+              data-attr-required="!this.schemaUri() ? true : false"
             />
             <span class="field-description"
               >One or more host:port pairs to use for establishing the initial connection (use a
@@ -168,8 +169,9 @@
               pattern="https?://.*"
               title="URL must begin with http or https"
               placeholder="https://example.com"
-              data-attr-value="this.schemaUri()"
+              data-value="this.schemaUri()"
               data-on-change="this.updateValue(event)"
+              data-attr-required="!this.kafkaBootstrapServers() ? true : false"
             />
             <span class="field-description"
               >The URL of the Schema Registry to use for serialization</span

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -43,7 +43,7 @@ class DirectConnectFormViewModel extends ViewModel {
 
   /** Kafka */
   kafkaBootstrapServers = this.derive(() => {
-    return this.spec()?.kafka_cluster?.bootstrap_servers || "";
+    return this.spec()?.kafka_cluster?.bootstrap_servers ?? null;
   });
   kafkaCreds = this.derive(() => {
     return this.spec()?.kafka_cluster?.credentials;
@@ -62,7 +62,7 @@ class DirectConnectFormViewModel extends ViewModel {
 
   /** Schema Registry */
   schemaUri = this.derive(() => {
-    return this.spec()?.schema_registry?.uri || "";
+    return this.spec()?.schema_registry?.uri ?? null;
   });
   schemaCreds = this.derive(() => {
     return this.spec()?.schema_registry?.credentials;
@@ -163,6 +163,12 @@ class DirectConnectFormViewModel extends ViewModel {
         break;
       case "schema_registry.ssl.enabled":
         this.schemaSslEnabled(input.checked);
+        break;
+      case "kafka_cluster.bootstrap_servers":
+        this.kafkaBootstrapServers(input.value);
+        break;
+      case "schema_registry.uri":
+        this.schemaUri(input.value);
         break;
       default:
         console.info(`No side effects for input update: ${input.name}`);


### PR DESCRIPTION
## Summary of Changes
- Some follow up tasks for the direct connect form.
- More to come, trying to keep PRs small

## Any additional details or context that should be provided?
- Now validating required fields in `auth-credentials` component & preventing form submission if they're missing
- Unit tests for `deepMerge` function
### ⚠️ Not Included:
- Custom patterns for validation. We may want to add this in the future for urls, etc
- Fancy JavaScript and CSS for validation messages. For now I'm using the default HTML validation. In the future we may want to add custom UI for validation messages so it matches other design choices

## How to Test
Choose any auth type except "None" in the form. You should not be able to submit without filling in the required fields for that type (which ones are required varies by type but all of them have > 2 required fields)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [NO] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
