### PR TITLE
Custom enter key event handler to submit

### DIFF
--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -17,6 +17,7 @@ addEventListener("DOMContentLoaded", () => {
   const ui = document.querySelector("main")!;
   const vm = new DirectConnectFormViewModel(os);
   applyBindings(ui, os, vm);
+  vm.setupEnterKeyHandler();
 });
 
 class DirectConnectFormViewModel extends ViewModel {
@@ -168,7 +169,33 @@ class DirectConnectFormViewModel extends ViewModel {
         console.info(`No side effects for input update: ${input.name}`);
     }
   }
-
+  /** This is a workaround for the default behavior of Enter key in forms
+   * Normally Enter submits the form with the first submit button, which would be "Test"
+   * We want Enter to trigger the "Save" or "Update" button instead
+   */
+  setupEnterKeyHandler() {
+    const form = document.querySelector("form.form-container");
+    if (form) {
+      form.addEventListener("keydown", (e: Event) => {
+        const keyEvent = e as KeyboardEvent;
+        if (
+          keyEvent.key === "Enter" &&
+          keyEvent.target instanceof HTMLElement &&
+          keyEvent.target.tagName !== "TEXTAREA"
+        ) {
+          e.preventDefault();
+          const saveButton = Array.from(form.querySelectorAll('input[type="submit"]')).find(
+            (btn) =>
+              (btn as HTMLInputElement).value === "Save" ||
+              (btn as HTMLInputElement).value === "Update",
+          );
+          if (saveButton) {
+            (saveButton as HTMLInputElement).click();
+          }
+        }
+      });
+    }
+  }
   /** Submit all form data to the extension host */
   async handleSubmit(event: SubmitEvent) {
     event.preventDefault();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
- Adds an event listener to the `Enter` keydown event and uses it to click the primary form submit button (Save or Update) instead of the default, which would be the first button in the DOM - here that is the left button, corresponding to the secondary action (Test). 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- We noticed that the analytics show an extremely high ratio of "Test" submissions vs "Save" submissions on the form. 
- Team members reported pressing `Enter` when making fast changes and expecting it to Save/Update but instead it would Test. 
- Since `Enter` by default _will_ Submit an HTML form, and most forms have only one submit action, it seems better to make sure that expectation is kept here by assuming a user pressing `Enter` key wants to Save not Test. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
