### PR TITLE
Have schema upload command use same events as delete schema command

### DIFF
--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -324,9 +324,18 @@ async function deleteSchemaVersionCommand(schema: Schema) {
 
     // Fire off event to update views if needed.
     if (wasOnlyVersionForSubject) {
-      schemaSubjectChanged.fire({ subject: schema.subjectObject(), change: "deleted" });
+      // Announce that the entire subject was deleted.
+      schemaSubjectChanged.fire({ change: "deleted", subject: schema.subjectObject() });
     } else {
-      schemaVersionsChanged.fire({ schema: schema, change: "deleted" });
+      // Announce that a schema version was deleted, and provide the updated schema group.
+
+      // Filter out the deleted schema version from the pre-delete
+      // fetched schema group.
+      const newSubject = schema.subjectWithSchemasObject(
+        schemaGroup.filter((s) => s.id !== schema.id),
+      );
+
+      schemaVersionsChanged.fire({ change: "deleted", subject: newSubject });
     }
   } catch (e) {
     success = false;

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { KafkaCluster } from "./models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "./models/resource";
-import { Schema, Subject } from "./models/schema";
+import { Subject, SubjectWithSchemas } from "./models/schema";
 import { SchemaRegistry } from "./models/schemaRegistry";
 
 // NOTE: these are kept at the global level to allow for easy access from any file and track where
@@ -27,19 +27,33 @@ export const localSchemaRegistryConnected = new vscode.EventEmitter<boolean>();
 
 export type EventChangeType = "added" | "deleted";
 
+/** A whole subject within a schema registry has been added or deleted. */
 export type SubjectChangeEvent = {
-  /** The subject that changed. */
-  subject: Subject;
   change: EventChangeType;
-};
+} & (
+  | {
+      change: "added";
+      /** When a subject is added, it will carry the new (probably singleton) schema(s) within. */
+      subject: SubjectWithSchemas;
+    }
+  | {
+      change: "deleted";
+      /** When a subject is deleted, it will not contain schemas */
+      subject: Subject;
+    }
+);
+
 /** Fired when a whole SR subject has either been added or deleted. */
 export const schemaSubjectChanged = new vscode.EventEmitter<SubjectChangeEvent>();
 
+/** A schema version was added or removed from a preexisting and remaining existing subject. */
 export type SchemaVersionChangeEvent = {
-  /** The schema that was added or removed. */
-  schema: Schema;
   change: EventChangeType;
+
+  /** The new Subject representation, with refreshed non-null and non-empty .schemas */
+  subject: SubjectWithSchemas;
 };
+
 /** Fired when a schema version has been either created or deleted within a preexisting subject.*/
 export const schemaVersionsChanged = new vscode.EventEmitter<SchemaVersionChangeEvent>();
 

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -299,6 +299,25 @@ describe("getSubjectIcon", () => {
       assert.deepEqual(icon, new vscode.ThemeIcon(expected as IconNames));
     });
   }
