### PR TITLE
#1456: Support ScopeContext interface for logError()

### DIFF
--- a/src/ccloudStatus/api.test.ts
+++ b/src/ccloudStatus/api.test.ts
@@ -44,7 +44,7 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     sinon.assert.notCalled(logErrorStub);
   });
 
-  it("should return function name and call logError() on a bad response", async () => {
+  it("should return undefined and call logError() on a bad response", async () => {
     const fakeResponse = new Response("Bad Request", {
       status: 400,
       statusText: "Bad Request",
@@ -76,7 +76,7 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     sinon.assert.notCalled(logErrorStub);
   });
 
-  it("should return function name and call logError when json parsing fails", async () => {
+  it("should return undefined and call logError when json parsing fails", async () => {
     const fakeResponse = new Response(JSON.stringify("not json data"), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -93,7 +93,7 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     });
   });
 
-  it("should return function name and log error for other unexpected errors", async () => {
+  it("should return undefined and log error for other unexpected errors", async () => {
     const unexpectedError = new Error("Unexpected error");
     fetchStub.rejects(unexpectedError);
 

--- a/src/ccloudStatus/api.test.ts
+++ b/src/ccloudStatus/api.test.ts
@@ -44,7 +44,7 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     sinon.assert.notCalled(logErrorStub);
   });
 
-  it("should return undefined and call logError() on a bad response", async () => {
+  it("should return function name and call logError() on a bad response", async () => {
     const fakeResponse = new Response("Bad Request", {
       status: 400,
       statusText: "Bad Request",
@@ -58,10 +58,11 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     sinon.assert.calledOnce(logErrorStub);
     sinon.assert.calledWithMatch(
       logErrorStub,
-      sinon.match.instanceOf(Error),
+      sinon.match
+        .instanceOf(Error)
+        .and(sinon.match.has("message", "Failed to fetch Confluent Cloud status: 400 Bad Request")),
       "CCloud status",
-      {},
-      true,
+      { extra: { functionName: "fetchCCloudStatus" } },
     );
   });
 
@@ -75,7 +76,7 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     sinon.assert.notCalled(logErrorStub);
   });
 
-  it("should return undefined and call logError when json parsing fails", async () => {
+  it("should return function name and call logError when json parsing fails", async () => {
     const fakeResponse = new Response(JSON.stringify("not json data"), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -87,16 +88,20 @@ describe("ccloudStatus/api.ts fetchCCloudStatus()", () => {
     const result: types.CCloudStatusSummary | undefined = await fetchCCloudStatus();
 
     assert.strictEqual(result, undefined);
-    sinon.assert.calledWith(logErrorStub, parsingError, "CCloud status", {}, true);
+    sinon.assert.calledWith(logErrorStub, parsingError, "CCloud status", {
+      extra: { functionName: "fetchCCloudStatus" },
+    });
   });
 
-  it("should return undefined and log error for other unexpected errors", async () => {
+  it("should return function name and log error for other unexpected errors", async () => {
     const unexpectedError = new Error("Unexpected error");
     fetchStub.rejects(unexpectedError);
 
     const result: types.CCloudStatusSummary | undefined = await fetchCCloudStatus();
 
     assert.strictEqual(result, undefined);
-    sinon.assert.calledWith(logErrorStub, unexpectedError, "CCloud status", {}, true);
+    sinon.assert.calledWith(logErrorStub, unexpectedError, "CCloud status", {
+      extra: { functionName: "fetchCCloudStatus" },
+    });
   });
 });

--- a/src/ccloudStatus/api.ts
+++ b/src/ccloudStatus/api.ts
@@ -18,6 +18,6 @@ export async function fetchCCloudStatus(): Promise<CCloudStatusSummary | undefin
     if (error instanceof TypeError && error.message === "fetch failed") {
       return; // network error
     }
-    logError(error, "CCloud status", {}, true);
+    logError(error, "CCloud status", { extra: { functionName: "fetchCCloudStatus" } });
   }
 }

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -82,21 +82,18 @@ export async function chatHandler(
         // this scenario and return a more user-friendly error message.
         const errMsg = `The "${model.name}" model is not currently supported. Please choose a different model from the dropdown and try again.`;
         // keep track of how often this is happening so we can
-        logError(
-          new ModelNotSupportedError(`${model.id} is not supported`),
-          "chatHandler",
-          {
+        logError(new ModelNotSupportedError(`${model.id} is not supported`), "chatHandler", {
+          extra: {
             model: JSON.stringify({ id: model.id, vendor: model.vendor, family: model.family }),
           },
-          true,
-        );
+        });
         return {
           errorDetails: { message: errMsg },
           metadata: { error: true, name: ModelNotSupportedError.name },
         };
       }
       // some other kind of error when sending the request or streaming the response
-      logError(error, "chatHandler", { model: model?.name ?? "unknown" });
+      logError(error, "chatHandler", { extra: { model: model?.name ?? "unknown" } });
       return {
         errorDetails: { message: error.message },
         metadata: { error: true, stack: error.stack, name: error.name },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -31,7 +31,7 @@ export function registerCommandWithLogging(
       if (e instanceof Error) {
         // gather more (possibly-ResponseError) context and send to Sentry (only enabled in
         // production builds)
-        logError(e, `${commandName}`, { command: commandName }, true);
+        logError(e, `${commandName}`, { extra: { command: commandName } });
         // also show error notification to the user with default buttons
         showErrorNotificationWithButtons(`Error invoking command "${commandName}": ${e}`);
       }

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -271,7 +271,7 @@ async function deleteSchemaVersionCommand(schema: Schema) {
       if (e.response.status !== 404) {
         // not a 404, something unexpected/
         logError(e, "Error fetching schemas for subject while deleting schema version", {
-          extra: { subject: schema.subject },
+          extra: { error: {} },
         });
       }
     }
@@ -341,7 +341,7 @@ async function deleteSchemaVersionCommand(schema: Schema) {
     }
   } catch (e) {
     success = false;
-    logError(e, "Error deleting schema version", { extra: { subject: schema.subject } });
+    logError(e, "Error deleting schema version", { extra: { error: {} } });
     showErrorNotificationWithButtons(
       `Error deleting schema version ${schema.version}: ${e instanceof Error ? e.message : String(e)}`,
     );
@@ -390,7 +390,7 @@ async function deleteSchemaSubjectCommand(subject: Subject) {
       if (e.response.status !== 404) {
         // not a 404, something unexpected/
         logError(e, "Error fetching schemas for subject while deleting schema subject", {
-          extra: { subject: subject.name },
+          extra: { error: {} },
         });
       }
     }
@@ -453,7 +453,7 @@ async function deleteSchemaSubjectCommand(subject: Subject) {
     );
   } catch (e) {
     success = false;
-    logError(e, "Error deleting schema subject", { extra: { subject: subject.name } });
+    logError(e, "Error deleting schema subject", { extra: { error: {} } });
     showErrorNotificationWithButtons(
       `Error deleting schema subject ${subject.name}: ${e instanceof Error ? e.message : String(e)}`,
     );

--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -270,12 +270,9 @@ async function deleteSchemaVersionCommand(schema: Schema) {
       // already deleted in other workspace or other means?
       if (e.response.status !== 404) {
         // not a 404, something unexpected/
-        logError(
-          e,
-          "Error fetching schemas for subject while deleting schema version",
-          { subject: schema.subject },
-          true,
-        );
+        logError(e, "Error fetching schemas for subject while deleting schema version", {
+          extra: { subject: schema.subject },
+        });
       }
     }
 
@@ -344,7 +341,7 @@ async function deleteSchemaVersionCommand(schema: Schema) {
     }
   } catch (e) {
     success = false;
-    logError(e, "Error deleting schema version", undefined, true);
+    logError(e, "Error deleting schema version", { extra: { subject: schema.subject } });
     showErrorNotificationWithButtons(
       `Error deleting schema version ${schema.version}: ${e instanceof Error ? e.message : String(e)}`,
     );
@@ -392,12 +389,9 @@ async function deleteSchemaSubjectCommand(subject: Subject) {
       // already deleted in other workspace or other means?
       if (e.response.status !== 404) {
         // not a 404, something unexpected/
-        logError(
-          e,
-          "Error fetching schemas for subject while deleting schema subject",
-          { subject: subject.name },
-          true,
-        );
+        logError(e, "Error fetching schemas for subject while deleting schema subject", {
+          extra: { subject: subject.name },
+        });
       }
     }
     showErrorNotificationWithButtons("Schema subject not found in registry.", {
@@ -459,7 +453,7 @@ async function deleteSchemaSubjectCommand(subject: Subject) {
     );
   } catch (e) {
     success = false;
-    logError(e, "Error deleting schema subject", undefined, true);
+    logError(e, "Error deleting schema subject", { extra: { subject: subject.name } });
     showErrorNotificationWithButtons(
       `Error deleting schema subject ${subject.name}: ${e instanceof Error ? e.message : String(e)}`,
     );

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -109,7 +109,7 @@ async function editTopicConfig(topic: KafkaTopic): Promise<void> {
       topic_name: topic.name,
     });
   } catch (err) {
-    logError(err, "list topic configs", {}, true);
+    logError(err, "list topic configs", { extra: { topicName: topic.name } });
     vscode.window.showErrorMessage("Failed to retrieve topic configs");
     return;
   }
@@ -157,7 +157,7 @@ async function editTopicConfig(topic: KafkaTopic): Promise<void> {
         const errorBody = await err.response.json();
         formError = errorBody.message;
       } else {
-        logError(err, "update topic config", {}, true);
+        logError(err, "update topic config", { extra: { functionName: "validateOrUpdateConfig" } });
         if (err instanceof Error && err.message) formError = err.message;
       }
       return { success: false, message: formError };

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -109,7 +109,7 @@ async function editTopicConfig(topic: KafkaTopic): Promise<void> {
       topic_name: topic.name,
     });
   } catch (err) {
-    logError(err, "list topic configs", { extra: { topicName: topic.name } });
+    logError(err, "list topic configs", { extra: { error: {} } });
     vscode.window.showErrorMessage("Failed to retrieve topic configs");
     return;
   }

--- a/src/consume.ts
+++ b/src/consume.ts
@@ -544,7 +544,7 @@ function messageViewerStartPollingCommand(
             }
             default: {
               reportable = { message: "Something went wrong." };
-              logError(error, "message viewer", { status: status.toString(), payload }, true);
+              logError(error, "message viewer", { extra: { status: status.toString(), payload } });
               showErrorNotificationWithButtons("Error response while consuming messages.");
               break;
             }

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -264,15 +264,13 @@ describe("errors.ts logError()", () => {
 
   it("should include extra context in error logs", async () => {
     const error = new Error("test");
-    const extra = { foo: "bar" };
     const logMessage = "test message";
-    await logError(error, logMessage, extra);
+    await logError(error, logMessage);
 
     sinon.assert.calledWithMatch(loggerErrorSpy, `Error: ${logMessage} --> ${error}`, {
       errorType: error.name,
       errorMessage: error.message,
       errorStack: error.stack,
-      ...extra,
     });
   });
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -267,11 +267,15 @@ describe("errors.ts logError()", () => {
     const logMessage = "test message";
     await logError(error, logMessage);
 
-    sinon.assert.calledWithMatch(loggerErrorSpy, `Error: ${logMessage} --> ${error}`, {
-      errorType: error.name,
-      errorMessage: error.message,
-      errorStack: error.stack,
-    });
+    sinon.assert.calledWithMatch(
+      loggerErrorSpy,
+      `[${logMessage}] error: ${error.name}: ${error.message}`,
+      {
+        errorType: error.name,
+        errorMessage: error.message,
+        errorStack: error.stack,
+      },
+    );
   });
 
   it("should truncate long 'body' values for ResponseErrors", async () => {

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -257,7 +257,7 @@ describe("errors.ts logError()", () => {
       sinon.assert.calledWithExactly(
         loggerErrorSpy,
         `non-Error passed: ${JSON.stringify(nonError)}`,
-        extra,
+        // no 'extra' context
       );
     });
   }
@@ -272,7 +272,7 @@ describe("errors.ts logError()", () => {
       errorType: error.name,
       errorMessage: error.message,
       errorStack: error.stack,
-      extra,
+      ...extra,
     });
   });
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -264,18 +264,16 @@ describe("errors.ts logError()", () => {
 
   it("should include extra context in error logs", async () => {
     const error = new Error("test");
+    const extra = { extra: { foo: "bar" } };
     const logMessage = "test message";
-    await logError(error, logMessage);
+    await logError(error, logMessage, extra);
 
-    sinon.assert.calledWithMatch(
-      loggerErrorSpy,
-      `[${logMessage}] error: ${error.name}: ${error.message}`,
-      {
-        errorType: error.name,
-        errorMessage: error.message,
-        errorStack: error.stack,
-      },
-    );
+    sinon.assert.calledWithMatch(loggerErrorSpy, `Error: ${logMessage} --> ${error}`, {
+      errorType: error.name,
+      errorMessage: error.message,
+      errorStack: error.stack,
+      extra,
+    });
   });
 
   it("should truncate long 'body' values for ResponseErrors", async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -262,7 +262,9 @@ async function showNotificationWithButtons(
       await buttonMap[selection]();
     } catch (e) {
       // log the error and send telemetry if the callback function throws an error
-      logError(e, `"${selection}" button callback`, { extra: {} });
+      logError(e, `"${selection}" button callback`, {
+        extra: { functionName: "showNotifcationWithButtons" },
+      });
     }
     // send telemetry for which button was clicked
     logUsage(UserEvent.NotificationButtonClicked, {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -258,7 +258,7 @@ async function showNotificationWithButtons(
     } catch (e) {
       // log the error and send telemetry if the callback function throws an error
       logError(e, `"${selection}" button callback`, {
-        extra: { functionName: "showNotifcationWithButtons" },
+        extra: { functionName: "showNotificationWithButtons" },
       });
     }
     // send telemetry for which button was clicked

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -161,21 +161,18 @@ export async function logError(
 
   logger.error(logErrorMessage, { ...errorContext, ...sentryContext });
   // TODO: follow up to reuse EventHint type for capturing tags and other more fine-grained data
-  const hasMeaningfulSentryContext =
-    [
-      sentryContext.extra,
-      sentryContext.contexts,
-      sentryContext.tags,
-      sentryContext.propagationContext,
-    ].some((context) => context && Object.keys(context).length > 0) ||
-    sentryContext.user?.id !== undefined ||
-    (sentryContext.fingerprint && sentryContext.fingerprint.length > 0);
-
-  if (hasMeaningfulSentryContext) {
+  if (Object.keys(sentryContext).length) {
     sentryCaptureException(e, {
       captureContext: {
-        contexts: { response: { status_code: responseStatusCode } },
-        extra: { ...errorContext, ...sentryContext.extra },
+        ...sentryContext,
+        contexts: {
+          ...(sentryContext.contexts ?? {}),
+          response: { status_code: responseStatusCode },
+        },
+        extra: {
+          ...(sentryContext.extra ?? {}),
+          ...errorContext,
+        },
       },
     });
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,4 @@
+import { ScopeContext } from "@sentry/core";
 import { commands, window } from "vscode";
 import { ResponseError as DockerResponseError } from "./clients/docker";
 import { ResponseError as FlinkArtifactsResponseError } from "./clients/flinkArtifacts";
@@ -10,7 +11,6 @@ import { ResponseError as SidecarResponseError } from "./clients/sidecar";
 import { Logger } from "./logging";
 import { logUsage, UserEvent } from "./telemetry/events"; // Ensure this is the correct module
 import { sentryCaptureException } from "./telemetry/sentryClient";
-import { ScopeContext } from "@sentry/core";
 
 const logger = new Logger("errors");
 
@@ -156,8 +156,6 @@ export async function logError(
       };
     }
   }
-
-  logger.error(logErrorMessage, { ...errorContext });
 
   logger.error(logErrorMessage, { ...errorContext, ...sentryContext });
   // TODO: follow up to reuse EventHint type for capturing tags and other more fine-grained data

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -160,7 +160,7 @@ export async function logError(
   logger.error(logErrorMessage, { ...errorContext, ...sentryContext });
   // TODO: follow up to reuse EventHint type for capturing tags and other more fine-grained data
   if (Object.keys(sentryContext).length) {
-    sentryCaptureException(e, {
+    sentryCaptureException(wrappedError, {
       captureContext: {
         ...sentryContext,
         contexts: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,7 +9,7 @@ import { ResponseError as ScaffoldingServiceResponseError } from "./clients/scaf
 import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRegistryRest";
 import { ResponseError as SidecarResponseError } from "./clients/sidecar";
 import { Logger } from "./logging";
-import { logUsage, UserEvent } from "./telemetry/events"; // Ensure this is the correct module
+import { logUsage, UserEvent } from "./telemetry/events";
 import { sentryCaptureException } from "./telemetry/sentryClient";
 
 const logger = new Logger("errors");

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -94,7 +94,7 @@ export class CustomError extends Error {
  * additional error context.
  *
  * @param e Error to log
- * @param messagePrefix Prefix to include in the logger.error() message
+ * @param message Text to add in the logger.error() message and top-level Sentry error message
  * @param sentryContext Optional Sentry context to include with the error
  * */
 export async function logError(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -490,7 +490,7 @@ export function deactivate() {
     getTelemetryLogger().dispose();
   } catch (e) {
     const msg = "Error disposing telemetry logger during extension deactivation";
-    logError(new Error(msg, { cause: e }), msg, {}, true);
+    logError(new Error(msg, { cause: e }), msg, { extra: {} });
   }
   closeSentryClient();
 

--- a/src/featureFlags/client.ts
+++ b/src/featureFlags/client.ts
@@ -45,7 +45,7 @@ export function getLaunchDarklyClient(): LDElectronMainClient | undefined {
   } catch (error) {
     // try to send any client init issues to Sentry, but if the user is offline and the extension
     // can't reach LD (which probably means Sentry isn't available either), this will just log
-    logError(error, "LD client init", {}, true);
+    logError(error, "LD client init", { extra: { functionName: "getLaunchDarklyClient" } });
   }
 }
 
@@ -56,7 +56,7 @@ function handleFailedEvent(error: unknown) {
   if (error instanceof Error) {
     // if online, send any failed events to Sentry so we can troubleshoot
     // if offline, just log the failed event
-    logError(error, "LD failed event", {}, true);
+    logError(error, "LD failed event", { extra: { functionName: "handleFailedEvent" } });
   } else {
     logger.error("LD failed event:", error);
   }

--- a/src/featureFlags/handlers.ts
+++ b/src/featureFlags/handlers.ts
@@ -48,7 +48,7 @@ export function handleErrorEvent(error: unknown) {
     if (!error.message.includes("network error")) {
       // send any non-'network error' events to Sentry (if online) so we can troubleshoot
       // https://support.launchdarkly.com/hc/en-us/articles/12998125691419-Error-LaunchDarklyFlagFetchError-network-error
-      logError(error, "LD error event", {}, true);
+      logError(error, "LD error event", { extra: { functionName: "handleErrorEvent" } });
     }
   } else {
     logger.error("LD error event:", error);

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -39,7 +39,9 @@ export async function getDirectResources(): Promise<DirectEnvironment[]> {
   try {
     response = await sidecar.query(query);
   } catch (error) {
-    logError(error, "direct connection resources", {}, true);
+    logError(error, "direct connection resources", {
+      extra: { functionName: "getDirectResources" },
+    });
     showErrorNotificationWithButtons(
       `Failed to fetch resources for direct Kafka / Schema Registry connection(s): ${error}`,
     );

--- a/src/graphql/environments.ts
+++ b/src/graphql/environments.ts
@@ -55,7 +55,7 @@ export async function getEnvironments(): Promise<CCloudEnvironment[]> {
   try {
     response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
   } catch (error) {
-    logError(error, "CCloud environments", { connectionId: CCLOUD_CONNECTION_ID }, true);
+    logError(error, "CCloud environments", { extra: { connectionId: CCLOUD_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch CCloud resources: ${error}`);
     return envs;
   }

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -46,7 +46,7 @@ export async function getLocalResources(): Promise<LocalEnvironment[]> {
   try {
     response = await sidecar.query(query, LOCAL_CONNECTION_ID);
   } catch (error) {
-    logError(error, "local resources", { connectionId: LOCAL_CONNECTION_ID }, true);
+    logError(error, "local resources", { extra: { connectionId: LOCAL_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch local resources: ${error}`);
     return envs;
   }

--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -27,7 +27,7 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   try {
     response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
   } catch (error) {
-    logError(error, "CCloud organizations", { connectionId: CCLOUD_CONNECTION_ID }, true);
+    logError(error, "CCloud organizations", { extra: { connectionId: CCLOUD_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch CCloud organizations: ${error}`);
     return orgs;
   }

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -457,8 +457,6 @@ describe("ResourceLoader::deleteSchemaVersion()", () => {
     const logErrorArgs = logErrorStub.getCall(0).args;
     assert.strictEqual(logErrorArgs[0], thrownError);
     assert.strictEqual(logErrorArgs[1], "Error deleting schema version");
-    // would send to Sentry.
-    assert.strictEqual(logErrorArgs[3], true);
   });
 });
 

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -457,6 +457,8 @@ describe("ResourceLoader::deleteSchemaVersion()", () => {
     const logErrorArgs = logErrorStub.getCall(0).args;
     assert.strictEqual(logErrorArgs[0], thrownError);
     assert.strictEqual(logErrorArgs[1], "Error deleting schema version");
+    // would send to Sentry.
+    assert.ok(logErrorArgs[2]);
   });
 });
 

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -160,12 +160,9 @@ export abstract class ResourceLoader implements IResourceBase {
         return [];
       } else {
         // Unexpected error, log it to sentry.
-        logError(
-          error,
-          "Unexpected error within getSubjects",
-          { registryOrEnvironmentId: JSON.stringify(registryOrEnvironmentId, null, 2) },
-          true,
-        );
+        logError(error, "Unexpected error within getSubjects", {
+          extra: { registryOrEnvironmentId: JSON.stringify(registryOrEnvironmentId, null, 2) },
+        });
       }
       throw error;
     }
@@ -303,17 +300,14 @@ export abstract class ResourceLoader implements IResourceBase {
 
       await subjectApi.deleteSchemaVersion(deleteRequest);
     } catch (error) {
-      logError(
-        error,
-        "Error deleting schema version",
-        {
+      logError(error, "Error deleting schema version", {
+        extra: {
           connectionId: schema.connectionId,
           environmentId: schema.environmentId ? schema.environmentId : "unknown",
           schemaRegistryId: schema.schemaRegistryId,
           hardDelete: hardDelete ? "true" : "false",
         },
-        true,
-      );
+      });
       throw error;
     }
 
@@ -356,17 +350,14 @@ export abstract class ResourceLoader implements IResourceBase {
         await subjectApi.deleteSubject(request);
       }
     } catch (error) {
-      logError(
-        error,
-        "Error deleting schema subject",
-        {
+      logError(error, "Error deleting schema subject", {
+        extra: {
           connectionId: subject.connectionId,
           environmentId: subject.environmentId,
           schemaRegistryId: subject.schemaRegistryId,
           hardDelete: hardDelete ? "true" : "false",
         },
-        true,
-      );
+      });
       throw error;
     } finally {
       // Always clear out the subject cache, regardless of whether the delete was successful.

--- a/src/preferences/updates.test.ts
+++ b/src/preferences/updates.test.ts
@@ -151,15 +151,11 @@ describe("preferences/updates", function () {
       sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
       "updating preferences",
       { extra: { functionName: "updatePreferences" } },
-      true, // Ensure the `true` value is included
     );
 
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    sinon.assert.calledWithExactly(
-      showErrorNotificationWithButtonsStub,
-      `Failed to sync settings: ${error.message}`,
-      undefined,
-    );
+    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
+    assert.strictEqual(callArgs[0], `Failed to sync settings: ${error.message}`);
   });
 
   it("updatePreferences() should show an error notification with a settings button when a ResponseError is caught and valid failure errors are returned", async function () {

--- a/src/preferences/updates.test.ts
+++ b/src/preferences/updates.test.ts
@@ -151,11 +151,15 @@ describe("preferences/updates", function () {
       sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
       "updating preferences",
       { extra: { functionName: "updatePreferences" } },
+      true, // Ensure the `true` value is included
     );
 
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
-    assert.strictEqual(callArgs[0], `Failed to sync settings: ${error.message}`);
+    sinon.assert.calledWithExactly(
+      showErrorNotificationWithButtonsStub,
+      `Failed to sync settings: ${error.message}`,
+      undefined,
+    );
   });
 
   it("updatePreferences() should show an error notification with a settings button when a ResponseError is caught and valid failure errors are returned", async function () {

--- a/src/preferences/updates.test.ts
+++ b/src/preferences/updates.test.ts
@@ -133,9 +133,10 @@ describe("preferences/updates", function () {
       sinon.match.instanceOf(Error).and(sinon.match.has("message", errorMessage)),
       "updating preferences",
       { extra: { functionName: "updatePreferences" } },
-      true,
     );
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
+    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
+    assert.strictEqual(callArgs[0], `Failed to sync settings: ${errorMessage}`);
   });
 
   it("updatePreferences() should show an error notification when an Error is caught", async function () {
@@ -150,15 +151,11 @@ describe("preferences/updates", function () {
       sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
       "updating preferences",
       { extra: { functionName: "updatePreferences" } },
-      true, // Ensure the `true` value is included
     );
 
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    sinon.assert.calledWithExactly(
-      showErrorNotificationWithButtonsStub,
-      `Failed to sync settings: ${error.message}`,
-      undefined,
-    );
+    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
+    assert.strictEqual(callArgs[0], `Failed to sync settings: ${error.message}`);
   });
 
   it("updatePreferences() should show an error notification with a settings button when a ResponseError is caught and valid failure errors are returned", async function () {

--- a/src/preferences/updates.test.ts
+++ b/src/preferences/updates.test.ts
@@ -122,16 +122,17 @@ describe("preferences/updates", function () {
 
   it("updatePreferences() should log and not re-throw errors when updating preferences", async function () {
     const errorMessage = "Failed to update preferences";
-    mockClient.gatewayV1PreferencesPut.rejects(new Error(errorMessage));
+    const error = new Error(errorMessage);
+    mockClient.gatewayV1PreferencesPut.rejects(error);
 
     await updates.updatePreferences();
 
     sinon.assert.calledOnce(mockClient.gatewayV1PreferencesPut);
     sinon.assert.calledWithExactly(
       logErrorStub,
-      sinon.match.instanceOf(Error),
+      sinon.match.instanceOf(Error).and(sinon.match.has("message", errorMessage)),
       "updating preferences",
-      {},
+      { extra: { functionName: "updatePreferences" } },
       true,
     );
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
@@ -140,19 +141,23 @@ describe("preferences/updates", function () {
   it("updatePreferences() should show an error notification when an Error is caught", async function () {
     const error = new Error("uh oh");
     mockClient.gatewayV1PreferencesPut.rejects(error);
-    // used for logging and the notification:
-    const errorMessage = "Failed to sync settings";
 
     await updates.updatePreferences();
 
     sinon.assert.calledOnce(logErrorStub);
-    sinon.assert.calledWithExactly(logErrorStub, error, "updating preferences", {}, true);
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
+      "updating preferences",
+      { extra: { functionName: "updatePreferences" } },
+      true, // Ensure the `true` value is included
+    );
 
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
     sinon.assert.calledWithExactly(
       showErrorNotificationWithButtonsStub,
-      `${errorMessage}: ${error.message}`,
-      undefined, // no buttons set here, use the defaults
+      `Failed to sync settings: ${error.message}`,
+      undefined,
     );
   });
 
@@ -164,25 +169,24 @@ describe("preferences/updates", function () {
       detail: "The cert file '/foo/bar/baz' cannot be found.",
       source: "/spec/tls_pem_paths",
     };
-    // have to stub both `.clone()` and `.json()` to get the error details
     sandbox.stub(errorResponse, "clone").returns(errorResponse);
-    sandbox.stub(errorResponse, "json").resolves({
-      errors: [fakeFailureError],
-    });
+    sandbox.stub(errorResponse, "json").resolves({ errors: [fakeFailureError] });
     const error = new ResponseError(errorResponse);
+
     mockClient.gatewayV1PreferencesPut.rejects(error);
-    // used for logging and the notification:
-    const errorMessage = `Failed to sync settings: ${fakeFailureError.detail}`;
-    // simulate the user dismissing the notification
-    showErrorNotificationWithButtonsStub.resolves(undefined);
 
     await updates.updatePreferences();
 
     sinon.assert.calledOnce(logErrorStub);
-    sinon.assert.calledWithExactly(logErrorStub, error, "updating preferences", {}, true);
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      sinon.match.instanceOf(ResponseError).and(sinon.match.has("response", errorResponse)),
+      "updating preferences",
+      { extra: { functionName: "updatePreferences" } },
+    );
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
     const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
-    assert.strictEqual(callArgs[0], errorMessage);
+    assert.strictEqual(callArgs[0], `Failed to sync settings: ${fakeFailureError.detail}`);
     assert.ok(Object.keys(callArgs[1]).includes("Update Settings"));
     assert.ok(Object.keys(callArgs[1]).includes("Open Logs"));
     assert.ok(Object.keys(callArgs[1]).includes("File Issue"));

--- a/src/preferences/updates.ts
+++ b/src/preferences/updates.ts
@@ -66,7 +66,7 @@ export async function updatePreferences() {
     });
     logger.debug("Successfully updated preferences: ", { resp });
   } catch (error) {
-    logError(error, "updating preferences", {}, true);
+    logError(error, "updating preferences", { extra: { functionName: "updatePreferences" } });
     if (error instanceof Error) {
       let errorMsg = error.message;
       let buttons: Record<string, () => void> | undefined;

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -17,15 +17,15 @@ import { ResponseError } from "./clients/sidecar";
 import { registerCommandWithLogging } from "./commands";
 import { projectScaffoldUri } from "./emitters";
 import { logError } from "./errors";
+import { KafkaCluster } from "./models/kafkaCluster";
+import { KafkaTopic } from "./models/topic";
+import { getResourceManager } from "./storage/resourceManager";
 import { UserEvent, logUsage } from "./telemetry/events";
+import { fileUriExists } from "./utils/file";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { PostResponse, type post } from "./webview/scaffold-form";
 import scaffoldFormTemplate from "./webview/scaffold-form.html";
-import { fileUriExists } from "./utils/file";
-import { KafkaTopic } from "./models/topic";
-import { KafkaCluster } from "./models/kafkaCluster";
-import { getResourceManager } from "./storage/resourceManager";
 type MessageSender = OverloadUnion<typeof post>;
 type MessageResponse<MessageType extends string> = Awaited<
   ReturnType<Extract<MessageSender, (type: MessageType, body: any) => any>>

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -57,7 +57,7 @@ export const scaffoldProjectRequest = async (item?: KafkaCluster | KafkaTopic) =
       (template) => template.spec!.display_name === pickedItem?.label,
     );
   } catch (err) {
-    logError(err, "template listing", {}, true);
+    logError(err, "template listing", { extra: {} });
     vscode.window.showErrorMessage("Failed to retrieve template list");
     return;
   }
@@ -218,7 +218,7 @@ export async function applyTemplate(
     }
     return { success: true, message: "Project generated successfully." };
   } catch (e) {
-    logError(e, "applying template", { templateName: pickedTemplate.spec!.name! }, true);
+    logError(e, "applying template", { extra: { templateName: pickedTemplate.spec!.name! } });
     let message = "Failed to generate template. An unknown error occurred.";
     if (e instanceof Error) {
       message = e.message;

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -57,7 +57,7 @@ export const scaffoldProjectRequest = async (item?: KafkaCluster | KafkaTopic) =
       (template) => template.spec!.display_name === pickedItem?.label,
     );
   } catch (err) {
-    logError(err, "template listing", { extra: {} });
+    logError(err, "template listing", { extra: { functionName: "scaffoldProjectRequest" } });
     vscode.window.showErrorMessage("Failed to retrieve template list");
     return;
   }

--- a/src/sidecar/connections/index.ts
+++ b/src/sidecar/connections/index.ts
@@ -31,12 +31,9 @@ export async function tryToCreateConnection(
     });
     return connection;
   } catch (error) {
-    logError(
-      error,
-      `${dryRun ? "testing" : "creating"} new connection:`,
-      { connectionId: spec.id! },
-      true,
-    );
+    logError(error, `${dryRun ? "testing" : "creating"} new connection:`, {
+      extra: { connectionId: spec.id! },
+    });
     throw error;
   }
 }
@@ -53,7 +50,7 @@ export async function tryToGetConnection(id: string): Promise<Connection | null>
       logger.debug("No connection found", { connectionId: id });
     } else {
       // only log the non-404 errors, since we expect a 404 if the connection doesn't exist
-      logError(error, "fetching connection", { connectionId: id }, true);
+      logError(error, "fetching connection", { extra: { connectionId: id } });
     }
   }
   return connection;
@@ -75,7 +72,7 @@ export async function tryToUpdateConnection(spec: ConnectionSpec): Promise<Conne
     logger.debug("updated connection:", { id: connection.id });
     return connection;
   } catch (error) {
-    logError(error, "updating connection", { connectionId: spec.id! }, true);
+    logError(error, "updating connection", { extra: { connectionId: spec.id! } });
     throw error;
   }
 }
@@ -91,7 +88,7 @@ export async function tryToDeleteConnection(id: string): Promise<void> {
       logger.debug("no connection found to delete:", { id });
       return;
     }
-    logError(error, "deleting connection", { connectionId: id }, true);
+    logError(error, "deleting connection", { extra: { connectionId: id } });
     throw error;
   }
 }

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -364,15 +364,12 @@ export class SidecarManager {
           try {
             fs.accessSync(executablePath);
           } catch (e) {
-            logError(
-              e,
-              `Sidecar executable "${executablePath}" does not exist`,
-              {
+            logError(e, `Sidecar executable "${executablePath}" does not exist`, {
+              extra: {
                 originalExecutablePath: sidecarExecutablePath,
                 currentSidecarVersion,
               },
-              true,
-            );
+            });
             reject(new NoSidecarExecutableError(`Component ${executablePath} does not exist`));
           }
 
@@ -412,7 +409,9 @@ export class SidecarManager {
             });
           } catch (e) {
             // Failure to spawn the process. Reject and return (we're the main codepath here).
-            logError(e, `${logPrefix}: sidecar component spawn error`, {}, true);
+            logError(e, `${logPrefix}: sidecar component spawn error`, {
+              extra: { functionName: "startSidecar" },
+            });
             reject(e);
             return;
           } finally {
@@ -431,7 +430,7 @@ export class SidecarManager {
             const err = new SidecarFatalError(
               `${logPrefix}: sidecar process returned undefined PID`,
             );
-            logError(err, "sidecar process spawn", {}, true);
+            logError(err, "sidecar process spawn", { extra: { functionName: "startSidecar" } });
             reject(err);
             return;
           } else {
@@ -448,7 +447,9 @@ export class SidecarManager {
                   // reject the promise if the sidecar process is not running so we stop attempting
                   // to handshake with it
                   const err = new SidecarFatalError(`${logPrefix}: sidecar process is not running`);
-                  logError(err, "sidecar process check", {}, true);
+                  logError(err, "sidecar process check", {
+                    extra: { functionName: "startSidecar" },
+                  });
                   reject(err);
                   // show a notification to the user to Open Logs or File Issue
                   showErrorNotificationWithButtons(
@@ -457,7 +458,7 @@ export class SidecarManager {
                   return;
                 }
               } catch (e) {
-                logError(e, "sidecar process check", {}, true);
+                logError(e, "sidecar process check", { extra: { functionName: "startSidecar" } });
               }
             }, 2000);
           }
@@ -466,7 +467,9 @@ export class SidecarManager {
           // but the sidecar file architecture check above should catch most of those cases.
         } catch (e) {
           // Failure to spawn the process. Reject and return (we're the main codepath here).
-          logError(e, `${logPrefix}: sidecar component spawn fatal error`, {}, true);
+          logError(e, `${logPrefix}: sidecar component spawn fatal error`, {
+            extra: { functionName: "startSidecar" },
+          });
           reject(e);
           return;
         }
@@ -493,12 +496,9 @@ export class SidecarManager {
           } catch (e) {
             // We expect ECONNREFUSED while the sidecar is coming up, but log + rethrow other unexpected errors.
             if (!wasConnRefused(e)) {
-              logError(
-                e,
-                `${logPrefix}: Attempt raised unexpected error`,
-                { handshake_attempt: `${i}` },
-                true,
-              );
+              logError(e, `${logPrefix}: Attempt raised unexpected error`, {
+                extra: { handshake_attempt: `${i}` },
+              });
             }
             if (i < MAX_ATTEMPTS - 1) {
               logger.info(
@@ -903,15 +903,9 @@ function confirmSidecarProcessIsRunning(
     // report to Sentry so we can investigate
     const failureMsg = `${logPrefix}: Sidecar process ${pid} died immediately after startup`;
     const error = new SidecarFatalError(failureMsg);
-    logError(
-      error,
-      `sidecar process failed to start`,
-      {
-        stderr: stderrContent,
-        logs: logLines.join("\n"),
-      },
-      true,
-    );
+    logError(error, `sidecar process failed to start`, {
+      extra: { stderr: stderrContent, logs: logLines.join("\n") },
+    });
   }
   return isRunning;
 }

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -299,14 +299,11 @@ export class WebsocketManager implements Disposable {
       try {
         message.body = additionalDeserializer(body);
       } catch (e) {
-        logError(
-          e,
-          "Websocket message body higher-level body deserialization error",
-          {
+        logError(e, "Websocket message body higher-level body deserialization error", {
+          extra: {
             message: strMessage,
           },
-          true,
-        );
+        });
 
         // rethrow the error
         throw e;

--- a/src/utils/workerPool.ts
+++ b/src/utils/workerPool.ts
@@ -110,10 +110,12 @@ export async function executeInWorkerPool<T, R>(
       } catch (error) {
         errorCount++;
         logError(error, "workerPool", {
-          taskName: String(options.taskName),
-          errorCount: errorCount.toString(),
-          resultCount: resultCount.toString(),
-          totalCount: totalCount.toString(),
+          extra: {
+            taskName: String(options.taskName),
+            errorCount: errorCount.toString(),
+            resultCount: resultCount.toString(),
+            totalCount: totalCount.toString(),
+          },
         });
         if (error instanceof Error) {
           results[taskIndex] = { error };

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -573,7 +573,9 @@ export async function loadCCloudResources(
       // if we fail to load CCloud environments, we need to get as much information as possible as to
       // what went wrong since the user is effectively locked out of the CCloud resources for this org
       const msg = `Failed to load Confluent Cloud environments for the "${currentOrg?.name}" organization.`;
-      logError(e, "loading CCloud environments", {}, true);
+      logError(e, "loading CCloud environments", {
+        extra: { functionName: "loadCCloudResources" },
+      });
       showErrorNotificationWithButtons(msg);
     }
 

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -568,7 +568,9 @@ export class SchemasViewProvider implements vscode.TreeDataProvider<SchemasViewP
     try {
       await this.treeView.reveal(schema, { focus: true, select: true });
     } catch (e) {
-      logError(e, "Error revealing schema in tree view", undefined, true);
+      logError(e, "Error revealing schema in tree view", {
+        extra: { functionName: "revealSchema" },
+      });
     }
   }
 


### PR DESCRIPTION
## Summary of Changes

Thank you for the clear and detailed issue, @shouples ! 

Drafting since I had a question. 
I [didn't remove the TODO](https://github.com/confluentinc/vscode/compare/main...scope-ctx-for-logerr#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0L134), because the [beforeSend](https://docs.sentry.io/platforms/native/guides/crashpad/configuration/filtering/#event-hints) callback wasn't present in the codebase, and [this was the only documentation I ](https://docs.sentry.io/platforms/native/guides/crashpad/configuration/filtering/#event-hints)could find on the `EventHint` type. Can you say more about what you were thinking?  

```
  logger.error(errorMessage, { ...errorContext, ...sentryContext });
  // TODO: follow up to reuse EventHint type for capturing tags and other more fine-grained data
  const hasMeaningfulSentryContext =
    [
      sentryContext.extra,
      sentryContext.contexts,
      sentryContext.tags,
      sentryContext.propagationContext,
    ].some((context) => context && Object.keys(context).length > 0) ||
    sentryContext.user?.id !== undefined ||
    (sentryContext.fingerprint && sentryContext.fingerprint.length > 0);

  if (hasMeaningfulSentryContext) {
    sentryCaptureException(e, {
      captureContext: {
        contexts: { response: { status_code: responseStatusCode } },
        extra: { ...errorContext, ...sentryContext.extra },
      },
    });
  }
}
```

-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
