### PR TITLE
MINOR: fix test for windows `docker/configs functions: getSocketPath() should return socket path from user settings`

### DIFF
--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -47,7 +47,8 @@ describe("docker/configs functions", function () {
 
     const path: string = configs.getSocketPath();
 
-    assert.strictEqual(path, "/custom/path/docker.sock");
+    // normalized to adjust slashes for Windows vs Unix
+    assert.strictEqual(path, normalize("/custom/path/docker.sock"));
     assert.ok(getConfigStub.calledOnce);
   });
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

No functional changes, just a test fix for Windows. Closes https://github.com/confluentinc/vscode/issues/1250.

Related code:
https://github.com/confluentinc/vscode/blob/cfa4284a89536010569341753344cce17bbc815a/src/docker/configs.ts#L36-L37

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
