### PR TITLE
feat: show Flink compute pools in Resources view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable changes to this extension will be documented in this file.
 - New "Delete Schema Version" context menu action for schemas to drive either soft or hard deletions
   of single schema versions. If the final schema within a subject is deleted, the subject will no
   longer exist.
-- New "Delete All Schemas in Subject" context menu action for subjects to drive either soft or hard deletions
-  of all schema versions within a subject. The subject will no longer exist.
-- Unsaved file contents can now be used for schema upload or message producing actions without the need to save the file first.
-- Preview setting to enable/disable Flink resources' and associated actions' visibility
+- New "Delete All Schemas in Subject" context menu action for subjects to drive either soft or hard
+  deletions of all schema versions within a subject. The subject will no longer exist.
+- Unsaved file contents can now be used for schema upload or message producing actions without the
+  need to save the file first.
+- Preview setting to enable/disable Flink resources' and associated actions' visibility, including:
+  - CCloud Flink compute pools in the Resources view
 - Experimental setting to enable/disable the Confluent chat participant for Copilot chat
 - Support for diffing schema definitions and Kafka topic message documents from the editor title or
   right-click context areas
@@ -21,7 +23,8 @@ All notable changes to this extension will be documented in this file.
 ### Fixed
 
 - Improved resolving newly created direct connection connectivity state.
-- Expanded maximum length of direct connection usernames and API keys, from 64 to 96 characters. Should improve WarpStream compatibility.
+- Expanded maximum length of direct connection usernames and API keys, from 64 to 96 characters.
+  Should improve WarpStream compatibility.
 
 ## 1.0.2
 

--- a/package.json
+++ b/package.json
@@ -631,6 +631,11 @@
         "view": "confluent-topics",
         "contents": "No topics match search string. [Clear search](command:confluent.topics.search.clear) or [try a new search](command:confluent.topics.search).",
         "when": "(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable) && confluent.kafkaClusterSelected && confluent.topicSearchApplied"
+      },
+      {
+        "view": "confluent-flink",
+        "contents": "No Flink compute pools available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)",
+        "when": "!confluent.ccloudConnectionAvailable"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -636,6 +636,11 @@
         "view": "confluent-flink",
         "contents": "No Flink compute pools available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)",
         "when": "!confluent.ccloudConnectionAvailable"
+      },
+      {
+        "view": "confluent-flink",
+        "contents": "NOT YET IMPLEMENTED: Flink resources coming soon.",
+        "when": "confluent.ccloudConnectionAvailable"
       }
     ],
     "menus": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export enum IconNames {
   OTHER_SUBJECT = "question",
   TOPIC = "confluent-topic",
   TOPIC_WITHOUT_SCHEMA = "confluent-topic-without-schema",
+  FLINK_COMPUTE_POOL = "confluent-flink-compute-pool",
   EXPERIMENTAL = "beaker",
   LOADING = "loading~spin",
 }

--- a/src/graphql/environments.ts
+++ b/src/graphql/environments.ts
@@ -1,4 +1,5 @@
 import { graphql } from "gql.tada";
+import { workspace, WorkspaceConfiguration } from "vscode";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { logError, showErrorNotificationWithButtons } from "../errors";
 import { CCloudEnvironment } from "../models/environment";
@@ -6,6 +7,7 @@ import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
 import { EnvironmentId } from "../models/resource";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
+import { ENABLE_FLINK } from "../preferences/constants";
 import { getSidecar } from "../sidecar";
 
 /**
@@ -63,6 +65,10 @@ export async function getEnvironments(): Promise<CCloudEnvironment[]> {
     return envs;
   }
 
+  // TODO: remove this once Flink support is enabled by default
+  const config: WorkspaceConfiguration = workspace.getConfiguration();
+  const flinkEnabled: boolean = config.get(ENABLE_FLINK, false);
+
   environments.forEach((env) => {
     if (!env) {
       return;
@@ -93,7 +99,7 @@ export async function getEnvironments(): Promise<CCloudEnvironment[]> {
 
     // parse Flink Compute Pools
     let flinkComputePools: CCloudFlinkComputePool[] = [];
-    if (env.flinkComputePools) {
+    if (flinkEnabled && env.flinkComputePools) {
       const envFlinkComputePools = env.flinkComputePools.map(
         (pool: any): CCloudFlinkComputePool =>
           new CCloudFlinkComputePool({

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -53,7 +53,7 @@ export abstract class Environment implements IResourceBase, ISearchable {
    */
   kafkaClusters!: KafkaCluster[];
   schemaRegistry?: SchemaRegistry | undefined;
