### PR TITLE
re-enable message diffing and allow diff commands from more areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this extension will be documented in this file.
   longer exist.
 - Preview setting to enable/disable Flink resources' and associated actions' visibility
 - Experimental setting to enable/disable the Confluent chat participant for Copilot chat
+- Support for diffing schema definitions and Kafka topic message documents from the editor title or
+  right-click context areas
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -785,6 +785,28 @@
           "command": "confluent.topic.consume.duplicate",
           "group": "navigation",
           "when": "activeWebviewPanelId == message-viewer"
+        },
+        {
+          "command": "confluent.diff.selectForCompare",
+          "when": "resourceScheme in confluent.diffableResources",
+          "group": "3_compare"
+        },
+        {
+          "command": "confluent.diff.compareWithSelected",
+          "when": "resourceScheme in confluent.diffableResources && confluent.resourceSelectedForCompare",
+          "group": "3_compare"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "confluent.diff.selectForCompare",
+          "when": "resourceScheme in confluent.diffableResources",
+          "group": "1_diff"
+        },
+        {
+          "command": "confluent.diff.compareWithSelected",
+          "when": "resourceScheme in confluent.diffableResources && confluent.resourceSelectedForCompare",
+          "group": "1_diff"
         }
       ],
       "view/title": [

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -60,7 +60,9 @@ export function registerDiffCommands(): vscode.Disposable[] {
  * @throws Error if the resource item is not yet supported
  */
 function convertItemToUri(item: any): vscode.Uri {
-  if (item instanceof Schema) {
+  if (item instanceof vscode.Uri) {
+    return item;
+  } else if (item instanceof Schema) {
     return new SchemaDocumentProvider().resourceToUri(item, item.fileName());
   } else {
     throw new Error("Unsupported resource type for comparison");

--- a/src/commands/diffs.ts
+++ b/src/commands/diffs.ts
@@ -14,7 +14,10 @@ export async function selectForCompareCommand(item: any) {
   if (!item) {
     return;
   }
-  const uri: vscode.Uri = convertItemToUri(item);
+  // if the arg was provided from the sidebar, it's likely an instance of a view provider's data
+  // type, so we'll have to convert it. otherwise, the item came from the editor/explorer areas and
+  // is likely already a Uri
+  const uri: vscode.Uri = item instanceof vscode.Uri ? item : convertItemToUri(item);
   logger.debug("Selected item for compare", uri);
   // convert to string before storing so we can Uri.parse it later since Uri is not serializable
   await getStorageManager().setWorkspaceState(WorkspaceStorageKeys.DIFF_BASE_URI, uri.toString());
@@ -26,7 +29,10 @@ export async function compareWithSelectedCommand(item: any) {
   if (!item) {
     return;
   }
-  const uri2: vscode.Uri = convertItemToUri(item);
+  // if the arg was provided from the sidebar, it's likely an instance of a view provider's data
+  // type, so we'll have to convert it. otherwise, the item came from the editor/explorer areas and
+  // is likely already a Uri
+  const uri2: vscode.Uri = item instanceof vscode.Uri ? item : convertItemToUri(item);
   logger.debug("Comparing with selected item", uri2);
   const uri1str: string | undefined = await getStorageManager().getWorkspaceState(
     WorkspaceStorageKeys.DIFF_BASE_URI,
@@ -65,6 +71,8 @@ function convertItemToUri(item: any): vscode.Uri {
   } else if (item instanceof Schema) {
     return new SchemaDocumentProvider().resourceToUri(item, item.fileName());
   } else {
-    throw new Error("Unsupported resource type for comparison");
+    const msg = "Unsupported resource type for comparison";
+    logger.error(msg, item);
+    throw new Error(msg);
   }
 }

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -39,6 +39,8 @@ export enum ContextValues {
   RESOURCES_WITH_NAMES = "confluent.resourcesWithNames",
   /** Array of resources that have a `uri` property for enabling the `Copy URI` action. */
   RESOURCES_WITH_URIS = "confluent.resourcesWithURIs",
+  /** Array of resources that can be selected for comparison and presented in a diff view. */
+  DIFFABLE_RESOURCES = "confluent.diffableResources",
 
   // -- ADJUSTABLE CONTEXT VALUES --
   /** The user has a valid, authenticated connection to Confluent Cloud.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -421,12 +421,16 @@ function setupDocumentProviders(): vscode.Disposable[] {
   const disposables: vscode.Disposable[] = [];
   // any document providers set here must provide their own `scheme` to register with
   const providerClasses = [SchemaDocumentProvider, MessageDocumentProvider];
+  const diffSchemes: string[] = [];
   for (const providerClass of providerClasses) {
     const provider = new providerClass();
     disposables.push(
       vscode.workspace.registerTextDocumentContentProvider(provider.scheme, provider),
     );
+    // add the scheme to the list of diffable schemes so we can compare them
+    diffSchemes.push(provider.scheme);
   }
+  setContextValue(ContextValues.DIFFABLE_RESOURCES, diffSchemes);
   logger.info("Document providers registered");
   return disposables;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR addresses some necessary follow-up from #799 where we lost the built-in ability to diff (Kafka topic) message documents with the move from JSON editors to `confluent.topic.message`-schemed URIs.

Using that URI scheme (along with `confluent.schema`-schemed URIs), we can provide the existing "Select for Compare" and "Compare with Selected" commands in both the editor title area as well as the editor context itself:

https://github.com/user-attachments/assets/d5d5cbb5-3f26-422d-863c-75ec035f75ea


Closes #1343.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

I also tried exposing these commands in the "Open Editors" view, but nothing in https://code.visualstudio.com/api/references/contribution-points#contributes.menus or https://code.visualstudio.com/api/references/when-clause-contexts#available-context-keys seems to indicate exactly how that should be done. The `contributes.menus` sections don't point to anything specifically about the "Open Editors" view, using `explorer/context` doesn't work, and adjusting the existing sections under `view/item/context` to just check `resourceScheme in confluent.diffableResources` also doesn't make the actions appear in "Open Editors".

But there's also [this discussion](https://github.com/microsoft/vscode-discussions/discussions/1122) which seems to indicate that the Open Editors view is being deprecated.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
