### PR TITLE
add basic Copilot chat participant behind experimental setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this extension will be documented in this file.
   of single schema versions. If the final schema within a subject is deleted, the subject will no
   longer exist.
 - Preview setting to enable/disable Flink resources' and associated actions' visibility
+- Experimental setting to enable/disable the Confluent chat participant for Copilot chat
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,17 @@
         "label": "Confluent Cloud"
       }
     ],
+    "chatParticipants": [
+      {
+        "id": "confluent.chat-participant",
+        "name": "Confluent",
+        "description": "Provides a Copilot-powered chat assistant for Confluent and Apache Kafka® developers, offering guidance on configuration, development best practices, and troubleshooting for Kafka clusters, Schema Registry, Flink, and streaming applications.",
+        "isSticky": true,
+        "commands": [],
+        "disambiguation": [],
+        "when": "confluent.chatParticipantEnabled"
+      }
+    ],
     "commands": [
       {
         "command": "confluent.connections.ccloud.signIn",
@@ -492,6 +503,14 @@
           "markdownDescription": "Enable Flink-related resource loading and associated actions.",
           "tags": [
             "preview"
+          ]
+        },
+        "confluent.experimental.enableChatParticipant": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the Confluent chat participant for Copilot.",
+          "tags": [
+            "experimental"
           ]
         }
       }

--- a/src/chat/constants.ts
+++ b/src/chat/constants.ts
@@ -1,0 +1,4 @@
+export const PARTICIPANT_ID = "confluent.chat-participant";
+
+/** The first message sent to the language model in the chat request. */
+export const INITIAL_PROMPT = `You are an assistant who helps developers working with Confluent and Apache Kafka® ecosystems, including Kafka clusters, topics, Schema Registry, Flink, and streaming applications. You provide guidance on configuration, development best practices, and troubleshooting for all Confluent-related technologies.`;

