### PR TITLE
Enable "Copy Name" for flink statements and artifacts; enable "Copy ID" for just Flink artifacts.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -290,20 +290,28 @@ async function setupContextValues() {
     "confluent-resources",
     "confluent-topics",
     "confluent-schemas",
+    "confluent-flink-statements",
+    "confluent-flink-artifacts",
   ]);
+
   // enables the "Copy ID" command; these resources must have the "id" property
   const resourcesWithIds = setContextValue(ContextValues.RESOURCES_WITH_ID, [
     "ccloud-environment", // direct/local environments only have internal IDs
     "ccloud-kafka-cluster",
     "ccloud-schema-registry", // only ID, no name
+    "ccloud-flink-artifact",
     "local-kafka-cluster",
     "local-schema-registry",
     "direct-kafka-cluster",
     "direct-schema-registry",
   ]);
+
+  // enables the "Copy Name" command; these resources must have the "name" property
   const resourcesWithNames = setContextValue(ContextValues.RESOURCES_WITH_NAMES, [
     "ccloud-environment",
     "ccloud-kafka-cluster",
+    "ccloud-flink-statement",
+    "ccloud-flink-artifact",
     "local-kafka-cluster",
     "direct-kafka-cluster",
     // topics also have names, but their context values vary wildly and must be regex-matched

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -21,7 +21,7 @@ describe("FlinkStatement", () => {
   });
 });
 
-describe("FlinkStatementTreeItme", () => {
+describe("FlinkStatementTreeItem", () => {
   // Prove context value is "ccloud-flink-statement"
   it("has the correct context value", () => {
     const statement = TEST_CCLOUD_FLINK_STATEMENT;

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -1,0 +1,32 @@
+import * as assert from "assert";
+
+import { TEST_CCLOUD_ENVIRONMENT_ID } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_FLINK_STATEMENT } from "../../tests/unit/testResources/flinkStatement";
+import { ConnectionType } from "../clients/sidecar";
+import { CCLOUD_CONNECTION_ID } from "../constants";
+import { FlinkStatement, FlinkStatementTreeItem } from "./flinkStatement";
+
+describe("FlinkStatement", () => {
+  it("uses name as id", () => {
+    const statement = new FlinkStatement({
+      connectionId: CCLOUD_CONNECTION_ID,
+      connectionType: ConnectionType.Ccloud,
+      environmentId: TEST_CCLOUD_ENVIRONMENT_ID,
+      computePoolId: "ckp-456",
+      name: "my-statement",
+      status: "RUNNING",
+    });
+
+    assert.strictEqual(statement.id, statement.name, "Expect name and id to be the same");
+  });
+});
+
+describe("FlinkStatementTreeItme", () => {
+  // Prove context value is "ccloud-flink-statement"
+  it("has the correct context value", () => {
+    const statement = TEST_CCLOUD_FLINK_STATEMENT;
+
+    const treeItem = new FlinkStatementTreeItem(statement);
+    assert.strictEqual(treeItem.contextValue, "ccloud-flink-statement");
+  });
+});

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -12,7 +12,7 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   environmentId!: EnvironmentId;
   computePoolId!: string;
 
-  id!: string;
+  name!: string;
   status!: string;
 
   // TODO: add more properties as needed
@@ -20,19 +20,27 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   constructor(
     props: Pick<
       FlinkStatement,
-      "connectionId" | "connectionType" | "environmentId" | "computePoolId" | "id" | "status"
+      "connectionId" | "connectionType" | "environmentId" | "computePoolId" | "name" | "status"
     >,
   ) {
     this.connectionId = props.connectionId;
     this.connectionType = props.connectionType;
     this.environmentId = props.environmentId;
     this.computePoolId = props.computePoolId;
-    this.id = props.id;
+    this.name = props.name;
     this.status = props.status;
   }
 
   searchableText(): string {
-    return `${this.id} ${this.status}`;
+    return `${this.name} ${this.status}`;
+  }
+
+  /**
+   * Return the name of the statement as its id.
+   * This is guaranteed to be unique within the environment, per API docs.
+   */
+  get id(): string {
+    return this.name;
   }
 }
 

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -24,12 +24,12 @@ class TestViewProvider extends BaseViewProvider<FlinkComputePool, FlinkStatement
       TEST_CCLOUD_FLINK_STATEMENT,
       new FlinkStatement({
         ...TEST_CCLOUD_FLINK_STATEMENT,
-        id: "statement1",
+        name: "statement1",
         status: "PENDING",
       }),
       new FlinkStatement({
         ...TEST_CCLOUD_FLINK_STATEMENT,
-        id: "statement2",
+        name: "statement2",
         status: "STOPPED",
       }),
     ];
@@ -340,14 +340,14 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
 
     const matchingStatement = new FlinkStatement({
       ...TEST_CCLOUD_FLINK_STATEMENT,
-      id: "first-statement",
+      name: "first-statement",
       status: "STOPPED",
     });
     const items = [
       matchingStatement,
       new FlinkStatement({
         ...TEST_CCLOUD_FLINK_STATEMENT,
-        id: "second-statement",
+        name: "second-statement",
         status: "PENDING",
       }),
     ];
@@ -367,12 +367,12 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     const items = [
       new FlinkStatement({
         ...TEST_CCLOUD_FLINK_STATEMENT,
-        id: "first-statement",
+        name: "first-statement",
         status: "RUNNING",
       }),
       new FlinkStatement({
         ...TEST_CCLOUD_FLINK_STATEMENT,
-        id: "second-statement",
+        name: "second-statement",
         status: "PENDING",
       }),
     ];

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -43,7 +43,7 @@ export class FlinkStatementsViewProvider
         connectionType: pool.connectionType,
         environmentId: pool.environmentId,
         computePoolId: pool.id,
-        id: `statement${i + 1}-${pool.name}`,
+        name: `statement${i + 1}-${pool.name}`,
         status: possibleStatuses[Math.floor(Math.random() * possibleStatuses.length)].toLowerCase(),
       });
       children.push(fakeArtifact);


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Enable "Copy Name" for flink statements and artifacts; enable "Copy ID" for just Flink artifacts.
- Revise Flink statements model to take in `name` at constructor time, since that's what will be coming from  [real API responses](https://docs.confluent.io/cloud/current/api.html#tag/Statements-(sqlv1)/The-Statements-Model). Have its `id` be a gettable property for our codebase-internal needs (namely for `FlinkStatementTreeItem` readability, and probable upcoming `BaseViewController` changes.

## Any additional details or context that should be provided?

![flink-resource-copy-name-id](https://github.com/user-attachments/assets/d082ff6a-6ba0-4937-b84e-423915d10166)

- Closes #1419

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
