### PR TITLE
update minimum supported VS Code version from `1.87.0` to `1.97.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@types/sanitize-html": "^2.13.0",
         "@types/sinon": "^17.0.3",
         "@types/tail": "^2.2.3",
-        "@types/vscode": "^1.87.0",
+        "@types/vscode": "^1.97.0",
         "@types/ws": "^8.5.13",
         "@vscode/test-cli": "^0.0.6",
         "@vscode/test-electron": "^2.3.9",
@@ -3811,9 +3811,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.90.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
-      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+      "version": "1.97.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.97.0.tgz",
+      "integrity": "sha512-ueE73loeOTe7olaVyqP9mrRI54kVPJifUPjblZo9fYcv1CuVLPOEKEkqW0GkqPC454+nCEoigLWnC2Pp7prZ9w==",
       "dev": true
     },
     "node_modules/@types/ws": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "icon": "resources/confluent_logo-mark-meadow.png",
   "engines": {
-    "vscode": "^1.87.0"
+    "vscode": "^1.97.0"
   },
   "categories": [
     "Programming Languages",
@@ -1467,7 +1467,7 @@
     "@types/sanitize-html": "^2.13.0",
     "@types/sinon": "^17.0.3",
     "@types/tail": "^2.2.3",
-    "@types/vscode": "^1.87.0",
+    "@types/vscode": "^1.97.0",
     "@types/ws": "^8.5.13",
     "@vscode/test-cli": "^0.0.6",
     "@vscode/test-electron": "^2.3.9",

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -208,7 +208,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
    * @remarks We don't use `scopes` at all here, since the sidecar manages all connection->access
    * token and scope information.
    */
-  async getSessions(): Promise<readonly vscode.AuthenticationSession[]> {
+  async getSessions(): Promise<vscode.AuthenticationSession[]> {
     logger.debug("getSessions()");
 
     let connection: Connection | null = null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -484,14 +484,15 @@ export function deactivate() {
     logError(new Error(msg, { cause: e }), msg, {}, true);
   }
   closeSentryClient();
-  // close the file stream used with OUTPUT_CHANNEL
-  const logStream = getLogFileStream();
-  if (logStream) {
-    logStream.end();
-  }
 
   disposeLaunchDarklyClient();
   disableCCloudStatusPolling();
 
+  // close the file stream used with OUTPUT_CHANNEL -- needs to be done last to avoid any other
+  // cleanup logging attempting to write to the file stream
+  const logStream = getLogFileStream();
+  if (logStream) {
+    logStream.end();
+  }
   console.info("Extension deactivated");
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -493,5 +493,5 @@ export function deactivate() {
   disposeLaunchDarklyClient();
   disableCCloudStatusPolling();
 
-  logger.info("Extension deactivated");
+  console.info("Extension deactivated");
 }

--- a/src/models/topic.test.ts
+++ b/src/models/topic.test.ts
@@ -133,7 +133,6 @@ describe("KafkaTopicTreeItem constructor", () => {
     const icon = noSchemaTopicTreeItem.iconPath;
     assert.strictEqual(icon instanceof vscode.ThemeIcon, true);
     assert.strictEqual((icon as vscode.ThemeIcon).id, IconNames.TOPIC_WITHOUT_SCHEMA);
-    // @ts-expect-error we need to update @types/vscode to make ThemeColor.id public
     assert.strictEqual((icon as vscode.ThemeIcon).color!.id, "problemsWarningIcon.foreground");
     assert.strictEqual(noSchemaTopicTreeItem.contextValue!.includes("-with-schema"), false);
     assert.strictEqual(

--- a/src/statusBar/ccloudItem.test.ts
+++ b/src/statusBar/ccloudItem.test.ts
@@ -81,7 +81,6 @@ describe("statusBar/ccloudItem.ts", () => {
 
       assert.strictEqual(statusBarItem.text, `$(${IconNames.CONFLUENT_LOGO}) ${incidents.length}`);
       assert.ok(statusBarItem.backgroundColor instanceof ThemeColor);
-      // @ts-expect-error - update vscode types so ThemeColor exposes .id
       assert.strictEqual(statusBarItem.backgroundColor.id, ERROR_BACKGROUND_COLOR_ID);
     });
   }
@@ -102,11 +101,7 @@ describe("statusBar/ccloudItem.ts", () => {
         `$(${IconNames.CONFLUENT_LOGO}) ${maintenances.length}`,
       );
       assert.ok(statusBarItem.backgroundColor instanceof ThemeColor);
-      assert.strictEqual(
-        // @ts-expect-error - update vscode types so ThemeColor exposes .id
-        statusBarItem.backgroundColor.id,
-        WARNING_BACKGROUND_COLOR_ID,
-      );
+      assert.strictEqual(statusBarItem.backgroundColor.id, WARNING_BACKGROUND_COLOR_ID);
     });
   }
 
@@ -123,11 +118,7 @@ describe("statusBar/ccloudItem.ts", () => {
     assert.strictEqual(statusBarItem.text, "$(confluent-logo) 2");
     assert.ok(statusBarItem.backgroundColor instanceof ThemeColor);
     // incident color takes priority
-    assert.strictEqual(
-      // @ts-expect-error - update vscode types so ThemeColor exposes .id
-      statusBarItem.backgroundColor.id,
-      ERROR_BACKGROUND_COLOR_ID,
-    );
+    assert.strictEqual(statusBarItem.backgroundColor.id, ERROR_BACKGROUND_COLOR_ID);
   });
 
   for (const status of COMPLETED_INCIDENT_STATUSES) {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We're aiming to start supporting two minor versions behind the current `stable` release so we don't get too far behind features/APIs/interfaces/etc. This PR updates the requirement under `engine` as well as our `@types/vscode` for development.

Also closes #1353 since I'm tired of the error showing up during extension deactivation.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
