### PR TITLE
Connection form: make sure we don't flip out on undefined fields

### DIFF
--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -57,7 +57,7 @@ class DirectConnectFormViewModel extends ViewModel {
 
   // SSL enabled is true by default. If this is undefined it means the user never set/saved it
   kafkaSslEnabled = this.derive(() => {
-    if (this.spec()?.kafka_cluster?.ssl?.enabled.toString() === "false") return false;
+    if (this.spec()?.kafka_cluster?.ssl?.enabled?.toString() === "false") return false;
     else return true;
   });
   kafkaSslConfig = this.derive(() => {
@@ -75,7 +75,7 @@ class DirectConnectFormViewModel extends ViewModel {
     return this.getAuthTypes()?.schema || "None";
   });
   schemaSslEnabled = this.derive(() => {
-    if (this.spec()?.schema_registry?.ssl?.enabled.toString() === "false") return false;
+    if (this.spec()?.schema_registry?.ssl?.enabled?.toString() === "false") return false;
     else return true;
   });
   schemaSslConfig = this.derive(() => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- We get a TypeError on first form load since this field isn't defined until the config is passed along. I think this is affecting all other JS in the form, causing silent errors for other SSL fields in that section

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- To test - verify that you can save & edit a new connection with TLS config details. Verify you can use the "Select File" button to add the file. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
