### PR TITLE
fix: test for VS Code Insiders and add version check for local test runner

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -645,8 +645,17 @@ export async function testRun() {
   const reportCoverage = IS_CI || process.argv.indexOf("--coverage", 2) >= 0;
   // argv array is something like ['gulp', 'test', '-t', 'something'], we look for the one after -t
   const testFilter = process.argv.find((v, i, a) => i > 0 && a[i - 1] === "-t");
+
+  // check for VS Code stable vs Insiders based on TERM_PROGRAM_VERSION
+  // - stable: "1.x.x"
+  // - insiders: "1.x.x-insider"
+  const isInsiders = process.env.TERM_PROGRAM_VERSION?.endsWith("insider");
+  // specify the version of VS Code to use for testing if it isn't provided as an env var
+  const vscodeVersion = process.env.VSCODE_VERSION || (isInsiders ? "insiders" : "stable");
+  console.info(`Starting test runner for VS Code ${vscodeVersion}...`);
+
   await runTests({
-    version: process.env.VSCODE_VERSION,
+    version: vscodeVersion,
     extensionDevelopmentPath: resolve(DESTINATION),
     extensionTestsPath: resolve(DESTINATION + "/src/testing.js"),
     extensionTestsEnv: {

--- a/src/featureFlags/evaluation.test.ts
+++ b/src/featureFlags/evaluation.test.ts
@@ -139,7 +139,7 @@ describe("featureFlags/evaluation.ts", function () {
     // globally enabled, current version disabled but missing reason
     FeatureFlags[FeatureFlag.GLOBAL_ENABLED] = true;
     const disabledVersion: any = {
-      product: "vscode",
+      product: env.uriScheme,
       extensionId: EXTENSION_ID,
       version: EXTENSION_VERSION,
     };

--- a/src/featureFlags/evaluation.test.ts
+++ b/src/featureFlags/evaluation.test.ts
@@ -128,6 +128,7 @@ describe("featureFlags/evaluation.ts", function () {
       reason: fakeReason,
     };
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [disabledVersion];
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns([disabledVersion]);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 

--- a/src/featureFlags/evaluation.test.ts
+++ b/src/featureFlags/evaluation.test.ts
@@ -100,7 +100,7 @@ describe("featureFlags/evaluation.ts", function () {
     // globally enabled, no versions disabled
     FeatureFlags[FeatureFlag.GLOBAL_ENABLED] = true;
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [];
-    clientVariationStub.withArgs(FeatureFlag.GLOBAL_ENABLED, true).returns(true);
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_ENABLED).returns(true);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
@@ -108,8 +108,10 @@ describe("featureFlags/evaluation.ts", function () {
   });
 
   it("checkForExtensionDisabledReason() should handle non-array GLOBAL_DISABLED_VERSIONS", function () {
+    // globally enabled, weird disabled version format
     FeatureFlags[FeatureFlag.GLOBAL_ENABLED] = true;
-    FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = "not-an-array" as any;
+    FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = "not-an-array";
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns("not-an-array");
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
@@ -129,7 +131,6 @@ describe("featureFlags/evaluation.ts", function () {
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
-    assert.ok(reason);
     assert.strictEqual(reason, disabledVersion.reason);
   });
 
@@ -142,10 +143,10 @@ describe("featureFlags/evaluation.ts", function () {
       version: EXTENSION_VERSION,
     };
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [disabledVersion];
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns([disabledVersion]);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
-    assert.ok(reason);
     assert.strictEqual(reason, "Unspecified reason");
   });
 
@@ -168,6 +169,7 @@ describe("featureFlags/evaluation.ts", function () {
       reason: fakeReason,
     };
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [disabledVersion];
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns([disabledVersion]);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
@@ -184,6 +186,7 @@ describe("featureFlags/evaluation.ts", function () {
       reason: fakeReason,
     };
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [disabledVersion];
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns([disabledVersion]);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
@@ -200,6 +203,7 @@ describe("featureFlags/evaluation.ts", function () {
       reason: fakeReason,
     };
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [disabledVersion];
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns([disabledVersion]);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
@@ -214,6 +218,7 @@ describe("featureFlags/evaluation.ts", function () {
       baz: 123,
     };
     FeatureFlags[FeatureFlag.GLOBAL_DISABLED_VERSIONS] = [disabledVersion];
+    clientVariationStub.withArgs(FeatureFlag.GLOBAL_DISABLED_VERSIONS).returns([disabledVersion]);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 
@@ -226,6 +231,7 @@ describe("featureFlags/evaluation.ts", function () {
     for (const key of Object.keys(FEATURE_FLAG_DEFAULTS)) {
       delete FeatureFlags[key];
     }
+    clientVariationStub.returns(undefined);
 
     const reason: string | undefined = checkForExtensionDisabledReason();
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

VS Code Insiders runner kept failing this one test in CI:
<img width="1340" alt="image" src="https://github.com/user-attachments/assets/5355d657-402d-43a1-9908-d6addfaefbfb" />

I originally thought it was flaky and couldn't produce locally, but that was because we had an issue with the way we were setting the `version` in the Mocha runner: because we likely weren't specifying the `VSCODE_VERSION` environment variable locally, any `gulp testRun` would spin up a VS Code (stable) runner.

Now we have another check based on whether the `gulp` task was kicked off within a VS Code stable/insiders terminal (using the VS Code built-in `TERM_PROGRAM_VERSION` env var), to then use that if `VSCODE_VERSION` wasn't provided. This means running `gulp test` inside a VS Code Insiders terminal will use `insiders` by default:
<img width="773" alt="image" src="https://github.com/user-attachments/assets/cfdef9de-4ea5-46fb-9701-ca9e3db8286f" />

...and `gulp test` from inside a VS Code (stable) terminal will use `stable` by default:
<img width="774" alt="image" src="https://github.com/user-attachments/assets/7205f62d-e1f3-47fb-859e-e654b4b9ac00" />

And testing outside of VS Code terminals altogether will default to `stable` as well:
<img width="865" alt="image" src="https://github.com/user-attachments/assets/d6258615-16e1-4b7c-a6ed-9e5b86ca3e56" />



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
