### PR TITLE
implement Flink compute pool selection commands and quickpick

### DIFF
--- a/package.json
+++ b/package.json
@@ -689,8 +689,13 @@
       },
       {
         "view": "confluent-flink-artifacts",
-        "contents": "No Flink statements found.\n[Create Statement](command:confluent.artifacts.flink-compute-pool.select)",
+        "contents": "No Flink compute pool selected. Click below to get started.\n[Select Flink Compute Pool](command:confluent.artifacts.flink-compute-pool.select)",
         "when": "confluent.ccloudConnectionAvailable && !confluent.flinkArtifactsPoolSelected"
+      },
+      {
+        "view": "confluent-flink-artifacts",
+        "contents": "No Flink artifacts found.",
+        "when": "confluent.ccloudConnectionAvailable && confluent.flinkArtifactsPoolSelected"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -674,8 +674,13 @@
       },
       {
         "view": "confluent-flink-statements",
-        "contents": "NOT YET IMPLEMENTED: Flink statements coming soon.",
-        "when": "confluent.ccloudConnectionAvailable"
+        "contents": "No Flink compute pool selected. Click below to get started.\n[Select Flink Compute Pool](command:confluent.statements.flink-compute-pool.select)",
+        "when": "confluent.ccloudConnectionAvailable && !confluent.flinkStatementsPoolSelected"
+      },
+      {
+        "view": "confluent-flink-statements",
+        "contents": "No Flink statements found.",
+        "when": "confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected"
       },
       {
         "view": "confluent-flink-artifacts",
@@ -684,8 +689,8 @@
       },
       {
         "view": "confluent-flink-artifacts",
-        "contents": "NOT YET IMPLEMENTED: Flink artifacts coming soon.",
-        "when": "confluent.ccloudConnectionAvailable"
+        "contents": "No Flink statements found.\n[Create Statement](command:confluent.artifacts.flink-compute-pool.select)",
+        "when": "confluent.ccloudConnectionAvailable && !confluent.flinkArtifactsPoolSelected"
       }
     ],
     "menus": {
@@ -967,6 +972,16 @@
           "command": "confluent.topics.copyKafkaClusterBootstrapServers",
           "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "2_copy@3"
+        },
+        {
+          "command": "confluent.statements.flink-compute-pool.select",
+          "when": "view == confluent-flink-statements && confluent.ccloudConnectionAvailable",
+          "group": "navigation@1"
+        },
+        {
+          "command": "confluent.artifacts.flink-compute-pool.select",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -207,6 +207,24 @@
         "category": "Confluent: Resources"
       },
       {
+        "command": "confluent.resources.flink-compute-pool.select",
+        "icon": "$(confluent-flink-compute-pool)",
+        "title": "Select Flink Compute Pool",
+        "category": "Confluent: Resources"
+      },
+      {
+        "command": "confluent.statements.flink-compute-pool.select",
+        "icon": "$(confluent-flink-compute-pool)",
+        "title": "Select Flink Compute Pool",
+        "category": "Confluent: Flink Statements"
+      },
+      {
+        "command": "confluent.artifacts.flink-compute-pool.select",
+        "icon": "$(confluent-flink-compute-pool)",
+        "title": "Select Flink Compute Pool",
+        "category": "Confluent: Flink Artifacts"
+      },
+      {
         "command": "confluent.resources.search",
         "icon": "$(search)",
         "title": "Search",

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -1,0 +1,48 @@
+import { Disposable } from "vscode";
+import { registerCommandWithLogging } from ".";
+import { FlinkComputePool } from "../models/flinkComputePool";
+
+/**
+ * Select a {@link FlinkComputePool} from the "Resources" view to focus both the "Statements" and
+ * "Artifacts" views.
+ *
+ * This is the same as selecting the same pool for both the
+ * `confluent.statements.flink-compute-pool.select` and
+ * `confluent.artifacts.flink-compute-pool.select` commands.
+ */
+export function selectPoolFromResourcesViewCommand(pool?: FlinkComputePool) {
+  if (!(pool instanceof FlinkComputePool)) {
+    return;
+  }
+}
+
+/** Select a {@link FlinkComputePool} to focus in the "Statements" view. */
+export function selectPoolForStatementsViewCommand(pool?: FlinkComputePool) {
+  if (!(pool instanceof FlinkComputePool)) {
+    return;
+  }
+}
+
+/** Select a {@link FlinkComputePool} to focus in the "Artifacts" view. */
+export function selectPoolForArtifactsViewCommand(pool?: FlinkComputePool) {
+  if (!(pool instanceof FlinkComputePool)) {
+    return;
+  }
+}
+
+export function registerFlinkComputePoolCommands(): Disposable[] {
+  return [
+    registerCommandWithLogging(
+      "confluent.resources.flink-compute-pool.select",
+      selectPoolFromResourcesViewCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.statements.flink-compute-pool.select",
+      selectPoolForStatementsViewCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.artifacts.flink-compute-pool.select",
+      selectPoolForArtifactsViewCommand,
+    ),
+  ];
+}

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -1,6 +1,8 @@
-import { Disposable } from "vscode";
+import { commands, Disposable } from "vscode";
 import { registerCommandWithLogging } from ".";
+import { currentFlinkArtifactsPoolChanged, currentFlinkStatementsPoolChanged } from "../emitters";
 import { FlinkComputePool } from "../models/flinkComputePool";
+import { flinkComputePoolQuickPickWithViewProgress } from "../quickpicks/flinkComputePools";
 
 /**
  * Select a {@link FlinkComputePool} from the "Resources" view to focus both the "Statements" and
@@ -10,24 +12,49 @@ import { FlinkComputePool } from "../models/flinkComputePool";
  * `confluent.statements.flink-compute-pool.select` and
  * `confluent.artifacts.flink-compute-pool.select` commands.
  */
-export function selectPoolFromResourcesViewCommand(pool?: FlinkComputePool) {
-  if (!(pool instanceof FlinkComputePool)) {
+export async function selectPoolFromResourcesViewCommand(item?: FlinkComputePool) {
+  // the user either clicked a pool in the Resources view or used the command palette
+  const pool: FlinkComputePool | undefined =
+    item instanceof FlinkComputePool
+      ? item
+      : await flinkComputePoolQuickPickWithViewProgress("confluent-resources");
+  if (!pool) {
     return;
   }
+
+  // TODO: check if views are visible and pass an arg in here to prevent `focus` if not
+  await Promise.all([
+    selectPoolForArtifactsViewCommand(pool),
+    selectPoolForStatementsViewCommand(pool),
+  ]);
 }
 
 /** Select a {@link FlinkComputePool} to focus in the "Statements" view. */
-export function selectPoolForStatementsViewCommand(pool?: FlinkComputePool) {
-  if (!(pool instanceof FlinkComputePool)) {
+export async function selectPoolForStatementsViewCommand(item?: FlinkComputePool) {
+  // the user either clicked a pool in the Flink Statements view or used the command palette
+  const pool: FlinkComputePool | undefined =
+    item instanceof FlinkComputePool
+      ? item
+      : await flinkComputePoolQuickPickWithViewProgress("confluent-flink-statements");
+  if (!pool) {
     return;
   }
+  currentFlinkStatementsPoolChanged.fire(pool);
+  commands.executeCommand("confluent-flink-statements.focus");
 }
 
 /** Select a {@link FlinkComputePool} to focus in the "Artifacts" view. */
-export function selectPoolForArtifactsViewCommand(pool?: FlinkComputePool) {
-  if (!(pool instanceof FlinkComputePool)) {
+export async function selectPoolForArtifactsViewCommand(item?: FlinkComputePool) {
+  // the user either clicked a pool in the Flink Artifacts view or used the command palette
+  const pool: FlinkComputePool | undefined =
+    item instanceof FlinkComputePool
+      ? item
+      : await flinkComputePoolQuickPickWithViewProgress("confluent-flink-artifacts");
+  if (!pool) {
     return;
   }
+  currentFlinkArtifactsPoolChanged.fire(pool);
+  commands.executeCommand("confluent-flink-artifacts.focus");
 }
 
 export function registerFlinkComputePoolCommands(): Disposable[] {

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -60,6 +60,10 @@ export enum ContextValues {
   kafkaClusterSelected = "confluent.kafkaClusterSelected",
   /** The user clicked a Schema Registry tree item. */
   schemaRegistrySelected = "confluent.schemaRegistrySelected",
+  /** The user focused a Flink compute pool for the Flink Statements view. */
+  flinkStatementsPoolSelected = "confluent.flinkStatementsPoolSelected",
+  /** The user focused a Flink compute pool for the Flink Artifacts view. */
+  flinkArtifactsPoolSelected = "confluent.flinkArtifactsPoolSelected",
   /** The user applied a search string to the Resources view. */
   resourceSearchApplied = "confluent.resourceSearchApplied",
   /** The user applied a search string to the Topics view. */

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { FlinkComputePool } from "./models/flinkComputePool";
 import { KafkaCluster } from "./models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "./models/resource";
 import { Subject, SubjectWithSchemas } from "./models/schema";
@@ -83,6 +84,18 @@ export const currentKafkaClusterChanged = new vscode.EventEmitter<KafkaCluster |
  * (or CCloud organization) change.
  */
 export const currentSchemaRegistryChanged = new vscode.EventEmitter<SchemaRegistry | null>();
+/**
+ * Fired whenever a Flink compute pool is selected from the Resources view or the Flink Statements
+ * view, chosen from the "Select Flink Compute Pool" action from the Flink Statements view or
+ * command palette, or cleared out from a connection (or CCloud organization) change.
+ */
+export const currentFlinkStatementsPoolChanged = new vscode.EventEmitter<FlinkComputePool | null>();
+/**
+ * Fired whenever a Flink compute pool is selected from the Resources view or the Flink Artifacts
+ * view, chosen from the "Select Flink Compute Pool" action from the Flink Artifacts view or
+ * command palette, or cleared out from a connection (or CCloud organization) change.
+ */
+export const currentFlinkArtifactsPoolChanged = new vscode.EventEmitter<FlinkComputePool | null>();
 
 export const connectionStable = new vscode.EventEmitter<ConnectionId>();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import { registerDiffCommands } from "./commands/diffs";
 import { registerDockerCommands } from "./commands/docker";
 import { registerEnvironmentCommands } from "./commands/environments";
 import { registerExtraCommands } from "./commands/extra";
+import { registerFlinkComputePoolCommands } from "./commands/flinkComputePools";
 import { registerKafkaClusterCommands } from "./commands/kafkaClusters";
 import { registerOrganizationCommands } from "./commands/organizations";
 import { registerSchemaRegistryCommands } from "./commands/schemaRegistry";
@@ -201,6 +202,7 @@ async function _activateExtension(
     ...registerExtraCommands(),
     ...registerDockerCommands(),
     ...registerProjectGenerationCommands(),
+    ...registerFlinkComputePoolCommands(),
   ];
   logger.info("Commands registered");
 

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -63,6 +63,14 @@ export class FlinkComputePoolTreeItem extends TreeItem {
     this.description = resource.id;
 
     this.tooltip = createFlinkComputePoolTooltip(resource);
+
+    // command that allows the user to select a Flink compute pool from the Resources view and
+    // focus it in the Flink Statements and Flink Artifacts views
+    this.command = {
+      command: "confluent.resources.flink-compute-pool.select",
+      title: "Select Flink Compute Pool",
+      arguments: [resource],
+    };
   }
 }
 

--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -6,7 +6,7 @@ import { showInfoNotificationWithButtons } from "../errors";
 import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
-import { FlinkComputePool } from "../models/flinkComputePool";
+import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { getConnectionLabel, isCCloud } from "../models/resource";
 import { FlinkArtifactsViewProvider } from "../viewProviders/flinkArtifacts";
 import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
@@ -47,7 +47,9 @@ export async function flinkComputePoolQuickPick(): Promise<FlinkComputePool | un
   const computePools: FlinkComputePool[] = [];
   for (const env of environments) {
     if (env.flinkComputePools) {
-      computePools.push(...env.flinkComputePools);
+      const pools = env.flinkComputePools as CCloudFlinkComputePool[];
+      // convert the pools data to CCloudFlinkComputePool instances
+      computePools.push(...pools.map((pool) => new CCloudFlinkComputePool(pool)));
     }
   }
 

--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -3,7 +3,7 @@ import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "../authn/constants";
 import { IconNames } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
 import { showInfoNotificationWithButtons } from "../errors";
-import { getEnvironments } from "../graphql/environments";
+import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
 import { FlinkComputePool } from "../models/flinkComputePool";
@@ -42,8 +42,8 @@ export async function flinkComputePoolQuickPickWithViewProgress(
  * ccloud-pool3 (lfcp-id3)
  */
 export async function flinkComputePoolQuickPick(): Promise<FlinkComputePool | undefined> {
-  // TODO: implement and use ResourceLoader methods
-  const environments: Environment[] = await getEnvironments();
+  const loader = CCloudResourceLoader.getInstance();
+  const environments: Environment[] = await loader.getEnvironments();
   const computePools: FlinkComputePool[] = [];
   for (const env of environments) {
     if (env.flinkComputePools) {

--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -1,0 +1,128 @@
+import { commands, QuickPickItemKind, ThemeIcon, window } from "vscode";
+import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "../authn/constants";
+import { IconNames } from "../constants";
+import { ContextValues, getContextValue } from "../context/values";
+import { showInfoNotificationWithButtons } from "../errors";
+import { Logger } from "../logging";
+import { Environment } from "../models/environment";
+import { FlinkComputePool } from "../models/flinkComputePool";
+import { getConnectionLabel, isCCloud } from "../models/resource";
+import { FlinkArtifactsViewProvider } from "../viewProviders/flinkArtifacts";
+import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
+import { QuickPickItemWithValue } from "./types";
+
+const logger = new Logger("quickpicks.flinkComputePools");
+
+/** Wrapper for the Flink Compute Pool quickpick to accomodate data-fetching time and display a progress indicator on the Flink Statements/Artifacts view(s). */
+export async function flinkComputePoolQuickPickWithViewProgress(
+  viewId: "confluent-flink-statements" | "confluent-flink-artifacts",
+): Promise<FlinkComputePool | undefined> {
+  return await window.withProgress(
+    {
+      location: { viewId },
+      title: "Loading Flink compute pools...",
+    },
+    async () => {
+      return await flinkComputePoolQuickPick();
+    },
+  );
+}
+
+/**
+ * Create and await a quickpick to let the user choose a {@link FlinkComputePool}, separated by
+ * environment.
+ *
+ * Example:
+ * ---------------------------------- Confluent Cloud: env1
+ * ccloud-pool1 (lfcp-id1)
+ * ccloud-pool2 (lfcp-id2)
+ * ---------------------------------- Confluent Cloud: env2
+ * ccloud-pool3 (lfcp-id3)
+ */
+export async function flinkComputePoolQuickPick(): Promise<FlinkComputePool | undefined> {
+  const environments: Environment[] = [];
+  const computePools: FlinkComputePool[] = [];
+
+  if (computePools.length === 0) {
+    let login: string = "";
+    if (!getContextValue(ContextValues.ccloudConnectionAvailable)) {
+      login = CCLOUD_SIGN_IN_BUTTON_LABEL;
+    }
+    showInfoNotificationWithButtons("No Flink compute pools available.", {
+      [login]: () => commands.executeCommand("confluent.connections.ccloud.signIn"),
+    });
+    return;
+  }
+
+  logger.debug("generating Flink compute pool quickpick", {
+    // local: computePools.filter((pool) => isLocal(pool)).length,
+    ccloud: computePools.filter((pool) => isCCloud(pool)).length,
+    // direct: computePools.filter((pool) => isDirect(pool)).length,
+  });
+
+  // convert all available Flink comptue pools to quick pick items and keep track of the last env
+  // name used for the separators
+  const items: QuickPickItemWithValue<FlinkComputePool>[] = [];
+
+  // if any pools are focused in the Statements/Artifacts views, move them to the top of the list
+  const focusedPoolIds: string[] = [];
+  for (const provider of [FlinkStatementsViewProvider, FlinkArtifactsViewProvider]) {
+    const focusedPool: FlinkComputePool | undefined =
+      FlinkStatementsViewProvider.getInstance().resource;
+    if (!focusedPool) {
+      continue;
+    }
+
+    focusedPoolIds.push(focusedPool.id);
+    const focusedPoolIndex: number = computePools.findIndex((pool) =>
+      focusedPoolIds.includes(pool.id),
+    );
+    if (focusedPoolIndex !== -1) {
+      computePools.splice(focusedPoolIndex, 1);
+      computePools.unshift(focusedPool!);
+    }
+  }
+
+  let lastSeparator: string = "";
+  for (const pool of computePools) {
+    const environment: Environment | undefined = environments.find(
+      (env) => env.id === pool.environmentId,
+    );
+    if (!environment) {
+      logger.warn(`No environment found for Flink compute pool "${pool.name}"`);
+      return;
+    }
+    const isFocusedPool = focusedPoolIds.includes(pool.id);
+    // show a separator by environment to make it easier to differentiate between the connection types
+    // and make it clear which environment the pool(s) are associated with
+    const connectionLabel = getConnectionLabel(environment.connectionType);
+    // if the connection label is the same as the environment name, only show one
+    const separatorLabel =
+      connectionLabel === environment.name
+        ? connectionLabel
+        : `${connectionLabel}: ${environment.name}`;
+    if (lastSeparator !== separatorLabel) {
+      items.push({
+        kind: QuickPickItemKind.Separator,
+        label: separatorLabel,
+      });
+      lastSeparator = separatorLabel;
+    }
+    // show the currently-focused pool, if there is one
+    const icon = isFocusedPool ? IconNames.CURRENT_RESOURCE : pool.iconName;
+    items.push({
+      label: pool.name,
+      description: pool.id,
+      iconPath: new ThemeIcon(icon),
+      value: pool,
+    });
+  }
+
+  // prompt the user to select a Flink compute pool
+  const chosenItem: QuickPickItemWithValue<FlinkComputePool> | undefined =
+    await window.showQuickPick(items, {
+      placeHolder: "Select a Flink compute pool",
+      ignoreFocusOut: true,
+    });
+  return chosenItem ? chosenItem.value : undefined;
+}

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -65,6 +65,14 @@ export abstract class BaseViewProvider<
    * - Flink Artifacts view: `FlinkComputePool`
    */
   resource: P | null = null;
+  /**
+   * Optional {@link EventEmitter} to listen for when this view provider's parent
+   * {@linkcode resource} is set/unset. This is used in order to control the tree view description,
+   * context value, and search string updates internally.
+   */
+  parentResourceChangedEmitter?: EventEmitter<P | null>;
+  /** Optional context value to adjust when the parent {@linkcode resource} is set/unset. */
+  parentResourceChangedContextValue?: ContextValues;
 
   /** Optional context value to adjust when the search string is set/unset. */
   searchContextValue?: ContextValues;
@@ -114,11 +122,36 @@ export abstract class BaseViewProvider<
 
   /** Set up event listeners for this view provider. */
   private setEventListeners(): Disposable[] {
+    const disposables: Disposable[] = [];
+
     const ccloudConnectedSub: Disposable = ccloudConnected.event((connected: boolean) => {
       this.handleCCloudConnectionChange(connected);
     });
 
-    return [ccloudConnectedSub, ...this.setCustomEventListeners()];
+    const parentResourceChangedSub: Disposable | undefined =
+      this.parentResourceChangedEmitter?.event(async (resource: P | null) => {
+        this.logger.debug(
+          `parent resource change event fired, ${resource ? "refreshing" : "resetting"}.`,
+          { resource },
+        );
+        this.setSearch(null); // reset search when parent resource changes
+        if (!resource) {
+          this.reset();
+        } else {
+          if (this.parentResourceChangedContextValue) {
+            setContextValue(this.parentResourceChangedContextValue, true);
+          }
+          this.resource = resource;
+          await this.updateTreeViewDescription();
+          this.refresh();
+        }
+      });
+    if (parentResourceChangedSub) {
+      disposables.push(parentResourceChangedSub);
+    }
+
+    disposables.push(ccloudConnectedSub, ...this.setCustomEventListeners());
+    return disposables;
   }
 
   /** Optional method for subclasses to provide their own event listeners. */

--- a/src/viewProviders/flinkArtifacts.ts
+++ b/src/viewProviders/flinkArtifacts.ts
@@ -1,14 +1,8 @@
 import { TreeDataProvider, TreeItem } from "vscode";
-import { ConnectionType } from "../clients/sidecar";
-import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues } from "../context/values";
-import { Logger } from "../logging";
 import { FlinkArtifact, FlinkArtifactTreeItem } from "../models/flinkArtifact";
-import { FlinkComputePool } from "../models/flinkComputePool";
-import { EnvironmentId } from "../models/resource";
+import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { BaseViewProvider } from "./base";
-
-const logger = new Logger("viewProviders.flinkArtifacts");
 
 export class FlinkArtifactsViewProvider
   extends BaseViewProvider<FlinkComputePool, FlinkArtifact>
@@ -24,25 +18,24 @@ export class FlinkArtifactsViewProvider
       return children;
     }
 
-    // TODO: replace this with real data
-    const fakeArtifact = new FlinkArtifact({
-      connectionId: CCLOUD_CONNECTION_ID,
-      connectionType: ConnectionType.Ccloud,
-      environmentId: "env1" as EnvironmentId,
-      id: "artifact1",
-      name: "artifact1",
-      description: "This is a test artifact",
-      provider: "aws",
-      region: "us-west-2",
-    });
-    children.push(
-      fakeArtifact,
-      new FlinkArtifact({
-        ...fakeArtifact,
-        name: "artifact2",
-        description: "Best test UDF ever",
-      }),
-    );
+    const pool: CCloudFlinkComputePool = this.computePool as CCloudFlinkComputePool;
+
+    // TODO: replace this with real data -- this should not require any pool-specific filtering,
+    // but use the environment, provider, and region from the pool
+    const numArtifacts = Math.floor(Math.random() * 10) + 1;
+    for (let i = 0; i < numArtifacts; i++) {
+      const fakeArtifact = new FlinkArtifact({
+        connectionId: pool.connectionId,
+        connectionType: pool.connectionType,
+        environmentId: pool.environmentId,
+        id: `artifact${i + 1}`,
+        name: `artifact${i + 1}-${pool.name}`,
+        description: `Test artifact #${i + 1}`,
+        provider: pool.provider,
+        region: pool.region,
+      });
+      children.push(fakeArtifact);
+    }
 
     return this.filterChildren(undefined, children);
   }

--- a/src/viewProviders/flinkArtifacts.ts
+++ b/src/viewProviders/flinkArtifacts.ts
@@ -1,5 +1,6 @@
 import { TreeDataProvider, TreeItem } from "vscode";
 import { ContextValues } from "../context/values";
+import { currentFlinkArtifactsPoolChanged } from "../emitters";
 import { FlinkArtifact, FlinkArtifactTreeItem } from "../models/flinkArtifact";
 import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { BaseViewProvider } from "./base";
@@ -10,6 +11,10 @@ export class FlinkArtifactsViewProvider
 {
   loggerName = "viewProviders.flinkArtifacts";
   viewId = "confluent-flink-artifacts";
+
+  parentResourceChangedEmitter = currentFlinkArtifactsPoolChanged;
+  parentResourceChangedContextValue = ContextValues.flinkArtifactsPoolSelected;
+
   searchContextValue = ContextValues.flinkArtifactsSearchApplied;
 
   async getChildren(): Promise<FlinkArtifact[]> {

--- a/src/viewProviders/flinkArtifacts.ts
+++ b/src/viewProviders/flinkArtifacts.ts
@@ -2,10 +2,13 @@ import { TreeDataProvider, TreeItem } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues } from "../context/values";
+import { Logger } from "../logging";
 import { FlinkArtifact, FlinkArtifactTreeItem } from "../models/flinkArtifact";
 import { FlinkComputePool } from "../models/flinkComputePool";
 import { EnvironmentId } from "../models/resource";
 import { BaseViewProvider } from "./base";
+
+const logger = new Logger("viewProviders.flinkArtifacts");
 
 export class FlinkArtifactsViewProvider
   extends BaseViewProvider<FlinkComputePool, FlinkArtifact>
@@ -17,6 +20,9 @@ export class FlinkArtifactsViewProvider
 
   async getChildren(): Promise<FlinkArtifact[]> {
     const children: FlinkArtifact[] = [];
+    if (!this.computePool) {
+      return children;
+    }
 
     // TODO: replace this with real data
     const fakeArtifact = new FlinkArtifact({

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -1,5 +1,6 @@
 import { TreeDataProvider, TreeItem } from "vscode";
 import { ContextValues } from "../context/values";
+import { currentFlinkStatementsPoolChanged } from "../emitters";
 import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { FlinkStatement, FlinkStatementTreeItem } from "../models/flinkStatement";
 import { BaseViewProvider } from "./base";
@@ -10,6 +11,10 @@ export class FlinkStatementsViewProvider
 {
   loggerName = "viewProviders.flinkStatements";
   viewId = "confluent-flink-statements";
+
+  parentResourceChangedEmitter = currentFlinkStatementsPoolChanged;
+  parentResourceChangedContextValue = ContextValues.flinkStatementsPoolSelected;
+
   searchContextValue = ContextValues.flinkStatementsSearchApplied;
 
   async getChildren(): Promise<FlinkStatement[]> {

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -1,11 +1,8 @@
 import { TreeDataProvider, TreeItem } from "vscode";
 import { ContextValues } from "../context/values";
-import { Logger } from "../logging";
 import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { FlinkStatement, FlinkStatementTreeItem } from "../models/flinkStatement";
 import { BaseViewProvider } from "./base";
-
-const logger = new Logger("viewProviders.flinkStatements");
 
 export class FlinkStatementsViewProvider
   extends BaseViewProvider<FlinkComputePool, FlinkStatement>

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -1,11 +1,8 @@
 import { TreeDataProvider, TreeItem } from "vscode";
-import { ConnectionType } from "../clients/sidecar";
-import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues } from "../context/values";
 import { Logger } from "../logging";
-import { FlinkComputePool } from "../models/flinkComputePool";
+import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { FlinkStatement, FlinkStatementTreeItem } from "../models/flinkStatement";
-import { EnvironmentId } from "../models/resource";
 import { BaseViewProvider } from "./base";
 
 const logger = new Logger("viewProviders.flinkStatements");
@@ -24,28 +21,31 @@ export class FlinkStatementsViewProvider
       return children;
     }
 
+    const pool: CCloudFlinkComputePool = this.computePool as CCloudFlinkComputePool;
+
     // TODO: replace this with real data
-    const fakeStatement = new FlinkStatement({
-      connectionId: CCLOUD_CONNECTION_ID,
-      connectionType: ConnectionType.Ccloud,
-      environmentId: "env1" as EnvironmentId,
-      computePoolId: "pool1",
-      id: "statement1",
-      status: "running",
-    });
-    children.push(
-      fakeStatement,
-      new FlinkStatement({
-        ...fakeStatement,
-        id: "statement2",
-        status: "failed",
-      }),
-      new FlinkStatement({
-        ...fakeStatement,
-        id: "statement3",
-        status: "stopped",
-      }),
-    );
+    const numStatements = Math.floor(Math.random() * 20) + 1;
+    const possibleStatuses = [
+      "RUNNING",
+      "CANCELLING",
+      "CANCELED",
+      "FAILED",
+      "FINISHED",
+      "CREATED",
+      "RESTARTING",
+      "SUSPENDED",
+    ];
+    for (let i = 0; i < numStatements; i++) {
+      const fakeArtifact = new FlinkStatement({
+        connectionId: pool.connectionId,
+        connectionType: pool.connectionType,
+        environmentId: pool.environmentId,
+        computePoolId: pool.id,
+        id: `statement${i + 1}-${pool.name}`,
+        status: possibleStatuses[Math.floor(Math.random() * possibleStatuses.length)].toLowerCase(),
+      });
+      children.push(fakeArtifact);
+    }
 
     return this.filterChildren(undefined, children);
   }

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -2,10 +2,13 @@ import { TreeDataProvider, TreeItem } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues } from "../context/values";
+import { Logger } from "../logging";
 import { FlinkComputePool } from "../models/flinkComputePool";
 import { FlinkStatement, FlinkStatementTreeItem } from "../models/flinkStatement";
 import { EnvironmentId } from "../models/resource";
 import { BaseViewProvider } from "./base";
+
+const logger = new Logger("viewProviders.flinkStatements");
 
 export class FlinkStatementsViewProvider
   extends BaseViewProvider<FlinkComputePool, FlinkStatement>
@@ -17,6 +20,9 @@ export class FlinkStatementsViewProvider
 
   async getChildren(): Promise<FlinkStatement[]> {
     const children: FlinkStatement[] = [];
+    if (!this.computePool) {
+      return children;
+    }
 
     // TODO: replace this with real data
     const fakeStatement = new FlinkStatement({


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR adds a Flink compute pool quickpick and three new commands:
- `confluent.resources.flink-compute-pool.select`: the primary action on any Flink compute pools displayed in the Resources view. This will focus that pool in both the Flink Statements and Flink Artifacts views.
- `confluent.statements.flink-compute-pool.select`: the nav action at the top of the **Flink Statements view** to focus a compute pool for only that view
- `confluent.artifacts.flink-compute-pool.select`: the nav action at the top of the **Flink Artifacts view** to focus a compute pool for only that view (but follow-on work shouldn't handle any pool-specific filtering, just env+region+provider)

https://github.com/user-attachments/assets/1a771c7a-1aef-4f44-89f5-77adf86cfb06

(Slight adjustments to the fake data being used to indicate which pool is selected, but that will all be removed in https://github.com/confluentinc/vscode/issues/1362 and https://github.com/confluentinc/vscode/issues/1384.)

Closes #1361.

### Associated PRs
- https://github.com/confluentinc/vscode/pull/1399
  - https://github.com/confluentinc/vscode/pull/1400
    - https://github.com/confluentinc/vscode/pull/1405
      - https://github.com/confluentinc/vscode/pull/1406
        - https://github.com/confluentinc/vscode/pull/1408 👈 


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
