### PR TITLE
"View in Confluent Cloud" item added to ccloud-based subjects 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this extension will be documented in this file.
 ### Added
 
 - New actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new project. The project generation form will still be opened, and known form fields will be filled in automatically for the clicked resource.
-- "View in Confluent Cloud" item added to ccloud-based subjects (previously only available on indivdual schemas).
+- "View in Confluent Cloud" item added to ccloud-based subjects (previously only available on individual schemas).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this extension will be documented in this file.
 ### Added
 
 - New actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new project. The project generation form will still be opened, and known form fields will be filled in automatically for the clicked resource.
+- "View in Confluent Cloud" item added to ccloud-based subjects (previously only available on indivdual schemas).
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1171,7 +1171,7 @@
         },
         {
           "command": "confluent.openCCloudLink",
-          "when": "view in confluent.viewsWithResources && (viewItem in confluent.ccloudResources || viewItem =~ /ccloud-kafka-topic.*/ || viewItem =~ /.*ccloud.*schema$/)",
+          "when": "view in confluent.viewsWithResources && (viewItem in confluent.ccloudResources || viewItem =~ /ccloud-kafka-topic.*/ || viewItem =~ /.*ccloud.*subject$/ || viewItem =~ /.*ccloud.*schema$/)",
           "group": "z_openInCloud"
         },
         {

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -7,6 +7,7 @@ import {
   TEST_CCLOUD_SUBJECT_WITH_SCHEMA,
   TEST_CCLOUD_SUBJECT_WITH_SCHEMAS,
   TEST_LOCAL_SCHEMA,
+  TEST_LOCAL_SUBJECT,
 } from "../../tests/unit/testResources";
 import { CCLOUD_CONNECTION_ID, IconNames, UTM_SOURCE_VSCODE } from "../constants";
 import { EnvironmentId } from "./resource";
@@ -357,7 +358,7 @@ describe("SchemaTreeItem", () => {
 describe("SubjectTreeItem", () => {
   it("constructor should do the right things when no schemas present", () => {
     const subjectTreeItem = new SubjectTreeItem(TEST_CCLOUD_SUBJECT);
-    assert.equal(subjectTreeItem.contextValue, "schema-subject");
+    assert.equal(subjectTreeItem.contextValue, "ccloud-schema-subject");
 
     assert.equal(subjectTreeItem.label, TEST_CCLOUD_SUBJECT.name);
     assert.equal(subjectTreeItem.id, TEST_CCLOUD_SUBJECT.name);
@@ -367,7 +368,7 @@ describe("SubjectTreeItem", () => {
 
   it("constructor should do the right things when single schema version present", () => {
     const subjectTreeItem = new SubjectTreeItem(TEST_CCLOUD_SUBJECT_WITH_SCHEMA);
-    assert.equal(subjectTreeItem.contextValue, "schema-subject");
+    assert.equal(subjectTreeItem.contextValue, "ccloud-schema-subject");
 
     assert.equal(subjectTreeItem.label, TEST_CCLOUD_SUBJECT.name);
     assert.equal(subjectTreeItem.id, TEST_CCLOUD_SUBJECT.name);
@@ -377,7 +378,10 @@ describe("SubjectTreeItem", () => {
 
   it("constructor should do the right things when multiple schema versions present", () => {
     const subjectWithSchemasTreeItem = new SubjectTreeItem(TEST_CCLOUD_SUBJECT_WITH_SCHEMAS);
-    assert.equal(subjectWithSchemasTreeItem.contextValue, "multiple-versions-schema-subject");
+    assert.equal(
+      subjectWithSchemasTreeItem.contextValue,
+      "ccloud-multiple-versions-schema-subject",
+    );
 
     assert.equal(subjectWithSchemasTreeItem.label, TEST_CCLOUD_SUBJECT_WITH_SCHEMAS.name);
     assert.equal(subjectWithSchemasTreeItem.id, TEST_CCLOUD_SUBJECT_WITH_SCHEMAS.name);
@@ -386,5 +390,11 @@ describe("SubjectTreeItem", () => {
       vscode.TreeItemCollapsibleState.Collapsed,
     );
     assert.equal(subjectWithSchemasTreeItem.description, "AVRO (2)");
+  });
+
+  it("non-ccloud subject should have the right context value", () => {
+    const subjectTreeItem = new SubjectTreeItem(TEST_LOCAL_SUBJECT);
+
+    assert.equal(subjectTreeItem.contextValue, "local-schema-subject");
   });
 });

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -91,6 +91,13 @@ export class Subject implements IResourceBase, ISearchable, ISchemaRegistryResou
     return connectionIdToType(this.connectionId);
   }
 
+  get ccloudUrl(): string {
+    if (isCCloud(this)) {
+      return `https://confluent.cloud/environments/${this.environmentId}/stream-governance/schema-registry/data-contracts/${this.name}?utm_source=${UTM_SOURCE_VSCODE}`;
+    }
+    return "";
+  }
+
   searchableText(): string {
     return this.name;
   }
@@ -266,6 +273,9 @@ export class SubjectTreeItem extends vscode.TreeItem {
     this.iconPath = getSubjectIcon(subject.name);
 
     const propertyParts: string[] = new Array<string>();
+
+    propertyParts.push(subject.connectionType.toLowerCase());
+
     if (subject.schemas) {
       this.description = `${subject.schemas[0].type} (${subject.schemas.length})`;
       if (subject.schemas.length > 1) {


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- "View in Confluent Cloud" item added to ccloud-based subjects (previously only available on individual schemas).

## Any additional details or context that should be provided?

<img width="510" alt="image" src="https://github.com/user-attachments/assets/26a6bc84-cb6a-4f1d-94f7-70d138362806" />

- Closes #1424 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
