### PR TITLE
Add right-click scaffold actions for cluster, topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+- Add new actions in the context (right-click) menu for Clusters & Topics to generate a new project.
+  The project generation form will still be opened, and known form fields will be filled in
+  automatically for the clicked resource.
+
 ## 1.1.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
-- Add new actions in the context (right-click) menu for Clusters & Topics to generate a new project.
-  The project generation form will still be opened, and known form fields will be filled in
+- Add new actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new
+  project. The project generation form will still be opened, and known form fields will be filled in
   automatically for the clicked resource.
 
 ## 1.1.0

--- a/package.json
+++ b/package.json
@@ -1039,7 +1039,7 @@
         },
         {
           "command": "confluent.resources.scaffold",
-          "when": "viewItem =~ /.*-kafka-cluster.*/ || viewItem =~ /.*-topic.*/"
+          "when": "view in confluent.viewsWithResources && (viewItem =~ /.*-kafka-cluster.*/ || viewItem =~ /.*-topic.*/)"
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",

--- a/package.json
+++ b/package.json
@@ -218,6 +218,11 @@
         "category": "Confluent: Resources View"
       },
       {
+        "command": "confluent.resources.scaffold",
+        "title": "Generate Project From Resource",
+        "category": "Confluent: Resource Project"
+      },
+      {
         "command": "confluent.scaffold",
         "title": "Generate New Project",
         "category": "Confluent: Project"
@@ -1031,6 +1036,10 @@
           "command": "confluent.resources.kafka-cluster.copyBootstrapServers",
           "when": "view == confluent-resources && viewItem =~ /.*-kafka-cluster.*/",
           "group": "2_copy@3"
+        },
+        {
+          "command": "confluent.resources.scaffold",
+          "when": "viewItem =~ /.*-kafka-cluster.*/ || viewItem =~ /.*-topic.*/"
         },
         {
           "command": "confluent.schemas.copySchemaRegistryId",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ import { cleanupOldLogFiles, getLogFileStream, Logger, OUTPUT_CHANNEL } from "./
 import { ENABLE_CHAT_PARTICIPANT, ENABLE_FLINK } from "./preferences/constants";
 import { createConfigChangeListener } from "./preferences/listener";
 import { updatePreferences } from "./preferences/updates";
-import { registerProjectGenerationCommand } from "./scaffold";
+import { registerProjectGenerationCommands } from "./scaffold";
 import { JSON_DIAGNOSTIC_COLLECTION } from "./schemas/diagnosticCollection";
 import { getSidecar, getSidecarManager } from "./sidecar";
 import { ConnectionStateWatcher } from "./sidecar/connections/watcher";
@@ -194,6 +194,7 @@ async function _activateExtension(
     ...registerDiffCommands(),
     ...registerExtraCommands(),
     ...registerDockerCommands(),
+    ...registerProjectGenerationCommands(),
   ];
   logger.info("Commands registered");
 
@@ -212,7 +213,6 @@ async function _activateExtension(
 
   // these are also just handling command registration and setting disposables
   activateMessageViewer(context);
-  registerProjectGenerationCommand(context);
 
   // Construct the singletons, let them register their event listeners.
   context.subscriptions.push(...constructResourceLoaderSingletons());

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -87,6 +87,7 @@ export const scaffoldProjectRequest = async (item?: KafkaCluster | KafkaTopic) =
 
   /** Stores a map of options with key: value pairs that is then updated on form input
    * This keeps a sort of "state" so that users don't lose inputs when the form goes in the background
+   * It also initializes the options with either the initial values or known values from the item
    */
   let optionValues: { [key: string]: string | boolean } = {};
   let options = templateSpec.options || {};
@@ -102,11 +103,9 @@ export const scaffoldProjectRequest = async (item?: KafkaCluster | KafkaTopic) =
     }
     return properties.initial_value ?? "";
   }
-
-  Object.entries(options).forEach(async ([option, properties]) => {
+  for (const [option, properties] of Object.entries(options)) {
     optionValues[option] = await getInitialOptionValue(option, properties);
-  });
-
+  }
   function updateOptionValue(key: string, value: string) {
     optionValues[key] = value;
   }

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -12,7 +12,7 @@ import {
 } from "./clients/scaffoldingService";
 import { getSidecar } from "./sidecar";
 
-import { ExtensionContext, ViewColumn } from "vscode";
+import { ViewColumn } from "vscode";
 import { ResponseError } from "./clients/sidecar";
 import { registerCommandWithLogging } from "./commands";
 import { logError } from "./errors";
