### PR TITLE
MINOR: remove skipped test fragment

### DIFF
--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -172,8 +172,6 @@ describe("getLanguageTypes", () => {
       assert.deepEqual(languageType, expected);
     });
   }
-
-  it(`Schema.get`);
 });
 
 describe("SchemaTreeItem", () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We had a lingering "skipped" test that didn't have a `.skip()`, but looks like this was leftover from https://github.com/confluentinc/vscode/pull/1071

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
