### PR TITLE
chore: move Sentry init logic, manually setup client

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -134,7 +134,6 @@ export function build(done) {
         project: "vscode-extension",
         release: { name: process.env.SENTRY_RELEASE },
         disable: !process.env.SENTRY_AUTH_TOKEN,
-        applicationKey: "confluent-vscode-extension-sentry-do-not-use",
       }),
     ],
     onLog: handleBuildLog,

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import {
   CancellationToken,
   Disposable,
@@ -19,6 +18,7 @@ import { ConnectionLabel } from "../models/resource";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../preferences/constants";
 import { localResourcesQuickPick } from "../quickpicks/localResources";
 import { UserEvent } from "../telemetry/events";
+import { sentryCaptureException } from "../telemetry/sentryClient";
 
 const logger = new Logger("commands.docker");
 
@@ -137,11 +137,13 @@ export async function runWorkflowWithProgress(
               status: "workflow failed",
               start,
             });
-            Sentry.captureException(error, {
-              tags: {
-                dockerImage: workflow.imageRepoTag,
-                extensionUserFlow: "Local Resource Management",
-                localResourceKind: workflow.resourceKind,
+            sentryCaptureException(error, {
+              data: {
+                tags: {
+                  dockerImage: workflow.imageRepoTag,
+                  extensionUserFlow: "Local Resource Management",
+                  localResourceKind: workflow.resourceKind,
+                },
               },
             });
             let errorMsg: string = "";

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -138,7 +138,7 @@ export async function runWorkflowWithProgress(
               start,
             });
             sentryCaptureException(error, {
-              data: {
+              captureContext: {
                 tags: {
                   dockerImage: workflow.imageRepoTag,
                   extensionUserFlow: "Local Resource Management",

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import {
@@ -19,6 +18,7 @@ import { MESSAGE_URI_SCHEME } from "../documentProviders/message";
 import {
   DEFAULT_ERROR_NOTIFICATION_BUTTONS,
   isResponseError,
+  logError,
   showErrorNotificationWithButtons,
 } from "../errors";
 import { Logger } from "../logging";
@@ -104,8 +104,7 @@ async function editTopicConfig(topic: KafkaTopic): Promise<void> {
       topic_name: topic.name,
     });
   } catch (err) {
-    logger.error("Failed to retrieve topic configs list", err);
-    Sentry.captureException(err);
+    logError(err, "list topic configs", {}, true);
     vscode.window.showErrorMessage("Failed to retrieve topic configs");
     return;
   }
@@ -153,8 +152,7 @@ async function editTopicConfig(topic: KafkaTopic): Promise<void> {
         const errorBody = await err.response.json();
         formError = errorBody.message;
       } else {
-        logger.error("Failed to update topic config", err);
-        Sentry.captureException(err);
+        logError(err, "update topic config", {}, true);
         if (err instanceof Error && err.message) formError = err.message;
       }
       return { success: false, message: formError };

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import { utcTicks } from "d3-time";
 import { Data } from "dataclass";
 import { ObservableScope } from "inertial";
@@ -46,6 +45,7 @@ import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { type post } from "./webview/message-viewer";
 import messageViewerTemplate from "./webview/message-viewer.html";
+import { logError, showErrorNotificationWithButtons } from "./errors";
 
 const logger = new Logger("consume");
 
@@ -544,14 +544,8 @@ function messageViewerStartPollingCommand(
             }
             default: {
               reportable = { message: "Something went wrong." };
-              Sentry.captureException(error, { extra: { status, payload } });
-              window
-                .showErrorMessage("Error response while consuming messages.", "Open Logs")
-                .then((action) => {
-                  if (action === "Open Logs") {
-                    commands.executeCommand("confluent.showSidecarOutputChannel");
-                  }
-                });
+              logError(error, "message viewer", { status: status.toString(), payload }, true);
+              showErrorNotificationWithButtons("Error response while consuming messages.");
               break;
             }
           }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,7 +6,7 @@ import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRe
 import { ResponseError as SidecarResponseError } from "./clients/sidecar";
 import { Logger } from "./logging";
 import { logUsage, UserEvent } from "./telemetry/events";
-import { sentryCaptureException } from "./telemetry/eventProcessors";
+import { sentryCaptureException } from "./telemetry/sentryClient";
 
 const logger = new Logger("errors");
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -122,9 +122,10 @@ export async function logError(
   }
 
   logger.error(errorMessage, { ...errorContext, ...extra });
+  // TODO: follow up to reuse EventHint type for capturing tags and other more fine-grained data
   if (sendTelemetry) {
     sentryCaptureException(e, {
-      data: {
+      captureContext: {
         contexts: { response: { status_code: responseStatusCode } },
         extra: { ...errorContext, ...extra },
       },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,3 @@
-import * as Sentry from "@sentry/node";
-
 import { commands, window } from "vscode";
 import { ResponseError as DockerResponseError } from "./clients/docker";
 import { ResponseError as KafkaResponseError } from "./clients/kafkaRest";
@@ -8,6 +6,7 @@ import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRe
 import { ResponseError as SidecarResponseError } from "./clients/sidecar";
 import { Logger } from "./logging";
 import { logUsage, UserEvent } from "./telemetry/events";
+import { sentryCaptureException } from "./telemetry/eventProcessors";
 
 const logger = new Logger("errors");
 
@@ -124,9 +123,11 @@ export async function logError(
 
   logger.error(errorMessage, { ...errorContext, ...extra });
   if (sendTelemetry) {
-    Sentry.captureException(e, {
-      contexts: { response: { status_code: responseStatusCode } },
-      extra: { ...errorContext, ...extra },
+    sentryCaptureException(e, {
+      data: {
+        contexts: { response: { status_code: responseStatusCode } },
+        extra: { ...errorContext, ...extra },
+      },
     });
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,47 +1,10 @@
-// Import this first!
-import * as SentryCore from "@sentry/core";
-import * as Sentry from "@sentry/node";
-/**
- * Initialize Sentry for error tracking (and future performance monitoring?).
- * Sentry.init needs to be run first before any other code so that Sentry can capture all errors.
- * `process.env.SENTRY_DSN` is fetched & defined during production builds only for Confluent official release process
- *
- * @see https://docs.sentry.io/platforms/node/
- */
-if (process.env.SENTRY_DSN) {
-  Sentry.init({
-    // debug: true, // enable for local "prod" debugging with dev console
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENV,
-    release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: 0,
-    profilesSampleRate: 0,
-    integrations: [
-      // https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
-      SentryCore.thirdPartyErrorFilterIntegration({
-        filterKeys: ["confluent-vscode-extension-sentry-do-not-use"],
-        behaviour: "drop-error-if-exclusively-contains-third-party-frames",
-      }),
-      Sentry.rewriteFramesIntegration(),
-    ],
-    ignoreErrors: [
-      "The request failed and the interceptors did not return an alternative response",
-      "ENOENT: no such file or directory",
-      "EPERM: operation not permitted",
-      "Canceled",
-      // rejected promises from the CCloud auth provider that can't be wrapped in try/catch:
-      "User cancelled the authentication flow.",
-      "User reset their password.",
-      "Confluent Cloud authentication failed. See browser for details.",
-    ],
-  });
-}
-
 import * as vscode from "vscode";
-import { checkTelemetrySettings, includeObservabilityContext } from "./telemetry/eventProcessors";
+/** First things first, setup Sentry to catch errors during activation and beyond
+ * `process.env.SENTRY_DSN` is fetched & defined during production builds only for Confluent official release process
+ * */
+import { closeSentryClient, initSentry } from "./telemetry/eventProcessors";
 if (process.env.SENTRY_DSN) {
-  Sentry.addEventProcessor(checkTelemetrySettings);
-  Sentry.addEventProcessor(includeObservabilityContext);
+  initSentry();
 }
 
 import { ConfluentCloudAuthProvider, getAuthProvider } from "./authn/ccloudProvider";
@@ -100,6 +63,7 @@ import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SEARCH_DECORATION_PROVIDER } from "./viewProviders/search";
 import { SupportViewProvider } from "./viewProviders/support";
 import { TopicViewProvider } from "./viewProviders/topics";
+import { sentryCaptureException } from "./telemetry/eventProcessors";
 
 const logger = new Logger("extension");
 
@@ -125,7 +89,7 @@ export async function activate(
   } catch (e) {
     logger.error(`Error activating extension version "${extVersion}":`, e);
     // if the extension is failing to activate for whatever reason, we need to know about it to fix it
-    Sentry.captureException(e);
+    sentryCaptureException(e);
     logUsage(UserEvent.ExtensionActivation, { status: "failed" });
     throw e;
   }
@@ -453,7 +417,7 @@ export function deactivate() {
     const msg = "Error disposing telemetry logger during extension deactivation";
     logError(new Error(msg, { cause: e }), msg, {}, true);
   }
-
+  closeSentryClient();
   // close the file stream used with OUTPUT_CHANNEL
   const logStream = getLogFileStream();
   if (logStream) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 /** First things first, setup Sentry to catch errors during activation and beyond
  * `process.env.SENTRY_DSN` is fetched & defined during production builds only for Confluent official release process
  * */
-import { closeSentryClient, initSentry } from "./telemetry/eventProcessors";
+import { closeSentryClient, initSentry } from "./telemetry/sentryClient";
 if (process.env.SENTRY_DSN) {
   initSentry();
 }
@@ -63,7 +63,7 @@ import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SEARCH_DECORATION_PROVIDER } from "./viewProviders/search";
 import { SupportViewProvider } from "./viewProviders/support";
 import { TopicViewProvider } from "./viewProviders/topics";
-import { sentryCaptureException } from "./telemetry/eventProcessors";
+import { sentryCaptureException } from "./telemetry/sentryClient";
 
 const logger = new Logger("extension");
 

--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -1,9 +1,109 @@
-import * as Sentry from "@sentry/node";
+import {
+  EventHint,
+  Event,
+  NodeClient,
+  Scope,
+  defaultStackParser,
+  getDefaultIntegrations,
+  makeNodeTransport,
+  rewriteFramesIntegration,
+} from "@sentry/node";
 import { env, workspace } from "vscode";
 import { observabilityContext } from "../context/observability";
+import { configDotenv } from "dotenv";
+import { Logger } from "../logging";
 
+/**
+ * Initialize Sentry for error tracking (and future performance monitoring?).
+ * Manually setup Sentry client to avoid polluting global scope.
+ * @see https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/#shared-environment-setup
+ * @see https://docs.sentry.io/platforms/node/
+ */
+// Previous Sentry config for reference:
+//     integrations: [
+//       // https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
+//       SentryCore.thirdPartyErrorFilterIntegration({
+//         filterKeys: ["confluent-vscode-extension-sentry-do-not-use"],
+//         behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+//       }),
+//       Sentry.rewriteFramesIntegration(),
+//     ],
+//     ignoreErrors: [
+//       "The request failed and the interceptors did not return an alternative response",
+//       "ENOENT: no such file or directory",
+//       "EPERM: operation not permitted",
+//       "Canceled",
+//       // rejected promises from the CCloud auth provider that can't be wrapped in try/catch:
+//       "User cancelled the authentication flow.",
+//       "User reset their password.",
+//       "Confluent Cloud authentication failed. See browser for details.",
+//     ],
+
+const logger = new Logger("sentry");
+
+const SentryScope: Scope = new Scope();
+configDotenv();
+export function initSentry() {
+  logger.debug("Initializing Sentry");
+  // filter out integrations that use the global variable
+  const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
+    return ![
+      "Breadcrumbs",
+      "BrowserAPIErrors",
+      "OnUnhandledRejection",
+      "OnUncaughtException",
+      "CaptureConsole",
+    ].includes(defaultIntegration.name);
+  });
+
+  const client = new NodeClient({
+    // debug: true, // enable for local "prod" debugging with dev console
+    dsn: process.env.SENTRY_DSN,
+    initialScope: {
+      tags: { "my-tag": "my value" },
+      user: { id: 42, email: "john.doe@example.com" },
+    },
+    environment: process.env.SENTRY_ENV,
+    release: process.env.SENTRY_RELEASE,
+    integrations: [...integrations, rewriteFramesIntegration()],
+    beforeSend(event) {
+      logger.debug(`Sentry beforeSend: ${JSON.stringify(event?.exception?.values)}`);
+      return event;
+    },
+    tracesSampleRate: 0, // We do not use Sentry tracing
+    profilesSampleRate: 0, // We do not use Sentry profiling
+    sampleRate: 1.0,
+    attachStacktrace: true,
+    includeLocalVariables: true,
+    transport: makeNodeTransport,
+    stackParser: defaultStackParser,
+  });
+  SentryScope.setTag("extension", "vscode-confluent");
+  SentryScope.setClient(client);
+  SentryScope.addEventProcessor(checkTelemetrySettings);
+  SentryScope.addEventProcessor(includeObservabilityContext);
+  client.init();
+}
+
+export function sentryCaptureException(ex: unknown, hint?: EventHint | undefined): unknown {
+  // TODO NC remove debug logs
+  logger.debug("Attempting to send to Sentry:", ex);
+  const client = SentryScope.getClient();
+  if (!client) {
+    logger.error("No Sentry client available");
+    return ex;
+  }
+  logger.debug(`Sending to Sentry with DSN: ${process.env.SENTRY_DSN?.substring(0, 5)}...`);
+  SentryScope.captureException(ex, hint);
+  logger.debug("Sent to Sentry");
+  return ex;
+}
+
+export async function closeSentryClient() {
+  await SentryScope.getClient()?.close(2000);
+}
 /** Helper function to make sure the user has Telemetry ON before sending Sentry error events */
-export function checkTelemetrySettings(event: Sentry.Event) {
+function checkTelemetrySettings(event: Event) {
   const telemetryLevel = workspace.getConfiguration()?.get("telemetry.telemetryLevel");
   if (!env.isTelemetryEnabled || telemetryLevel === "off") {
     // Returning `null` will drop the event
@@ -13,7 +113,7 @@ export function checkTelemetrySettings(event: Sentry.Event) {
 }
 
 /** Include this extension instance's {@link observabilityContext} under the `extra` context. */
-export function includeObservabilityContext(event: Sentry.Event): Sentry.Event {
+function includeObservabilityContext(event: Event): Event {
   event.extra = { ...event.extra, ...observabilityContext.toRecord() };
   return event;
 }

--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -1,109 +1,9 @@
-import {
-  EventHint,
-  Event,
-  NodeClient,
-  Scope,
-  defaultStackParser,
-  getDefaultIntegrations,
-  makeNodeTransport,
-  rewriteFramesIntegration,
-} from "@sentry/node";
+import { Event } from "@sentry/node";
 import { env, workspace } from "vscode";
 import { observabilityContext } from "../context/observability";
-import { configDotenv } from "dotenv";
-import { Logger } from "../logging";
 
-/**
- * Initialize Sentry for error tracking. Manually setup Sentry client to avoid polluting global scope.
- * @see https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/#shared-environment-setup
- * @see https://docs.sentry.io/platforms/node/
- */
-// Previous Sentry config for reference:
-//     integrations: [
-//       // https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
-//       SentryCore.thirdPartyErrorFilterIntegration({
-//         filterKeys: ["confluent-vscode-extension-sentry-do-not-use"],
-//         behaviour: "drop-error-if-exclusively-contains-third-party-frames",
-//       }),
-//       Sentry.rewriteFramesIntegration(),
-//     ],
-//     ignoreErrors: [
-//       "The request failed and the interceptors did not return an alternative response",
-//       "ENOENT: no such file or directory",
-//       "EPERM: operation not permitted",
-//       "Canceled",
-//       // rejected promises from the CCloud auth provider that can't be wrapped in try/catch:
-//       "User cancelled the authentication flow.",
-//       "User reset their password.",
-//       "Confluent Cloud authentication failed. See browser for details.",
-//     ],
-
-const logger = new Logger("sentry");
-
-const SentryScope: Scope = new Scope();
-configDotenv();
-export function initSentry() {
-  logger.debug("Initializing Sentry");
-  // filter out integrations that use the global variable
-  const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
-    return ![
-      "Breadcrumbs",
-      "BrowserAPIErrors",
-      "OnUnhandledRejection",
-      "OnUncaughtException",
-      "CaptureConsole",
-    ].includes(defaultIntegration.name);
-  });
-
-  const client = new NodeClient({
-    // debug: true, // enable for local "prod" debugging with dev console
-    dsn: process.env.SENTRY_DSN,
-    // TODO NC remove - Fake values to test
-    initialScope: {
-      tags: { "my-tag": "my value" },
-      user: { id: 42, email: "john.doe@example.com" },
-    },
-    environment: process.env.SENTRY_ENV,
-    release: process.env.SENTRY_RELEASE,
-    integrations: [...integrations, rewriteFramesIntegration()],
-    beforeSend(event) {
-      logger.debug(`Sentry beforeSend: ${JSON.stringify(event?.exception?.values)}`);
-      return event;
-    },
-    tracesSampleRate: 0, // We do not use Sentry tracing
-    profilesSampleRate: 0, // We do not use Sentry profiling
-    sampleRate: 1.0,
-    attachStacktrace: true,
-    includeLocalVariables: true,
-    transport: makeNodeTransport,
-    stackParser: defaultStackParser,
-  });
-  // SentryScope.setTag("extension", "vscode-confluent");
-  SentryScope.setClient(client);
-  SentryScope.addEventProcessor(checkTelemetrySettings);
-  SentryScope.addEventProcessor(includeObservabilityContext);
-  client.init();
-}
-
-export function sentryCaptureException(ex: unknown, hint?: EventHint | undefined): unknown {
-  // TODO NC remove debug logs
-  logger.debug("Attempting to send to Sentry:", ex);
-  const client = SentryScope.getClient();
-  if (!client) {
-    logger.error("No Sentry client available");
-    return ex;
-  }
-  logger.debug(`Sending to Sentry with DSN: ${process.env.SENTRY_DSN?.substring(0, 5)}...`);
-  SentryScope.captureException(ex, hint);
-  logger.debug("Sent to Sentry");
-  return ex;
-}
-
-export async function closeSentryClient() {
-  await SentryScope.getClient()?.close(2000);
-}
 /** Helper function to make sure the user has Telemetry ON before sending Sentry error events */
-function checkTelemetrySettings(event: Event) {
+export function checkTelemetrySettings(event: Event) {
   const telemetryLevel = workspace.getConfiguration()?.get("telemetry.telemetryLevel");
   if (!env.isTelemetryEnabled || telemetryLevel === "off") {
     // Returning `null` will drop the event
@@ -113,7 +13,7 @@ function checkTelemetrySettings(event: Event) {
 }
 
 /** Include this extension instance's {@link observabilityContext} under the `extra` context. */
-function includeObservabilityContext(event: Event): Event {
+export function includeObservabilityContext(event: Event): Event {
   event.extra = { ...event.extra, ...observabilityContext.toRecord() };
   return event;
 }

--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -14,8 +14,7 @@ import { configDotenv } from "dotenv";
 import { Logger } from "../logging";
 
 /**
- * Initialize Sentry for error tracking (and future performance monitoring?).
- * Manually setup Sentry client to avoid polluting global scope.
+ * Initialize Sentry for error tracking. Manually setup Sentry client to avoid polluting global scope.
  * @see https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/#shared-environment-setup
  * @see https://docs.sentry.io/platforms/node/
  */
@@ -59,6 +58,7 @@ export function initSentry() {
   const client = new NodeClient({
     // debug: true, // enable for local "prod" debugging with dev console
     dsn: process.env.SENTRY_DSN,
+    // TODO NC remove - Fake values to test
     initialScope: {
       tags: { "my-tag": "my value" },
       user: { id: 42, email: "john.doe@example.com" },
@@ -78,7 +78,7 @@ export function initSentry() {
     transport: makeNodeTransport,
     stackParser: defaultStackParser,
   });
-  SentryScope.setTag("extension", "vscode-confluent");
+  // SentryScope.setTag("extension", "vscode-confluent");
   SentryScope.setClient(client);
   SentryScope.addEventProcessor(checkTelemetrySettings);
   SentryScope.addEventProcessor(includeObservabilityContext);

--- a/src/telemetry/sentryClient.ts
+++ b/src/telemetry/sentryClient.ts
@@ -76,7 +76,7 @@ export function sentryCaptureException(ex: unknown, hint?: EventHint | undefined
     logger.error("No Sentry client available");
     return ex;
   }
-  logger.debug(`Sending to Sentry`);
+  logger.debug("sending exception to Sentry", { ex, hint });
   scope.captureException(ex, hint);
   return ex;
 }

--- a/src/telemetry/sentryClient.ts
+++ b/src/telemetry/sentryClient.ts
@@ -1,0 +1,86 @@
+import {
+  EventHint,
+  NodeClient,
+  Scope,
+  defaultStackParser,
+  getDefaultIntegrations,
+  makeNodeTransport,
+  rewriteFramesIntegration,
+} from "@sentry/node";
+import { Logger } from "../logging";
+import { checkTelemetrySettings, includeObservabilityContext } from "./eventProcessors";
+
+const logger = new Logger("sentry");
+let sentryScope: Scope | null = null;
+let sentryClient: NodeClient | null = null;
+
+/**
+ * Returns the Sentry Scope singleton, creating it if it doesn't exist
+ */
+export function getSentryScope(): Scope {
+  if (!sentryScope) {
+    logger.debug("Creating new Sentry scope");
+    sentryScope = new Scope();
+  }
+  return sentryScope;
+}
+
+/**
+ * Initialize Sentry for error tracking. Manually setup Sentry client to avoid polluting global scope.
+ * @see https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/#shared-environment-setup
+ * @see https://docs.sentry.io/platforms/node/
+ */
+export function initSentry() {
+  if (sentryClient) {
+    logger.debug("Sentry already initialized");
+    return;
+  }
+  // filter out integrations that use the global variable
+  const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
+    return ![
+      "Breadcrumbs",
+      "BrowserAPIErrors",
+      "OnUnhandledRejection",
+      "OnUncaughtException",
+      "CaptureConsole",
+    ].includes(defaultIntegration.name);
+  });
+
+  sentryClient = new NodeClient({
+    // debug: true, // enable for local "prod" debugging with dev console
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENV,
+    release: process.env.SENTRY_RELEASE,
+    integrations: [...integrations, rewriteFramesIntegration()],
+    tracesSampleRate: 0, // We do not use Sentry tracing
+    profilesSampleRate: 0, // We do not use Sentry profiling
+    sampleRate: 1.0,
+    attachStacktrace: true,
+    includeLocalVariables: true,
+    transport: makeNodeTransport,
+    stackParser: defaultStackParser,
+  });
+
+  const scope = getSentryScope();
+  scope.setClient(sentryClient);
+  scope.addEventProcessor(checkTelemetrySettings);
+  scope.addEventProcessor(includeObservabilityContext);
+
+  sentryClient.init();
+}
+
+export function sentryCaptureException(ex: unknown, hint?: EventHint | undefined): unknown {
+  const scope = getSentryScope();
+  const client = scope.getClient();
+  if (!client) {
+    logger.error("No Sentry client available");
+    return ex;
+  }
+  logger.debug(`Sending to Sentry`);
+  scope.captureException(ex, hint);
+  return ex;
+}
+
+export async function closeSentryClient() {
+  await getSentryScope().getClient()?.close(2000);
+}

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import * as vscode from "vscode";
 import { ConnectionStatus } from "../clients/sidecar";
 import {
@@ -20,7 +19,7 @@ import {
   localSchemaRegistryConnected,
   resourceSearchSet,
 } from "../emitters";
-import { ExtensionContextNotSetError, showErrorNotificationWithButtons } from "../errors";
+import { ExtensionContextNotSetError, logError, showErrorNotificationWithButtons } from "../errors";
 import { getDirectResources } from "../graphql/direct";
 import { getLocalResources } from "../graphql/local";
 import { getCurrentOrganization } from "../graphql/organizations";
@@ -562,8 +561,7 @@ export async function loadCCloudResources(
       // if we fail to load CCloud environments, we need to get as much information as possible as to
       // what went wrong since the user is effectively locked out of the CCloud resources for this org
       const msg = `Failed to load Confluent Cloud environments for the "${currentOrg?.name}" organization.`;
-      logger.error(msg, e);
-      Sentry.captureException(e);
+      logError(e, "loading CCloud environments", {}, true);
       showErrorNotificationWithButtons(msg);
     }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Change the way we setup Sentry to manually create the NodeClient and Scope (instead of using the node package's managed `init` function), giving us full control over the exceptions captured and removing the possibility that 3rd party errors will make it in our Sentry account. 
- Move any calls to `Sentry.captureException()` to either call the new method, or use the new-ish `logError()` function, which was updated with the new capture method as well. 
- Closes #982  <-- see issue for more info

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Made it similar to the `telemetryLogger.ts` pattern where Sentry Scope and Client will be initialized only once. 
- ⚠️ We will need to be extra diligent about catching & sending any exceptions to Sentry in the code, since this setup removes the global handlers (e.g. "OnUnhandledRejection", "OnUncaughtException") 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
