### PR TITLE
chore: Require Ubuntu 22.04 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
   windows/workspaces of the same IDE type.
 - The extension has minimum operating system requirements based on the sidecar executable builds:
   - Windows: Windows 10 and above (built on Windows Server 2019)
-  - Ubuntu: Ubuntu 20 and above
+  - Ubuntu: Ubuntu 22.04 and above
   - macOS: macOS 13 and above (built on macOS 13.5)
   - Running the extension on older operating systems may result in the sidecar process failing to
     start, which prevents the extension from establishing a successful handshake.


### PR DESCRIPTION
## Summary of Changes

We'll have to [update the Semaphore agent used for building the ide-sidecar's native executable to a newer Ubuntu version](https://github.com/confluentinc/ide-sidecar/pull/396). As a consequence, the native executables can't be executed on Ubuntu versions older than 22.04.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
