### PR TITLE
hotfix: updating tls configs could remove existing configs

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -147,9 +147,7 @@ export function openDirectConnectionForm(connection: CustomConnectionSpec | null
 
   function getSpec() {
     if (connection) {
-      if (action === "import" || action === "update") {
-        return { ...connection, ...specUpdatedValues };
-      }
+      return deepMerge(connection, specUpdatedValues);
     }
     return { ...specUpdatedValues };
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

### 🪳 Bug fix! 
- We need to `deepMerge` the existing connection with the updated values, or we can lose nested parts of the spec. 
- I also removed the unnecessary `if` block to check import/edit status. These conditions are mutually exclusive - if you have a `connection` already, you are either `import`ing or `update`ing it. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
### How to test/reproduce
- This is hard to run into as a user - I only found it because I was testing a different fix for that pesky `Select File` button. 
- Reproducible if you're `Edit`ing an existing connection, and the spec you're editing already has `keystore` OR `truststore` (but _not both_). Then, for your very first Edit, use the `Select File` button to choose a path for the key/trust you did **not** already have.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
