### PR TITLE
update global test setup to confirm we can activate the extension and start the sidecar before the actual test suites run

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -2,6 +2,10 @@ import { writeFile } from "fs/promises";
 import { globSync } from "glob";
 import Mocha from "mocha";
 import { resolve } from "path";
+import { getTestExtensionContext } from "../tests/unit/testUtils";
+import { Logger } from "./logging";
+
+const logger = new Logger("testing");
 
 export async function run() {
   const version = process.env.VSCODE_VERSION ?? "stable";
@@ -40,8 +44,20 @@ export async function run() {
   }
 }
 
-function globalBeforeAll() {
+async function globalBeforeAll() {
   console.log("Global test suite setup");
 
-  // Nothing for now. Just a hook for the future.
+  // smoke-test to make sure we can set up the environment for tests by activating the extension:
+  // - set the extension context
+  // - start the sidecar process
+  logger.log(
+    "Activating the extension, setting extension context, and attempting to start the sidecar...",
+  );
+  await getTestExtensionContext();
+  // if this fails, it will throw and we'll see something like:
+  // 1) "before all" hook: Global suite setup in "{root}":
+  //    Activating extension 'confluentinc.vscode-confluent' failed: ...
+
+  // otherwise, we should see this log line and tests should continue:
+  logger.log("✅ Test environment is ready. Running tests...");
 }


### PR DESCRIPTION
In different scenarios, we may try running tests and end up with a ton of mysterious failures. This PR attempts to activate the extension and start the sidecar before all other tests kick off as part of the Mocha (global) `beforeAll` hook, because otherwise we end up with dozens of unhelpful test failures.

## Scenario 1: we haven't pulled the sidecar as part of `gulp build` (due to updated `.versions/ide-sidecar`, failure to pull from GH, or otherwise)
### Before
Wall of test failures:
<img width="960" alt="image" src="https://github.com/user-attachments/assets/8da12b61-ade9-4eb9-9e42-1c2f08f73e6a" />

...when the actual culprit is nested in the middle of the test output where the passing/pending/failing summary starts listing all failures:
<img width="960" alt="image" src="https://github.com/user-attachments/assets/6410becf-8349-4180-8030-6db2e6b4e524" />

### After
<img width="966" alt="image" src="https://github.com/user-attachments/assets/9c776623-aad5-43b1-8630-3f3d9c665d66" />

## Scenario 2: sidecar executable exists but can't start for some non-platform/-architecture related reason
### Before
Same wall of test errors, but unhelpful initial failure(s):
<img width="825" alt="image" src="https://github.com/user-attachments/assets/1c3f83a0-36f5-4dc7-bec9-b6eb1ae51cca" />

...which then means the reason is more toward the top of the test output after a number of tests have already run (and the non-sidecar-dependent tests have passed):
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/c6a0cea7-cdc2-4fc0-9b20-8085be11bf53" />

### After
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/698e0394-e211-49dd-93dd-2f027ce700f7" />

---

And if all is good, we should get this log line to give us the warm-and-fuzzy feeling that the tests should run as intended:
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/06658be9-fb88-46c6-a052-fe1c0fef0454" />