-  flinkComputePools!: FlinkComputePool[];
+  flinkComputePools: FlinkComputePool[] = [];
 
   // updated by the ResourceViewProvider from connectionUsable events
   // (DirectEnvironment instances are constructed with isLoading = true)

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -15,6 +15,7 @@ import {
   UTM_SOURCE_VSCODE,
 } from "../constants";
 import { FormConnectionType } from "../directConnections/types";
+import { FlinkComputePool } from "./flinkComputePool";
 import {
   CCloudKafkaCluster,
   DirectKafkaCluster,
@@ -52,13 +53,16 @@ export abstract class Environment implements IResourceBase, ISearchable {
    */
   kafkaClusters!: KafkaCluster[];
   schemaRegistry?: SchemaRegistry | undefined;
+  flinkComputePools!: FlinkComputePool[];
 
   // updated by the ResourceViewProvider from connectionUsable events
   // (DirectEnvironment instances are constructed with isLoading = true)
   isLoading: boolean = false;
 
   get hasClusters(): boolean {
-    return this.kafkaClusters.length > 0 || !!this.schemaRegistry;
+    return (
+      this.kafkaClusters.length > 0 || !!this.schemaRegistry || this.flinkComputePools.length > 0
+    );
   }
 
   get children(): ISearchable[] {
@@ -87,7 +91,12 @@ export class CCloudEnvironment extends Environment {
   constructor(
     props: Pick<
       CCloudEnvironment,
-      "id" | "name" | "streamGovernancePackage" | "kafkaClusters" | "schemaRegistry"
+      | "id"
+      | "name"
+      | "streamGovernancePackage"
+      | "kafkaClusters"
+      | "schemaRegistry"
+      | "flinkComputePools"
     >,
   ) {
     super();
@@ -96,6 +105,7 @@ export class CCloudEnvironment extends Environment {
     this.streamGovernancePackage = props.streamGovernancePackage;
     this.kafkaClusters = props.kafkaClusters;
     this.schemaRegistry = props.schemaRegistry;
+    this.flinkComputePools = props.flinkComputePools;
   }
 
   get ccloudUrl(): string {

--- a/src/models/flinkComputePool.test.ts
+++ b/src/models/flinkComputePool.test.ts
@@ -1,0 +1,67 @@
+import * as assert from "assert";
+import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { IconNames } from "../constants";
+import {
+  CCloudFlinkComputePool,
+  FlinkComputePoolTreeItem,
+  createFlinkComputePoolTooltip,
+} from "./flinkComputePool";
+
+describe("models/flinkComputePool.ts CCloudFlinkComputePool", () => {
+  it("should generate the correct ccloudUrl", () => {
+    const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+    assert.strictEqual(
+      pool.ccloudUrl,
+      `https://confluent.cloud/environments/${pool.environmentId}/flink/pools/${pool.id}/overview`,
+    );
+  });
+
+  it("should generate correct searchableText", () => {
+    const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+    assert.strictEqual(pool.searchableText(), `${pool.name} ${pool.id}`);
+  });
+});
+
+describe("models/flinkComputePool.ts FlinkComputePoolTreeItem", () => {
+  it("should create correct tree item for CCloud Flink pool", () => {
+    const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+    const treeItem = new FlinkComputePoolTreeItem(pool);
+
+    // internal properties
+    assert.strictEqual(treeItem.id, `${pool.connectionId}-${pool.id}`);
+    assert.strictEqual(
+      treeItem.contextValue,
+      `${pool.connectionType.toLowerCase()}-flink-compute-pool`,
+    );
+    // user-facing properties
+    assert.strictEqual(treeItem.label, pool.name);
+    assert.strictEqual(treeItem.description, pool.id);
+    assert.strictEqual(treeItem.collapsibleState, TreeItemCollapsibleState.None);
+    assert.deepStrictEqual(treeItem.iconPath, new ThemeIcon(IconNames.FLINK_COMPUTE_POOL));
+  });
+});
+
+describe("models/flinkComputePool.ts createFlinkComputePoolTooltip", () => {
+  it("should include basic info for a Flink compute pool", () => {
+    // TODO: revisit this once we have non-CCloud compute pool models
+    const tooltip = createFlinkComputePoolTooltip(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+
+    assert.ok(tooltip.value.includes("Flink Compute Pool"));
+    assert.ok(tooltip.value.includes(`ID: \`${TEST_CCLOUD_FLINK_COMPUTE_POOL.id}\``));
+    assert.ok(tooltip.value.includes(`Name: \`${TEST_CCLOUD_FLINK_COMPUTE_POOL.name}\``));
+  });
+
+  it("should include CCloud-specific info for a CCloud Flink compute pool", () => {
+    const tooltip = createFlinkComputePoolTooltip(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+
+    assert.ok(tooltip.value.includes(`Provider: \`${TEST_CCLOUD_FLINK_COMPUTE_POOL.provider}\``));
+    assert.ok(tooltip.value.includes(`Region: \`${TEST_CCLOUD_FLINK_COMPUTE_POOL.region}\``));
+    assert.ok(tooltip.value.includes(`Max CFU: \`${TEST_CCLOUD_FLINK_COMPUTE_POOL.maxCfu}\``));
+    assert.ok(tooltip.value.includes("Open in Confluent Cloud"));
+    assert.ok(tooltip.value.includes(TEST_CCLOUD_FLINK_COMPUTE_POOL.ccloudUrl));
+  });
+});

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -66,7 +66,7 @@ export class FlinkComputePoolTreeItem extends TreeItem {
   }
 }
 
-function createFlinkComputePoolTooltip(resource: FlinkComputePool) {
+export function createFlinkComputePoolTooltip(resource: FlinkComputePool) {
   const tooltip = new CustomMarkdownString()
     .appendMarkdown(`#### $(${resource.iconName}) Flink Compute Pool\n`)
     .appendMarkdown("\n\n---")

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -43,7 +43,7 @@ export class CCloudFlinkComputePool extends FlinkComputePool {
   }
 
   get ccloudUrl(): string {
-    return `https://confluent.cloud/environments/${this.connectionId}/compute-pools/${this.id}`;
+    return `https://confluent.cloud/environments/${this.environmentId}/flink/pools/${this.id}/overview`;
   }
 }
 

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -60,7 +60,7 @@ export class FlinkComputePoolTreeItem extends TreeItem {
 
     // user-facing properties
     this.iconPath = new ThemeIcon(resource.iconName);
-    this.description = resource.connectionId;
+    this.description = resource.id;
 
     this.tooltip = createFlinkComputePoolTooltip(resource);
   }
@@ -68,9 +68,9 @@ export class FlinkComputePoolTreeItem extends TreeItem {
 
 function createFlinkComputePoolTooltip(resource: FlinkComputePool) {
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${resource.iconName}) ${resource.name}\n`)
+    .appendMarkdown(`#### $(${resource.iconName}) Flink Compute Pool\n`)
     .appendMarkdown("\n\n---")
-    .appendMarkdown(`\n\n**ID:** \`${resource.id}\``)
+    .appendMarkdown(`\n\nID: \`${resource.id}\``)
     .appendMarkdown(`\n\nName: \`${resource.name}\``);
   if (isCCloud(resource)) {
     const ccloudPool = resource as CCloudFlinkComputePool;

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -1,0 +1,87 @@
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ConnectionType } from "../clients/sidecar";
+import { CCLOUD_CONNECTION_ID, IconNames } from "../constants";
+import { CustomMarkdownString } from "./main";
+import { ConnectionId, EnvironmentId, IResourceBase, isCCloud, ISearchable } from "./resource";
+
+export abstract class FlinkComputePool implements IResourceBase, ISearchable {
+  abstract connectionId: ConnectionId;
+  abstract connectionType: ConnectionType;
+  iconName: IconNames = IconNames.FLINK_COMPUTE_POOL;
+
+  environmentId!: EnvironmentId;
+
+  id!: string;
+  name!: string;
+
+  searchableText(): string {
+    return `${this.name} ${this.id}`;
+  }
+}
+
+export class CCloudFlinkComputePool extends FlinkComputePool {
+  readonly connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
+  readonly connectionType: ConnectionType = ConnectionType.Ccloud;
+
+  provider!: string;
+  region!: string;
+  maxCfu!: number;
+
+  constructor(
+    props: Pick<
+      CCloudFlinkComputePool,
+      "id" | "name" | "provider" | "region" | "maxCfu" | "environmentId"
+    >,
+  ) {
+    super();
+    this.id = props.id;
+    this.name = props.name;
+    this.provider = props.provider;
+    this.region = props.region;
+    this.maxCfu = props.maxCfu;
+    this.environmentId = props.environmentId;
+  }
+
+  get ccloudUrl(): string {
+    return `https://confluent.cloud/environments/${this.connectionId}/compute-pools/${this.id}`;
+  }
+}
+
+export class FlinkComputePoolTreeItem extends TreeItem {
+  resource: FlinkComputePool;
+
+  constructor(resource: FlinkComputePool) {
+    super(resource.name, TreeItemCollapsibleState.None);
+
+    // internal properties
+    this.id = `${resource.connectionId}-${resource.id}`;
+    this.resource = resource;
+    this.contextValue = `${resource.connectionType.toLowerCase()}-flink-compute-pool`;
+
+    // user-facing properties
+    this.iconPath = new ThemeIcon(resource.iconName);
+    this.description = resource.connectionId;
+
+    this.tooltip = createFlinkComputePoolTooltip(resource);
+  }
+}
+
+function createFlinkComputePoolTooltip(resource: FlinkComputePool) {
+  const tooltip = new CustomMarkdownString()
+    .appendMarkdown(`#### $(${resource.iconName}) ${resource.name}\n`)
+    .appendMarkdown("\n\n---")
+    .appendMarkdown(`\n\n**ID:** \`${resource.id}\``)
+    .appendMarkdown(`\n\nName: \`${resource.name}\``);
+  if (isCCloud(resource)) {
+    const ccloudPool = resource as CCloudFlinkComputePool;
+    tooltip.appendMarkdown(`\n\nProvider: \`${ccloudPool.provider}\``);
+    tooltip.appendMarkdown(`\n\nRegion: \`${ccloudPool.region}\``);
+    tooltip.appendMarkdown(`\n\nMax CFU: \`${ccloudPool.maxCfu}\``);
+    tooltip.appendMarkdown("\n\n---");
+    tooltip.appendMarkdown(
+      `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudPool.ccloudUrl})`,
+    );
+  }
+
+  return tooltip;
+}

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -1,6 +1,13 @@
-import { ConfigurationChangeEvent, Disposable, workspace, WorkspaceConfiguration } from "vscode";
+import {
+  commands,
+  ConfigurationChangeEvent,
+  Disposable,
+  workspace,
+  WorkspaceConfiguration,
+} from "vscode";
 import { ContextValues, setContextValue } from "../context/values";
 import { Logger } from "../logging";
+import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import {
   ENABLE_CHAT_PARTICIPANT,
   ENABLE_FLINK,
@@ -51,6 +58,10 @@ export function createConfigChangeListener(): Disposable {
         const enabled = configs.get(ENABLE_FLINK, false);
         logger.debug(`"${ENABLE_FLINK}" config changed`, { enabled });
         setContextValue(ContextValues.flinkEnabled, enabled);
+        // refresh the Resources view to toggle visibility of compute pools under environments
+        if (hasCCloudAuthSession()) {
+          commands.executeCommand("confluent.resources.refresh");
+        }
         return;
       }
 

--- a/tests/unit/testResources/environments.ts
+++ b/tests/unit/testResources/environments.ts
@@ -13,6 +13,7 @@ export const TEST_CCLOUD_ENVIRONMENT: CCloudEnvironment = new CCloudEnvironment(
   streamGovernancePackage: "NONE",
   kafkaClusters: [],
   schemaRegistry: undefined,
+  flinkComputePools: [],
 });
 
 export const TEST_DIRECT_ENVIRONMENT_ID = "test-direct-connection" as EnvironmentId;

--- a/tests/unit/testResources/flinkComputePool.ts
+++ b/tests/unit/testResources/flinkComputePool.ts
@@ -1,0 +1,15 @@
+import { CCloudFlinkComputePool } from "../../../src/models/flinkComputePool";
+import {
+  TEST_CCLOUD_ENVIRONMENT_ID,
+  TEST_CCLOUD_PROVIDER,
+  TEST_CCLOUD_REGION,
+} from "./environments";
+
+export const TEST_CCLOUD_FLINK_COMPUTE_POOL = new CCloudFlinkComputePool({
+  id: "lfcp-123",
+  name: "Test Flink Pool",
+  provider: TEST_CCLOUD_PROVIDER,
+  region: TEST_CCLOUD_REGION,
+  maxCfu: 10,
+  environmentId: TEST_CCLOUD_ENVIRONMENT_ID,
+} as CCloudFlinkComputePool);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR adds the first few Flink compute pool related models, and updates our CCloud environment (GraphQL) query to add them as children to `CCloudEnvironment`s. When the `confluent.preview.enableFlink` setting is toggled and the user is signed in to CCloud, it will trigger a refresh of the Resources view:

https://github.com/user-attachments/assets/1759ea63-c956-4913-8fd1-aff819ad4c15

This also includes some initial empty-states for the Flink view (also toggled from the same preview setting) that will be updated further in follow-on branches for https://github.com/confluentinc/vscode/milestone/17.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
