### PR TITLE
show error notification on failure to sync settings to the sidecar preferences API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ All notable changes to this extension will be documented in this file.
 
 ### Added
 
-- New actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new project. The project generation form will still be opened, and known form fields will be filled in automatically for the clicked resource.
-- "View in Confluent Cloud" item added to ccloud-based subjects (previously only available on individual schemas).
+- New actions in the context (right-click) menu for Kafka Clusters & Topics to generate a new
+  project. The project generation form will still be opened, and known form fields will be filled in
+  automatically for the clicked resource.
+- "View in Confluent Cloud" item added to ccloud-based subjects (previously only available on
+  individual schemas).
+- Error notifications if CCloud TLS/SSL settings fail to sync with the sidecar process.
 
 ### Changed
 
-- When deleting a subject containing a single schema, use the simpler
-  confirmation flow for deleting a single schema.
-  
+- When deleting a subject containing a single schema, use the simpler confirmation flow for deleting
+  a single schema.
+
 ## 1.1.0
 
 ### Added


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Floats an error notification whenever we try to push workspace configs to the sidecar for CCloud TLS/SSL settings. In most cases, this issue comes up because of an invalid cert path, so there's an "Update Settings" button added if the error `source` includes `"tls_pem_paths"`:

https://github.com/user-attachments/assets/b40aa756-bf77-4f12-90df-86d5efb51986



Closes #1011.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

I realized partway through this branch that our specs (sidecar, ce-kafka-reset, scaffolding-service) are using an [`Error` schema](https://github.com/confluentinc/vscode/blob/af88393600e09f319619230587d870189a79f5fb/src/clients/sidecar-openapi-specs/sidecar.openapi.yaml#L795-L810) (as part of the [`Failure` schema](https://github.com/confluentinc/vscode/blob/af88393600e09f319619230587d870189a79f5fb/src/clients/sidecar-openapi-specs/sidecar.openapi.yaml#L818-L834)) that fails to get converted to an interface under [`src/clients/sidecar/models/`](https://github.com/confluentinc/vscode/tree/af88393600e09f319619230587d870189a79f5fb/src/clients/sidecar/models), so I ended up using a basic interface:
https://github.com/confluentinc/vscode/blob/af88393600e09f319619230587d870189a79f5fb/src/preferences/updates.ts#L43-L51

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
