### PR TITLE
stop sending common `network error` events to sentry

### DIFF
--- a/src/featureFlags/handlers.ts
+++ b/src/featureFlags/handlers.ts
@@ -45,8 +45,11 @@ export async function handleFlagChanges(changes: LDFlagChangeset) {
 /** Callback function for handling "error" events from the LD stream. */
 export function handleErrorEvent(error: unknown) {
   if (error instanceof Error) {
-    // send any error events to Sentry (if online) so we can troubleshoot
-    logError(error, "LD error event", {}, true);
+    if (!error.message.includes("network error")) {
+      // send any non-'network error' events to Sentry (if online) so we can troubleshoot
+      // https://support.launchdarkly.com/hc/en-us/articles/12998125691419-Error-LaunchDarklyFlagFetchError-network-error
+      logError(error, "LD error event", {}, true);
+    }
   } else {
     logger.error("LD error event:", error);
   }


### PR DESCRIPTION
https://support.launchdarkly.com/hc/en-us/articles/12998125691419-Error-LaunchDarklyFlagFetchError-network-error
> It is relatively common to see general network errors logged. Our SDKs are designed to be resilient and maintain a network connection to LaunchDarkly. If the SDK ever loses connectivity, it will continue to attempt to reconnect until it can. Until then, the SDK will evaluate flags using the most recently cached values.

Closes #1404.