### PR TITLE
Connection form - TLS Config section copy/ux updates 

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -214,7 +214,7 @@
             />
             <span>SSL/TLS enabled</span>
           </label>
-          <template data-if="this.schemaSslEnabled()">
+          <template data-if="this.schemaSslEnabled() && this.platformType() !== 'Confluent Cloud'">
             <ssl-config
               data-prop-config="this.schemaSslConfig()"
               data-prop-namespace="'schema_registry'"

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -284,10 +284,6 @@
       .msg-banner.success::before {
         background-color: var(--vscode-testing-iconPassed);
       }
-      .info > .button {
-        padding: 2px;
-        font-size: smaller;
-      }
       /* These styles are specific to the form SSL section */
       .clickable-header {
         cursor: pointer;
@@ -311,6 +307,24 @@
       }
       .input-sub-group > .input-container {
         margin-bottom: 12px;
+      }
+      /** Align an Input with Button next to it e.g ssl select file
+      * div.button-input
+      *  .input
+      *  .button
+      */
+      .button-input {
+        display: flex;
+        align-items: start;
+        gap: 8px;
+      }
+      .button-input .input {
+        flex: 1 0 60%;
+      }
+      .button-input .button {
+        flex: 0 0 60px;
+        padding: 4px 2px;
+        font-size: smaller;
       }
     </style>
   </body>

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -297,10 +297,10 @@ test("submits the form with namespaced ssl advanced config fields when filled", 
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
   // Click to show the advanced settings, then fill them in
   await page.click("p:has-text('TLS Configuration')");
-  await page.selectOption("select[name='kafka_cluster.ssl.truststore.type']", "PEM");
+  await page.selectOption("select[name='kafka_cluster.ssl.truststore.type']", "PKCS12");
   await page.fill("input[name='kafka_cluster.ssl.truststore.path']", "/path/to/truststore");
   await page.fill("input[name='kafka_cluster.ssl.truststore.password']", "truststore-password");
-  await page.selectOption("select[name='kafka_cluster.ssl.keystore.type']", "PEM");
+  await page.selectOption("select[name='kafka_cluster.ssl.keystore.type']", "PKCS12");
   await page.fill("input[name='kafka_cluster.ssl.keystore.path']", "/path/to/keystore");
   await page.fill("input[name='kafka_cluster.ssl.keystore.password']", "keystore-password");
   await page.fill("input[name='kafka_cluster.ssl.keystore.key_password']", "key-password");
@@ -326,10 +326,10 @@ test("submits the form with namespaced ssl advanced config fields when filled", 
     "kafka_cluster.ssl.keystore.key_password": "key-password",
     "kafka_cluster.ssl.keystore.password": "keystore-password",
     "kafka_cluster.ssl.keystore.path": "/path/to/keystore",
-    "kafka_cluster.ssl.keystore.type": "PEM",
+    "kafka_cluster.ssl.keystore.type": "PKCS12",
     "kafka_cluster.ssl.truststore.password": "truststore-password",
     "kafka_cluster.ssl.truststore.path": "/path/to/truststore",
-    "kafka_cluster.ssl.truststore.type": "PEM",
+    "kafka_cluster.ssl.truststore.type": "PKCS12",
   });
 });
 test("adds only edited ssl fields to form data", async ({ execute, page }) => {
@@ -451,7 +451,7 @@ test("adds advanced ssl fields even if section is collapsed", async ({ execute, 
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
   // Click to show the advanced settings, then fill them in
   await page.click("p:has-text('TLS Configuration')");
-  await page.selectOption("select[name='kafka_cluster.ssl.truststore.type']", "PEM");
+  await page.selectOption("select[name='kafka_cluster.ssl.truststore.type']", "PKCS12");
   await page.fill("input[name='kafka_cluster.ssl.truststore.path']", "/path/to/truststore");
   await page.fill("input[name='kafka_cluster.ssl.truststore.password']", "truststore-password");
 
@@ -474,7 +474,7 @@ test("adds advanced ssl fields even if section is collapsed", async ({ execute, 
     "kafka_cluster.ssl.enabled": "true",
     "kafka_cluster.ssl.truststore.password": "truststore-password",
     "kafka_cluster.ssl.truststore.path": "/path/to/truststore",
-    "kafka_cluster.ssl.truststore.type": "PEM",
+    "kafka_cluster.ssl.truststore.type": "PKCS12",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
     "schema_registry.uri": "",

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -140,17 +140,30 @@ export class SslConfig extends HTMLElement {
               data-attr-checked="this.verifyHostname()"
               data-on-change="this.updateValue(event);"
               data-attr-value="this.verifyHostname()"
+              title="Enable verification of the host name matching the Distinguished Name (DN) in the certificate."
             />
             <span>Verify Server Hostname</span>
           </label>
         </div>
         <div class="input-container">
           <label class="label">Key Store Configuration</label>
+          <label class="info" style="margin-bottom: 5px">
+            Certificate used to authenticate the client. This is used to configure mutual TLS (mTLS)
+            authentication.
+            <a
+              href="https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/mtls/configure.html#steps-to-configure-mtls-authentication-on-ccloud"
+            >
+              <span class="link"
+                >Click here for steps to configure mTLS authentication on Confluent Cloud.
+              </span>
+            </a>
+          </label>
           <div class="input-row">
             <div class="input-container" style="flex: 1">
               <label data-attr-for="this.getInputId('keystore.type')" class="info">Type</label>
               <select
                 class="input dropdown"
+                title="File format of the Key Store file."
                 data-attr-id="this.getInputId('keystore.type')"
                 data-attr-name="this.getInputId('keystore.type')"
                 data-value="this.keystoreType()"
@@ -161,26 +174,27 @@ export class SslConfig extends HTMLElement {
                 <option value="PEM">PEM</option>
               </select>
             </div>
-            <div class="input-container">
-              <label data-attr-for="this.getInputId('keystore.path')" class="info"
-                >Path
+            <div class="input-container" style="align-items: stretch">
+              <label data-attr-for="this.getInputId('keystore.path')" class="info">Path </label>
+              <div class="button-input">
+                <input
+                  class="input"
+                  title="The absolute path to the Key Store file."
+                  data-attr-id="this.getInputId('keystore.path')"
+                  data-attr-name="this.getInputId('keystore.path')"
+                  type="text"
+                  placeholder="/path/to/keystore"
+                  data-value="this.keystorePath()"
+                  data-on-change="this.updateValue(event)"
+                />
                 <span
                   class="button secondary"
                   data-attr-id="this.getInputId('keystore.path')"
                   data-attr-name="this.getInputId('keystore.path')"
                   data-on-click="this.handleFileSelection(this.getInputId('keystore.path'))"
-                  >Choose file</span
-                ></label
-              >
-              <input
-                class="input"
-                data-attr-id="this.getInputId('keystore.path')"
-                data-attr-name="this.getInputId('keystore.path')"
-                type="text"
-                placeholder="/path/to/keystore"
-                data-value="this.keystorePath()"
-                data-on-change="this.updateValue(event)"
-              />
+                  >Select file</span
+                >
+              </div>
             </div>
           </div>
           <div class="input-row">
@@ -190,9 +204,11 @@ export class SslConfig extends HTMLElement {
               >
               <input
                 class="input"
+                title="The store password for the Key Store file. Key Store password is not supported for PEM format."
                 data-attr-id="this.getInputId('keystore.password')"
                 data-attr-name="this.getInputId('keystore.password')"
                 type="password"
+                data-attr-disabled="this.keystoreType() === 'PEM'"
                 data-value="this.keystorePassword()"
                 data-on-change="this.updateValue(event)"
               />
@@ -203,6 +219,7 @@ export class SslConfig extends HTMLElement {
               >
               <input
                 class="input"
+                title="Private key password (if any)"
                 data-attr-id="this.getInputId('keystore.key_password')"
                 data-attr-name="this.getInputId('keystore.key_password')"
                 type="password"
@@ -214,11 +231,16 @@ export class SslConfig extends HTMLElement {
         </div>
         <div class="input-container">
           <label class="label">Trust Store Configuration</label>
+          <label class="info" style="margin-bottom: 5px">
+            Certificates for verifying SSL/TLS connections. This is required if a self-signed or a
+            non-public Certificate Authority (CA) is used.
+          </label>
           <div class="input-row">
             <div class="input-container" style="flex: 1">
               <label data-attr-for="this.getInputId('truststore.type')" class="info">Type</label>
               <select
                 class="input dropdown"
+                title="The file format of the Trust Store file."
                 data-attr-id="this.getInputId('truststore.type')"
                 data-attr-name="this.getInputId('truststore.type')"
                 data-value="this.truststoreType()"
@@ -229,40 +251,43 @@ export class SslConfig extends HTMLElement {
                 <option value="PEM">PEM</option>
               </select>
             </div>
-            <div class="input-container">
-              <label data-attr-for="this.getInputId('truststore.path')" class="info"
-                >Path
+            <div class="input-container" style="align-items: stretch">
+              <label data-attr-for="this.getInputId('truststore.path')" class="info">Path </label>
+              <div class="button-input">
+                <input
+                  class="input"
+                  title="The absolute path to the Trust Store file."
+                  data-attr-id="this.getInputId('truststore.path')"
+                  data-attr-name="this.getInputId('truststore.path')"
+                  type="text"
+                  placeholder="/path/to/truststore"
+                  data-value="this.truststorePath()"
+                  data-on-change="this.updateValue(event)"
+                />
                 <span
                   class="button secondary"
                   data-attr-id="this.getInputId('truststore.path')"
                   data-attr-name="this.getInputId('truststore.path')"
                   data-on-click="this.handleFileSelection(this.getInputId('truststore.path'))"
-                  >Choose file</span
-                ></label
-              >
-              <input
-                class="input"
-                data-attr-id="this.getInputId('truststore.path')"
-                data-attr-name="this.getInputId('truststore.path')"
-                type="text"
-                placeholder="/path/to/truststore"
-                data-value="this.truststorePath()"
-                data-on-change="this.updateValue(event)"
-              />
+                  >Select file</span
+                >
+              </div>
             </div>
-            <div class="input-container">
-              <label data-attr-for="this.getInputId('truststore.password')" class="info"
-                >Password</label
-              >
-              <input
-                class="input"
-                data-attr-id="this.getInputId('truststore.password')"
-                data-attr-name="this.getInputId('truststore.password')"
-                type="password"
-                data-value="this.truststorePassword()"
-                data-on-change="this.updateValue(event)"
-              />
-            </div>
+          </div>
+          <div class="input-container">
+            <label data-attr-for="this.getInputId('truststore.password')" class="info"
+              >Password</label
+            >
+            <input
+              class="input"
+              title="The password for the Trust Store file. If a password is not set, the configured Trust Store file will still be used, but integrity checking of the Trust Store file is disabled. Trust Store password is not supported for PEM format."
+              data-attr-disabled="this.truststoreType() === 'PEM'"
+              data-attr-id="this.getInputId('truststore.password')"
+              data-attr-name="this.getInputId('truststore.password')"
+              type="password"
+              data-value="this.truststorePassword()"
+              data-on-change="this.updateValue(event)"
+            />
           </div>
         </div>
       </template>


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Add doc titles/headers to the sections
- Align file button with input
- Disable password fields if PEM type file (not supported)
- Hide advanced TLS config for Schema Registry on CCloud (not supported)

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Copy edits for titles come from internal wiki doc. 
- Not done but mentioned in the wiki doc - conditionally display certain text for Confluent Cloud. At the moment this component has no knowledge of the platform type selected in the parent form. This feature can be added in a future PR if desired. 
<img width="942" alt="Screenshot 2025-03-14 at 11 46 50 AM" src="https://github.com/user-attachments/assets/fbdbc733-e37f-493b-99c8-58866ef53d4c" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
