### PR TITLE
[v1.0.x] fix: `ProduceMessageBadRequestError` needs to wrap the `Response`, not the `ResponseError`

### DIFF
--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -588,7 +588,7 @@ describe("commands/topics.ts handleSchemaValidationErrors()", function () {
         key: { subject_name_strategy: SubjectNameStrategy.TOPIC_NAME },
         value: {},
       } as any,
-      new ResponseError(new Response()),
+      new Response(),
     );
     const results: ExecutionResult<ProduceResult>[] = [
       { result: undefined, error: badRequestError },
@@ -610,7 +610,7 @@ describe("commands/topics.ts handleSchemaValidationErrors()", function () {
         key: {},
         value: { subject_name_strategy: SubjectNameStrategy.TOPIC_NAME },
       } as any,
-      new ResponseError(new Response()),
+      new Response(),
     );
     const results: ExecutionResult<ProduceResult>[] = [
       { result: undefined, error: badRequestError },
@@ -637,7 +637,7 @@ describe("commands/topics.ts handleSchemaValidationErrors()", function () {
         key: { subject_name_strategy: SubjectNameStrategy.TOPIC_NAME },
         value: { subject_name_strategy: SubjectNameStrategy.TOPIC_NAME },
       } as any,
-      new ResponseError(new Response()),
+      new Response(),
     );
     const results: ExecutionResult<ProduceResult>[] = [
       { result: undefined, error: badRequestError },
@@ -675,12 +675,12 @@ describe("commands/topics.ts handleSchemaValidationErrors()", function () {
     const error1 = new ProduceMessageBadRequestError(
       "Invalid key schema at index 0",
       { key: { subject_name_strategy: SubjectNameStrategy.TOPIC_NAME } } as any,
-      new ResponseError(new Response()),
+      new Response(),
     );
     const error2 = new ProduceMessageBadRequestError(
       "Invalid value schema at index 1",
       { value: { subject_name_strategy: SubjectNameStrategy.TOPIC_NAME } } as any,
-      new ResponseError(new Response()),
+      new Response(),
     );
     const results: ExecutionResult<ProduceResult>[] = [
       { result: undefined, error: error1 },
@@ -762,7 +762,7 @@ describe("commands/topics.ts produceMessage()", function () {
         assert.ok(error instanceof ProduceMessageBadRequestError);
         assert.strictEqual(error.name, "ProduceMessageBadRequestError");
         assert.strictEqual(error.message, jsonBodyMsg);
-        assert.strictEqual(error.response, responseError);
+        assert.strictEqual(error.response, responseError.response);
         return true;
       },
     );
@@ -784,7 +784,7 @@ describe("commands/topics.ts produceMessage()", function () {
         assert.ok(error instanceof ProduceMessageBadRequestError);
         assert.strictEqual(error.name, "ProduceMessageBadRequestError");
         assert.strictEqual(error.message, notJsonBody);
-        assert.strictEqual(error.response, responseError);
+        assert.strictEqual(error.response, responseError.response);
         return true;
       },
     );

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -664,7 +664,7 @@ export async function produceMessage(
         errBody = await err.response.clone().text();
       }
       if (errBody !== undefined)
-        throw new ProduceMessageBadRequestError(errBody, produceRequest, err);
+        throw new ProduceMessageBadRequestError(errBody, produceRequest, err.response);
     }
     throw err;
   }
@@ -676,8 +676,8 @@ export async function produceMessage(
 
 export class ProduceMessageBadRequestError extends Error {
   request: ProduceRequest;
-  response: ResponseError;
-  constructor(message: string, request: ProduceRequest, response: ResponseError) {
+  response: Response;
+  constructor(message: string, request: ProduceRequest, response: Response) {
     super(message);
     this.name = "ProduceMessageBadRequestError";
     this.request = request;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

`ProduceMessageBadRequestError` was incorrectly wrapping the `ResponseError` instead of the `Response`, so when it was caught and handled by `logError()`, trying to `clone()` it didn't make any sense and would throw a `TypeError`.

However, it didn't affect the behavior of the error-handling as far as the produce-message flow goes, so there are no user-facing changes here, and this is mainly cleanup. See the noisy `telemetry` logs here:
<img width="1898" alt="image" src="https://github.com/user-attachments/assets/169d6e9c-d42b-43c6-84c1-82a955cd7986" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
