### PR TITLE
MINOR: fix test for windows `commands/support.ts: sidecarLogFileUri() should return the correct URI for the sidecar log`

### DIFF
--- a/src/commands/support.test.ts
+++ b/src/commands/support.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { normalize } from "path";
 import * as sinon from "sinon";
 import { Uri } from "vscode";
 import * as logging from "../logging";
@@ -48,6 +49,7 @@ describe("commands/support.ts", function () {
   it("sidecarLogFileUri() should return the correct URI for the sidecar log file", function () {
     const logFileUri: Uri = sidecarLogFileUri();
 
-    assert.strictEqual(logFileUri.path, SIDECAR_LOGFILE_PATH);
+    // normalized to adjust slashes for Windows vs Unix
+    assert.strictEqual(logFileUri.path, Uri.file(normalize(SIDECAR_LOGFILE_PATH)).path);
   });
 });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

No functional changes, just a test fix for Windows. Closes https://github.com/confluentinc/vscode/issues/1251.

Related code:
https://github.com/confluentinc/vscode/blob/cfa4284a89536010569341753344cce17bbc815a/src/commands/support.ts#L74-L76

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