+
+  for (const [subjectName, iconName, strategy] of [
+    ["test-key", IconNames.KEY_SUBJECT, "TopicNameStrategy"],
+    ["test-value", IconNames.VALUE_SUBJECT, "TopicNameStrategy"],
+    ["test-other", IconNames.OTHER_SUBJECT, "**NOT** TopicNameStrategy"],
+  ]) {
+    it(`subject "${subjectName}" should use the "${iconName}" icon (${strategy})`, () => {
+      const subject = new Subject(
+        subjectName,
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+        [TEST_CCLOUD_SCHEMA],
+      );
+      const subjectTreeItem = new SubjectTreeItem(subject);
+
+      assert.deepEqual((subjectTreeItem.iconPath as vscode.ThemeIcon).id, iconName);
+    });
+  }
 });
 
 describe("getLanguageTypes", () => {

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -129,6 +129,149 @@ describe("Schema model methods", () => {
     // Non-ccloud schemas do not
     assert.equal(TEST_LOCAL_SCHEMA.ccloudUrl, "");
   });
+
+  describe("mergeSchemas() tests", () => {
+    it("should accept new schemas when subject.schemas is null", () => {
+      const subject = new Subject(
+        "test-subject",
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+      );
+      assert.equal(subject.schemas, null);
+
+      const newSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 }),
+      ];
+
+      subject.mergeSchemas(newSchemas);
+      assert.deepEqual(subject.schemas, newSchemas);
+    });
+
+    it("should merge schemas preserving additional schemas from newSchemas", () => {
+      // As if we had two versions originally in our Subject ...
+      const originalSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 }),
+      ];
+
+      const subject = new Subject(
+        "test-subject",
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+        originalSchemas,
+      );
+
+      // And then version three was created, and we want to merge it in.
+      // These will be the results of the latest 'get all schema versions' call for the subject.
+      const newSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 3 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 }),
+      ];
+
+      subject.mergeSchemas(newSchemas);
+
+      // Expect the resulting merge to have the versions ordered 3, 2, 1, and that v2 and v1 are the same objects as the originals.
+      const resultingSchemas = subject.schemas!;
+      assert.strictEqual(resultingSchemas.length, 3);
+      assert.strictEqual(resultingSchemas[0].version, 3);
+      assert.strictEqual(resultingSchemas[1].version, 2);
+      assert.strictEqual(resultingSchemas[2].version, 1);
+
+      assert.strictEqual(resultingSchemas[1], originalSchemas[0]); // version 2
+      assert.strictEqual(resultingSchemas[2], originalSchemas[1]); // version 1
+    });
+
+    it("should remove schemas that are not in newSchemas", () => {
+      const originalSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 3 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 }),
+      ];
+
+      const subject = new Subject(
+        "test-subject",
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+        originalSchemas,
+      );
+
+      // As if both versions 3 and 1 were deleted.
+      const newSchemas = [Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 })];
+
+      subject.mergeSchemas(newSchemas);
+
+      // Expect the resulting merge to have the versions ordered 3, 1, and that v2 is removed.
+      const resultingSchemas = subject.schemas!;
+      assert.strictEqual(resultingSchemas.length, 1);
+      assert.strictEqual(resultingSchemas[0], originalSchemas[1]); // Should have kept the original v2 schema.
+    });
+
+    it("Should add and remove schemas when needed", () => {
+      const originalSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 3 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 }),
+      ];
+
+      const subject = new Subject(
+        "test-subject",
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+        originalSchemas,
+      );
+
+      // As if both versions 3 and 1 were deleted, and version 4 was added.
+      const newSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 4 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+      ];
+
+      subject.mergeSchemas(newSchemas);
+
+      // Expect the resulting merge to have the versions ordered 4, 2, and that v3 and v1 are removed.
+      const resultingSchemas = subject.schemas!;
+      assert.strictEqual(resultingSchemas.length, 2);
+      assert.strictEqual(resultingSchemas[0].version, 4);
+      assert.strictEqual(resultingSchemas[1].version, 2);
+
+      // v2 should be the same object as the original v2 schema.
+      assert.strictEqual(resultingSchemas[1], originalSchemas[1]);
+    });
+
+    it("Will handle when new schemas is longer than old schemas", () => {
+      const originalSchemas = [Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 })];
+
+      const subject = new Subject(
+        "test-subject",
+        CCLOUD_CONNECTION_ID,
+        "envId" as EnvironmentId,
+        "srId",
+        originalSchemas,
+      );
+
+      // As if both versions 2 and 3 were just added.
+      const newSchemas = [
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 3 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 2 }),
+        Schema.create({ ...TEST_CCLOUD_SCHEMA, version: 1 }),
+      ];
+
+      subject.mergeSchemas(newSchemas);
+
+      // Expect the resulting merge to have the versions ordered 4, 2, and that v3 and v1 are removed.
+      const resultingSchemas = subject.schemas!;
+      assert.strictEqual(resultingSchemas.length, 3);
+      assert.strictEqual(resultingSchemas[0], newSchemas[0]); // version 3
+      assert.strictEqual(resultingSchemas[1], newSchemas[1]); // version 2
+      assert.strictEqual(resultingSchemas[2], originalSchemas[0]); // version 1
+    });
+  });
 });
 
 describe("getSubjectIcon", () => {
@@ -225,23 +368,4 @@ describe("SubjectTreeItem", () => {
     );
     assert.equal(subjectWithSchemasTreeItem.description, "AVRO (2)");
   });
-
-  for (const [subjectName, iconName, strategy] of [
-    ["test-key", IconNames.KEY_SUBJECT, "TopicNameStrategy"],
-    ["test-value", IconNames.VALUE_SUBJECT, "TopicNameStrategy"],
-    ["test-other", IconNames.OTHER_SUBJECT, "**NOT** TopicNameStrategy"],
-  ]) {
-    it(`subject "${subjectName}" should use the "${iconName}" icon (${strategy})`, () => {
-      const subject = new Subject(
-        subjectName,
-        CCLOUD_CONNECTION_ID,
-        "envId" as EnvironmentId,
-        "srId",
-        [TEST_CCLOUD_SCHEMA],
-      );
-      const subjectTreeItem = new SubjectTreeItem(subject);
-
-      assert.deepEqual((subjectTreeItem.iconPath as vscode.ThemeIcon).id, iconName);
-    });
-  }
 });

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -294,56 +294,29 @@ export class TopicViewProvider implements vscode.TreeDataProvider<TopicViewProvi
       },
     );
 