@@ -22,6 +22,9 @@ import { handleWebviewMessage } from "./webview/comms/comms";
 import { PostResponse, type post } from "./webview/scaffold-form";
 import scaffoldFormTemplate from "./webview/scaffold-form.html";
 import { fileUriExists } from "./utils/file";
+import { KafkaTopic } from "./models/topic";
+import { KafkaCluster } from "./models/kafkaCluster";
+import { getResourceManager } from "./storage/resourceManager";
 type MessageSender = OverloadUnion<typeof post>;
 type MessageResponse<MessageType extends string> = Awaited<
   ReturnType<Extract<MessageSender, (type: MessageType, body: any) => any>>
@@ -29,18 +32,25 @@ type MessageResponse<MessageType extends string> = Awaited<
 
 const scaffoldWebviewCache = new WebviewPanelCache();
 
-export const registerProjectGenerationCommand = (context: ExtensionContext) => {
-  const scaffoldProjectCommand = registerCommandWithLogging("confluent.scaffold", () =>
-    scaffoldProjectRequest(),
-  );
-  context.subscriptions.push(scaffoldProjectCommand);
-};
+export function registerProjectGenerationCommands(): vscode.Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.scaffold", scaffoldProjectRequest),
+    registerCommandWithLogging("confluent.resources.scaffold", scaffoldProjectRequest),
+  ];
+}
 
-export const scaffoldProjectRequest = async () => {
+export const scaffoldProjectRequest = async (item?: KafkaCluster | KafkaTopic) => {
   let pickedTemplate: ScaffoldV1Template | undefined = undefined;
   try {
     const templateListResponse: ScaffoldV1TemplateList = await getTemplatesList();
-    const templateList = Array.from(templateListResponse.data) as ScaffoldV1Template[];
+    let templateList = Array.from(templateListResponse.data) as ScaffoldV1Template[];
+    if (item) {
+      templateList = templateList.filter((template) => {
+        const tags = template.spec?.tags || [];
+        const hasProducerOrConsumer = tags.includes("producer") || tags.includes("consumer");
+        return hasProducerOrConsumer;
+      });
+    }
     const pickedItem = await pickTemplate(templateList);
     pickedTemplate = templateList.find(
       (template) => template.spec!.display_name === pickedItem?.label,
@@ -55,6 +65,7 @@ export const scaffoldProjectRequest = async () => {
     logUsage(UserEvent.ProjectScaffoldingAction, {
       status: "template picked",
       templateName: pickedTemplate.spec!.display_name,
+      itemType: item ? (item instanceof KafkaTopic ? "topic" : "cluster") : undefined,
     });
   } else {
     return;
@@ -79,9 +90,23 @@ export const scaffoldProjectRequest = async () => {
    */
   let optionValues: { [key: string]: string | boolean } = {};
   let options = templateSpec.options || {};
-  Object.entries(options).map(([option, properties]) => {
-    optionValues[option] = properties.initial_value ?? "";
+  async function getInitialOptionValue(option: string, properties: any): Promise<string | boolean> {
+    if ((option === "topic" || option === "cc_topic") && item instanceof KafkaTopic)
+      return item.name;
+    else if (option === "bootstrap_server" || option === "cc_bootstrap_server") {
+      if (item instanceof KafkaCluster) return item.bootstrapServers;
+      else if (item instanceof KafkaTopic) {
+        const cluster = await getResourceManager().getClusterForTopic(item);
+        return cluster?.bootstrapServers ?? "";
+      }
+    }
+    return properties.initial_value ?? "";
+  }
+
+  Object.entries(options).forEach(async ([option, properties]) => {
+    optionValues[option] = await getInitialOptionValue(option, properties);
   });
+
   function updateOptionValue(key: string, value: string) {
     optionValues[key] = value;
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Adds a new command & context menu action to scaffold a new project from a Topic or Cluster in the sidebar, filling in the known bootstrap server address and topic name if we can find it. 
- Closes #1333 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
<img width="541" alt="Screenshot 2025-04-03 at 8 18 11 AM" src="https://github.com/user-attachments/assets/1d9be08d-19e5-4524-9c3e-44f3115ec100" />

- This depends on project template options being named with specific strings: `topic` or `cc_topic` for example. To make this the most useful, we will need to decide how to encourage or reinforce that pattern for template authors. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
