### PR TITLE
fix(windows): handle lowercase first character for stringified Uri path

### DIFF
--- a/src/commands/diffs.test.ts
+++ b/src/commands/diffs.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { homedir } from "os";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { TEST_LOCAL_SCHEMA } from "../../tests/unit/testResources";
@@ -69,22 +70,16 @@ describe("commands/diffs.ts", () => {
     const uri2 = new SchemaDocumentProvider().resourceToUri(schema2, schema2.fileName());
     await diffs.compareWithSelectedCommand(schema2);
 
-    assert.ok(executeCommandStub.calledOnce);
-    sinon.assert.calledWith(
-      executeCommandStub,
-      "vscode.diff",
-      // fsPath will show up as `null`, so just compare the scheme, path, and query
-      sinon.match((value) => {
-        return (
-          value.scheme === uri1.scheme && value.path === uri1.path && value.query === uri1.query
-        );
-      }),
-      sinon.match((value) => {
-        return (
-          value.scheme === uri2.scheme && value.path === uri2.path && value.query === uri2.query
-        );
-      }),
-      sinon.match.string, // for the title argument
+    sinon.assert.calledOnce(executeCommandStub);
+    const callArgs = executeCommandStub.getCall(0).args;
+    assert.strictEqual(callArgs.length, 4); // command, uri1, uri2, title
+    const [argCommand, argUri1, argUri2, argTitle] = callArgs;
+    assert.strictEqual(argCommand, "vscode.diff");
+    assert.strictEqual(argUri1.toString(), uri1.toString());
+    assert.strictEqual(argUri2.toString(), uri2.toString());
+    assert.strictEqual(
+      argTitle,
+      `${uri1.fsPath.replace(homedir(), "~")} ↔ ${uri2.fsPath.replace(homedir(), "~")}`,
     );
   });
 

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -36,7 +36,13 @@ export async function compareWithSelectedCommand(item: any) {
     return;
   }
   // convert back to Uri
-  const uri1: vscode.Uri = vscode.Uri.parse(uri1str);
+  let uri1: vscode.Uri = vscode.Uri.parse(uri1str);
+  if (process.platform === "win32") {
+    // for some reason, the first character for a windows path is lowercase when stringified, so we
+    // need to change it back to uppercase to be consistent with the other URI's path
+    // e.g. "c:\Users\username" => "C:\Users\username"
+    uri1 = uri1.with({ path: uri1.path.charAt(0).toUpperCase() + uri1.path.slice(1) });
+  }
 
   // replace fsPaths with ~ if they contain $HOME
   const uri1Path = uri1.fsPath.replace(homedir(), "~");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fixes behavior when reading the "select for compare"d Uri from storage to ensure the first character of the path isn't lowercase and breaking our Uri comparison. The diff view would still show up, but the `title` was wrong:

|  | |
|--------|--------|
| Before | ![image](https://github.com/user-attachments/assets/89bb5f21-771a-4e5c-8875-23044d519385) | 
| After | ![image](https://github.com/user-attachments/assets/cfc98753-2479-4e2a-bc39-6ad347957d40) | 

- Updates the test to make it easier to see if any particular `executeCommand` call arg isn't what we expect

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
