### PR TITLE
Ncothren/fix ssl fields

### DIFF
--- a/src/directConnect.test.ts
+++ b/src/directConnect.test.ts
@@ -261,6 +261,37 @@ describe("directConnect.ts", () => {
       assert.ok(!spec.kafka_cluster.ssl.truststore);
       assert.ok(!spec.kafka_cluster.ssl.keystore);
     });
+    it("should include keystore and truststore information if paths are provided", () => {
+      const formData = {
+        name: "Test Connection",
+        formconnectiontype: "Apache Kafka",
+        "kafka_cluster.bootstrap_servers": "localhost:9092",
+        "kafka_cluster.auth_type": "None",
+        "kafka_cluster.ssl.enabled": "true",
+        "kafka_cluster.ssl.keystore.type": "PEM",
+        "kafka_cluster.ssl.keystore.password": "keypass",
+        "kafka_cluster.ssl.keystore.key_password": "keykeypass",
+        "kafka_cluster.ssl.truststore.path": "/path/to/truststore",
+        "kafka_cluster.ssl.truststore.password": "trustpass",
+        "kafka_cluster.ssl.truststore.type": "JKS",
+        "schema_registry.uri": "",
+        "schema_registry.auth_type": "None",
+        "schema_registry.ssl.enabled": "true",
+      };
+
+      const spec = getConnectionSpecFromFormData(formData);
+
+      assert.strictEqual(spec.name, "Test Connection");
+      assert.ok(spec.kafka_cluster);
+      assert.ok(spec.kafka_cluster.ssl);
+      // keystore path was missing, we should not include values in that section
+      assert.ok(!spec.kafka_cluster.ssl.keystore);
+      // truststore path was provided, we should include all values in that section
+      assert.ok(spec.kafka_cluster.ssl.truststore);
+      assert.strictEqual(spec.kafka_cluster.ssl.truststore.path, "/path/to/truststore");
+      assert.strictEqual(spec.kafka_cluster.ssl.truststore.password, "trustpass");
+      assert.strictEqual(spec.kafka_cluster.ssl.truststore.type, "JKS");
+    });
     it("should not include truststore or keystore for schema if paths are empty", () => {
       const formData = {
         name: "Test Connection",

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -270,7 +270,7 @@ test("submits the form with empty trust/key stores as defaults when ssl enabled"
     "schema_registry.uri": "http://localhost:8081",
   });
 });
