### PR TITLE
Stop setting now-removed sidecar flag

### DIFF
--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -676,7 +676,6 @@ export function constructSidecarEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   sidecar_env["QUARKUS_LOG_FILE_PATH"] = SIDECAR_LOGFILE_PATH;
   sidecar_env["VSCODE_VERSION"] = vscode.version;
   sidecar_env["VSCODE_EXTENSION_VERSION"] = EXTENSION_VERSION;
-  sidecar_env["IDE_SIDECAR_WEBSOCKETS_BROADCAST_UNCHANGED_UPDATES"] = "false";
 
   // If we are running within WSL, then need to have sidecar bind to 0.0.0.0 instead of its default
   // localhost so that browsers running on Windows can connect to it during OAuth flow. The server


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Remove setting sidecar env disabling the websocket hack, since removed in https://github.com/confluentinc/ide-sidecar/pull/362 , sidecar 0.181, which we're already up to speed on as of https://github.com/confluentinc/vscode/pull/1304
