### PR TITLE
fix(windows dev): remove end-of-line checks from prettier/eslint configs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
     "tabWidth": 2,
     "semi": true,
     "trailingComma": "all",
-    "proseWrap": "always"
+    "proseWrap": "always",
+    "endOfLine": "auto"
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,8 @@ export default [
       ...js.configs.recommended.rules,
       eqeqeq: ["error", "smart"],
       "no-unused-vars": "warn",
+      // ignore line endings between Windows and Unix
+      "prettier/prettier": ["error", { endOfLine: "auto" }],
     },
     languageOptions: {
       globals: {
@@ -36,6 +38,8 @@ export default [
       "@typescript-eslint/no-explicit-any": "off",
       // replacement of ESLint's no-redeclare with support for function overload
       "@typescript-eslint/no-redeclare": "error",
+      // ignore line endings between Windows and Unix
+      "prettier/prettier": ["error", { endOfLine: "auto" }],
     },
     languageOptions: {
       parser,


### PR DESCRIPTION
This is a pretty terrible experience on Windows:
![image](https://github.com/user-attachments/assets/19424cb4-dcf3-42e4-ae7d-ff520b446ed9)

After these changes, no prettier errors and `npx gulp lint` works as expected:
![image](https://github.com/user-attachments/assets/e6ac8af0-6e7b-4a18-957a-3674792c2ef1)


https://prettier.io/docs/options#end-of-line
