### PR TITLE
direct connections form: validate auth types

### DIFF
--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -121,12 +121,9 @@
               data-value="this.kafkaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <option value="None" selected>None</option>
-              <option value="Basic">Username & Password (SASL/PLAIN)</option>
-              <option value="API">API Credentials (SASL/PLAIN)</option>
-              <option value="SCRAM">SASL/SCRAM</option>
-              <option value="OAuth">SASL/OAUTHBEARER</option>
-              <option value="Kerberos">Kerberos (SASL/GSSAPI)</option>
+              <template data-for="auth of this.getValidAuthTypes()">
+                <option data-attr-value="this.auth().value" data-text="this.auth().label"></option>
+              </template>
             </select>
           </div>
           <div class="content-wrapper">

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -209,13 +209,15 @@
               id="schema_registry.auth_type"
               name="schema_registry.auth_type"
               data-on-input="this.updateValue(event)"
-              data-value="this.schemaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <option value="None" selected>None</option>
-              <option value="Basic">Username & Password</option>
-              <option value="API">API Credentials</option>
-              <option value="OAuth">OAuth</option>
+              <template data-for="auth of this.getValidAuthTypes()">
+                <option
+                  data-attr-value="this.auth().value"
+                  data-text="this.auth().label"
+                  data-attr-selected="this.auth().value === this.schemaAuthType()"
+                ></option>
+              </template>
             </select>
           </div>
           <div class="content-wrapper">

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -118,11 +118,14 @@
               id="kafka_cluster.auth_type"
               name="kafka_cluster.auth_type"
               data-on-input="this.updateValue(event)"
-              data-value="this.kafkaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
               <template data-for="auth of this.getValidAuthTypes()">
-                <option data-attr-value="this.auth().value" data-text="this.auth().label"></option>
+                <option
+                  data-attr-value="this.auth().value"
+                  data-text="this.auth().label"
+                  data-attr-selected="this.auth().value === this.kafkaAuthType()"
+                ></option>
               </template>
             </select>
           </div>

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -120,7 +120,7 @@
               data-on-input="this.updateValue(event)"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <template data-for="auth of this.getValidAuthTypes()">
+              <template data-for="auth of this.getValidKafkaAuthTypes()">
                 <option
                   data-attr-value="this.auth().value"
                   data-text="this.auth().label"
@@ -209,15 +209,13 @@
               id="schema_registry.auth_type"
               name="schema_registry.auth_type"
               data-on-input="this.updateValue(event)"
