### PR TITLE
Fix #1429 in v.1.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Consult the list of *workspace* open files when submitting schema documents, not the list of
+  *window* open editors, #1429. The user may have chosen an untitled document from a window distinct
+  from the one they have the extension open in.
+
 ## 1.1.0
 
 ### Added

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -53,24 +53,23 @@ describe("getEditorOrFileContents", () => {
 
   it("should prefer editor contents if editor is open over what is on disk", async () => {
     const uri = vscode.Uri.file("file:///file.ts");
-    const fakeEditorContents = "Fake editor contents";
-    const fakeEditor = {
-      document: {
-        uri,
-        getText: () => fakeEditorContents,
-      },
+    const fakeDocumentContents = "Fake editor contents";
+    const fakeDocument = {
+      uri,
+      getText: () => fakeDocumentContents,
     };
-    sandbox.stub(vscode.window, "visibleTextEditors").get(() => [fakeEditor as any]);
+    sandbox.stub(vscode.workspace, "textDocuments").get(() => [fakeDocument as any]);
 
     // Also stub out differing file contents on disk. getEditorOrFileContents() should
     // prefer the editor contents over this.
     const fakeFileContents = "Bad on-disk contents";
-    sandbox.stub(fsWrappers, "readFile").resolves(fakeFileContents);
+    const readFileStub = sandbox.stub(fsWrappers, "readFile").resolves(fakeFileContents);
 
     const result: LoadedDocumentContent = await getEditorOrFileContents(uri);
 
-    assert.strictEqual(result.content, fakeEditorContents);
-    assert.strictEqual(result.openDocument, fakeEditor.document);
+    assert.strictEqual(result.content, fakeDocumentContents);
+    assert.strictEqual(result.openDocument, fakeDocument);
+    assert.ok(readFileStub.notCalled, "readFile should not be called if editor is open");
   });
 
   it("should return file contents if editor is not open", async () => {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -34,13 +34,11 @@ export interface LoadedDocumentContent {
  * @throws An error if the file cannot be read (and is not open in an editor).
  */
 export async function getEditorOrFileContents(uri: vscode.Uri): Promise<LoadedDocumentContent> {
-  const editor = vscode.window.visibleTextEditors.find(
-    (e) => e.document.uri.toString() === uri.toString(),
-  );
-  if (editor) {
+  const document = vscode.workspace.textDocuments.find((e) => e.uri.toString() === uri.toString());
+  if (document) {
     return {
-      content: editor.document.getText(),
-      openDocument: editor.document,
+      content: document.getText(),
+      openDocument: document,
     };
   }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Consult the list of *workspace* open files when submitting schema documents, not the list of
  *window* open editors, #1429. The user may have chosen an untitled document from a window distinct
  from the one they have the extension open in.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1429.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
