### PR TITLE
MINOR: bump Mocha timeout to 30sec for CI

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -18,7 +18,7 @@ export async function run() {
   const mocha = new Mocha({
     color: true,
     ui: "bdd",
-    timeout: 10_000,
+    timeout: process.env.CI !== null ? 30_000 : 10_000,
     reporter: "mocha-multi-reporters",
     reporterOptions: {
       reporterEnabled: "spec, mocha-junit-reporter",


### PR DESCRIPTION
We've seen occasional timeouts on the CCloud auth test in CI where it hits the 10sec timeout, and in https://github.com/confluentinc/vscode/pull/453 we're seeing many more timeouts on specifically the Windows runner.