### PR TITLE
introduce `BaseViewProvider` and add `FlinkStatementsViewProvider`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ import { sentryCaptureException } from "./telemetry/sentryClient";
 import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { getUriHandler } from "./uriHandler";
+import { FlinkStatementsViewProvider } from "./viewProviders/flinkStatements";
 import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SEARCH_DECORATION_PROVIDER } from "./viewProviders/search";
@@ -154,11 +155,13 @@ async function _activateExtension(
   const resourceViewProvider = ResourceViewProvider.getInstance();
   const topicViewProvider = TopicViewProvider.getInstance();
   const schemasViewProvider = SchemasViewProvider.getInstance();
+  const statementsViewProvider = FlinkStatementsViewProvider.getInstance();
   const supportViewProvider = new SupportViewProvider();
   const viewProviderDisposables: vscode.Disposable[] = [
     ...resourceViewProvider.disposables,
     ...topicViewProvider.disposables,
     ...schemasViewProvider.disposables,
+    ...statementsViewProvider.disposables,
     ...supportViewProvider.disposables,
   ];
   logger.info("View providers initialized");

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -1,9 +1,10 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { IconNames } from "../constants";
+import { IdItem } from "./main";
 import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
 
-export class FlinkStatement implements IResourceBase, ISearchable {
+export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   connectionId!: ConnectionId;
   connectionType!: ConnectionType;
   iconName: IconNames = IconNames.FLINK_STATEMENT;
@@ -28,6 +29,10 @@ export class FlinkStatement implements IResourceBase, ISearchable {
     this.computePoolId = props.computePoolId;
     this.name = props.name;
     this.status = props.status;
+  }
+
+  get id(): string {
+    return `${this.connectionId}-${this.computePoolId}-${this.name}`;
   }
 
   searchableText(): string {

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -1,0 +1,130 @@
+import * as vscode from "vscode";
+import { getExtensionContext } from "../context/extension";
+import { ContextValues, setContextValue } from "../context/values";
+import { ExtensionContextNotSetError } from "../errors";
+import { ResourceLoader } from "../loaders";
+import { Logger } from "../logging";
+import { Environment } from "../models/environment";
+import { IdItem } from "../models/main";
+import { EnvironmentId, IResourceBase } from "../models/resource";
+
+const logger = new Logger("viewProviders.base");
+
+export abstract class BaseViewProvider<
+  T extends IResourceBase & IdItem & { environmentId: EnvironmentId },
+> implements vscode.TreeDataProvider<T>
+{
+  /** Disposables belonging to this provider to be added to the extension context during activation,
+   * cleaned up on extension deactivation. */
+  disposables: vscode.Disposable[] = [];
+
+  private _onDidChangeTreeData: vscode.EventEmitter<T | undefined | void> = new vscode.EventEmitter<
+    T | undefined | void
+  >();
+  readonly onDidChangeTreeData: vscode.Event<T | undefined | void> =
+    this._onDidChangeTreeData.event;
+
+  async refresh(): Promise<void> {
+    this._onDidChangeTreeData.fire();
+  }
+
+  private treeView: vscode.TreeView<T>;
+
+  /** The parent {@link Environment} of the focused resource.  */
+  environment: Environment | null = null;
+  /** The resource instance associated with this provider. */
+  resource: T | null = null;
+
+  /** String to filter items returned by `getChildren`, if provided. */
+  itemSearchString: string | null = null;
+  /** Count of how many times the user has set a search string */
+  searchStringSetCount: number = 0;
+  /** Items directly matching the {@linkcode itemSearchString}, if provided. */
+  searchMatches: Set<T> = new Set();
+  /** Count of all items returned from `getChildren()`. */
+  totalItemCount: number = 0;
+
+  /** The id of the view associated with this provider, set in package.json. */
+  protected viewId: string = "confluent-resource";
+
+  private static instanceMap = new Map<string, BaseViewProvider<any>>();
+
+  protected constructor() {
+    if (!getExtensionContext()) {
+      // getChildren() will fail without the extension context
+      throw new ExtensionContextNotSetError(this.constructor.name);
+    }
+
+    this.treeView = vscode.window.createTreeView(this.viewId, { treeDataProvider: this });
+
+    const listeners: vscode.Disposable[] = this.setEventListeners();
+
+    this.disposables = [this.treeView, ...listeners];
+  }
+
+  static getInstance<U extends BaseViewProvider<any>>(this: new () => U): U {
+    const className = this.name;
+    if (!BaseViewProvider.instanceMap.has(className)) {
+      BaseViewProvider.instanceMap.set(className, new this());
+    }
+    return BaseViewProvider.instanceMap.get(className) as U;
+  }
+
+  /** Convenience method to revert this view to its original state. */
+  async reset(): Promise<void> {
+    logger.debug("reset() called, clearing tree view");
+  }
+
+  abstract getChildren(): vscode.ProviderResult<T[]>;
+
+  abstract getTreeItem(element: T): vscode.TreeItem;
+
+  /** Set up event listeners for this view provider. */
+  abstract setEventListeners(): vscode.Disposable[];
+
+  /**
+   * Update the tree view description to show the currently-focused resource's parent env
+   * name and the resource ID.
+   *
+   * Reassigns this.environment to the parent environment of the resource.
+   * */
+  async updateTreeViewDescription(): Promise<void> {
+    const subLogger = logger.withCallpoint("updateTreeViewDescription");
+
+    const focusedResource = this.resource;
+    if (!focusedResource) {
+      subLogger.debug("called with no focused resource, clearing view description");
+      this.treeView.description = "";
+      this.environment = null;
+      return;
+    }
+
+    subLogger.debug(
+      `called with ${focusedResource.constructor.name}, checking for environments...`,
+    );
+    const loader = ResourceLoader.getInstance(focusedResource.connectionId);
+    const envs: Environment[] = await loader.getEnvironments();
+    const parentEnv: Environment | undefined = envs.find(
+      (env) => env.id === focusedResource.environmentId,
+    );
+    this.environment = parentEnv ?? null;
+    if (parentEnv) {
+      subLogger.debug("found environment, setting view description");
+      this.treeView.description = `${parentEnv.name} | ${focusedResource.id}`;
+    } else {
+      subLogger.debug(`couldn't find parent environment for ${focusedResource.constructor.name}`);
+      this.treeView.description = "";
+    }
+  }
+
+  /** Update internal state when the search string is set or unset. */
+  setSearch(searchString: string | null): void {
+    // set/unset the filter so any calls to getChildren() will filter appropriately
+    this.itemSearchString = searchString;
+    // set context value to toggle between "search" and "clear search" actions
+    setContextValue(ContextValues.schemaSearchApplied, searchString !== null);
+    // clear from any previous search filter
+    this.searchMatches = new Set();
+    this.totalItemCount = 0;
+  }
+}

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -1,0 +1,23 @@
+import { Disposable, TreeDataProvider, TreeItem } from "vscode";
+import { BaseViewProvider } from "./base";
+
+export class FlinkStatementsViewProvider
+  extends BaseViewProvider<FlinkStatement>
+  implements TreeDataProvider<FlinkStatement>
+{
+  viewId = "confluent-flink-statements";
+
+  private static instance: FlinkStatementsViewProvider;
+
+  async getChildren(): Promise<FlinkStatement[]> {
+    return [];
+  }
+
+  getTreeItem(element: FlinkStatement): TreeItem {
+    return new TreeItem(element.name);
+  }
+
+  setEventListeners(): Disposable[] {
+    return [];
+  }
+}

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -1,4 +1,8 @@
 import { Disposable, TreeDataProvider, TreeItem } from "vscode";
+import { ConnectionType } from "../clients/sidecar";
+import { CCLOUD_CONNECTION_ID } from "../constants";
+import { FlinkStatement, FlinkStatementTreeItem } from "../models/flinkStatement";
+import { EnvironmentId } from "../models/resource";
 import { BaseViewProvider } from "./base";
 
 export class FlinkStatementsViewProvider
@@ -7,14 +11,37 @@ export class FlinkStatementsViewProvider
 {
   viewId = "confluent-flink-statements";
 
-  private static instance: FlinkStatementsViewProvider;
-
   async getChildren(): Promise<FlinkStatement[]> {
-    return [];
+    const children: FlinkStatement[] = [];
+
+    // TODO: replace this with real data
+    const fakeStatement = new FlinkStatement({
+      connectionId: CCLOUD_CONNECTION_ID,
+      connectionType: ConnectionType.Ccloud,
+      environmentId: "env1" as EnvironmentId,
+      computePoolId: "pool1",
+      name: "statement1",
+      status: "running",
+    });
+    children.push(
+      fakeStatement,
+      new FlinkStatement({
+        ...fakeStatement,
+        name: "statement2",
+        status: "failed",
+      }),
+      new FlinkStatement({
+        ...fakeStatement,
+        name: "statement3",
+        status: "stopped",
+      }),
+    );
+
+    return this.filterChildren(undefined, children);
   }
 
   getTreeItem(element: FlinkStatement): TreeItem {
-    return new TreeItem(element.name);
+    return new FlinkStatementTreeItem(element);
   }
 
   setEventListeners(): Disposable[] {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #1320. 


### Associated PRs
- https://github.com/confluentinc/vscode/pull/1399
  - placeholder for #1320  👈 
    - placeholder for #1361

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Since we need to create two new view providers as part of the Flink milestone, copying all the disposable, event listener, search functionality would have been getting out of hand. As a result, this PR also closes #1022 by implementing an abstract base class to handle some of that boilerplate.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