-test("submits the form with namespaced ssl advanced config fields when filled", async ({
+test("submits the form with namespaced TLS config fields when filled", async ({
   execute,
   page,
 }) => {
@@ -332,7 +332,7 @@ test("submits the form with namespaced ssl advanced config fields when filled", 
     "kafka_cluster.ssl.truststore.type": "PEM",
   });
 });
-test("adds only edited ssl fields to form data", async ({ execute, page }) => {
+test("adds only edited TLS fields to form data", async ({ execute, page }) => {
   const sendWebviewMessage = await execute(async () => {
     const { sendWebviewMessage } = await import("./comms/comms");
     return sendWebviewMessage as SinonStub;
@@ -772,7 +772,6 @@ test("populates values for SASL/OAUTHBEARER auth type when they exist in the spe
     SPEC_SAMPLE_OAUTH.schema_registry.credentials.client_secret,
   );
 });
-
 test("submits values for Kerberos auth type when filled in", async ({ execute, page }) => {
   const sendWebviewMessage = await execute(async () => {
     const { sendWebviewMessage } = await import("./comms/comms");
@@ -824,7 +823,6 @@ test("submits values for Kerberos auth type when filled in", async ({ execute, p
     "schema_registry.uri": "",
   });
 });
-
 test("populates values for Kerberos auth type when they exist in the spec (edit/import)", async ({
   execute,
   page,
@@ -884,6 +882,117 @@ test("populates values for Kerberos auth type when they exist in the spec (edit/
     // @ts-expect-error credentials could be of different types
     SPEC_SAMPLE_KERBEROS.kafka_cluster.credentials.service_name,
   );
+});
+test("submits ssl verify_hostname as false when unchecked", async ({ execute, page }) => {
+  const sendWebviewMessage = await execute(async () => {
+    const { sendWebviewMessage } = await import("./comms/comms");
+    return sendWebviewMessage as SinonStub;
+  });
+
+  await execute(async (stub) => {
+    stub.withArgs("Submit").resolves(null);
+  }, sendWebviewMessage);
+
+  await execute(async () => {
+    await import("./main");
+    await import("./direct-connect-form");
+    window.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  await page.fill("input[name=name]", "SSL Verify Test");
+  await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
+  await page.fill("input[name='schema_registry.uri']", "http://localhost:8081");
+
+  await page.click("p:has-text('TLS Configuration')");
+  await page.uncheck("input[name='kafka_cluster.ssl.verify_hostname']");
+
+  // Submit the form
+  await page.click("input[type=submit][value='Save']");
+
+  // Verify the submitted data
+  const submitCall = await sendWebviewMessage.evaluateHandle(
+    (stub) => stub.getCalls().find((call) => call?.args[0] === "Submit")?.args[1],
+  );
+  const submitData = await submitCall?.jsonValue();
+  // ssl defaults to"true"; verify_hostname is "false" when unchecked
+  expect(submitData["kafka_cluster.ssl.enabled"]).toBe("true");
+  expect(submitData["kafka_cluster.ssl.verify_hostname"]).toBe("false");
+  expect(submitData["schema_registry.ssl.enabled"]).toBe("true");
+});
+test("submits ssl.enabled as false when unchecked", async ({ execute, page }) => {
+  const sendWebviewMessage = await execute(async () => {
+    const { sendWebviewMessage } = await import("./comms/comms");
+    return sendWebviewMessage as SinonStub;
+  });
+
+  await execute(async (stub) => {
+    stub.withArgs("Submit").resolves(null);
+  }, sendWebviewMessage);
+
+  await execute(async () => {
+    await import("./main");
+    await import("./direct-connect-form");
+    window.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  // Fill in basic form data
+  await page.fill("input[name=name]", "SSL Disabled Test");
+  await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
+  await page.fill("input[name='schema_registry.uri']", "http://localhost:8081");
+
+  // Ensure SSL is unchecked for both Kafka and Schema Registry
+  await page.uncheck("input[name='kafka_cluster.ssl.enabled']");
+  await page.uncheck("input[name='schema_registry.ssl.enabled']");
+
+  // Submit the form
+  await page.click("input[type=submit][value='Save']");
+
+  // Verify the submitted data
+  const submitCall = await sendWebviewMessage.evaluateHandle(
+    (stub) => stub.getCalls().find((call) => call?.args[0] === "Submit")?.args[1],
+  );
+  const submitData = await submitCall?.jsonValue();
+
+  // Verify that ssl.enabled was explicitly set to "false"
+  expect(submitData["kafka_cluster.ssl.enabled"]).toBe("false");
+  expect(submitData["schema_registry.ssl.enabled"]).toBe("false");
+});
+test("submits default types for keystore and truststore", async ({ execute, page }) => {
+  const sendWebviewMessage = await execute(async () => {
+    const { sendWebviewMessage } = await import("./comms/comms");
+    return sendWebviewMessage as SinonStub;
+  });
+  await execute(async (stub) => {
+    stub.withArgs("Submit").resolves(null);
+  }, sendWebviewMessage);
+
+  await execute(async () => {
+    await import("./main");
+    await import("./direct-connect-form");
+    window.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  // Fill in basic form data
+  await page.fill("input[name=name]", "SSL Disabled Test");
+  await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
+  await page.fill("input[name='schema_registry.uri']", "http://localhost:8081");
+  await page.click("p:has-text('TLS Configuration')");
+  await page.fill("input[name='kafka_cluster.ssl.keystore.path']", "/path/to/keystore");
+  await page.fill("input[name='kafka_cluster.ssl.truststore.path']", "/path/to/truststore");
+  // Small delay to ensure all default values are initialized; the test robot is faster than a human
+  await page.waitForTimeout(200);
+  // Submit the form
+  await page.click("input[type=submit][value='Save']");
+  const submitCallHandle = await sendWebviewMessage.evaluateHandle(
+    (stub) => stub.getCalls().find((call) => call?.args[0] === "Submit")?.args,
+  );
+  const submitCall = await submitCallHandle?.jsonValue();
+  expect(submitCall).not.toBeUndefined();
+  expect(submitCall?.[0]).toBe("Submit");
+
+  // Verify that the default type (JKS) for keystore and truststore are sent with form data if path is defined
+  expect(submitCall?.[1]["kafka_cluster.ssl.keystore.type"]).toBe("JKS");
+  expect(submitCall?.[1]["kafka_cluster.ssl.truststore.type"]).toBe("JKS");
 });
 
 // Test Fixtures

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -204,6 +204,21 @@ class DirectConnectFormViewModel extends ViewModel {
       data["kafka_cluster.ssl.enabled"] = "true";
       data["schema_registry.ssl.enabled"] = "true";
     }
+
+    // checkbox fields are not sent if the user unchecks them; add them back in form data
+    if (this.kafkaSslEnabled()) {
+      if (!data["kafka_cluster.ssl.verify_hostname"])
+        data["kafka_cluster.ssl.verify_hostname"] = "false";
+    } else {
+      data["kafka_cluster.ssl.enabled"] = "false";
+    }
+    if (this.schemaSslEnabled()) {
+      if (!data["schema_registry.ssl.verify_hostname"])
+        data["schema_registry.ssl.verify_hostname"] = "false";
+    } else {
+      data["schema_registry.ssl.enabled"] = "false";
+    }
+
     let result: PostResponse | TestResponse;
     if (submitter.value === "Test") {
       result = await post("Test", data);

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -301,6 +301,12 @@ export class SslConfig extends HTMLElement {
     applyBindings(shadow, this.os, this);
     // Initialize form values after bindings. Small timeout to ensure DOM is ready
     setTimeout(() => this.initializeFormValues(), 100);
+    this.os.watch(() => {
+      // re-initialize values if a path is changed by host file selector
+      this.truststorePath();
+      this.keystorePath();
+      setTimeout(() => this.initializeFormValues(), 100);
+    });
   }
 }
 

--- a/src/webview/ssl-config-inputs.ts
+++ b/src/webview/ssl-config-inputs.ts
@@ -60,6 +60,21 @@ export class SslConfig extends HTMLElement {
   set namespace(value: string) {
     this.identifier(value);
   }
+  // Add all initial form values to the form data, including defaults
+  initializeFormValues() {
+    // Get all input/select elements in the shadow DOM
+    const formElements = this.shadowRoot?.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
+      "input, select",
+    );
+    if (formElements) {
+      formElements.forEach((element) => {
+        if (element.name && element.value) {
+          this.entries.set(element.name, element.value);
+        }
+      });
+    }
+    this._internals.setFormValue(this.entries);
+  }
 
   handleFileSelection(inputId: string) {
     this.dispatchEvent(
@@ -284,6 +299,8 @@ export class SslConfig extends HTMLElement {
     shadow.adoptedStyleSheets = [sheet];
     shadow.innerHTML = this.template;
     applyBindings(shadow, this.os, this);
+    // Initialize form values after bindings. Small timeout to ensure DOM is ready
+    setTimeout(() => this.initializeFormValues(), 100);
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fixes https://github.com/confluentinc/vscode/issues/1242. This was a regression from the refactor of `getConnectionSpecFromFormData` earlier this week
- Similar to https://github.com/confluentinc/vscode/pull/1234 which implemented the default value init for the `auth-credentials` component. 
- SSL-related checkboxes fix was to manually add them back in form data, since HTML will not submit any unchecked checkbox type inputs. (This is now covered by Playwright tests.)
- Re-initializing the values when truststore/keystore paths are changed ensures these values are added to the form data if the path is selected with the Select File button instead of typed in the input.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

### 🕳️ 
These ssl inputs are in the web component shadow root. 👻  The `Select File` button calls a `CustomEvent` that crosses the vscode host/webview border to get an absolute file path. HTML has a file picker that _would_ work here, except [it will not give you an absolute path](https://github.com/confluentinc/vscode/pull/1049#issuecomment-2692357197), so we are stuck communicating with the vscode host. Now the values for the paths _are_ signals, so those get updated nicely, but they don't set the form entries like `updateValue` does on input (aka user typed changes). Thus there is now a watcher and call to (re)initialize the values when those change. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
