### PR TITLE
don't send `Canceled` errors to sentry

### DIFF
--- a/src/telemetry/sentryClient.ts
+++ b/src/telemetry/sentryClient.ts
@@ -59,6 +59,7 @@ export function initSentry() {
     includeLocalVariables: true,
     transport: makeNodeTransport,
     stackParser: defaultStackParser,
+    ignoreErrors: ["Canceled"],
   });
 
   const scope = getSentryScope();


### PR DESCRIPTION
Closes #1454, hopefully we won't need to add any of those other error message strings back in to the client-side filtering