### PR TITLE
MINOR(telemetry): standardize DirectConnectionAction body

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -141,13 +141,13 @@ export class DirectConnectionManager {
     );
 
     logUsage(UserEvent.DirectConnectionAction, {
-      type: spec.formConnectionType,
       action: dryRun ? "tested" : "created",
+      type: spec.formConnectionType,
+      specifiedConnectionType: spec.specifiedConnectionType,
       withKafka: !!spec.kafka_cluster,
       withSchemaRegistry: !!spec.schema_registry,
-      specifiedConnectionType: spec.specifiedConnectionType,
       kafkaAuthType: getCredentialsType(spec.kafka_cluster?.credentials),
-      schemaAuthType: getCredentialsType(spec.schema_registry?.credentials),
+      schemaRegistryAuthType: getCredentialsType(spec.schema_registry?.credentials),
     });
 
     if (connection && !dryRun) {
@@ -164,13 +164,15 @@ export class DirectConnectionManager {
     await Promise.all([getResourceManager().deleteDirectConnection(id), tryToDeleteConnection(id)]);
 
     logUsage(UserEvent.DirectConnectionAction, {
-      type: spec?.formConnectionType,
       action: "deleted",
+      type: spec?.formConnectionType,
+      specifiedConnectionType: spec?.specifiedConnectionType,
       withKafka: !!spec?.kafka_cluster,
       withSchemaRegistry: !!spec?.schema_registry,
-      specifiedConnectionType: spec?.specifiedConnectionType,
       kafkaAuthType: getCredentialsType(spec?.kafka_cluster?.credentials),
-      schemaAuthType: getCredentialsType(spec?.schema_registry?.credentials),
+      kafkaSslEnabled: spec?.kafka_cluster?.ssl?.enabled,
+      schemaRegistryAuthType: getCredentialsType(spec?.schema_registry?.credentials),
+      schemaRegistrySslEnabled: spec?.schema_registry?.ssl?.enabled,
     });
 
     ResourceLoader.deregisterInstance(id);
@@ -187,13 +189,15 @@ export class DirectConnectionManager {
     }
 
     logUsage(UserEvent.DirectConnectionAction, {
+      action: "updated",
       type: incomingSpec.formConnectionType,
       specifiedConnectionType: incomingSpec.specifiedConnectionType,
-      action: "updated",
       withKafka: !!incomingSpec.kafka_cluster,
-      kafkaAuthType: getCredentialsType(incomingSpec.kafka_cluster?.credentials),
       withSchemaRegistry: !!incomingSpec.schema_registry,
-      schemaAuthType: getCredentialsType(incomingSpec.schema_registry?.credentials),
+      kafkaAuthType: getCredentialsType(incomingSpec.kafka_cluster?.credentials),
+      kafkaSslEnabled: incomingSpec.kafka_cluster?.ssl?.enabled,
+      schemaRegistryAuthType: getCredentialsType(incomingSpec.schema_registry?.credentials),
+      schemaRegistrySslEnabled: incomingSpec.schema_registry?.ssl?.enabled,
     });
 
     // update the connection in secret storage (via full replace of the connection by its id)

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -24,7 +24,6 @@ import {
 } from "../../ws/messageTypes";
 import { WebsocketManager } from "../websocketManager";
 import { connectionEventHandler, isConnectionStable } from "./watcherUtils";
-import { spec } from "node:test/reporters";
 
 const logger = new Logger("sidecar.connections.watcher");
 

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -24,6 +24,7 @@ import {
 } from "../../ws/messageTypes";
 import { WebsocketManager } from "../websocketManager";
 import { connectionEventHandler, isConnectionStable } from "./watcherUtils";
+import { spec } from "node:test/reporters";
 
 const logger = new Logger("sidecar.connections.watcher");
 
@@ -121,23 +122,33 @@ export async function reportUsableState(connection: Connection) {
   // for which configs, etc.
   if (connection.spec.type === ConnectionType.Direct) {
     failedConnectionSummaries.forEach((state) => {
+      const configPrefix = state.configType === "Kafka" ? "kafka" : "schemaRegistry";
       logUsage(UserEvent.DirectConnectionAction, {
         action: "failed to connect",
-        connectionType: ConnectionType.Direct,
-        type: state.type,
+        type: state.type, // formConnectionType
+        specifiedConnectionType: state.specifiedConnectionType,
+        // withKafka or withSchemaRegistry
+        [`with${state.configType.replace(" ", "")}`]: true,
         configType: state.configType,
-        configAuthType: state.authType,
-        configSslEnabled: state.sslEnabled,
+        // kafkaAuthType or schemaRegistryAuthType
+        [`${configPrefix}AuthType`]: state.authType,
+        // kafkaConfigSslEnabled or schemaRegistryConfigSslEnabled
+        [`${configPrefix}SslEnabled`]: state.sslEnabled,
       });
     });
     successfulConnectionSummaries.forEach((state) => {
+      const configPrefix = state.configType === "Kafka" ? "kafka" : "schemaRegistry";
       logUsage(UserEvent.DirectConnectionAction, {
         action: "successfully connected",
-        connectionType: ConnectionType.Direct,
         type: state.type,
+        specifiedConnectionType: state.specifiedConnectionType,
+        // withKafka or withSchemaRegistry
+        [`with${state.configType.replace(" ", "")}`]: true,
         configType: state.configType,
-        configAuthType: state.authType,
-        configSslEnabled: state.sslEnabled,
+        // kafkaAuthType or schemaRegistryAuthType
+        [`${configPrefix}AuthType`]: state.authType,
+        // kafkaConfigSslEnabled or schemaRegistryConfigSslEnabled
+        [`${configPrefix}SslEnabled`]: state.sslEnabled,
       });
     });
   }
@@ -158,6 +169,7 @@ export interface ConnectionSummary {
   configType: ConfigType;
   connectedState: ConnectedState;
   type?: FormConnectionType;
+  specifiedConnectionType?: string; // "Other" form connection type's user-entered string
   authType?: SupportedAuthTypes | "Browser";
   sslEnabled?: boolean;
 }
@@ -188,6 +200,7 @@ export async function getConnectionSummaries(
           states.push({
             connectionType: ConnectionType.Direct,
             type: formSpec?.formConnectionType,
+            specifiedConnectionType: formSpec?.specifiedConnectionType,
             configType: "Kafka",
             authType: getCredentialsType(kafkaConfig?.credentials),
             sslEnabled: kafkaConfig?.ssl?.enabled ?? false,
@@ -203,6 +216,7 @@ export async function getConnectionSummaries(
           states.push({
             connectionType: ConnectionType.Direct,
             type: formSpec?.formConnectionType,
+            specifiedConnectionType: formSpec?.specifiedConnectionType,
             configType: "Schema Registry",
             authType: getCredentialsType(schemaRegistryConfig?.credentials),
             sslEnabled: schemaRegistryConfig?.ssl?.enabled ?? false,


### PR DESCRIPTION
Small changes so the telemetry from https://github.com/confluentinc/vscode/issues/1228 and https://github.com/confluentinc/vscode/pull/1238 play nicely together. Only real difference between those two events being reported is the `successfully connected`/`failed to connect` include `configType` to describe which part of the connection failed. Other fields

<img width="875" alt="image" src="https://github.com/user-attachments/assets/61e23016-0237-46a3-b7cf-1658ad476b76" />


Follow-on branch to implement an interface based on the `UserEvent` enum value.