### PR TITLE
when editing topics - return early if topic isn't the type we expected

### DIFF
--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -96,6 +96,10 @@ const topicWebviewCache = new WebviewPanelCache();
  * @param topic The topic to edit, from the topic tree item where the "confluent.topics.edit" command was invoked
  */
 async function editTopicConfig(topic: KafkaTopic): Promise<void> {
+  // Check this despite the type, since at runtime VSCode could pass the wrong selected item or undefined
+  if (!topic || !(topic instanceof KafkaTopic)) {
+    return;
+  }
   // Retrieve the current topic configuration data
   let topicConfigRemoteItems = null;
   try {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Add a check in `editTopicConfig` to return early if the topic is not defined or not a KafkaTopic. 
- Closes #1349 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-We've noticed that at runtime VS Code could pass an undefined or different type than expected if, for example, another item is highlighted/selected while invoking the command, or the tree view is refreshing.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
