### PR TITLE
MINOR: don't send handled CCloud auth errors to Sentry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,10 @@ if (process.env.SENTRY_DSN) {
       "ENOENT: no such file or directory",
       "EPERM: operation not permitted",
       "Canceled",
-      "captureException", // only ever floated by the Sentry SDK itself
+      // rejected promises from the CCloud auth provider that can't be wrapped in try/catch:
+      "User cancelled the authentication flow.",
+      "User reset their password.",
+      "Confluent Cloud authentication failed. See browser for details.",
     ],
   });
 }


### PR DESCRIPTION
We can't try/catch the errors in `createSession()` and return null/undefined since the interface [expects an `AuthenticationSession`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8c9533835001e60135d5ede3d75934e7b26aa4b3/types/vscode/index.d.ts#L17680) return type.

So we're ignoring these:
https://github.com/confluentinc/vscode/blob/260cbe86410f1c9f9bb5fdef0e371f3afebfe36b/src/authn/ccloudProvider.ts#L137-L157


Also removes `captureException` because that didn't seem to actually do anything.