### PR TITLE
add preview setting for upcoming Flink work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this extension will be documented in this file.
 
 - Initial LaunchDarkly integration for feature flag support
 - New "Delete Schema Version" context menu action for schemas to drive either soft or hard deletions
-  of single schema versions. If the final schema within a subject is deleted, the subject will no longer exist.
+  of single schema versions. If the final schema within a subject is deleted, the subject will no
+  longer exist.
+- Preview setting to enable/disable Flink resources' and associated actions' visibility
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -485,6 +485,14 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Allow older schema versions to be used when producing messages to Kafka topics.\n\n- Enabling this will require selecting the schema version to use.\n\n- Disabling this will use the **latest schema version**.\n\n---\n\n⚠️ **WARNING**: Producing messages with older schema versions can be in violation of some schema compatibility settings."
+        },
+        "confluent.preview.enableFlink": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable Flink-related resource loading and associated actions.",
+          "tags": [
+            "preview"
+          ]
         }
       }
     },
@@ -521,21 +529,32 @@
       "confluent": [
         {
           "id": "confluent-resources",
-          "name": "Resources"
+          "name": "Resources",
+          "icon": "$(confluent-logo)"
         },
         {
           "id": "confluent-topics",
           "name": "Topics",
-          "visibility": "collapsed"
+          "visibility": "collapsed",
+          "icon": "$(confluent-logo)"
         },
         {
           "id": "confluent-schemas",
           "name": "Schemas",
-          "visibility": "collapsed"
+          "visibility": "collapsed",
+          "icon": "$(confluent-logo)"
+        },
+        {
+          "id": "confluent-flink",
+          "name": "Flink",
+          "visibility": "collapsed",
+          "icon": "$(confluent-logo)",
+          "when": "confluent.flinkEnabled"
         },
         {
           "id": "confluent-support",
-          "name": "Support"
+          "name": "Support",
+          "icon": "$(confluent-logo)"
         }
       ]
     },

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -64,4 +64,9 @@ export enum ContextValues {
   topicSearchApplied = "confluent.topicSearchApplied",
   /** The user applied a search string to the Schemas view. */
   schemaSearchApplied = "confluent.schemaSearchApplied",
+  /**
+   * PREVIEW: Are Flink resources and associated actions visible?
+   * (This should go away once the `confluent.preview.enableFlink` setting is removed.)
+   */
+  flinkEnabled = "confluent.flinkEnabled",
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,6 +81,7 @@ import {
 } from "./featureFlags/evaluation";
 import { constructResourceLoaderSingletons } from "./loaders";
 import { cleanupOldLogFiles, getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
+import { ENABLE_FLINK } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
 import { registerProjectGenerationCommand } from "./scaffold";
@@ -276,6 +277,9 @@ async function _activateExtension(
 
 /** Configure any starting contextValues to use for view/menu controls during activation. */
 async function setupContextValues() {
+  // PREVIEW: set default values for enabling the Flink view, resource fetching, and associated actions
+  const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+  const flinkEnabled = setContextValue(ContextValues.flinkEnabled, config.get(ENABLE_FLINK, false));
   // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
   const kafkaClusterSelected = setContextValue(ContextValues.kafkaClusterSelected, false);
   const schemaRegistrySelected = setContextValue(ContextValues.schemaRegistrySelected, false);
@@ -318,6 +322,7 @@ async function setupContextValues() {
     "direct-schema-registry",
   ]);
   await Promise.all([
+    flinkEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,
     openInCCloudResources,

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -36,3 +36,5 @@ export const USE_TOPIC_NAME_STRATEGY =
 /** Whether to allow selecting older (than latest) schema versions when producing messages to a topic. */
 export const ALLOW_OLDER_SCHEMA_VERSIONS =
   prefix + "topic.produceMessages.schemas.allowOlderVersions";
+
+export const ENABLE_FLINK = prefix + "preview.enableFlink";

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,6 +1,8 @@
 import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration } from "vscode";
+import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
 import {
+  ENABLE_FLINK,
   LOCAL_DOCKER_SOCKET_PATH,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
@@ -43,6 +45,12 @@ export function createConfigChangeListener(): Disposable {
       // --- PREVIEW SETTINGS --
       // Remove the sections below once the behavior is enabled by default and a setting is no
       // longer needed to opt-in to the feature.
+      if (event.affectsConfiguration(ENABLE_FLINK)) {
+        // user toggled the "Enable Flink" preview setting
+        const enabled = configs.get(ENABLE_FLINK, false);
+        logger.debug(`"${ENABLE_FLINK}" config changed`, { enabled });
+        setContextValue(ContextValues.flinkEnabled, enabled);
+      }
     },
   );
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Adds a new preview setting (`confluent.preview.enableFlink`) to allow toggling in-development Flink work on/off, and also an associated context value (`confluent.flinkEnabled`) to inform the VS Code UI when upcoming commands/actions should be visible.
<img width="1221" alt="image" src="https://github.com/user-attachments/assets/23453c3c-a783-48fd-824a-55c49b04bb8f" />

For now, this context value only controls whether or not the placeholder `confluent-flink` view is available at all. There is no view provider for it, as it will be covered in a separate branch as part of https://github.com/confluentinc/vscode/issues/1320.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
