### PR TITLE
Added groupId to customConnectionSpec set to null

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -235,6 +235,7 @@ export function getConnectionSpecFromFormData(
     name: formData["name"] || "New Connection",
     type: ConnectionType.Direct,
     formConnectionType: formData["formconnectiontype"],
+    groupId: null, // Always set to null until connection form supports it
   };
   if (formData["formconnectiontype"] === "Other") {
     spec.specifiedConnectionType = formData["othertype"];

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -51,6 +51,8 @@ export interface CustomConnectionSpec extends ConnectionSpec {
   formConnectionType: FormConnectionType;
   /** If the formConnectionType is "Other" we prompt users to specify the type */
   specifiedConnectionType?: string;
+  /** The groupId for this connection. default to null until conection form supports it.  */
+  groupId?: string | null;
 }
 
 /** Map of {@link ConnectionId} to {@link CustomConnectionSpec}; only used for `DIRECT` connections. */
@@ -751,6 +753,7 @@ export function CustomConnectionSpecFromJSON(obj: any): CustomConnectionSpec {
     id: obj["id"] as ConnectionId,
     formConnectionType: obj["formConnectionType"],
     specifiedConnectionType: obj["specifiedConnectionType"],
+    groupId: null,  // Always set to null until connection form supports it
   };
 }
 
@@ -760,6 +763,7 @@ export function CustomConnectionSpecToJSON(spec: CustomConnectionSpec): any {
     ...ConnectionSpecToJSON(spec),
     formConnectionType: spec.formConnectionType,
     specifiedConnectionType: spec.specifiedConnectionType,
+    groupId: spec.groupId,
   };
 }
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -753,7 +753,7 @@ export function CustomConnectionSpecFromJSON(obj: any): CustomConnectionSpec {
     id: obj["id"] as ConnectionId,
     formConnectionType: obj["formConnectionType"],
     specifiedConnectionType: obj["specifiedConnectionType"],
-    groupId: null,  // Always set to null until connection form supports it
+    groupId: null, // Always set to null until connection form supports it
   };
 }
 

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -106,4 +106,5 @@ export const TEST_DIRECT_CONNECTION_FORM_SPEC: CustomConnectionSpec = {
   id: TEST_DIRECT_CONNECTION_ID, // enforced ConnectionId type
   formConnectionType: "Apache Kafka",
   specifiedConnectionType: undefined,
+  groupId: null, // Always set to null until connection form supports it
 };


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Updated `CustomConnectionSpec` Interface to support `groupId` by default set to null until new connection form supports allows setting it.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- #1039 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