--- a/src/chat/errors.ts
+++ b/src/chat/errors.ts
@@ -1,0 +1,6 @@
+export class ModelNotSupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ModelNotSupportedError";
+  }
+}

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -1,0 +1,149 @@
+import {
+  CancellationToken,
+  ChatContext,
+  ChatRequest,
+  ChatRequestTurn,
+  ChatResponseMarkdownPart,
+  ChatResponseStream,
+  ChatResponseTurn,
+  ChatResult,
+  LanguageModelChat,
+  LanguageModelChatMessage,
+  LanguageModelChatResponse,
+  LanguageModelChatSelector,
+  lm,
+} from "vscode";
+import { Logger } from "../logging";
+import { INITIAL_PROMPT, PARTICIPANT_ID } from "./constants";
+import { parseReferences } from "./references";
+
+const logger = new Logger("chat.participant");
+
+/** Main handler for the Copilot chat participant. */
+export async function chatHandler(
+  request: ChatRequest & { model?: LanguageModelChat },
+  context: ChatContext,
+  stream: ChatResponseStream,
+  token: CancellationToken,
+): Promise<ChatResult> {
+  logger.debug("received chat request", { request, context });
+
+  const messages: LanguageModelChatMessage[] = [];
+
+  // add the initial prompt to the messages
+  messages.push(LanguageModelChatMessage.User(INITIAL_PROMPT, "user"));
+
+  const userPrompt = request.prompt.trim();
+  // check for empty request
+  if (userPrompt === "" && request.references.length === 0 && request.command === undefined) {
+    stream.markdown("Hmm... I don't know how to respond to that.");
+    return {};
+  }
+
+  // add historical messages to the context, along with the user prompt if provided
+  const historyMessages = filterContextHistory(context.history);
+  messages.push(...historyMessages);
+  if (userPrompt) {
+    messages.push(LanguageModelChatMessage.User(request.prompt, "user"));
+  }
+
+  // add any additional references like `#file:<name>`
+  if (request.references.length > 0) {
+    const referenceMessages = await parseReferences(request.references);
+    logger.debug(`adding ${referenceMessages.length} reference message(s)`);
+    messages.push(...referenceMessages);
+  }
+
+  try {
+    if (request.command) {
+      // TODO: implement command handling
+      return { metadata: { command: request.command } };
+    } else {
+      await handleChatMessage(messages, stream, token, request.model);
+      return {};
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error("error handling messages:", error);
+      stream.markdown("Error: " + error.message);
+      return {
+        errorDetails: { message: error.message },
+        metadata: { error: true, stack: error.stack, name: error.name },
+      };
+    }
+    throw error;
+  }
+}
+
+/** Get the language model to use. */
+async function getModel(model?: LanguageModelChat): Promise<LanguageModelChat> {
+  if (model) {
+    // use model provided in the ChatRequest
+    return model;
+  }
+
+  const modelSelector: LanguageModelChatSelector = { vendor: "copilot", family: "gpt-4o" };
+  const models: LanguageModelChat[] = await lm.selectChatModels(modelSelector);
+  logger.debug("available chat models:", models);
+  if (!models.length) {
+    throw new Error(`no language models found for ${JSON.stringify(modelSelector)}`);
+  }
+  const selectedModel = models[0];
+  logger.debug("using language model:", selectedModel);
+  return selectedModel;
+}
+
+/** Send message(s) and stream the response in markdown format. */
+async function handleChatMessage(
+  messages: LanguageModelChatMessage[],
+  stream: ChatResponseStream,
+  token: CancellationToken,
+  requestModel?: LanguageModelChat,
+): Promise<void> {
+  logger.debug("handling chat messages:", messages);
+
+  const model: LanguageModelChat = requestModel ?? (await getModel());
+  const chatResponse: LanguageModelChatResponse = await model.sendRequest(messages, {}, token);
+  logger.debug("chat response:", chatResponse);
+
+  for await (const fragment of chatResponse.text) {
+    if (token.isCancellationRequested) {
+      logger.debug("chat request cancelled");
+      return;
+    }
+    stream.markdown(fragment);
+  }
+}
+
+/** Filter the chat history to only relevant messages for the current chat. */
+function filterContextHistory(
+  history: readonly (ChatRequestTurn | ChatResponseTurn)[],
+): LanguageModelChatMessage[] {
+  logger.debug("context history:", history);
+
+  // only use messages where the participant was tagged, or messages where the participant responded
+  const filteredHistory: (ChatRequestTurn | ChatResponseTurn)[] = history.filter(
+    (msg) => msg.participant === PARTICIPANT_ID,
+  );
+  logger.debug("filtered history:", filteredHistory);
+  if (filteredHistory.length === 0) {
+    return [];
+  }
+
+  const messages: LanguageModelChatMessage[] = [];
+  for (const turn of filteredHistory) {
+    // don't re-use previous prompts since the model may misinterpret them as part of the current prompt
+    if (turn instanceof ChatRequestTurn) {
+      // TODO: check for references/commands used?
+      continue;
+    }
+    if (turn instanceof ChatResponseTurn) {
+      // responses from the participant:
+      if (turn.response instanceof ChatResponseMarkdownPart) {
+        messages.push(LanguageModelChatMessage.User(turn.response.value.value, PARTICIPANT_ID));
+      }
+    }
+  }
+
+  return messages;
+}

--- a/src/chat/references.ts
+++ b/src/chat/references.ts
@@ -1,7 +1,13 @@
-import { readFile } from "fs/promises";
-import { ChatPromptReference, LanguageModelChatMessage, Uri } from "vscode";
+import {
+  ChatPromptReference,
+  LanguageModelChatMessage,
+  Location,
+  Range,
+  TextDocument,
+  Uri,
+  workspace,
+} from "vscode";
 import { Logger } from "../logging";
-import { PARTICIPANT_ID } from "./constants";
 
 const logger = new Logger("chat.references");
 
