### PR TITLE
improve: handle response errors from producing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this extension will be documented in this file.
   re-authenticate.
 - "View Messages" and "Send Message(s)" icons have been updated for better visibility and
   accessibility.
+- Errors encountered while producing messages to a topic have been improved:
+  - Schema validation errors will now highlight problematic message content in the Problems panel
+    for easier troubleshooting.
+  - Non-validation errors are aggregated and summarized in the error notification.
 
 ### Fixed
 

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -467,7 +467,7 @@ async function produceMessages(
     // only display up to the top three non-validation errors and their counts
     const errorSummary: string = summarizeErrors(
       errorResults.map((result) => result.error),
-      ["ProduceMessageSchemaValidationError"],
+      ["ProduceMessageBadRequestError"],
       3,
     );
 
@@ -683,7 +683,7 @@ export class ProduceMessageBadRequestError extends Error {
   response: ResponseError;
   constructor(message: string, request: ProduceRequest, response: ResponseError) {
     super(message);
-    this.name = "ProduceMessageSchemaValidationError";
+    this.name = "ProduceMessageBadRequestError";
     this.request = request;
     this.response = response;
   }

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -593,7 +593,7 @@ export async function handleSchemaValidationErrors(
   return messageDiagnostics;
 }
 
-interface ProduceResult {
+export interface ProduceResult {
   timestamp: Date;
   response: ProduceResponse;
 }

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -16,7 +16,11 @@ import {
 } from "../clients/sidecar";
 import { MessageViewerConfig } from "../consume";
 import { MESSAGE_URI_SCHEME } from "../documentProviders/message";
-import { showErrorNotificationWithButtons } from "../errors";
+import {
+  DEFAULT_ERROR_NOTIFICATION_BUTTONS,
+  isResponseError,
+  showErrorNotificationWithButtons,
+} from "../errors";
 import { Logger } from "../logging";
 import { KafkaCluster } from "../models/kafkaCluster";
 import { isCCloud } from "../models/resource";
@@ -27,6 +31,7 @@ import { loadDocumentContent, LoadedDocumentContent, uriQuickpick } from "../qui
 import { promptForSchema } from "../quickpicks/utils/schemas";
 import { getSubjectNameStrategy } from "../quickpicks/utils/schemaSubjects";
 import { JSON_DIAGNOSTIC_COLLECTION } from "../schemas/diagnosticCollection";
+import { getRangeForDocument } from "../schemas/parsing";
 import {
   PRODUCE_MESSAGE_SCHEMA,
   ProduceMessage,
@@ -441,12 +446,100 @@ async function produceMessages(
   }
 
   if (errorResults.length) {
-    const errorMessages = errorResults.map(({ error }) => error).join("\n");
-    // this format isn't great if there are multiple errors, but it's better than nothing
+    // send all results to the error diagnostics handler since we want the indices of the results
+    // for any error diagnostics
+    const diagnostics = await handleSchemaValidationErrors(results, messageUri);
+
+    let buttons = DEFAULT_ERROR_NOTIFICATION_BUTTONS;
+    if (diagnostics.length) {
+      buttons = {
+        "Show Validation Errors": () => {
+          vscode.window.showTextDocument(messageUri, { preview: false }).then(() => {
+            vscode.commands.executeCommand("workbench.action.showErrorsWarnings");
+          });
+        },
+        ...DEFAULT_ERROR_NOTIFICATION_BUTTONS,
+      };
+    }
+
+    // aggregate error message counts and show them in descending order by count
+    const errorTypeCounts: { [key: string]: number } = {};
+    errorResults.forEach((errorResult) => {
+      errorTypeCounts[errorResult.error.message] =
+        (errorTypeCounts[errorResult.error.message] ?? 0) + 1;
+    });
+    const errorSummary = Object.entries(errorTypeCounts)
+      .sort(([, a], [, b]) => b - a)
+      .map(([msg, count]) => `${count}x ${msg}`)
+      .slice(0, 3); // limit to 3 most common errors
     showErrorNotificationWithButtons(
-      `Failed to produce ${errorResults.length.toLocaleString()}${ofTotal} message${plural} to topic "${topic.name}":\n${errorMessages}`,
+      `Failed to produce ${errorResults.length.toLocaleString()}${ofTotal} message${plural} to topic "${topic.name}":\n\n${errorSummary}`,
+      buttons,
     );
   }
+}
+
+export async function handleSchemaValidationErrors(
+  results: ExecutionResult<ProduceResult>[],
+  messageUri: vscode.Uri,
+) {
+  // map the original error position, the error itself, and the promise for looking up the range
+  interface ErrorMapping {
+    resultIndex: number;
+    error: Error;
+    rangePromise: Promise<vscode.Range>;
+  }
+
+  const errorMappings: ErrorMapping[] = [];
+
+  // collect all errors and their range promises while maintaining the index mapping
+  results.forEach((result, idx) => {
+    if (result.error instanceof ProduceMessageBadRequestError) {
+      // check if the validation error was caused by the key and/or the value by looking at the
+      // request, which may create multiple ranges for a single message
+      // TODO(shoup): this is a workaround for the fact that we don't get more information from the
+      // serializer errors, but we should revisit this once we're able to get more information like
+      // key/value and specific field(s) or paths
+      const forKey = typeof result.error.request.key?.subject_name_strategy === "string";
+      const forValue = typeof result.error.request.value?.subject_name_strategy === "string";
+      if (forKey) {
+        errorMappings.push({
+          resultIndex: idx,
+          error: result.error,
+          rangePromise: getRangeForDocument(messageUri, PRODUCE_MESSAGE_SCHEMA, idx, "key"),
+        });
+      }
+      if (forValue) {
+        errorMappings.push({
+          resultIndex: idx,
+          error: result.error,
+          rangePromise: getRangeForDocument(messageUri, PRODUCE_MESSAGE_SCHEMA, idx, "value"),
+        });
+      }
+    }
+  });
+  const resolvedMappings = await Promise.all(
+    errorMappings.map(async (mapping) => ({
+      ...mapping,
+      range: await mapping.rangePromise,
+    })),
+  );
+
+  const messageDiagnostics: vscode.Diagnostic[] = [];
+  if (resolvedMappings.length > 0) {
+    // apply the validation-related error diagnostics to the document
+    resolvedMappings.forEach((mapping) => {
+      messageDiagnostics.push(
+        new vscode.Diagnostic(
+          mapping.range,
+          mapping.error.message,
+          vscode.DiagnosticSeverity.Error,
+        ),
+      );
+    });
+    JSON_DIAGNOSTIC_COLLECTION.set(messageUri, messageDiagnostics);
+  }
+  return messageDiagnostics;
 }
 
 interface ProduceResult {
@@ -493,25 +586,56 @@ export async function produceMessage(
 
   const sidecar = await getSidecar();
 
-  if (forCCloudTopic) {
-    const ccloudClient: ConfluentCloudProduceRecordsResourceApi =
-      sidecar.getConfluentCloudProduceRecordsResourceApi(topic.connectionId);
-    const ccloudResponse = await ccloudClient.gatewayV1ClustersClusterIdTopicsTopicNameRecordsPost({
-      ...request,
-      x_connection_id: topic.connectionId,
-      dry_run: false,
-      ProduceRequest: produceRequest as CCloudProduceRequest,
-    });
-    response = ccloudResponse as ProduceResponse;
-  } else {
-    // non-CCloud topic route:
-    const client: RecordsV3Api = sidecar.getRecordsV3Api(topic.clusterId, topic.connectionId);
-    response = await client.produceRecord({ ...request, ProduceRequest: produceRequest });
+  try {
+    if (forCCloudTopic) {
+      const ccloudClient: ConfluentCloudProduceRecordsResourceApi =
+        sidecar.getConfluentCloudProduceRecordsResourceApi(topic.connectionId);
+      const ccloudResponse =
+        await ccloudClient.gatewayV1ClustersClusterIdTopicsTopicNameRecordsPost({
+          ...request,
+          x_connection_id: topic.connectionId,
+          dry_run: false,
+          ProduceRequest: produceRequest as CCloudProduceRequest,
+        });
+      response = ccloudResponse as ProduceResponse;
+    } else {
+      // non-CCloud topic route:
+      const client: RecordsV3Api = sidecar.getRecordsV3Api(topic.clusterId, topic.connectionId);
+      response = await client.produceRecord({ ...request, ProduceRequest: produceRequest });
+    }
+  } catch (err) {
+    // only attempt to catch schema validation errors
+    if (isResponseError(err) && err.response.status === 400) {
+      let errBody: string | undefined;
+      try {
+        // should be {"message":"Failed to parse data: ... ","error_code":400}
+        const respJson = await err.response.clone().json();
+        if (respJson && typeof respJson === "object" && respJson.message) {
+          errBody = respJson.message;
+        }
+      } catch {
+        errBody = await err.response.clone().text();
+      }
+      if (errBody !== undefined)
+        throw new ProduceMessageBadRequestError(errBody, produceRequest, err);
+    }
+    throw err;
   }
 
   timestamp = response.timestamp ? new Date(response.timestamp) : timestamp;
 
   return { timestamp, response };
+}
+
+export class ProduceMessageBadRequestError extends Error {
+  request: ProduceRequest;
+  response: ResponseError;
+  constructor(message: string, request: ProduceRequest, response: ResponseError) {
+    super(message);
+    this.name = "ProduceMessageSchemaValidationError";
+    this.request = request;
+    this.response = response;
+  }
 }
 
 export function registerTopicCommands(): vscode.Disposable[] {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,6 +26,16 @@ export type AnyResponseError =
   | ScaffoldingServiceResponseError
   | DockerResponseError;
 
+export function isResponseError(error: unknown): error is AnyResponseError {
+  return (
+    error instanceof SidecarResponseError ||
+    error instanceof KafkaResponseError ||
+    error instanceof SchemaRegistryResponseError ||
+    error instanceof ScaffoldingServiceResponseError ||
+    error instanceof DockerResponseError
+  );
+}
+
 /**
  * Check if an {@link Error} has a `cause` property of type `Error`, indicating it has at least
  * one nested error.

--- a/src/schemas/parsing.test.ts
+++ b/src/schemas/parsing.test.ts
@@ -1,0 +1,251 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { BaseASTNode, Position as LSPosition, TextDocument } from "vscode-json-languageservice";
+import * as uris from "../quickpicks/uris";
+import { convertToVSPosition, createRange, getRangeForDocument } from "./parsing";
+import * as validateDocument from "./validateDocument";
+
+describe("schemas/parsing.ts convertToVSPosition()", () => {
+  it(" should convert a language service position to VS Code position", () => {
+    const lsPosition: LSPosition = { line: 5, character: 10 };
+
+    const vsPosition = convertToVSPosition(lsPosition);
+
+    assert.strictEqual(vsPosition instanceof vscode.Position, true);
+    assert.strictEqual(vsPosition.line, 5);
+    assert.strictEqual(vsPosition.character, 10);
+  });
+
+  it("should handle zero values", () => {
+    const lsPosition: LSPosition = { line: 0, character: 0 };
+
+    const vsPosition = convertToVSPosition(lsPosition);
+
+    assert.strictEqual(vsPosition.line, 0);
+    assert.strictEqual(vsPosition.character, 0);
+  });
+
+  it("should handle large values", () => {
+    const lsPosition: LSPosition = { line: 9999, character: 12345 };
+
+    const vsPosition = convertToVSPosition(lsPosition);
+
+    assert.strictEqual(vsPosition.line, 9999);
+    assert.strictEqual(vsPosition.character, 12345);
+  });
+});
+
+describe("schemas/parsing.ts createRange()", () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockTextDocument: TextDocument;
+  let positionAtStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // stub TextDocument's positionAt method to control its return value
+    positionAtStub = sandbox.stub();
+    mockTextDocument = {
+      positionAt: positionAtStub,
+    } as unknown as TextDocument;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should create a range from a node's offset and length", () => {
+    // return fake positions
+    positionAtStub.withArgs(100).returns({ line: 5, character: 10 });
+    positionAtStub.withArgs(150).returns({ line: 7, character: 20 });
+
+    const fakeNode = {
+      offset: 100,
+      length: 50,
+    } as BaseASTNode;
+
+    const range = createRange(mockTextDocument, fakeNode);
+
+    assert.strictEqual(range instanceof vscode.Range, true);
+    assert.strictEqual(range.start.line, 5);
+    assert.strictEqual(range.start.character, 10);
+    assert.strictEqual(range.end.line, 7);
+    assert.strictEqual(range.end.character, 20);
+
+    // verify the text document's positionAt was called with the correct offsets
+    sinon.assert.calledWith(positionAtStub.firstCall, 100);
+    sinon.assert.calledWith(positionAtStub.secondCall, 150);
+  });
+
+  it("should handle zero offset", () => {
+    positionAtStub.withArgs(0).returns({ line: 0, character: 0 });
+    positionAtStub.withArgs(25).returns({ line: 0, character: 25 });
+
+    const fakeNode = {
+      offset: 0,
+      length: 25,
+    } as BaseASTNode;
+
+    const range = createRange(mockTextDocument, fakeNode);
+
+    assert.strictEqual(range.start.line, 0);
+    assert.strictEqual(range.start.character, 0);
+    assert.strictEqual(range.end.line, 0);
+    assert.strictEqual(range.end.character, 25);
+  });
+});
+
+describe("schemas/parsing.ts getRangeForDocument()", () => {
+  let sandbox: sinon.SinonSandbox;
+  let loadDocumentContentStub: sinon.SinonStub;
+  let initializeJsonDocumentStub: sinon.SinonStub;
+
+  const fakeFileUri = vscode.Uri.parse("file:///test.json");
+  const fakeSchema = { type: "object" };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    loadDocumentContentStub = sandbox.stub(uris, "loadDocumentContent");
+    initializeJsonDocumentStub = sandbox.stub(validateDocument, "initializeJsonDocument");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return empty range for empty document", async () => {
+    loadDocumentContentStub.resolves({ content: "{}" });
+    initializeJsonDocumentStub.returns({
+      textDocument: {} as TextDocument,
+      jsonDocument: { root: null },
+    });
+
+    const range = await getRangeForDocument(fakeFileUri, fakeSchema);
+
+    assert.strictEqual(range.start.line, 0);
+    assert.strictEqual(range.start.character, 0);
+    assert.strictEqual(range.end.line, 0);
+    assert.strictEqual(range.end.character, 0);
+  });
+
+  it("should find property in single object document", async () => {
+    loadDocumentContentStub.resolves({ content: '{"test": "value"}' });
+
+    const fakeTextDocument = {
+      positionAt: (offset: number) => {
+        if (offset === 1) return { line: 0, character: 1 };
+        if (offset === 15) return { line: 0, character: 15 };
+        return { line: 0, character: 0 };
+      },
+    } as unknown as TextDocument;
+    initializeJsonDocumentStub.returns({
+      textDocument: fakeTextDocument,
+      jsonDocument: {
+        root: {
+          type: "object",
+          properties: [
+            {
+              keyNode: { value: "test" },
+              offset: 1,
+              length: 14,
+            },
+          ],
+        },
+      },
+    });
+
+    const range = await getRangeForDocument(fakeFileUri, fakeSchema, 0, "test");
+
+    assert.strictEqual(range.start.line, 0);
+    assert.strictEqual(range.start.character, 1);
+    assert.strictEqual(range.end.line, 0);
+    assert.strictEqual(range.end.character, 15);
+  });
+
+  it("should find item in array document", async () => {
+    loadDocumentContentStub.resolves({ content: '[{"key": "value1"}, {"key": "value2"}]' });
+
+    const fakeTextDocument = {
+      positionAt: (offset: number) => {
+        if (offset === 1) return { line: 0, character: 1 };
+        if (offset === 18) return { line: 0, character: 18 };
+        if (offset === 20) return { line: 0, character: 20 };
+        if (offset === 37) return { line: 0, character: 37 };
+        return { line: 0, character: 0 };
+      },
+    } as unknown as TextDocument;
+    initializeJsonDocumentStub.returns({
+      textDocument: fakeTextDocument,
+      jsonDocument: {
+        root: {
+          type: "array",
+          items: [
+            {
+              offset: 1,
+              length: 17,
+              type: "object",
+            },
+            {
+              offset: 20,
+              length: 17,
+              type: "object",
+            },
+          ],
+        },
+      },
+    });
+
+    // test finding the second item (index 1)
+    const range = await getRangeForDocument(fakeFileUri, fakeSchema, 1);
+
+    assert.strictEqual(range.start.line, 0);
+    assert.strictEqual(range.start.character, 20);
+    assert.strictEqual(range.end.line, 0);
+    assert.strictEqual(range.end.character, 37);
+  });
+
+  it("should find property in array item", async () => {
+    loadDocumentContentStub.resolves({ content: '[{"key": "value1"}, {"key": "value2"}]' });
+
+    const fakeTextDocument = {
+      positionAt: (offset: number) => {
+        if (offset === 22) return { line: 0, character: 22 };
+        if (offset === 35) return { line: 0, character: 35 };
+        return { line: 0, character: 0 };
+      },
+    } as unknown as TextDocument;
+    initializeJsonDocumentStub.returns({
+      textDocument: fakeTextDocument,
+      jsonDocument: {
+        root: {
+          type: "array",
+          // property node within the object at index 1
+          items: [
+            {},
+            {
+              offset: 20,
+              length: 17,
+              type: "object",
+              properties: [
+                {
+                  offset: 22,
+                  length: 13,
+                  keyNode: { value: "key" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    // find the "key" property in the second item (index 1)
+    const range = await getRangeForDocument(fakeFileUri, fakeSchema, 1, "key");
+
+    assert.strictEqual(range.start.line, 0);
+    assert.strictEqual(range.start.character, 22);
+    assert.strictEqual(range.end.line, 0);
+    assert.strictEqual(range.end.character, 35);
+  });
+});

--- a/src/schemas/parsing.ts
+++ b/src/schemas/parsing.ts
@@ -1,0 +1,86 @@
+import { Uri, Position as VSPosition, Range as VSRange } from "vscode";
+import {
+  BaseASTNode,
+  JSONSchema,
+  Position as LSPosition,
+  TextDocument,
+} from "vscode-json-languageservice";
+import { Logger } from "../logging";
+import { loadDocumentContent } from "../quickpicks/uris";
+import { initializeJsonDocument } from "./validateDocument";
+
+const logger = new Logger("schemas.parsing");
+
+export async function getRangeForDocument(
+  documentUri: Uri,
+  schema: JSONSchema,
+  itemIndex: number = 0,
+  key?: string,
+): Promise<VSRange> {
+  const { content } = await loadDocumentContent(documentUri);
+  const { textDocument, jsonDocument } = initializeJsonDocument(documentUri, content, schema);
+
+  let range: VSRange = new VSRange(0, 0, 0, 0);
+  if (!jsonDocument.root) {
+    // if the document is empty, return an empty range
+    return range;
+  }
+
+  if (jsonDocument.root.type === "object") {
+    // single object, ignore the index and just look for the key if provided
+    if (key) {
+      const propertyNode = jsonDocument.root.properties?.find(
+        (prop) => prop.keyNode?.value === key,
+      );
+      if (propertyNode) {
+        logger.trace(`found property node for key '${key}'`);
+        range = createRange(textDocument, propertyNode);
+      }
+    }
+  } else if (jsonDocument.root.type === "array") {
+    // multiple objects, look for the item at the specified index before checking the key
+    const childNode: BaseASTNode = jsonDocument.root.items[itemIndex];
+    if (childNode) {
+      logger.trace(`found child node ${childNode} at index ${itemIndex}`);
+      // found a single object at the provided index, set the range to cover the whole object
+      range = createRange(textDocument, childNode);
+      if (key && childNode.type === "object") {
+        // TODO: figure out why TS is complaining about childNode not having properties
+        const objectNode = childNode as {
+          properties?: Array<{
+            keyNode?: { value: string };
+            valueNode?: any;
+          }>;
+        };
+        const propertyNode = objectNode.properties?.find((prop) => prop.keyNode?.value === key);
+        if (propertyNode) {
+          logger.trace(`found property node for key '${key}' in item at index ${itemIndex}`);
+          range = createRange(textDocument, propertyNode as BaseASTNode);
+        }
+      }
+    }
+  }
+
+  return range;
+}
+
+/**
+ * Converts a {@link LSPosition Position} from the `vscode-json-languageservice` to a
+ * {@link VSPosition Position} from the `vscode` module.
+ */
+export function convertToVSPosition(position: LSPosition): VSPosition {
+  return new VSPosition(position.line, position.character);
+}
+
+/**
+ * Generates a {@link VSRange Range} from a {@link BaseASTNode} and a {@link TextDocument}.
+ */
+export function createRange(textDocument: TextDocument, childNode: BaseASTNode): VSRange {
+  const objStartPosition: VSPosition = convertToVSPosition(
+    textDocument.positionAt(childNode.offset),
+  );
+  const objEndPosition: VSPosition = convertToVSPosition(
+    textDocument.positionAt(childNode.offset + childNode.length),
+  );
+  return new VSRange(objStartPosition, objEndPosition);
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

### Before
When producing messages to a topic, the current behavior on `main` when any errors occur is we show a notification that repeats the error names over and over, doesn't provide any help for scenarios like validation-related issues (unless you go digging through the logs):
<img width="1523" alt="image" src="https://github.com/user-attachments/assets/2cd3b8ea-a5c4-4094-b65a-334ce2f99553" />

### After
This PR adds an extra parsing step to any `ResponseError`s we see from the produce request to specifically catch `status: 400` messages and re-throw as a `ProduceMessageBadRequestError` with the response body. Those are then combined with the index of the failed message(s) to add diagnostics to the original document rather than show a generic `Response returned an error code`.

#### Single validation error
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/187b82fa-1398-4649-9978-442108898c71" />

#### Single non-validation error
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/c285eb80-939f-4466-ac63-5e1d87c382e8" />

#### Multiple validation errors
<img width="1525" alt="image" src="https://github.com/user-attachments/assets/6d434ce0-7e25-4528-b772-c377f8cc1e9a" />

#### Multiple non-validation errors
<img width="1521" alt="image" src="https://github.com/user-attachments/assets/ca7963a5-5ac1-4099-8559-6efe52152abc" />

#### Mix of validation and non-validation errors
<img width="1522" alt="image" src="https://github.com/user-attachments/assets/f80e8bac-ba56-4610-abb3-24105fd727e9" />

While adding some extra handling for these error cases, we're also now aggregating `message` values for multiple errors to summarize in the notification instead of listing the error name multiple times.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Unfortunately for the validation-error handling, we don't get enough information back from the response to determine whether the `key` or `value` was problematic (or both), so we naively go off of whatever was passed with schema-related information in the original request. We also don't get specific field IDs or paths in order to pinpoint exactly which item(s) caused any kind of validation error.

We basically have two options (neither of which are possible before the 1.0.0 release):
- the sidecar would have to provide more information from the serializer
- the extension would try to look up schema definitions and preemptively convert AVRO/PROTOBUF schemas to JSON schemas, then apply the existing document validation like we do with https://github.com/confluentinc/vscode/blob/main/src/schemas/produceMessageSchema.ts

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
