### PR TITLE
fix: don't send `type` for produce message requests

### DIFF
--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -613,11 +613,7 @@ export async function produceMessage(
     }),
   );
   // dig up any schema-related information we may need in the request body
-  const { keyData, valueData } = await createProduceRequestData(
-    content,
-    schemaOptions,
-    forCCloudTopic,
-  );
+  const { keyData, valueData } = await createProduceRequestData(content, schemaOptions);
 
   const produceRequest: ProduceRequest = {
     headers,

--- a/src/commands/utils/produceMessage.test.ts
+++ b/src/commands/utils/produceMessage.test.ts
@@ -26,29 +26,7 @@ describe("commands/utils/produceMessage.ts createProduceRequestData()", function
     sandbox.restore();
   });
 
-  it("should create request data with 'type' set for CCloud topics", async function () {
-    const result = await createProduceRequestData(
-      {
-        key: "test-key",
-        value: "test-value",
-      },
-      {},
-      true,
-    );
-
-    assert.deepStrictEqual(result, {
-      keyData: {
-        type: "JSON",
-        data: "test-key",
-      },
-      valueData: {
-        type: "JSON",
-        data: "test-value",
-      },
-    });
-  });
-
-  it("should create request data without 'type' for local topics", async function () {
+  it("should nest key/value data under keyData.data and valueData.data", async function () {
     const result = await createProduceRequestData({
       key: "test-key",
       value: "test-value",

--- a/src/commands/utils/produceMessage.test.ts
+++ b/src/commands/utils/produceMessage.test.ts
@@ -85,7 +85,6 @@ describe("commands/utils/produceMessage.ts extractSchemaInfo()", function () {
       subject: docContentSchemaInfo.subject,
       schema_version: docContentSchemaInfo.schema_version,
       subject_name_strategy: docContentSchemaInfo.subject_name_strategy,
-      type: undefined,
     });
   });
 
@@ -100,7 +99,6 @@ describe("commands/utils/produceMessage.ts extractSchemaInfo()", function () {
       subject: TEST_LOCAL_SCHEMA.subject,
       schema_version: TEST_LOCAL_SCHEMA.version,
       subject_name_strategy: SubjectNameStrategy.TOPIC_NAME,
-      type: undefined,
     });
   });
 
@@ -124,7 +122,6 @@ describe("commands/utils/produceMessage.ts extractSchemaInfo()", function () {
       subject: docContentSchemaInfo.subject,
       schema_version: docContentSchemaInfo.schema_version,
       subject_name_strategy: docContentSchemaInfo.subject_name_strategy,
-      type: undefined,
     });
   });
 

--- a/src/commands/utils/produceMessage.ts
+++ b/src/commands/utils/produceMessage.ts
@@ -11,20 +11,12 @@ import { ProduceMessageSchemaOptions } from "./types";
 export async function createProduceRequestData(
   message: ProduceMessage,
   schemaOptions: ProduceMessageSchemaOptions = {},
-  forCCloudTopic: boolean = false,
 ): Promise<{ keyData: ProduceRequestData; valueData: ProduceRequestData }> {
   // snake case since this is coming from a JSON document:
   const { key, value, key_schema, value_schema } = message;
   // user-selected schema information via settings and quickpicks
   const { keySchema, keySubjectNameStrategy, valueSchema, valueSubjectNameStrategy } =
     schemaOptions;
-
-  // determine if we have to provide `type` based on whether this is a CCloud-flavored topic or not
-  const schemaless = "JSON";
-  const schemaType: { type?: string } = {};
-  if (forCCloudTopic && !(keySchema || key_schema || valueSchema || value_schema)) {
-    schemaType.type = schemaless;
-  }
 
   // message-provided schema information takes precedence over quickpicked schema
   const keySchemaData: SchemaInfo | undefined = extractSchemaInfo(
@@ -33,7 +25,6 @@ export async function createProduceRequestData(
     keySubjectNameStrategy,
   );
   const keyData: ProduceRequestData = {
-    ...schemaType,
     ...(keySchemaData ?? {}),
     data: key,
   };
@@ -43,7 +34,6 @@ export async function createProduceRequestData(
     valueSubjectNameStrategy,
   );
   const valueData: ProduceRequestData = {
-    ...schemaType,
     ...(valueSchemaData ?? {}),
     data: value,
   };
@@ -68,5 +58,5 @@ export function extractSchemaInfo(
     schemaInfo?.subject_name_strategy ?? subjectNameStrategy ?? "TOPIC_NAME";
 
   // drop type since the sidecar rejects this with a 400
-  return { schema_version, subject, subject_name_strategy, type: undefined };
+  return { schema_version, subject, subject_name_strategy };
 }

--- a/src/schemas/produceMessageSchema.ts
+++ b/src/schemas/produceMessageSchema.ts
@@ -108,7 +108,6 @@ export interface SchemaInfo {
   schema_version: number;
   subject: string;
   subject_name_strategy: SubjectNameStrategy;
-  type?: "BINARY" | "JSON" | "STRING" | undefined;
 }
 
 export interface MessageHeader {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We previously had to send `type: "JSON"` for CCloud produce-message requests using the old route (before https://github.com/confluentinc/ide-sidecar/pull/335). Non-CCloud topics wouldn't pass `type` at all, and the new route doesn't support it, so we're dropping `type` from the `keyData`/`valueData` parts of the request body altogether.

Closes #1273.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
