### PR TITLE
split Flink view into Statements and Artifacts views

### DIFF
--- a/package.json
+++ b/package.json
@@ -553,26 +553,38 @@
         {
           "id": "confluent-resources",
           "name": "Resources",
-          "icon": "$(confluent-logo)"
+          "icon": "$(confluent-logo)",
+          "contextualTitle": "Confluent: Resources"
         },
         {
           "id": "confluent-topics",
           "name": "Topics",
           "visibility": "collapsed",
-          "icon": "$(confluent-logo)"
+          "icon": "$(confluent-logo)",
+          "contextualTitle": "Confluent: Topics"
         },
         {
           "id": "confluent-schemas",
           "name": "Schemas",
           "visibility": "collapsed",
-          "icon": "$(confluent-logo)"
+          "icon": "$(confluent-logo)",
+          "contextualTitle": "Confluent: Schemas"
         },
         {
-          "id": "confluent-flink",
-          "name": "Flink",
+          "id": "confluent-flink-statements",
+          "name": "Flink Statements",
           "visibility": "collapsed",
           "icon": "$(confluent-logo)",
-          "when": "confluent.flinkEnabled"
+          "when": "confluent.flinkEnabled",
+          "contextualTitle": "Confluent: Flink Statements"
+        },
+        {
+          "id": "confluent-flink-artifacts",
+          "name": "Flink Artifacts",
+          "visibility": "collapsed",
+          "icon": "$(confluent-logo)",
+          "when": "confluent.flinkEnabled",
+          "contextualTitle": "Confluent: Flink Artifacts"
         },
         {
           "id": "confluent-support",
@@ -633,13 +645,23 @@
         "when": "(confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable) && confluent.kafkaClusterSelected && confluent.topicSearchApplied"
       },
       {
-        "view": "confluent-flink",
+        "view": "confluent-flink-statements",
         "contents": "No Flink compute pools available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)",
         "when": "!confluent.ccloudConnectionAvailable"
       },
       {
-        "view": "confluent-flink",
-        "contents": "NOT YET IMPLEMENTED: Flink resources coming soon.",
+        "view": "confluent-flink-statements",
+        "contents": "NOT YET IMPLEMENTED: Flink statements coming soon.",
+        "when": "confluent.ccloudConnectionAvailable"
+      },
+      {
+        "view": "confluent-flink-artifacts",
+        "contents": "No Flink compute pools available.\n[Connect to Confluent Cloud](command:confluent.connections.ccloud.signIn)",
+        "when": "!confluent.ccloudConnectionAvailable"
+      },
+      {
+        "view": "confluent-flink-artifacts",
+        "contents": "NOT YET IMPLEMENTED: Flink artifacts coming soon.",
         "when": "confluent.ccloudConnectionAvailable"
       }
     ],


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We're preemptively trying to avoid any mixed-resource-type views and currently intending on only displaying Flink (SQL) statements in one view, and Flink artifacts in another view. This should reduce the need to complicate a view provider, and make it easier for users to hide one or the other view if desired.

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/6fe0074a-475c-489d-a5f4-90d3354c7611" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

The `contextualTitle`s added to each view to help when [a view is moved](https://code.visualstudio.com/api/references/contribution-points#contributes.views) out of the main "Confluent" view container:
> Human-readable context for when the view is moved out of its original location. By default, the view's container name will be used.

<img width="478" alt="image" src="https://github.com/user-attachments/assets/ca7e6e76-d2dc-425c-8458-dc424b183166" />
<img width="696" alt="image" src="https://github.com/user-attachments/assets/1dbb03a9-480b-4f03-8436-ed123c2ea8a0" />

Before this PR, each moved view would just say "Confluent", which wasn't particularly helpful.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
