### PR TITLE
[v1.0.x] fix: failing to fetch preferences when updating the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an issue where the extension would fail to sync CCloud authentication related user settings
+  to the sidecar process when updating the extension.
+
 ## 1.0.1
 
 ### Fixed

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -7,7 +7,7 @@ import { ContextValues, setContextValue } from "../context/values";
 import { ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
 import { ExtensionContextNotSetError } from "../errors";
 import { Logger } from "../logging";
-import { fetchPreferences } from "../preferences/updates";
+import { loadPreferencesFromWorkspaceConfig } from "../preferences/updates";
 import {
   clearCurrentCCloudResources,
   createCCloudConnection,
@@ -363,16 +363,12 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
             this._onAuthFlowCompletedSuccessfully.fire({ success, resetPassword });
 
             if (!success) {
-              // fetch+log current sidecar preferences to help debug any auth issues
-              try {
-                const preferences = await fetchPreferences();
-                logger.debug(
-                  `authProvider: ${SecretStorageKeys.AUTH_COMPLETED} changed (success=${success}); current sidecar preferences:`,
-                  { preferences },
-                );
-              } catch {
-                // fetchPreferences() will log the error before re-throwing; no need to do anything here
-              }
+              // log current preferences to help debug any auth issues
+              const preferences = loadPreferencesFromWorkspaceConfig();
+              logger.debug(
+                `authProvider: ${SecretStorageKeys.AUTH_COMPLETED} changed (success=${success}); current sidecar preferences:`,
+                { preferences },
+              );
             }
             break;
           }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,12 +72,11 @@ import { SchemaDocumentProvider } from "./documentProviders/schema";
 import { logError } from "./errors";
 import { constructResourceLoaderSingletons } from "./loaders";
 import { cleanupOldLogFiles, getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
-import { SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
 import { registerProjectGenerationCommand } from "./scaffold";
 import { JSON_DIAGNOSTIC_COLLECTION } from "./schemas/diagnosticCollection";
-import { getSidecarManager } from "./sidecar";
+import { getSidecar, getSidecarManager } from "./sidecar";
 import { ConnectionStateWatcher } from "./sidecar/connections/watcher";
 import { WebsocketManager } from "./sidecar/websocketManager";
 import { getStorageManager, StorageManager } from "./storage";
@@ -101,18 +100,19 @@ const logger = new Logger("extension");
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<vscode.ExtensionContext | undefined> {
-  observabilityContext.extensionVersion = context.extension.packageJSON.version;
+  const extVersion = context.extension.packageJSON.version;
+  observabilityContext.extensionVersion = extVersion;
   observabilityContext.extensionActivated = false;
 
-  logger.info(`Extension ${context.extension.id}" activate() triggered.`);
+  logger.info(`Extension ${context.extension.id}" activate() triggered for version ${extVersion}.`);
   logUsage(UserEvent.ExtensionActivation, { status: "started" });
   try {
     context = await _activateExtension(context);
-    logger.info("Extension fully activated");
+    logger.info(`Extension ${extVersion} fully activated`);
     observabilityContext.extensionActivated = true;
     logUsage(UserEvent.ExtensionActivation, { status: "completed" });
   } catch (e) {
-    logger.error("Error activating extension:", e);
+    logger.error(`Error activating extension version ${extVersion}:`, e);
     // if the extension is failing to activate for whatever reason, we need to know about it to fix it
     Sentry.captureException(e);
     logUsage(UserEvent.ExtensionActivation, { status: "failed" });
@@ -151,6 +151,12 @@ async function _activateExtension(
   // set the initial context values for the VS Code UI to inform the `when` clauses in package.json
   await Promise.all([setupStorage(), setupContextValues()]);
   logger.info("Storage and context values initialized");
+
+  // verify we can connect to the correct version of the sidecar, which may require automatically
+  // killing any (old) sidecar process and starting a new one, going through the handshake, etc.
+  logger.info("Starting/checking the sidecar...");
+  await getSidecar();
+  logger.info("Sidecar ready for use.");
 
   // set up the preferences listener to keep the sidecar in sync with the user/workspace settings
   const settingsListener: vscode.Disposable = await setupPreferences();
@@ -315,10 +321,7 @@ async function setupContextValues() {
  */
 async function setupPreferences(): Promise<vscode.Disposable> {
   // pass initial configs to the sidecar on startup
-  const configs: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
-  const pemPaths: string[] = configs.get(SSL_PEM_PATHS, []);
-  const trustAllCerts: boolean = configs.get(SSL_VERIFY_SERVER_CERT_DISABLED, false);
-  await updatePreferences({ tls_pem_paths: pemPaths, trust_all_certificates: trustAllCerts });
+  await updatePreferences();
   logger.info("Initial preferences passed to sidecar");
   return createConfigChangeListener();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,7 +108,7 @@ export async function activate(
   logUsage(UserEvent.ExtensionActivation, { status: "started" });
   try {
     context = await _activateExtension(context);
-    logger.info(`Extension ${extVersion} fully activated`);
+    logger.info(`Extension version ${extVersion} fully activated`);
     observabilityContext.extensionActivated = true;
     logUsage(UserEvent.ExtensionActivation, { status: "completed" });
   } catch (e) {

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -10,6 +10,8 @@ export const SCHEMA_RBAC_WARNINGS_ENABLED =
 
 /** Array of string paths pointing to .pem files in the current environment for SSL/TLS. */
 export const SSL_PEM_PATHS = prefix + "ssl.pemPaths";
+/** Default value for the {@link SSL_PEM_PATHS} setting. */
+export const DEFAULT_SSL_PEM_PATHS: string[] = [];
 
 /**
  * Disable SSL/TLS server certificate verification when making requests to Confluent/Kafka
@@ -17,6 +19,8 @@ export const SSL_PEM_PATHS = prefix + "ssl.pemPaths";
  */
 export const SSL_VERIFY_SERVER_CERT_DISABLED =
   prefix + "debugging.sslTls.serverCertificateVerificationDisabled";
+/** Default value for the {@link SSL_VERIFY_SERVER_CERT_DISABLED} setting. */
+export const DEFAULT_TRUST_ALL_CERTIFICATES = false;
 
 export const LOCAL_DOCKER_SOCKET_PATH = prefix + "localDocker.socketPath";
 

--- a/src/preferences/listener.test.ts
+++ b/src/preferences/listener.test.ts
@@ -28,7 +28,7 @@ describe("preferences/listener", function () {
     sandbox.restore();
   });
 
-  it("should call updatePreferences() with 'tls_pem_paths' when the SSL_PEM_PATHS config changes", async function () {
+  it("should call updatePreferences() when the SSL_PEM_PATHS config changes", async function () {
     const mockConfig = {
       get: sandbox.stub().withArgs(SSL_PEM_PATHS).returns(["path/to/pem"]),
     };
@@ -43,10 +43,10 @@ describe("preferences/listener", function () {
     createConfigChangeListener();
     await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
 
-    assert.ok(updatePreferencesStub.calledWith({ tls_pem_paths: ["path/to/pem"] }));
+    sinon.assert.called(updatePreferencesStub);
   });
 
-  it("should call updatePreferences() with 'trust_all_certificates' when the SSL_VERIFY_SERVER_CERT_DISABLED config changes", async function () {
+  it("should call updatePreferences() when the SSL_VERIFY_SERVER_CERT_DISABLED config changes", async function () {
     const mockConfig = {
       get: sandbox.stub().withArgs(SSL_VERIFY_SERVER_CERT_DISABLED).returns(true),
     };
@@ -61,7 +61,7 @@ describe("preferences/listener", function () {
     createConfigChangeListener();
     await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
 
-    assert.ok(updatePreferencesStub.calledWith({ trust_all_certificates: true }));
+    sinon.assert.called(updatePreferencesStub);
   });
 
   it("should not call updatePreferences() if config change does not affect SSL_PEM_PATHS or SSL_VERIFY_SERVER_CERT_DISABLED", async function () {

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -20,19 +20,14 @@ export function createConfigChangeListener(): Disposable {
       if (event.affectsConfiguration(SSL_PEM_PATHS)) {
         // inform the sidecar that the SSL/TLS .pem paths have changed
         logger.debug(`"${SSL_PEM_PATHS}" config changed`);
-        const pemPaths: string[] = configs.get(SSL_PEM_PATHS, []);
-        await updatePreferences({
-          tls_pem_paths: pemPaths,
-        });
+        await updatePreferences();
         return;
       }
 
       if (event.affectsConfiguration(SSL_VERIFY_SERVER_CERT_DISABLED)) {
         // inform the sidecar that the server cert verification has changed
         logger.debug(`"${SSL_VERIFY_SERVER_CERT_DISABLED}" config changed`);
-        // if the user disables server cert verification, trust all certs
-        const trustAllCerts: boolean = configs.get(SSL_VERIFY_SERVER_CERT_DISABLED, false);
-        await updatePreferences({ trust_all_certificates: trustAllCerts });
+        await updatePreferences();
         return;
       }
 

--- a/src/preferences/updates.test.ts
+++ b/src/preferences/updates.test.ts
@@ -1,20 +1,29 @@
 import * as assert from "assert";
-import sinon from "sinon";
-import {
-  Preferences,
-  PreferencesResourceApi,
-  PreferencesSpec,
-  ResponseError,
-} from "../clients/sidecar";
+import * as sinon from "sinon";
+import { workspace } from "vscode";
+import { Preferences, PreferencesResourceApi, PreferencesSpec } from "../clients/sidecar";
+import * as errors from "../errors";
 import * as sidecar from "../sidecar";
+import {
+  DEFAULT_SSL_PEM_PATHS,
+  DEFAULT_TRUST_ALL_CERTIFICATES,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 import * as updates from "./updates";
+import { loadPreferencesFromWorkspaceConfig } from "./updates";
 
 describe("preferences/updates", function () {
   let sandbox: sinon.SinonSandbox;
   let mockClient: sinon.SinonStubbedInstance<PreferencesResourceApi>;
+  let getConfigurationStub: sinon.SinonStub;
+  let logErrorStub: sinon.SinonStub;
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
+
+    logErrorStub = sandbox.stub(errors, "logError");
+
     // create the stubs for the sidecar + service client
     const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
       sandbox.createStubInstance(sidecar.SidecarHandle);
@@ -22,49 +31,97 @@ describe("preferences/updates", function () {
     mockSidecarHandle.getPreferencesApi.returns(mockClient);
     // stub the getSidecar function to return the mock sidecar handle
     sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+
+    // stub the WorkspaceConfiguration
+    getConfigurationStub = sandbox.stub();
+    sandbox.stub(workspace, "getConfiguration").returns({
+      get: getConfigurationStub,
+      has: sandbox.stub(),
+      update: sandbox.stub(),
+      inspect: sandbox.stub(),
+    });
   });
 
   afterEach(function () {
     sandbox.restore();
   });
 
-  it("should fetch preferences successfully", async function () {
-    const mockPreferences: Preferences = { spec: {} } as Preferences;
-    mockClient.gatewayV1PreferencesGet.resolves(mockPreferences);
+  it("loadDefaultPreferences() should load default preferences from the workspace configuration", async function () {
+    // default values, no user changes
+    const tlsPemPaths: string[] = DEFAULT_SSL_PEM_PATHS;
+    const trustAllCerts = DEFAULT_TRUST_ALL_CERTIFICATES;
 
-    const result = await updates.fetchPreferences();
+    getConfigurationStub.withArgs(SSL_PEM_PATHS, DEFAULT_SSL_PEM_PATHS).returns(tlsPemPaths);
+    getConfigurationStub
+      .withArgs(SSL_VERIFY_SERVER_CERT_DISABLED, DEFAULT_TRUST_ALL_CERTIFICATES)
+      .returns(trustAllCerts);
 
-    assert.strictEqual(result, mockPreferences);
+    const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
+
+    assert.deepStrictEqual(result, {
+      tls_pem_paths: DEFAULT_SSL_PEM_PATHS,
+      trust_all_certificates: DEFAULT_TRUST_ALL_CERTIFICATES,
+    });
   });
 
-  it("should rethrow if fetchPreferences fails with ResponseError", async function () {
-    const mockError = new ResponseError(
-      new Response(null, { status: 500, statusText: "Internal Server Error" }),
-    );
-    mockClient.gatewayV1PreferencesGet.rejects(mockError);
+  it("loadDefaultPreferences() should load preferences with custom values", async function () {
+    // simulate user changing from the default values
+    const tlsPemPaths: string[] = ["path/to/custom.pem"];
+    const trustAllCerts = true;
 
-    await assert.rejects(updates.fetchPreferences(), mockError);
-  });
+    getConfigurationStub.withArgs(SSL_PEM_PATHS, DEFAULT_SSL_PEM_PATHS).returns(tlsPemPaths);
+    getConfigurationStub
+      .withArgs(SSL_VERIFY_SERVER_CERT_DISABLED, DEFAULT_TRUST_ALL_CERTIFICATES)
+      .returns(trustAllCerts);
 
-  it("should rethrow if fetchPreferences fails with non-ResponseError", async function () {
-    const mockError = new Error("Some error");
-    mockClient.gatewayV1PreferencesGet.rejects(mockError);
+    const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
 
-    await assert.rejects(updates.fetchPreferences(), mockError);
+    assert.deepStrictEqual(result, {
+      tls_pem_paths: tlsPemPaths,
+      trust_all_certificates: trustAllCerts,
+    });
   });
 
   it("should update preferences successfully", async function () {
-    const mockPreferences: Preferences = { spec: {} } as Preferences;
-    mockClient.gatewayV1PreferencesGet.resolves(mockPreferences);
-    const mockUpdatedSpec: PreferencesSpec = { tls_pem_paths: ["path/to/pem"] };
-    const mockUpdatedPreferences: Preferences = {
-      ...mockPreferences,
-      spec: mockUpdatedSpec,
+    // simulate user changing from the default values
+    const tlsPemPaths: string[] = ["path/to/custom.pem"];
+    const trustAllCerts = true;
+
+    getConfigurationStub.withArgs(SSL_PEM_PATHS, DEFAULT_SSL_PEM_PATHS).returns(tlsPemPaths);
+    getConfigurationStub
+      .withArgs(SSL_VERIFY_SERVER_CERT_DISABLED, DEFAULT_TRUST_ALL_CERTIFICATES)
+      .returns(trustAllCerts);
+
+    const fakePreferences: Preferences = {
+      api_version: "gateway/v1",
+      kind: "Preferences",
+      spec: {
+        tls_pem_paths: tlsPemPaths,
+        trust_all_certificates: trustAllCerts,
+      },
     };
-    mockClient.gatewayV1PreferencesPut.resolves(mockUpdatedPreferences);
+    mockClient.gatewayV1PreferencesPut.resolves(fakePreferences);
 
-    await updates.updatePreferences(mockUpdatedSpec);
+    await updates.updatePreferences();
 
-    assert.ok(mockClient.gatewayV1PreferencesPut.calledOnce);
+    sinon.assert.calledWithExactly(mockClient.gatewayV1PreferencesPut, {
+      Preferences: fakePreferences,
+    });
+  });
+
+  it("updatePreferences() should log and not re-throw errors when updating preferences", async function () {
+    const errorMessage = "Failed to update preferences";
+    mockClient.gatewayV1PreferencesPut.rejects(new Error(errorMessage));
+
+    await updates.updatePreferences();
+
+    sinon.assert.calledOnce(mockClient.gatewayV1PreferencesPut);
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      sinon.match.instanceOf(Error),
+      "updating preferences",
+      {},
+      true,
+    );
   });
 });

--- a/src/preferences/updates.ts
+++ b/src/preferences/updates.ts
@@ -1,57 +1,52 @@
+import { workspace, WorkspaceConfiguration } from "vscode";
 import { Preferences, PreferencesResourceApi, PreferencesSpec } from "../clients/sidecar";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { getSidecar } from "../sidecar";
+import {
+  DEFAULT_SSL_PEM_PATHS,
+  DEFAULT_TRUST_ALL_CERTIFICATES,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 
 const logger = new Logger("preferences.updates");
 
-/** Fetch the current {@link Preferences} from the sidecar. */
-export async function fetchPreferences(): Promise<Preferences> {
-  const client: PreferencesResourceApi = (await getSidecar()).getPreferencesApi();
-  try {
-    return await client.gatewayV1PreferencesGet();
-  } catch (error) {
-    logError(error, "fetching preferences", {}, true);
-    throw error;
-  }
+/**
+ * Load the current preferences API related values from the workspace configuration / user settings.
+ * @returns {PreferencesSpec} The current preferences.
+ */
+export function loadPreferencesFromWorkspaceConfig(): PreferencesSpec {
+  const configs: WorkspaceConfiguration = workspace.getConfiguration();
+
+  const pemPaths: string[] = configs.get(SSL_PEM_PATHS, DEFAULT_SSL_PEM_PATHS);
+  const trustAllCerts: boolean = configs.get(
+    SSL_VERIFY_SERVER_CERT_DISABLED,
+    DEFAULT_TRUST_ALL_CERTIFICATES,
+  );
+
+  return {
+    tls_pem_paths: pemPaths,
+    trust_all_certificates: trustAllCerts,
+  };
 }
 
-/**
- * Update one or more items in the {@link PreferencesSpec} based on the WorkspaceConfiguration.
- * @param updates - Partial object of key-value pairs to update in the preferences.
- *
- * @example
- * // Update the `tls_pem_paths` preference with the latest value from the workspace configuration.
- * const pemPaths: string[] = configs.get(SSL_PEM_PATHS, []);
- * await updatePreferences({
- *  tls_pem_paths: pemPaths,
- * });
- */
-export async function updatePreferences(updates: Partial<Record<keyof PreferencesSpec, any>>) {
-  // merge the sidecar's current preferences with any updates passed in
-  const preferences: Preferences = await fetchPreferences();
-  const updatedSpec: PreferencesSpec = { ...preferences.spec };
-  for (const [key, value] of Object.entries(updates)) {
-    updatedSpec[key as keyof PreferencesSpec] = value;
-  }
+/** Update the sidecar's preferences API with the current user settings. */
+export async function updatePreferences() {
+  const preferencesSpec: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
+  const preferences: Preferences = {
+    api_version: "gateway/v1",
+    kind: "Preferences",
+    spec: preferencesSpec,
+  };
 
   const client: PreferencesResourceApi = (await getSidecar()).getPreferencesApi();
   try {
     const resp = await client.gatewayV1PreferencesPut({
-      Preferences: {
-        ...preferences, // api_version, kind, metadata
-        spec: updatedSpec,
-      },
+      Preferences: preferences,
     });
     logger.debug("Successfully updated preferences: ", { resp });
   } catch (error) {
-    logError(
-      error,
-      "updating preferences",
-      {
-        updateKeys: Object.keys(updates).join(","), // log extension setting ID(s) updated
-      },
-      true,
-    );
+    logError(error, "updating preferences", {}, true);
   }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR adds two main changes that should help users updating the extension:

1. We have an explicit step to `getSidecar()` before any other requests may start firing. This is to ensure we don't start piling on the async event loop and then discover we have an old version of the sidecar running (during an extension update), which then may result in a race condition where the old-sidecar access token header was used on new-sidecar.
2. User settings are now the ultimate source of truth for the SSL/TLS-related "preferences":
    <img width="575" alt="image" src="https://github.com/user-attachments/assets/1ddc8184-880f-438b-8d31-7940683ecc84" />

    - We were previously fetching the preferences from the sidecar, then merging any updates from the user settings, then sending an update (via `PUT` request) to the sidecar. Now we just look at the user settings and send the applicable settings to the sidecar, and that's the end of it.

We're also adding the extension version in the activation logs since it's handy to have for reference for these kinds of update scenarios.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
