### PR TITLE
Test possible temp file directories (for sidecar logfile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this extension will be documented in this file.
 - Consult the list of *workspace* open files when submitting schema documents, not the list of
   *window* open editors, #1429. The user may have chosen an untitled document from a window distinct
   from the one they have the extension open in.
-
+- Work around if `os.tmpdir()` ends up not being writeable by trying other probable locations. A writeable temp directory is needed for the sidecar logs.
 ## 1.1.0
 
 ### Added

--- a/src/commands/support.test.ts
+++ b/src/commands/support.test.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { Uri } from "vscode";
 import * as logging from "../logging";
-import { SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
+import { getSidecarLogfilePath } from "../sidecar/sidecarManager";
 import { extensionLogFileUris, sidecarLogFileUri } from "./support";
 
 describe("commands/support.ts", function () {
@@ -47,7 +47,8 @@ describe("commands/support.ts", function () {
 
   it("sidecarLogFileUri() should return the correct URI for the sidecar log file", function () {
     const logFileUri: Uri = sidecarLogFileUri();
+    const logfilePath = getSidecarLogfilePath();
 
-    assert.strictEqual(logFileUri.path, SIDECAR_LOGFILE_PATH);
+    assert.strictEqual(logFileUri.path, logfilePath);
   });
 });

--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -6,7 +6,8 @@ import { registerCommandWithLogging } from ".";
 import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
 import { CURRENT_LOGFILE_NAME, LOGFILE_DIR, Logger, ROTATED_LOGFILE_NAMES } from "../logging";
-import { SIDECAR_LOGFILE_NAME, SIDECAR_LOGFILE_PATH } from "../sidecar/constants";
+import { SIDECAR_LOGFILE_NAME } from "../sidecar/constants";
+import { getSidecarLogfilePath } from "../sidecar/sidecarManager";
 import { createZipFile, ZipContentEntry, ZipFileEntry } from "./utils/zipFiles";
 
 const logger = new Logger("commands.support");
@@ -72,7 +73,7 @@ export function extensionLogFileUris(): Uri[] {
 
 /** Return the file URI for the sidecar's log file, normalized for the user's OS. */
 export function sidecarLogFileUri(): Uri {
-  return Uri.file(normalize(SIDECAR_LOGFILE_PATH));
+  return Uri.file(normalize(getSidecarLogfilePath()));
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ import { sentryCaptureException } from "./telemetry/sentryClient";
 import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { getUriHandler } from "./uriHandler";
+import { WriteableTmpDir } from "./utils/file";
 import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { SEARCH_DECORATION_PROVIDER } from "./viewProviders/search";
@@ -139,6 +140,10 @@ async function _activateExtension(
   // set the initial context values for the VS Code UI to inform the `when` clauses in package.json
   await Promise.all([setupStorage(), setupContextValues()]);
   logger.info("Storage and context values initialized");
+
+  // determine the writeable tmpdir for the extension to use. Must be done prior
+  // to starting the sidecar, as it will use this tmpdir for sidecar logfile.
+  await WriteableTmpDir.getInstance().determine();
 
   // verify we can connect to the correct version of the sidecar, which may require automatically
   // killing any (old) sidecar process and starting a new one, going through the handshake, etc.

--- a/src/sidecar/constants.ts
+++ b/src/sidecar/constants.ts
@@ -1,6 +1,4 @@
 /** Constants needed in multiple modules for use within sidecar comms / management */
-import { tmpdir } from "os";
-import { join } from "path";
 
 export const SIDECAR_PORT: number = 26636;
 
@@ -20,6 +18,3 @@ export const ENABLE_REQUEST_RESPONSE_LOGGING: boolean =
 export const SIDECAR_PROCESS_ID_HEADER = "x-sidecar-pid";
 
 export const SIDECAR_LOGFILE_NAME = "vscode-confluent-sidecar.log";
-
-/** OS-independent path to the log file for the sidecar process. */
-export const SIDECAR_LOGFILE_PATH = join(tmpdir(), SIDECAR_LOGFILE_NAME);

--- a/src/sidecar/sidecarManager.test.ts
+++ b/src/sidecar/sidecarManager.test.ts
@@ -1,12 +1,15 @@
 import * as assert from "assert";
 import "mocha";
+import { join } from "path";
 import * as sinon from "sinon";
 import { SIDECAR_OUTPUT_CHANNEL } from "../constants";
 import { OUTPUT_CHANNEL } from "../logging";
-import { SIDECAR_LOGFILE_PATH } from "./constants";
+import { WriteableTmpDir } from "../utils/file";
+import { SIDECAR_LOGFILE_NAME } from "./constants";
 import {
   appendSidecarLogToOutputChannel,
   constructSidecarEnv,
+  getSidecarLogfilePath,
   killSidecar,
   wasConnRefused,
 } from "./sidecarManager";
@@ -42,6 +45,11 @@ describe("Test wasConnRefused", () => {
 });
 
 describe("constructSidecarEnv tests", () => {
+  before(async () => {
+    // Ensure the tmpdir is established
+    await WriteableTmpDir.getInstance().determine();
+  });
+
   it("Will set QUARKUS_HTTP_HOST if env indicates WSL", () => {
     const env = { WSL_DISTRO_NAME: "Ubuntu" };
     const result = constructSidecarEnv(env);
@@ -59,7 +67,7 @@ describe("constructSidecarEnv tests", () => {
     const result = constructSidecarEnv(env);
     assert.strictEqual(result.QUARKUS_LOG_FILE_ENABLE, "true");
     assert.strictEqual(result.QUARKUS_LOG_FILE_ROTATION_ROTATE_ON_BOOT, "false");
-    assert.strictEqual(result.QUARKUS_LOG_FILE_PATH, SIDECAR_LOGFILE_PATH);
+    assert.strictEqual(result.QUARKUS_LOG_FILE_PATH, getSidecarLogfilePath());
   });
 
   it("Other preset env vars are set as expected", () => {
@@ -246,5 +254,35 @@ describe("appendSidecarLogToOutputChannel() tests", () => {
     appendSidecarLogToOutputChannel(logLineWithMdc);
 
     sinon.assert.calledWith(infoStub, "[test] test message", mdc);
+  });
+});
+
+describe("getSidecarLogfilePath() tests", () => {
+  let sandbox: sinon.SinonSandbox;
+  let writeableTmpDirMock: sinon.SinonMock;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    writeableTmpDirMock = sandbox.mock(WriteableTmpDir.getInstance());
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Returns the expected path when getWriteableTmpDir() succeeds", () => {
+    writeableTmpDirMock.expects("get").returns("/tmp");
+    const expectedPath = join("/tmp", SIDECAR_LOGFILE_NAME);
+    const actualPath = getSidecarLogfilePath();
+    assert.strictEqual(actualPath, expectedPath);
+  });
+
+  it("When getWriteableTmpDir() fails, getSidecarLogfilePath() should throw an error", () => {
+    writeableTmpDirMock
+      .expects("get")
+      .throws(new Error("get() called before determine() was awaited."));
+    assert.throws(() => {
+      getSidecarLogfilePath();
+    }, /get\(\) called before determine\(\) was awaited./);
   });
 });

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -1,7 +1,12 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import * as vscode from "vscode";
-import { fileUriExists, getEditorOrFileContents, LoadedDocumentContent } from "./file";
+import {
+  fileUriExists,
+  getEditorOrFileContents,
+  LoadedDocumentContent,
+  WriteableTmpDir,
+} from "./file";
 import * as fsWrappers from "./fsWrappers";
 
 describe("fileUriExists", () => {
@@ -97,5 +102,62 @@ describe("getEditorOrFileContents", () => {
     assert.rejects(async () => {
       await getEditorOrFileContents(uri);
     });
+  });
+});
+
+describe("WriteableTmpDir", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  let tmpdirStub: sinon.SinonStub;
+  let writeFileStub: sinon.SinonStub;
+  let deleteFileStub: sinon.SinonStub;
+  let instance: WriteableTmpDir;
+  let originalInstance: WriteableTmpDir | undefined;
+  let originalEnvTMPDIR: string | undefined;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    tmpdirStub = sandbox.stub(fsWrappers, "tmpdir");
+    writeFileStub = sandbox.stub(fsWrappers, "writeFile");
+    deleteFileStub = sandbox.stub(fsWrappers, "deleteFile");
+
+    originalInstance = WriteableTmpDir["instance"];
+    originalEnvTMPDIR = process.env["TMPDIR"];
+    instance = WriteableTmpDir.getInstance();
+    // Set instance to initial state.
+    instance["_tmpdir"] = undefined;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    process.env["TMPDIR"] = originalEnvTMPDIR;
+    WriteableTmpDir["instance"] = originalInstance;
+  });
+
+  it("determine() should prefer tmpdir() if possible; get() then return it", async () => {
+    tmpdirStub.returns("/tmp");
+    await instance.determine();
+    const result = instance.get();
+    assert.strictEqual(result, "/tmp");
+    sinon.assert.calledOnce(tmpdirStub);
+    sinon.assert.calledOnce(writeFileStub);
+    sinon.assert.calledOnce(deleteFileStub);
+  });
+
+  it("determine() should throw an error if no writeable temporary directory is found", async () => {
+    writeFileStub.throws(new Error("writeFile() boom"));
+    await assert.rejects(async () => {
+      await instance.determine();
+    }, /No writeable tmpdir found/);
+
+    // Should have tried writing at least 4x, based on what env vars set.
+    assert.ok(writeFileStub.callCount >= 4);
+  });
+
+  it("get() should raise if called before determine()", () => {
+    assert.throws(() => {
+      instance.get();
+    }, /get\(\) called before determine\(\) was awaited/);
   });
 });

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,6 +1,11 @@
+import { join } from "path";
 import * as vscode from "vscode";
 import { TextDocument } from "vscode";
-import { readFile, statFile } from "./fsWrappers";
+import { logError } from "../errors";
+import { Logger } from "../logging";
+import { deleteFile, readFile, statFile, tmpdir, writeFile } from "./fsWrappers";
+
+const logger = new Logger("utils/file");
 
 /** Check if a file URI exists in the filesystem. */
 export async function fileUriExists(uri: vscode.Uri): Promise<boolean> {
@@ -49,5 +54,84 @@ export async function getEditorOrFileContents(uri: vscode.Uri): Promise<LoadedDo
   } catch (e) {
     // wrap error
     throw new Error(`Failed to read file ${uri.toString()}: ${e}`, { cause: e });
+  }
+}
+
+export class WriteableTmpDir {
+  static instance: WriteableTmpDir | undefined;
+
+  static getInstance(): WriteableTmpDir {
+    if (!WriteableTmpDir.instance) {
+      WriteableTmpDir.instance = new WriteableTmpDir();
+    }
+    return WriteableTmpDir.instance;
+  }
+
+  /** As determined by {@link determine} */
+  private _tmpdir: string | undefined;
+
+  private constructor() {
+    // Private constructor to prevent external instantiation
+  }
+
+  /**
+   * Determine a writeable temporary directory. This is a best-effort attempt.
+   *
+   * Should be called at extension startup to make subsequent calls to
+   * {@link get}.
+   *
+   * (We have reports that when installed through JamfAppInstallers on OSX, tmpdir() is not actually writeable.)
+   */
+  async determine(): Promise<void> {
+    const possibleDirs = [
+      tmpdir(), // Should work on all platforms, but JamfAppInstallers on OSX may mangle?
+      process.env["TMPDIR"], // UNIX-y, but should also have been what tmpdir() returned.
+      process.env["TEMP"], // Windows-y, probably also what tmpdir() returns on Windows.
+      process.env["TMP"], // sometimes Windows-y
+      "/var/tmp", // UNIX-y
+      "/tmp", // UNIX-y
+      "/private/tmp", // macOS
+    ];
+    const errorsEncountered: Error[] = [];
+
+    for (const dir of possibleDirs) {
+      if (!dir) {
+        continue; // Skip undefined or null directories
+      }
+      try {
+        // Check if the directory is writeable
+        const fileUri = vscode.Uri.file(join(dir, ".vscode_test.tmp"));
+        await writeFile(fileUri, Buffer.from("test"));
+        await deleteFile(fileUri);
+        this._tmpdir = dir;
+        logger.info(`Found writeable tmpdir: ${dir}`);
+        return;
+      } catch (e) {
+        logger.warn(`Failed to write to ${dir}: ${e}`);
+        errorsEncountered.push(e as Error);
+        // Ignore errors and try the next directory
+      }
+    }
+
+    logError(
+      logger,
+      "determineWriteableTmpDir(): No writeable tmpdir found.",
+      {
+        attemptedDirs: possibleDirs.join("; "),
+        errorsEncountered: errorsEncountered.map((e) => e.message).join("; "),
+      },
+      true,
+    );
+
+    throw new Error("No writeable tmpdir found");
+  }
+
+  /** Return the determined writeable tmpdir. Must have awaited determineWriteableTmpDir() prior. */
+  get(): string {
+    if (this._tmpdir) {
+      return this._tmpdir;
+    }
+
+    throw Error("get() called before determine() was awaited.");
   }
 }

--- a/src/utils/fsWrappers.ts
+++ b/src/utils/fsWrappers.ts
@@ -1,7 +1,8 @@
+import * as os from "os";
 import * as vscode from "vscode";
 
 /**
- * Very thin wrappers around {@link vscode.workspace.fs} methods which cannot
+ * Very thin wrappers around {@link vscode.workspace.fs} and related methods which cannot
  * be stubbed directly in tests due to implementation directly in C, not JS.
  */
 
@@ -20,4 +21,24 @@ export async function statFile(uri: vscode.Uri): Promise<vscode.FileStat> {
 export async function readFile(uri: vscode.Uri): Promise<string> {
   const data = await vscode.workspace.fs.readFile(uri);
   return Buffer.from(data).toString("utf8");
+}
+
+/**
+ * Call vscode.workspace.fs.writeFile() to write a file.
+ */
+export async function writeFile(uri: vscode.Uri, contents: Uint8Array): Promise<void> {
+  await vscode.workspace.fs.writeFile(uri, contents);
+}
+/**
+ * Call vscode.workspace.fs.delete() to delete a file.
+ */
+export async function deleteFile(uri: vscode.Uri): Promise<void> {
+  await vscode.workspace.fs.delete(uri);
+}
+
+/**
+ * Get the system's temporary directory.
+ */
+export function tmpdir(): string {
+  return os.tmpdir();
 }


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Test possible temp file directories by trying to create a file, then removing it. Try multiple locations, starting with `os.tmpdir()`.
- This is done through a new singleton class (easier testability) with an async part (doing the testing and determining which of the ordered list of possibilities should be used, assigning the chosen answer to data member), and a synchronous data member getter. The async part is called at extension startup before starting the sidecar, and will prevent extension initialization if it fails, we'll get clean logs as to why and what dirs were chosen and what exceptions happened when trying quick file create + delete.
- constant `SIDECAR_LOGFILE_PATH` removed, replaced by `src/sidecarManager.ts::getSidecarLogfilePath()` which wraps asking the singleton.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
