### PR TITLE
Connection form - fix default value submission

### DIFF
--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -397,8 +397,7 @@ export class AuthCredentials extends HTMLElement {
                 data-attr-id="this.getInputId('service_name')"
                 data-attr-name="this.getInputId('service_name')"
                 type="text"
-                placeholder="kafka"
-                data-value="this.creds()?.service_name ?? null"
+                data-value="this.creds()?.service_name ?? 'kafka'"
                 data-on-input="this.updateValue(event)"
               />
             </div>

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -56,6 +56,22 @@ export class AuthCredentials extends HTMLElement {
     return this.identifier() + ".credentials." + name;
   }
 
+  // Add all initial form values to the form data, including defaults
+  initializeFormValues() {
+    console.log("Initializing form values");
+    // Get all input/select elements in the shadow DOM
+    const formElements = this.shadowRoot?.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
+      "input, select",
+    );
+    if (formElements) {
+      formElements.forEach((element) => {
+        if (element.name && element.value) {
+          this.entries.set(element.name, element.value);
+        }
+      });
+    }
+    this._internals.setFormValue(this.entries);
+  }
   // Helper method to validate a single input
   validateInput(input: HTMLInputElement): boolean {
     if (!input.validity.valid) {
@@ -425,8 +441,11 @@ export class AuthCredentials extends HTMLElement {
     applyBindings(shadow, this.os, this);
     this.os.watch(() => {
       this.authType();
+      this.creds();
       // start with a clean slate when auth type changes
       this._internals.setValidity({});
+      // Initialize form values after bindings. Small timeout to ensure DOM is ready
+      setTimeout(() => this.initializeFormValues(), 100);
     });
 
     // Before form submits, invoke validation checks

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -58,7 +58,6 @@ export class AuthCredentials extends HTMLElement {
 
   // Add all initial form values to the form data, including defaults
   initializeFormValues() {
-    console.log("Initializing form values");
     // Get all input/select elements in the shadow DOM
     const formElements = this.shadowRoot?.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
       "input, select",
@@ -451,8 +450,7 @@ export class AuthCredentials extends HTMLElement {
     if (this._internals.form) {
       this._internals.form.addEventListener(
         "submit",
-        (event) => {
-          console.log("Form submitted:", event);
+        () => {
           // Validate all inputs on form submission
           if (!this.checkValidity()) {
             // Don't prevent default. Since we send validation checks to _internals,

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -428,6 +428,7 @@ export class AuthCredentials extends HTMLElement {
       // start with a clean slate when auth type changes
       this._internals.setValidity({});
     });
+
     // Before form submits, invoke validation checks
     if (this._internals.form) {
       this._internals.form.addEventListener(

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -796,7 +796,10 @@ test("submits values for Kerberos auth type when filled in", async ({ execute, p
   await page.selectOption("select[name='kafka_cluster.auth_type']", "Kerberos");
   await page.fill("input[name='kafka_cluster.credentials.principal']", "user@EXAMPLE.COM");
   await page.fill("input[name='kafka_cluster.credentials.keytab_path']", "/path/to/keytab");
-  await page.fill("input[name='kafka_cluster.credentials.service_name']", "kafka");
+  // Don't fill in service_name, so we can verify it is sent with default value
+  // await page.fill("input[name='kafka_cluster.credentials.service_name']", "kafka");
+  // Wait a few milliseconds to ensure the default value is set to form (test is much faster than human)
+  await page.waitForTimeout(200);
 
   // Submit the form
   await page.click("input[type=submit][value='Save']");

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -501,10 +501,13 @@ test("submits values for SASL/SCRAM auth type when filled in", async ({ execute,
   await page.fill("input[name=name]", "Test Connection");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
   await page.selectOption("select[name='kafka_cluster.auth_type']", "SCRAM");
-  await page.selectOption(
-    "select[name='kafka_cluster.credentials.hash_algorithm']",
-    "SCRAM_SHA_256",
-  );
+  // Don't update hash_algorithm, so we can verify it is sent with default value
+  // Wait a few milliseconds to ensure the default value is set to form (test is much faster than human)
+  await page.waitForTimeout(200);
+  // await page.selectOption(
+  //   "select[name='kafka_cluster.credentials.hash_algorithm']",
+  //   "SCRAM_SHA_256",
+  // );
   await page.fill("input[name='kafka_cluster.credentials.scram_username']", "user");
   await page.fill("input[name='kafka_cluster.credentials.scram_password']", "password");
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fixes a bug where default values don't get added to the form if they aren't touched. 
- Closes https://github.com/confluentinc/vscode/issues/1227

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Since we are deep in web component land, we need to send all the values explicitly to the parent form using `_internals.setFormValue`. 
- Previously we were only setting these values on the 'input' event, so if they weren't touched they were not submitted with the form data. 
- This PR introduces `initializeFormValues` method to go through inputs and add them to the form data, and calls it in the connectedCallback, as well as sets a watcher to call again if the auth type or creds change

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [NO] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