+              data-value="this.schemaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <template data-for="auth of this.getValidAuthTypes()">
-                <option
-                  data-attr-value="this.auth().value"
-                  data-text="this.auth().label"
-                  data-attr-selected="this.auth().value === this.schemaAuthType()"
-                ></option>
-              </template>
+              <option value="None" selected>None</option>
+              <option value="Basic">Username & Password</option>
+              <option value="API">API Credentials</option>
+              <option value="OAuth">OAuth</option>
             </select>
           </div>
           <div class="content-wrapper">

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -92,8 +92,6 @@ test("renders form html correctly", async ({ page }) => {
 
   const authKafka = page.locator("select[name='kafka_cluster.auth_type']");
   await expect(authKafka).toBeVisible();
-  // Don't check for options count - these are populated dynamically by JavaScript
-  // which isn't executed in this static HTML test
 
   const schemaUrlInput = page.locator("input[name='schema_registry.uri']");
   await expect(schemaUrlInput).toBeVisible();
@@ -105,8 +103,6 @@ test("renders form html correctly", async ({ page }) => {
 
   const authSchema = page.locator("select[name='schema_registry.auth_type']");
   await expect(authSchema).not.toBe(null);
-  const authSchemaOptions = await authSchema.locator("option").all();
-  await expect(authSchemaOptions.length).toBe(4); // None, Basic, API, OAuth
 });
 test("renders form with existing connection spec values (for edit/import)", async ({
   execute,

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -103,6 +103,8 @@ test("renders form html correctly", async ({ page }) => {
 
   const authSchema = page.locator("select[name='schema_registry.auth_type']");
   await expect(authSchema).not.toBe(null);
+  const authSchemaOptions = await authSchema.locator("option").all();
+  await expect(authSchemaOptions.length).toBe(4); // None, Basic, API, OAuth
 });
 test("renders form with existing connection spec values (for edit/import)", async ({
   execute,

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -12,9 +12,9 @@ import {
   ConnectionSpec,
   ConnectionType,
   HashAlgorithm,
+  KerberosCredentials,
   OAuthCredentials,
   ScramCredentials,
-  KerberosCredentials,
 } from "../clients/sidecar";
 
 const template = readFileSync(new URL("direct-connect-form.html", import.meta.url), "utf8");
@@ -91,9 +91,9 @@ test("renders form html correctly", async ({ page }) => {
   await expect(sslCheckbox).toBeVisible();
 
   const authKafka = page.locator("select[name='kafka_cluster.auth_type']");
-  await expect(authKafka).not.toBe(null);
-  const authKafkaOptions = await authKafka.locator("option").all();
-  await expect(authKafkaOptions.length).toBe(6);
+  await expect(authKafka).toBeVisible();
+  // Don't check for options count - these are populated dynamically by JavaScript
+  // which isn't executed in this static HTML test
 
   const schemaUrlInput = page.locator("input[name='schema_registry.uri']");
   await expect(schemaUrlInput).toBeVisible();

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -199,8 +199,6 @@ class DirectConnectFormViewModel extends ViewModel {
         if (input.value === "Confluent Cloud") {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
-          this.kafkaAuthType("API");
-          // this.schemaAuthType("API");
         }
         if (input.value === "WarpStream") {
           this.kafkaAuthType("Basic");

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -200,10 +200,6 @@ class DirectConnectFormViewModel extends ViewModel {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
         }
-        if (input.value === "WarpStream") {
-          this.kafkaAuthType("Basic");
-          // this.schemaAuthType("Basic");
-        }
         break;
       case "kafka_cluster.auth_type":
         this.kafkaAuthType(input.value as SupportedAuthTypes);

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -19,7 +19,14 @@ addEventListener("DOMContentLoaded", () => {
   applyBindings(ui, os, vm);
   vm.setupEnterKeyHandler();
 });
-
+const allAuthOptions: Array<{ label: string; value: SupportedAuthTypes }> = [
+  { label: "None", value: "None" },
+  { label: "Username & Password (SASL/PLAIN)", value: "Basic" },
+  { label: "API Credentials (SASL/PLAIN)", value: "API" },
+  { label: "SASL/SCRAM", value: "SCRAM" },
+  { label: "SASL/OAUTHBEARER", value: "OAuth" },
+  { label: "Kerberos (SASL/GSSAPI)", value: "Kerberos" },
+];
 class DirectConnectFormViewModel extends ViewModel {
   /** Load connection spec if it exists (for Edit) */
   spec = this.resolve(async () => {
@@ -106,6 +113,19 @@ class DirectConnectFormViewModel extends ViewModel {
   schemaSslConfig = this.derive(() => {
     return this.spec()?.schema_registry?.ssl || {};
   });
+
+  /** Get valid auth types based on form connection type */
+  getValidAuthTypes = this.derive(() => {
+    switch (this.platformType()) {
+      case "Confluent Cloud":
+        return allAuthOptions.filter((auth) => ["API", "SCRAM", "OAuth"].includes(auth.value));
+      case "WarpStream":
+        return allAuthOptions.filter((auth) => ["Basic", "SCRAM"].includes(auth.value));
+      default:
+        return allAuthOptions;
+    }
+  });
+
   /** Form State */
   message = this.signal("");
   success = this.signal(false);
@@ -179,6 +199,12 @@ class DirectConnectFormViewModel extends ViewModel {
         if (input.value === "Confluent Cloud") {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
+          this.kafkaAuthType("API");
+          // this.schemaAuthType("API");
+        }
+        if (input.value === "WarpStream") {
+          this.kafkaAuthType("Basic");
+          // this.schemaAuthType("Basic");
         }
         break;
       case "kafka_cluster.auth_type":

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -115,7 +115,7 @@ class DirectConnectFormViewModel extends ViewModel {
   });
 
   /** Get valid auth types based on form connection type */
-  getValidAuthTypes = this.derive(() => {
+  getValidKafkaAuthTypes = this.derive(() => {
     switch (this.platformType()) {
       case "Confluent Cloud":
         return allAuthOptions.filter((auth) => ["API", "SCRAM", "OAuth"].includes(auth.value));


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Update to use dynamic `options` for Kafka cluster auth type so that we can control which are available based on platform type selected. (note: schema registry already has limited auth options, those are staying the same)
- Add logic to check which auth types are valid for a given platform (CCloud, Warpstream have limitations) and only allow those options for the user. 

## Any additional details or context that should be provided?

| If CCloud, limited auth types | If WarpStream, limited auth types |
| -- | -- |
| <img width="288" height="335" alt="Screenshot 2025-07-22 at 8 23 23 AM" src="https://github.com/user-attachments/assets/66ecf166-f837-4f8c-8a44-4ab8ee9ca599" /> | <img width="329" height="304" alt="Screenshot 2025-07-22 at 8 23 07 AM" src="https://github.com/user-attachments/assets/4e431f47-ec8e-47af-82fd-67936a4bdbc1" /> |

- This is the first part of https://github.com/confluentinc/vscode/issues/1255. To keep it easier to click test, similar work for WarpStream SCRAM will be in separate PR

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
