### PR TITLE
Link FlinkComputePoolResponseError into isResponseError().

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 import { commands, window } from "vscode";
 import { ResponseError as DockerResponseError } from "./clients/docker";
+import { ResponseError as FlinkComputePoolResponseError } from "./clients/flinkComputePool";
 import { ResponseError as KafkaResponseError } from "./clients/kafkaRest";
 import { ResponseError as ScaffoldingServiceResponseError } from "./clients/scaffoldingService";
 import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRegistryRest";
@@ -22,6 +23,7 @@ export type AnyResponseError =
   | SidecarResponseError
   | KafkaResponseError
   | SchemaRegistryResponseError
+  | FlinkComputePoolResponseError
   | ScaffoldingServiceResponseError
   | DockerResponseError;
 
@@ -30,6 +32,7 @@ export function isResponseError(error: unknown): error is AnyResponseError {
     error instanceof SidecarResponseError ||
     error instanceof KafkaResponseError ||
     error instanceof SchemaRegistryResponseError ||
+    error instanceof FlinkComputePoolResponseError ||
     error instanceof ScaffoldingServiceResponseError ||
     error instanceof DockerResponseError
   );


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Link  `FlinkComputePoolResponseError` into `isResponseError()`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1372 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
