### PR TITLE
Harden getting subjects / gather more information if problem happens.

### DIFF
--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -149,12 +149,6 @@ export abstract class ResourceLoader implements IResourceBase {
       await resourceManager.setSubjects(schemaRegistry, subjects);
       return subjects;
     } catch (error) {
-      logError(
-        error,
-        "Error within getSubjects",
-        { registryOrEnvironmentId: JSON.stringify(registryOrEnvironmentId, null, 2) },
-        true,
-      );
       if (
         error instanceof Error &&
         error.message.match(/No schema registry found for environment/)
@@ -162,6 +156,14 @@ export abstract class ResourceLoader implements IResourceBase {
         // Expected error when no schema registry found for the environment.
         // Act as if there are no subjects / schemas.
         return [];
+      } else {
+        // Unexpected error, log it to sentry.
+        logError(
+          error,
+          "Unexpected error within getSubjects",
+          { registryOrEnvironmentId: JSON.stringify(registryOrEnvironmentId, null, 2) },
+          true,
+        );
       }
       throw error;
     }

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -1,6 +1,7 @@
 import { Disposable } from "vscode";
 import { TopicData } from "../clients/kafkaRest";
 import { ConnectionType } from "../clients/sidecar";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
 import { KafkaCluster } from "../models/kafkaCluster";
@@ -136,17 +137,24 @@ export abstract class ResourceLoader implements IResourceBase {
         // cache allowed ...
         const subjects = await resourceManager.getSubjects(schemaRegistry);
         if (subjects) {
-          // and had contents.
+          // and was either an empty or non-empty array --- just not undefined.
           return subjects;
         }
       }
+
+      // Undefined cache lookup result or was forced to refresh ...
 
       // Deep fetch the subjects from the schema registry, cache, return.
       const subjects = await fetchSubjects(schemaRegistry);
       await resourceManager.setSubjects(schemaRegistry, subjects);
       return subjects;
     } catch (error) {
-      logger.error("Error fetching subjects", error);
+      logError(
+        error,
+        "Error within getSubjects",
+        { registryOrEnvironmentId: JSON.stringify(registryOrEnvironmentId, null, 2) },
+        true,
+      );
       if (
         error instanceof Error &&
         error.message.match(/No schema registry found for environment/)

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -21,6 +21,23 @@ import {
   subjectMatchesTopicName,
 } from "./schema";
 
+describe("Subject model methods", () => {
+  it("Constructor vs bad subject name", () => {
+    const badSubjects = [undefined, null, ""];
+    for (const badSubject of badSubjects) {
+      assert.throws(
+        () => {
+          new Subject(badSubject as string, CCLOUD_CONNECTION_ID, "envId" as EnvironmentId, "srId");
+        },
+        {
+          name: "Error",
+          message: `Subject name cannot be undefined, null, or empty: ${badSubject} from ${CCLOUD_CONNECTION_ID}`,
+        },
+      );
+    }
+  });
+});
+
 describe("Schema model methods", () => {
   it(".matchesTopicName() success / fail tests", () => {
     type SchemaProperties = [string, string, boolean];

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -59,6 +59,14 @@ export class Subject implements IResourceBase, ISearchable {
     schemaRegistryId: string,
     schemas: Schema[] | null = null,
   ) {
+    // These may be constructed from either route responses or resource manager cache load,
+    // (i.e. outside of typescript's control), so be extra cautious.
+    if (name === undefined || name === null || name === "") {
+      throw new Error(
+        `Subject name cannot be undefined, null, or empty: ${name} from ${connectionId}`,
+      );
+    }
+
     this.name = name;
 
     this.connectionId = connectionId;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Inspired by the stack traces within #1262 , harden up some of the codepaths around fetching subjects / the latest schemas.
- But the code has changed a good bit between when the sentry issue happened and main, so is loosely inspired. Main bits are to harden `Subject` construction to recoil immediately if a Subject is attempted to be constructed with a bad (null, undefined, or empty string) name. And then if any unexpected errors happen within a call to `ResourceLoader.getSubjects()`, log a sentry report.
- The underlying issue in #1262 is that the old codepath for "show latest schemas for a topic" command fell over dead when encountering an undefined as one of the subject strings to consider (back when there were only `Schema` objects, no `Subject` vs `Schema` differentiation). This was reported against release 0.25, aka branch `v0.25.x`, a good number of changes ago in this section of the codebase. Am unsure where such an undefined could have originated from, but given the changes to the code between now and then, am happy to set things up to have collected more information if it is still possible.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Does not necessarily solve #1262, but it could be that existing changes to the codebase (the now caching of subject via `ResourceLoader`) may have either affected or fixed the issue. Let's consider this a "gathering more info" PR at least.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
