### PR TITLE
add IDE version/name/scheme to observability context

### DIFF
--- a/src/context/observability.ts
+++ b/src/context/observability.ts
@@ -1,4 +1,5 @@
 import { version } from "ide-sidecar";
+import { env, version as ideVersion } from "vscode";
 import { Status } from "../clients/sidecar";
 /**
  * Per-extension-instance singleton object for storing basic data to help debug issues, errors, etc.
@@ -17,6 +18,13 @@ import { Status } from "../clients/sidecar";
  */
 class ObservabilityContext {
   constructor(
+    /** The version of VS Code (or variant) in use. */
+    public productVersion: string = ideVersion,
+    /** The name of the VS Code (or variant) in use. */
+    public productName: string = env.appName,
+    /** The URI scheme of the VS Code (or variant) in use. */
+    public productUriScheme: string = env.uriScheme,
+
     /** The version of the activated extension instance, from `package.json`. */
     public extensionVersion: string = "",
     /** Whether or not the extension activated successfully. */


### PR DESCRIPTION
We've occasionally seen some errors in Sentry that didn't make sense with more recent versions of VS Code, but we don't currently have a way to confirm that with the current `extra` context. This PR adds some of those basics to ensure we get that information in Sentry, along with any support .zip downloads.

<img width="949" alt="image" src="https://github.com/user-attachments/assets/4e423853-dc4f-42bb-a0ac-cf2a3de8bff4" />

<img width="330" alt="image" src="https://github.com/user-attachments/assets/9357e392-d6fd-4890-95e7-218636fb34da" />

Closes #1095.