@@ -12,8 +18,10 @@ export async function parseReferences(
   const referenceMessages: LanguageModelChatMessage[] = [];
 
   for (const reference of references) {
-    const referenceMessage = await handleReference(reference);
-    referenceMessages.push(referenceMessage);
+    const referenceMessage: LanguageModelChatMessage | undefined = await handleReference(reference);
+    if (referenceMessage) {
+      referenceMessages.push(referenceMessage);
+    }
   }
 
   return referenceMessages;
@@ -22,25 +30,33 @@ export async function parseReferences(
 /** Handle a single reference from the user's chat message. */
 export async function handleReference(
   reference: ChatPromptReference,
-): Promise<LanguageModelChatMessage> {
+): Promise<LanguageModelChatMessage | undefined> {
   logger.debug("handling reference:", reference);
 
   switch (reference.id) {
-    case "file": {
-      const fileUri = Uri.from(reference.value as Uri);
-      const fileContent = await readFile(fileUri.fsPath, "utf8");
-      return LanguageModelChatMessage.User(
-        `${fileUri.path}:\n\n\`\`\`\n${fileContent}\n\`\`\``,
-        "user",
-      );
+    // custom URI (message preview, schema definitions, etc), editor, or file
+    case "vscode.implicit.viewport":
+    case "vscode.untitled":
+    case "vscode.file": {
+      let uri: Uri;
+      let range: Range | undefined;
+      if (reference.value instanceof Uri) {
+        uri = reference.value;
+      } else if (reference.value instanceof Location) {
+        // may be a selection in a document
+        uri = reference.value.uri;
+        range = reference.value.range;
+      } else {
+        logger.error("reference type not yet supported:", reference);
+        return;
+      }
+
+      const title = uri.path.split("/").pop() || "Untitled";
+      const document: TextDocument = await workspace.openTextDocument(uri);
+      const content: string = document.getText(range);
+      // TODO: clean up this formatting:
+      return LanguageModelChatMessage.User(`#file:${title}:\n\n\`\`\`\n${content}\n\`\`\``, "user");
     }
-    case "copilot.selection":
-      return LanguageModelChatMessage.User(`${reference.value}`, "user");
     // TODO: handle other reference types
-    default:
-      return LanguageModelChatMessage.Assistant(
-        "I don't know how to handle this reference",
-        PARTICIPANT_ID,
-      );
   }
 }

--- a/src/chat/references.ts
+++ b/src/chat/references.ts
@@ -1,0 +1,46 @@
+import { readFile } from "fs/promises";
+import { ChatPromptReference, LanguageModelChatMessage, Uri } from "vscode";
+import { Logger } from "../logging";
+import { PARTICIPANT_ID } from "./constants";
+
+const logger = new Logger("chat.references");
+
+/** Parse references from the user's chat message. */
+export async function parseReferences(
+  references: readonly ChatPromptReference[],
+): Promise<LanguageModelChatMessage[]> {
+  const referenceMessages: LanguageModelChatMessage[] = [];
+
+  for (const reference of references) {
+    const referenceMessage = await handleReference(reference);
+    referenceMessages.push(referenceMessage);
+  }
+
+  return referenceMessages;
+}
+
+/** Handle a single reference from the user's chat message. */
+export async function handleReference(
+  reference: ChatPromptReference,
+): Promise<LanguageModelChatMessage> {
+  logger.debug("handling reference:", reference);
+
+  switch (reference.id) {
+    case "file": {
+      const fileUri = Uri.from(reference.value as Uri);
+      const fileContent = await readFile(fileUri.fsPath, "utf8");
+      return LanguageModelChatMessage.User(
+        `${fileUri.path}:\n\n\`\`\`\n${fileContent}\n\`\`\``,
+        "user",
+      );
+    }
+    case "copilot.selection":
+      return LanguageModelChatMessage.User(`${reference.value}`, "user");
+    // TODO: handle other reference types
+    default:
+      return LanguageModelChatMessage.Assistant(
+        "I don't know how to handle this reference",
+        PARTICIPANT_ID,
+      );
+  }
+}

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -69,4 +69,9 @@ export enum ContextValues {
    * (This should go away once the `confluent.preview.enableFlink` setting is removed.)
    */
   flinkEnabled = "confluent.flinkEnabled",
+  /**
+   * EXPERIMENTAL: Is the chat participant enabled?
+   * (This should go away once the `confluent.experimental.enableChatParticipant` setting is removed.)
+   */
+  chatParticipantEnabled = "confluent.chatParticipantEnabled",
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ import {
 } from "./featureFlags/evaluation";
 import { constructResourceLoaderSingletons } from "./loaders";
 import { cleanupOldLogFiles, getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
-import { ENABLE_FLINK } from "./preferences/constants";
+import { ENABLE_CHAT_PARTICIPANT, ENABLE_FLINK } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
 import { registerProjectGenerationCommand } from "./scaffold";
@@ -289,9 +289,13 @@ async function _activateExtension(
 
 /** Configure any starting contextValues to use for view/menu controls during activation. */
 async function setupContextValues() {
-  // PREVIEW: set default values for enabling the Flink view, resource fetching, and associated actions
+  // EXPERIMENTAL/PREVIEW: set default values for enabling the Flink view, resource fetching, and associated actions
   const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
   const flinkEnabled = setContextValue(ContextValues.flinkEnabled, config.get(ENABLE_FLINK, false));
+  const chatParticipantEnabled = setContextValue(
+    ContextValues.chatParticipantEnabled,
+    config.get(ENABLE_CHAT_PARTICIPANT, true),
+  );
   // require re-selecting a cluster for the Topics/Schemas views on extension (re)start
   const kafkaClusterSelected = setContextValue(ContextValues.kafkaClusterSelected, false);
   const schemaRegistrySelected = setContextValue(ContextValues.schemaRegistrySelected, false);
@@ -335,6 +339,7 @@ async function setupContextValues() {
   ]);
   await Promise.all([
     flinkEnabled,
+    chatParticipantEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,
     openInCCloudResources,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,8 @@ if (process.env.SENTRY_DSN) {
 
 import { ConfluentCloudAuthProvider, getAuthProvider } from "./authn/ccloudProvider";
 import { getCCloudAuthSession } from "./authn/utils";
+import { PARTICIPANT_ID } from "./chat/constants";
+import { chatHandler } from "./chat/participant";
 import { registerCommandWithLogging } from "./commands";
 import { registerConnectionCommands } from "./commands/connections";
 import { registerDebugCommands } from "./commands/debugtools";
@@ -59,7 +61,12 @@ import { registerSchemaRegistryCommands } from "./commands/schemaRegistry";
 import { registerSchemaCommands } from "./commands/schemas";
 import { registerSupportCommands } from "./commands/support";
 import { registerTopicCommands } from "./commands/topics";
-import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL, SIDECAR_OUTPUT_CHANNEL } from "./constants";
+import {
+  AUTH_PROVIDER_ID,
+  AUTH_PROVIDER_LABEL,
+  IconNames,
+  SIDECAR_OUTPUT_CHANNEL,
+} from "./constants";
 import { activateMessageViewer } from "./consume";
 import { setExtensionContext } from "./context/extension";
 import { observabilityContext } from "./context/observability";
@@ -267,6 +274,11 @@ async function _activateExtension(
   context.subscriptions.push(
     vscode.window.registerFileDecorationProvider(SEARCH_DECORATION_PROVIDER),
   );
+
+  // register the Copilot chat participant
+  const chatParticipant = vscode.chat.createChatParticipant(PARTICIPANT_ID, chatHandler);
+  chatParticipant.iconPath = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);
+  context.subscriptions.push(chatParticipant);
 
   // one-time cleanup of old log files from before the rotating log file stream was implemented
   cleanupOldLogFiles();

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -38,3 +38,4 @@ export const ALLOW_OLDER_SCHEMA_VERSIONS =
   prefix + "topic.produceMessages.schemas.allowOlderVersions";
 
 export const ENABLE_FLINK = prefix + "preview.enableFlink";
+export const ENABLE_CHAT_PARTICIPANT = prefix + "experimental.enableChatParticipant";

--- a/src/preferences/listener.test.ts
+++ b/src/preferences/listener.test.ts
@@ -3,7 +3,12 @@ import sinon from "sinon";
 import { ConfigurationChangeEvent, workspace } from "vscode";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import * as contextValues from "../context/values";
-import { ENABLE_FLINK, SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
+import {
+  ENABLE_CHAT_PARTICIPANT,
+  ENABLE_FLINK,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 import { createConfigChangeListener } from "./listener";
 import * as updates from "./updates";
 
@@ -84,6 +89,7 @@ describe("preferences/listener", function () {
 
   for (const [previewSetting, previewContextValue] of [
     [ENABLE_FLINK, contextValues.ContextValues.flinkEnabled],
+    [ENABLE_CHAT_PARTICIPANT, contextValues.ContextValues.chatParticipantEnabled],
   ]) {
     for (const enabled of [true, false]) {
       it(`should update the "${previewContextValue}" context value when the "${previewSetting}" setting is changed to ${enabled} (REMOVE ONCE PREVIEW SETTING IS NO LONGER USED)`, async () => {

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -2,6 +2,7 @@ import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration
 import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
 import {
+  ENABLE_CHAT_PARTICIPANT,
   ENABLE_FLINK,
   LOCAL_DOCKER_SOCKET_PATH,
   SSL_PEM_PATHS,
@@ -42,7 +43,7 @@ export function createConfigChangeListener(): Disposable {
         return;
       }
 
-      // --- PREVIEW SETTINGS --
+      // --- EXPERIMENTAL/PREVIEW SETTINGS --
       // Remove the sections below once the behavior is enabled by default and a setting is no
       // longer needed to opt-in to the feature.
       if (event.affectsConfiguration(ENABLE_FLINK)) {
@@ -50,6 +51,15 @@ export function createConfigChangeListener(): Disposable {
         const enabled = configs.get(ENABLE_FLINK, false);
         logger.debug(`"${ENABLE_FLINK}" config changed`, { enabled });
         setContextValue(ContextValues.flinkEnabled, enabled);
+        return;
+      }
+
+      if (event.affectsConfiguration(ENABLE_CHAT_PARTICIPANT)) {
+        // user toggled the "Enable Chat Participant" experimental setting
+        const enabled = configs.get(ENABLE_CHAT_PARTICIPANT, false);
+        logger.debug(`"${ENABLE_CHAT_PARTICIPANT}" config changed`, { enabled });
+        setContextValue(ContextValues.chatParticipantEnabled, enabled);
+        return;
       }
     },
   );


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Another new setting + context value combo, but this time for the Copilot chat participant:
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/f6c5eaee-3fb5-4c65-b4e9-87ab03919038" />

Setting is marked as experimental since this is currently just a Q&A bot (which goes [against the guidelines](https://code.visualstudio.com/api/extension-guides/chat#guidelines:~:text=Chat%20participants%20should%20not%20be%20purely%20question%2Danswering%20bots.)) and doesn't have any helpful actions, tools, context, etc. Those should be handled in follow-up branches as part of the [Copilot chat participant integration milestone](https://github.com/confluentinc/vscode/milestone/16).

Closes #1327, closes #1328.

No wholly new tests since all of this is bound to change in the short term.

## Any additional details or context that should be provided?

In click-testing, it looks like the approach to use whatever language model is selected in the normal model dropdown may return an error 400 response while handling the response stream:
```
Request Failed: 400 {"error":{"message":"Model is not supported for this request.","param":"model","code":"model_not_supported","type":"invalid_request_error"}}
```
And at the moment, there isn't a property to check from the `lm.selectChatModels` results to determine whether a model should be excluded, but it seems to currently be limited to any of the Claude 3.7 Sonnet models.

Related: https://github.com/RooVetGit/Roo-Code/issues/1203


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
