### PR TITLE
When deleting a subject with a single schema, use the simpler single-schema-version deletion confirmation prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
-- Add new actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new
-  project. The project generation form will still be opened, and known form fields will be filled in
-  automatically for the clicked resource.
+### Added
 
+- New actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new project. The project generation form will still be opened, and known form fields will be filled in automatically for the clicked resource.
+
+### Changed
+
+- When deleting a subject containing a single schema, use the simpler
+  confirmation flow for deleting a single schema.
+  
 ## 1.1.0
 
 ### Added

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -415,8 +415,16 @@ async function deleteSchemaSubjectCommand(subject: Subject) {
     return;
   }
 
-  // Ask if they are sure they want to delete the schema subject.
-  const confirmation = await confirmSchemaSubjectDeletion(hardDelete, subject, schemaGroup);
+  let confirmation: boolean | undefined;
+
+  if (schemaGroup.length > 1) {
+    // Wordier confirmation message for deleting multiple schema versions.
+    confirmation = await confirmSchemaSubjectDeletion(hardDelete, subject, schemaGroup);
+  } else {
+    // If just one schema version, then defer to confirmSchemaVersionDeletion for simpler
+    // confirmation experience deleting the single version in the subject.
+    confirmation = await confirmSchemaVersionDeletion(hardDelete, schemaGroup[0], schemaGroup);
+  }
 
   if (!confirmation) {
     logger.debug("User canceled schema subject deletion.");

--- a/src/commands/utils/schemas.ts
+++ b/src/commands/utils/schemas.ts
@@ -166,6 +166,7 @@ export async function hardDeletionQuickPick(noun: string): Promise<boolean | und
 
   return strengthStr.label.startsWith("Hard");
 }
+
 /**
  * Ask the user if they're really sure they want to hard/soft delete this entire subject group?
  *


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Notice that when deleting a subject would be only deleting a single schema and is equivalent to deleting a single subject within, to then use the simpler prompt requiring the user to type fewer things (just the version number).
- Trying to make simpler things simpler. Unlike the sentence above.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
![different-prompts](https://github.com/user-attachments/assets/754a7283-0009-4032-9320-931faf298a59)



- Closes #1420


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
