### PR TITLE
Send more info to Sentry if cannot stat the sidecar executable.

### DIFF
--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -355,7 +355,15 @@ export class SidecarManager {
           try {
             fs.accessSync(executablePath);
           } catch (e) {
-            logger.error(`${logPrefix}: component ${executablePath} does not exist`, e);
+            logError(
+              e,
+              `Sidecar executable "${executablePath}" does not exist`,
+              {
+                originalExecutablePath: sidecarExecutablePath,
+                currentSidecarVersion,
+              },
+              true,
+            );
             reject(new NoSidecarExecutableError(`Component ${executablePath} does not exist`));
           }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Provide more detailed information to Sentry if a sidecar executable isn't stat-able, most interestingly the underlying exception raised by `fs.stat`.
- We received a sentry event over the `reject(new NoSidecarExecutableError(`Component ${executablePath} does not exist`))` line, but more information is needed.
- That said, it feels like a one-off error, perhaps the user actually deleted their sidecar executable.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Related to #1379, gathers more information if it happens again, but doesn't c l o s e anything.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
