### PR TITLE
Sentry: wrap ResponseErrors, include `message`, and set obs context as `tags`

### DIFF
--- a/src/telemetry/eventProcessors.ts
+++ b/src/telemetry/eventProcessors.ts
@@ -12,8 +12,9 @@ export function checkTelemetrySettings(event: Event) {
   return event;
 }
 
-/** Include this extension instance's {@link observabilityContext} under the `extra` context. */
+/** Include this extension instance's {@link observabilityContext} under the `extra` context and `tags`. */
 export function includeObservabilityContext(event: Event): Event {
   event.extra = { ...event.extra, ...observabilityContext.toRecord() };
+  event.tags = { ...event.tags, ...observabilityContext.toRecord() };
   return event;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

No user-facing changes here, just updates to our Sentry usage so we're able to more easily triage ResponseErrors.

This also addresses some gripes we've had in the past where the `message` passed to `logError()` wasn't used for anything except logging (client-side), so now that's included in the error sent to Sentry.

<img width="672" alt="image" src="https://github.com/user-attachments/assets/22370eb6-0864-45c5-bfc5-7add289c0afe" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
