### PR TITLE
telemetry: add "arg context" to send resource IDs and connection types for commands used

### DIFF
--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -1,0 +1,50 @@
+import * as assert from "assert";
+import { getCommandArgsContext, RESOURCE_ID_FIELDS } from ".";
+import { ConnectionType } from "../clients/sidecar";
+import { ConnectionId, IResourceBase } from "../models/resource";
+
+describe("getCommandArgsContext", () => {
+  it("should handle no args", () => {
+    const result = getCommandArgsContext([]);
+
+    assert.deepStrictEqual(result, {});
+  });
+
+  it("should handle undefined first arg", () => {
+    const result = getCommandArgsContext([undefined]);
+
+    assert.deepStrictEqual(result, {});
+  });
+
+  it("should include 'resourceConnectionType' when the first arg implements IResourceBase", () => {
+    const fakeResource: IResourceBase = {
+      connectionId: "abc123" as ConnectionId,
+      connectionType: ConnectionType.Direct,
+    };
+
+    const result = getCommandArgsContext([fakeResource]);
+
+    assert.deepStrictEqual(result, {
+      resourceConnectionType: fakeResource.connectionType,
+    });
+  });
+
+  it("should include 'resourceType'' when the first arg is one of our resource models");
+
+  for (const idField of RESOURCE_ID_FIELDS) {
+    const idFieldTitleCase = idField.charAt(0).toUpperCase() + idField.slice(1);
+    const expectedField = `resource${idFieldTitleCase}`;
+
+    it(`should include '${expectedField}' if '${idField}' exists on the first arg`, () => {
+      const fakeResource = {
+        [idField]: "abc123",
+      };
+
+      const result = getCommandArgsContext([fakeResource]);
+
+      assert.deepStrictEqual(result, {
+        [expectedField]: fakeResource[idField],
+      });
+    });
+  }
+});

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -29,8 +29,6 @@ describe("getCommandArgsContext", () => {
     });
   });
 
-  it("should include 'resourceType'' when the first arg is one of our resource models");
-
   for (const idField of RESOURCE_ID_FIELDS) {
     const idFieldTitleCase = idField.charAt(0).toUpperCase() + idField.slice(1);
     const expectedField = `resource${idFieldTitleCase}`;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { logError, showErrorNotificationWithButtons } from "../errors";
+import { IResourceBase, isResource } from "../models/resource";
 import { UserEvent, logUsage } from "../telemetry/events";
 
 export function registerCommandWithLogging(
@@ -7,7 +8,10 @@ export function registerCommandWithLogging(
   command: (...args: any[]) => void,
 ): vscode.Disposable {
   const wrappedCommand = async (...args: any[]) => {
-    logUsage(UserEvent.CommandInvoked, { command: commandName });
+    logUsage(UserEvent.CommandInvoked, {
+      command: commandName,
+      ...getCommandArgsContext(args),
+    });
     try {
       await command(...args);
     } catch (e) {
@@ -21,4 +25,34 @@ export function registerCommandWithLogging(
     }
   };
   return vscode.commands.registerCommand(commandName, wrappedCommand);
+}
+
+// TODO: move this somewhere else if we need it other than telemetry:
+export const RESOURCE_ID_FIELDS = ["id", "environmentId", "clusterId", "schemaRegistryId"];
+
+/** Checks if the first argument for a command function includes basic resource context for
+ * telemetry (e.g. `connectionType`, `id`, `environmentId`, etc.). */
+export function getCommandArgsContext(args: any[]): Record<string, any> {
+  const argsContext: Record<string, any> = {};
+  if (!args.length) {
+    return argsContext;
+  }
+  if (!args[0]) {
+    // bail if first arg is undefined or null
+    return argsContext;
+  }
+
+  if (isResource(args[0])) {
+    const resourceArg: IResourceBase = args[0];
+    argsContext["resourceConnectionType"] = resourceArg.connectionType;
+  }
+  for (const idField of RESOURCE_ID_FIELDS) {
+    if (args[0][idField] !== undefined) {
+      // e.g. "environmentId" to "EnvironmentId"
+      const idFieldTitleCase = idField.charAt(0).toUpperCase() + idField.slice(1);
+      argsContext[`resource${idFieldTitleCase}`] = args[0][idField];
+    }
+  }
+
+  return argsContext;
 }

--- a/src/models/resource.test.ts
+++ b/src/models/resource.test.ts
@@ -13,6 +13,7 @@ import {
   isCCloud,
   isDirect,
   isLocal,
+  isResource,
   isSearchable,
 } from "./resource";
 import { KafkaTopic } from "./topic";
@@ -90,4 +91,27 @@ describe("getConnectionLabel", () => {
   it("Should throw an error for an unknown connection type", () => {
     assert.throws(() => getConnectionLabel("unknown" as ConnectionType));
   });
+});
+
+describe("isResource", () => {
+  it("should return true for values correctly implementing IResourceBase", () => {
+    const value = {
+      connectionId: "abc123" as ConnectionId,
+      connectionType: ConnectionType.Direct,
+    };
+
+    assert.strictEqual(isResource(value), true);
+  });
+
+  for (const missingField of ["connectionId", "connectionType"]) {
+    it(`should return false for values missing "${missingField}"`, () => {
+      const value: any = {
+        connectionId: "abc123" as ConnectionId,
+        connectionType: ConnectionType.Direct,
+      };
+      delete value[missingField];
+
+      assert.strictEqual(isResource(value), false);
+    });
+  }
 });

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -29,6 +29,10 @@ export interface IResourceBase {
   iconName?: IconNames;
 }
 
+export function isResource(value: any): value is IResourceBase {
+  return value.connectionId !== undefined && value.connectionType !== undefined;
+}
+
 /** Does this resource come from a "local" connection? */
 export function isLocal(resource: IResourceBase): boolean {
   return resource.connectionType === ConnectionType.Local;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Mainly for `connectionType`, but once we were there it seemed easy enough to look at some of the other fields we care about for usage: `environmentId`, `clusterId`, etc:
![image](https://github.com/user-attachments/assets/cbf7caef-8c21-4ea9-b8d6-b7a786effc9a)

Closes #459

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