+    const subjectChangeHandler = (event: SubjectChangeEvent | SchemaVersionChangeEvent) => {
+      const [subject, change] = [event.subject, event.change];
+
+      if (this.kafkaCluster?.environmentId === subject.environmentId) {
+        logger.debug(
+          `A schema subject ${change} in the environment being viewed, refreshing toplevel`,
+          {
+            subject: subject.name,
+          },
+        );
+
+        // Toplevel repaint.
+        this.refresh();
+      }
+    };
+
     // A schema subject was added or removed.
-    const schemaSubjectChangedSub: vscode.Disposable = schemaSubjectChanged.event(
-      (event: SubjectChangeEvent) => {
-        // A subject was added or deleted. This may cause a topic's icon to change, and then also
-        // its corresponding key/value schemas shown as children.
-        //
-        // Refresh toplevel view if the subject is in the
-        // same environment as the currently selected Kafka cluster.
-
-        // If the topics view controller actually had its own model cache,
-        // we could do a much more fine-grained update here, but the best we can do
-        // for now is to refresh the whole view.
-        const [subject, change] = [event.subject, event.change];
-
-        if (this.kafkaCluster?.environmentId === subject.environmentId) {
-          logger.debug(
-            `A schema subject ${change} in the environment being viewed, refreshing toplevel`,
-            {
-              subject: subject.name,
-            },
-          );
-
-          // Toplevel repaint.
-          this.refresh();
-        }
-      },
-    );
+    const schemaSubjectChangedSub: vscode.Disposable =
+      schemaSubjectChanged.event(subjectChangeHandler);
 
     // A schema version was added or removed.
-    const schemaVersionsChangedSub: vscode.Disposable = schemaVersionsChanged.event(
-      (event: SchemaVersionChangeEvent) => {
-        // A schema version was added or deleted. For much the same reasons as
-        // for when a subject was added or deleted (schemaSubjectChangedSub),
-        // we need to refresh the toplevel view.
-        const [schema, change] = [event.schema, event.change];
-        if (this.kafkaCluster?.environmentId === schema.environmentId) {
-          logger.debug(
-            `A schema version ${change} in the environment being viewed, refreshing toplevel`,
-            {
-              subject: schema.subject,
-              version: schema.version,
-              action: change,
-            },
-          );
-
-          // Toplevel repaint.
-          this.refresh();
-        }
-      },
-    );
+    const schemaVersionsChangedSub: vscode.Disposable =
+      schemaVersionsChanged.event(subjectChangeHandler);
 
     return [
       environmentChangedSub,

--- a/tests/unit/testResources/schema.ts
+++ b/tests/unit/testResources/schema.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaType, Subject } from "../../../src/models/schema";
+import { Schema, SchemaType, Subject, SubjectWithSchemas } from "../../../src/models/schema";
 import { TEST_CCLOUD_SCHEMA_REGISTRY, TEST_LOCAL_SCHEMA_REGISTRY } from "./schemaRegistry";
 import { TEST_CCLOUD_KAFKA_TOPIC, TEST_LOCAL_KAFKA_TOPIC } from "./topic";
 
@@ -49,7 +49,7 @@ export const TEST_CCLOUD_SUBJECT_WITH_SCHEMA = new Subject(
 );
 
 /** A Subject group containing two schema versions */
-export const TEST_CCLOUD_SUBJECT_WITH_SCHEMAS = new Subject(
+export const TEST_CCLOUD_SUBJECT_WITH_SCHEMAS = new SubjectWithSchemas(
   TEST_CCLOUD_SUBJECT.name,
   TEST_CCLOUD_SUBJECT.connectionId,
   TEST_CCLOUD_SUBJECT.environmentId,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Have create schema command emit the same events as delete schema command does to decouple the action from the view controllers (as well as to improve behavior in the topics view, which was wholly ignorant of when a new subject was created or a new schema version added to an existing subject).
- New subtype for a Subject which _must_ have a non-null schema array, used for the events when we definitely know the new schema versions which should be shown in views.
- When a schema version is added or removed, and the subject is known to the subject view already, then do a smart merge join between the new known schema versions fresh from a route call and any existing versions known to the subject view:
  - If present in both, keep in the cached subject's schemas to keep the corresponding treeitems visible.
  - If in the new schema[], copy into the cached subject's schemas for new treeitems to be created.
  - If only in old cached schema list, then remove it so that its corresponding treeitem will be removed.
  - This can be done efficiently due to the sorted-by-version-descending-ness of both the old and new arrays. And because both input arrays are sorted, the resulting array will also be sorted (by version descending).
  - This is done carefully to always err on the side of preferring Schema objects from the preexisting array, because they'll be compared by address to prior results from `getChildren()`, and we don't want to invite conflicts in the treeitems.

- I can now see how to reduce down to a single event emitter and event type, handling when whole subjects created or removed as well as individual schema versions within the subject created or removed, but would be too much for this branch, so will do in the future.

End result is better behavior within the topics view controller when adding subjects/schemas, and more efficient handling in the schema view controller requiring zero new route round trips when reacting to schema creation/deletion events.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1332 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
