### PR TITLE
minor copy edit: not yet

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -110,7 +110,7 @@
           </div>
           <div
             class="input-container"
-            data-attr-title="this.editing() ? 'Changing the authentication type of an existing connection is not supported yet' : false"
+            data-attr-title="this.editing() ? 'Changing the authentication type of an existing connection is not supported' : false"
           >
             <label for="kafka_cluster.auth_type" class="label">Authentication Type</label>
             <select
@@ -189,7 +189,7 @@
           </div>
           <div
             class="input-container"
-            data-attr-title="this.editing() ? 'Changing the authentication type of an existing connection is not supported yet' : false"
+            data-attr-title="this.editing() ? 'Changing the authentication type of an existing connection is not supported' : false"
           >
             <label for="schema_registry.auth_type" class="label">Authentication Type</label>
             <select


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Remove the word "yet" from the tooltip
"Changing the authentication type of an existing connection is not supported ~yet~"

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Maybe we'll support it, maybe we don't need to 🤷 