### PR TITLE
feat: set up initial chat participant tool integration with "list project templates" tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
           "projects"
         ],
         "displayName": "List Project Templates",
-        "modelDescription": "List all available templates for creating a streaming data project or application.",
+        "modelDescription": "List all available templates for creating a streaming data project or application. Use this when the user asks about available templates or you want to show them a list of templates.",
         "canBeReferencedInPrompt": false,
         "icon": "$(list-selection)",
         "inputSchema": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,32 @@
         "when": "confluent.chatParticipantEnabled"
       }
     ],
+    "languageModelTools": [
+      {
+        "name": "list_projectTemplates",
+        "when": "confluent.chatParticipantEnabled",
+        "tags": [
+          "projects"
+        ],
+        "displayName": "List Project Templates",
+        "modelDescription": "List all available templates for creating a streaming data project or application.",
+        "canBeReferencedInPrompt": false,
+        "icon": "$(list-selection)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [],
+              "description": "Optional tags to filter the list of templates."
+            }
+          }
+        }
+      }
+    ],
     "commands": [
       {
         "command": "confluent.connections.ccloud.signIn",

--- a/src/chat/constants.ts
+++ b/src/chat/constants.ts
@@ -1,4 +1,6 @@
 export const PARTICIPANT_ID = "confluent.chat-participant";
 
 /** The first message sent to the language model in the chat request. */
-export const INITIAL_PROMPT = `You are an assistant who helps developers working with Confluent and Apache Kafka® ecosystems, including Kafka clusters, topics, Schema Registry, Flink, and streaming applications. You provide guidance on configuration, development best practices, and troubleshooting for all Confluent-related technologies.`;
+export const INITIAL_PROMPT = `You are an assistant who helps developers working with Confluent and Apache Kafka® ecosystems, including Kafka clusters, topics, Schema Registry, Flink, and streaming applications. You provide guidance on configuration, development best practices, and troubleshooting for all Confluent-related technologies.
+
+You may use tools to help you answer questions. Do not refer to them by name/ID, but describe what are you are trying to do when invoking them.`;

--- a/src/chat/constants.ts
+++ b/src/chat/constants.ts
@@ -3,4 +3,4 @@ export const PARTICIPANT_ID = "confluent.chat-participant";
 /** The first message sent to the language model in the chat request. */
 export const INITIAL_PROMPT = `You are an assistant who helps developers working with Confluent and Apache Kafka® ecosystems, including Kafka clusters, topics, Schema Registry, Flink, and streaming applications. You provide guidance on configuration, development best practices, and troubleshooting for all Confluent-related technologies.
 
-You may use tools to help you answer questions. Do not refer to them by name/ID, but describe what are you are trying to do when invoking them.`;
+You may use tools to help you answer questions. Do not refer to them by name/ID, but describe what you are trying to do when invoking them.`;

--- a/src/chat/messageTypes.test.ts
+++ b/src/chat/messageTypes.test.ts
@@ -1,0 +1,30 @@
+import * as assert from "assert";
+import { LanguageModelChatMessage, LanguageModelChatMessageRole } from "vscode";
+import { PARTICIPANT_ID } from "./constants";
+import { participantMessage, systemMessage, userMessage } from "./messageTypes";
+
+describe("chat/messageTypes.ts", () => {
+  it("userMessage() should return a User message with a 'user' name", () => {
+    const msg: LanguageModelChatMessage = userMessage("hello");
+
+    assert.strictEqual(msg.content, "hello");
+    assert.strictEqual(msg.name, "user");
+    assert.strictEqual(msg.role, LanguageModelChatMessageRole.User);
+  });
+
+  it("participantMessage() should return an Assistant message with the participant ID as a name", () => {
+    const msg: LanguageModelChatMessage = participantMessage("beep boop");
+
+    assert.strictEqual(msg.content, "beep boop");
+    assert.strictEqual(msg.name, PARTICIPANT_ID);
+    assert.strictEqual(msg.role, LanguageModelChatMessageRole.Assistant);
+  });
+
+  it("systemMessage() should return a User message with a SYSTEM prefix and name", () => {
+    const msg: LanguageModelChatMessage = systemMessage("you are helpful");
+
+    assert.strictEqual(msg.content, "SYSTEM: you are helpful");
+    assert.strictEqual(msg.name, "system");
+    assert.strictEqual(msg.role, LanguageModelChatMessageRole.User);
+  });
+});

--- a/src/chat/messageTypes.test.ts
+++ b/src/chat/messageTypes.test.ts
@@ -1,5 +1,9 @@
 import * as assert from "assert";
-import { LanguageModelChatMessage, LanguageModelChatMessageRole } from "vscode";
+import {
+  LanguageModelChatMessage,
+  LanguageModelChatMessageRole,
+  LanguageModelTextPart,
+} from "vscode";
 import { PARTICIPANT_ID } from "./constants";
 import { participantMessage, systemMessage, userMessage } from "./messageTypes";
 
@@ -7,7 +11,7 @@ describe("chat/messageTypes.ts", () => {
   it("userMessage() should return a User message with a 'user' name", () => {
     const msg: LanguageModelChatMessage = userMessage("hello");
 
-    assert.strictEqual(msg.content, "hello");
+    assert.strictEqual((msg.content as LanguageModelTextPart[])[0].value, "hello");
     assert.strictEqual(msg.name, "user");
     assert.strictEqual(msg.role, LanguageModelChatMessageRole.User);
   });
@@ -15,7 +19,7 @@ describe("chat/messageTypes.ts", () => {
   it("participantMessage() should return an Assistant message with the participant ID as a name", () => {
     const msg: LanguageModelChatMessage = participantMessage("beep boop");
 
-    assert.strictEqual(msg.content, "beep boop");
+    assert.strictEqual((msg.content as LanguageModelTextPart[])[0].value, "beep boop");
     assert.strictEqual(msg.name, PARTICIPANT_ID);
     assert.strictEqual(msg.role, LanguageModelChatMessageRole.Assistant);
   });
@@ -23,7 +27,10 @@ describe("chat/messageTypes.ts", () => {
   it("systemMessage() should return a User message with a SYSTEM prefix and name", () => {
     const msg: LanguageModelChatMessage = systemMessage("you are helpful");
 
-    assert.strictEqual(msg.content, "SYSTEM: you are helpful");
+    assert.strictEqual(
+      (msg.content as LanguageModelTextPart[])[0].value,
+      "SYSTEM: you are helpful",
+    );
     assert.strictEqual(msg.name, "system");
     assert.strictEqual(msg.role, LanguageModelChatMessageRole.User);
   });

--- a/src/chat/messageTypes.ts
+++ b/src/chat/messageTypes.ts
@@ -1,0 +1,33 @@
+import { LanguageModelChatMessage } from "vscode";
+import { PARTICIPANT_ID } from "./constants";
+
+/**
+ * Returns a {@link LanguageModelChatMessage.User User message} with a "user" tag to clearly
+ * distinguish it from other `User` message implementations.
+ *
+ * This should only be used for the most recent {@link ChatRequest.prompt} and any historic messages.
+ */
+export function userMessage(message: string) {
+  return LanguageModelChatMessage.User(message, "user");
+}
+
+/**
+ * Returns an {@link LanguageModelChatMessage.Assistant Assistant message} with a participant tag as
+ * the {@linkcode PARTICIPANT_ID} to clearly separate it from other `Assistant` message implementations.
+ */
+export function participantMessage(message: string) {
+  return LanguageModelChatMessage.Assistant(message, PARTICIPANT_ID);
+}
+
+// TODO: update this if the `LanguageModelChatMessage` API changes and a `System` message is added
+/**
+ * Prefix and tag a {@link LanguageModelChatMessage.User User message} message to treat as a
+ * `System` message for providing additional context.
+ */
+export function systemMessage(message: string) {
+  return LanguageModelChatMessage.User(`SYSTEM: ${message}`, "system");
+}
+
+// NOTE: "tool" messages should be handled via the `.toolMessage()` method from the
+// `BaseLanguageModelTool` class, but we may want to migrate it here for easier access and
+// consistency in the future

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -21,6 +21,7 @@ import { logError } from "../errors";
 import { Logger } from "../logging";
 import { INITIAL_PROMPT, PARTICIPANT_ID } from "./constants";
 import { ModelNotSupportedError } from "./errors";
+import { participantMessage, systemMessage, userMessage } from "./messageTypes";
 import { parseReferences } from "./references";
 import { BaseLanguageModelTool } from "./tools/base";
 import { ListTemplatesTool } from "./tools/listTemplates";
@@ -40,7 +41,7 @@ export async function chatHandler(
   const messages: LanguageModelChatMessage[] = [];
 
   // add the initial prompt to the messages
-  messages.push(LanguageModelChatMessage.User(INITIAL_PROMPT, "user"));
+  messages.push(systemMessage(INITIAL_PROMPT));
 
   const userPrompt = request.prompt.trim();
   // check for empty request
@@ -53,7 +54,7 @@ export async function chatHandler(
   const historyMessages = filterContextHistory(context.history);
   messages.push(...historyMessages);
   if (userPrompt) {
-    messages.push(LanguageModelChatMessage.User(request.prompt, "user"));
+    messages.push(userMessage(request.prompt));
   }
 
   // add any additional references like `#file:<name>`
@@ -142,17 +143,30 @@ export async function handleChatMessage(
   token: CancellationToken,
 ): Promise<string[]> {
   const toolsCalled: string[] = [];
+  // keep track of which calls the model has made to prevent repeats by stringifying any
+  // `LanguageModelToolCallPart` results
+  const toolCallsMade = new Set<string>();
+
+  // limit number of iterations to prevent infinite loops
+  let iterations = 0;
+  const maxIterations = 10; // TODO: make this user-configurable?
+
+  // hint at focusing recency instead of attempting to (re)respond to older messages
+  messages.push(
+    systemMessage(
+      "Focus on answering the user's most recent query directly unless explicitly asked to address previous messages.",
+    ),
+  );
 
   // inform the model that tools can be invoked as part of the response stream
   const requestOptions: LanguageModelChatRequestOptions = {
     tools: [new ListTemplatesTool().toChatTool()],
     toolMode: LanguageModelChatToolMode.Auto,
   };
-
   // determine whether or not to continue sending chat requests to the model as a result of any tool
   // calls
   let continueConversation = true;
-  while (continueConversation) {
+  while (continueConversation && iterations < maxIterations) {
     continueConversation = false;
 
     const response: LanguageModelChatResponse = await model.sendRequest(
@@ -160,12 +174,12 @@ export async function handleChatMessage(
       requestOptions,
       token,
     );
+    iterations++;
 
     const toolResultMessages: LanguageModelChatMessage[] = [];
-    const toolCallsMade: string[] = [];
     for await (const fragment of response.stream) {
       if (token.isCancellationRequested) {
-        logger.debug("chat request cancelled");
+        logger.debug("chat request canceled");
         return toolsCalled;
       }
 
@@ -184,6 +198,18 @@ export async function handleChatMessage(
         }
         stream.progress(tool.progressMessage);
 
+        if (toolCallsMade.has(JSON.stringify(toolCall))) {
+          // don't process the same tool call twice
+          logger.debug(`Tool "${toolCall.name}" already called with input "${toolCall.input}"`);
+          messages.push(
+            systemMessage(
+              `Tool "${toolCall.name}" already called with input "${JSON.stringify(toolCall.input)}". Do not repeatedly call tools with the same inputs. Use previous result(s) if possible.`,
+            ),
+          );
+          continueConversation = true;
+          continue;
+        }
+
         // each registered tool should contribute its own way of handling the invocation and
         // interacting with the stream, and can return an array of messages to be sent for another
         // round of processing
@@ -196,7 +222,7 @@ export async function handleChatMessage(
         );
         toolResultMessages.push(...newMessages);
 
-        toolCallsMade.push(`${toolCall.name}: ${toolCall.input}`);
+        toolCallsMade.add(JSON.stringify(toolCall));
         if (!toolsCalled.includes(toolCall.name)) {
           // keep track of the tools that have been called so far as part of this chat request flow
           toolsCalled.push(toolCall.name);
@@ -207,6 +233,9 @@ export async function handleChatMessage(
     if (toolResultMessages.length) {
       // add results to the messages and let the model process them and decide what to do next
       messages.push(...toolResultMessages);
+      messages.push(
+        systemMessage("Please continue the conversation using the information from the tool call."),
+      );
       continueConversation = true;
     }
   }
@@ -224,7 +253,6 @@ function filterContextHistory(
   const filteredHistory: (ChatRequestTurn | ChatResponseTurn)[] = history.filter(
     (msg) => msg.participant === PARTICIPANT_ID,
   );
-  logger.debug("filtered history:", filteredHistory);
   if (filteredHistory.length === 0) {
     return [];
   }
@@ -233,19 +261,18 @@ function filterContextHistory(
     // don't re-use previous prompts since the model may misinterpret them as part of the current prompt
     if (turn instanceof ChatRequestTurn) {
       if (turn.participant === PARTICIPANT_ID) {
-        messages.push(LanguageModelChatMessage.User(turn.prompt, "user"));
+        messages.push(userMessage(turn.prompt));
       }
       continue;
     }
     if (turn instanceof ChatResponseTurn) {
       // responses from the participant:
       if (turn.response instanceof ChatResponseMarkdownPart) {
-        messages.push(
-          LanguageModelChatMessage.Assistant(turn.response.value.value, PARTICIPANT_ID),
-        );
+        messages.push(participantMessage(turn.response.value.value));
       }
     }
   }
 
+  logger.debug("filtered messages for historic context:", messages);
   return messages;
 }

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -233,6 +233,9 @@ export async function handleChatMessage(
     if (toolResultMessages.length) {
       // add results to the messages and let the model process them and decide what to do next
       messages.push(...toolResultMessages);
+      // send synthetic "user" message to the model to indicate that the conversation should continue
+      // (.sendRequest requires the last message to be a `User` message; see
+      // https://github.com/microsoft/vscode-extension-samples/blob/26acb262b8b2b41e9e466115f13a7f72ef63d59d/chat-sample/src/toolsPrompt.tsx#L83)
       messages.push(
         systemMessage("Please continue the conversation using the information from the tool call."),
       );

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -9,8 +9,12 @@ import {
   ChatResult,
   LanguageModelChat,
   LanguageModelChatMessage,
+  LanguageModelChatRequestOptions,
   LanguageModelChatResponse,
   LanguageModelChatSelector,
+  LanguageModelChatToolMode,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
   lm,
 } from "vscode";
 import { logError } from "../errors";
@@ -18,6 +22,9 @@ import { Logger } from "../logging";
 import { INITIAL_PROMPT, PARTICIPANT_ID } from "./constants";
 import { ModelNotSupportedError } from "./errors";
 import { parseReferences } from "./references";
+import { BaseLanguageModelTool } from "./tools/base";
+import { ListTemplatesTool } from "./tools/listTemplates";
+import { getToolMap } from "./tools/toolMap";
 
 const logger = new Logger("chat.participant");
 
@@ -71,8 +78,8 @@ export async function chatHandler(
 
   // non-command request
   try {
-    await handleChatMessage(messages, stream, token, model);
-    return {};
+    const toolsCalled: string[] = await handleChatMessage(request, model, messages, stream, token);
+    return { metadata: { toolsCalled } };
   } catch (error) {
     if (error instanceof Error) {
       if (error.message.includes("model_not_supported")) {
@@ -127,21 +134,84 @@ async function getModel(selector: LanguageModelChatSelector): Promise<LanguageMo
 }
 
 /** Send message(s) and stream the response in markdown format. */
-async function handleChatMessage(
+export async function handleChatMessage(
+  request: ChatRequest,
+  model: LanguageModelChat,
   messages: LanguageModelChatMessage[],
   stream: ChatResponseStream,
   token: CancellationToken,
-  model: LanguageModelChat,
-): Promise<void> {
-  const response: LanguageModelChatResponse = await model.sendRequest(messages, {}, token);
+): Promise<string[]> {
+  const toolsCalled: string[] = [];
 
-  for await (const fragment of response.text) {
-    if (token.isCancellationRequested) {
-      logger.debug("chat request cancelled");
-      return;
+  // inform the model that tools can be invoked as part of the response stream
+  const requestOptions: LanguageModelChatRequestOptions = {
+    tools: [new ListTemplatesTool().toChatTool()],
+    toolMode: LanguageModelChatToolMode.Auto,
+  };
+
+  // determine whether or not to continue sending chat requests to the model as a result of any tool
+  // calls
+  let continueConversation = true;
+  while (continueConversation) {
+    continueConversation = false;
+
+    const response: LanguageModelChatResponse = await model.sendRequest(
+      messages,
+      requestOptions,
+      token,
+    );
+
+    const toolResultMessages: LanguageModelChatMessage[] = [];
+    const toolCallsMade: string[] = [];
+    for await (const fragment of response.stream) {
+      if (token.isCancellationRequested) {
+        logger.debug("chat request cancelled");
+        return toolsCalled;
+      }
+
+      if (fragment instanceof LanguageModelTextPart) {
+        // basic text response
+        stream.markdown(fragment.value);
+      } else if (fragment instanceof LanguageModelToolCallPart) {
+        // tool call: look up the tool from the map, process its invocation result(s), and continue on
+        const toolCall: LanguageModelToolCallPart = fragment as LanguageModelToolCallPart;
+        const tool: BaseLanguageModelTool<any> | undefined = getToolMap().get(toolCall.name);
+        if (!tool) {
+          const errorMsg = `Tool "${toolCall.name}" not found.`;
+          logger.error(errorMsg);
+          stream.markdown(errorMsg);
+          return toolsCalled;
+        }
+        stream.progress(tool.progressMessage);
+
+        // each registered tool should contribute its own way of handling the invocation and
+        // interacting with the stream, and can return an array of messages to be sent for another
+        // round of processing
+        logger.debug(`Processing tool invocation for "${toolCall.name}"`);
+        const newMessages: LanguageModelChatMessage[] = await tool.processInvocation(
+          request,
+          stream,
+          toolCall,
+          token,
+        );
+        toolResultMessages.push(...newMessages);
+
+        toolCallsMade.push(`${toolCall.name}: ${toolCall.input}`);
+        if (!toolsCalled.includes(toolCall.name)) {
+          // keep track of the tools that have been called so far as part of this chat request flow
+          toolsCalled.push(toolCall.name);
+        }
+      }
     }
-    stream.markdown(fragment);
+
+    if (toolResultMessages.length) {
+      // add results to the messages and let the model process them and decide what to do next
+      messages.push(...toolResultMessages);
+      continueConversation = true;
+    }
   }
+
+  return toolsCalled;
 }
 
 /** Filter the chat history to only relevant messages for the current chat. */
@@ -158,18 +228,21 @@ function filterContextHistory(
   if (filteredHistory.length === 0) {
     return [];
   }
-
   const messages: LanguageModelChatMessage[] = [];
   for (const turn of filteredHistory) {
     // don't re-use previous prompts since the model may misinterpret them as part of the current prompt
     if (turn instanceof ChatRequestTurn) {
-      // TODO: check for references/commands used?
+      if (turn.participant === PARTICIPANT_ID) {
+        messages.push(LanguageModelChatMessage.User(turn.prompt, "user"));
+      }
       continue;
     }
     if (turn instanceof ChatResponseTurn) {
       // responses from the participant:
       if (turn.response instanceof ChatResponseMarkdownPart) {
-        messages.push(LanguageModelChatMessage.User(turn.response.value.value, PARTICIPANT_ID));
+        messages.push(
+          LanguageModelChatMessage.Assistant(turn.response.value.value, PARTICIPANT_ID),
+        );
       }
     }
   }

--- a/src/chat/tools/README.md
+++ b/src/chat/tools/README.md
@@ -1,0 +1,9 @@
+This subdirectory houses the registration and handling of "tools" that can be invoked by the user
+(if registered in `package.json`'s `languageModelTools` section with
+`canBeReferencedInPrompt: true`) and/or by the language model (if sent as part of `tools` in the
+`LanguageModelChatRequestOptions`).
+
+Tools that provide additional context to conversations should return messages via the
+`.toolMessage()` method, which will tag an `Assistant` message with the tool name and a `tool` role.
+(This is different than the `systemMessage()` function, which wraps a `User` message to provide
+non-tool context to the language model.)

--- a/src/chat/tools/base.ts
+++ b/src/chat/tools/base.ts
@@ -18,6 +18,8 @@ import { LanguageModelToolContribution } from "./types";
  */
 export abstract class BaseLanguageModelTool<T> implements LanguageModelTool<T> {
   abstract readonly name: string;
+  /** Message to be shown when this tool is called in a chat session via `stream.progress()`. */
+  abstract readonly progressMessage: string;
 
   abstract invoke(
     options: LanguageModelToolInvocationOptions<T>,

--- a/src/chat/tools/base.ts
+++ b/src/chat/tools/base.ts
@@ -37,6 +37,15 @@ export abstract class BaseLanguageModelTool<T> implements LanguageModelTool<T> {
     token: CancellationToken,
   ): Promise<LanguageModelChatMessage[]>;
 
+  /** Return an `Assistant` message with tool-call related information. */
+  toolMessage(message: string, status?: string): LanguageModelChatMessage {
+    let roleName = `tool:${this.name}`;
+    if (status !== undefined) {
+      roleName = `${roleName}:${status}`;
+    }
+    return LanguageModelChatMessage.Assistant(message, roleName);
+  }
+
   /** Converts this tool to a {@link LanguageModelChatTool} for use in chat requests. */
   toChatTool(): LanguageModelChatTool {
     const packageJson = getExtensionContext().extension.packageJSON;

--- a/src/chat/tools/base.ts
+++ b/src/chat/tools/base.ts
@@ -1,0 +1,54 @@
+import {
+  CancellationToken,
+  ChatRequest,
+  ChatResponseStream,
+  LanguageModelChatMessage,
+  LanguageModelChatTool,
+  LanguageModelTool,
+  LanguageModelToolCallPart,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolResult,
+} from "vscode";
+import { getExtensionContext } from "../../context/extension";
+import { LanguageModelToolContribution } from "./types";
+
+/**
+ * Base class for a {@link LanguageModelTool} that adds a {@linkcode toChatTool} method for
+ * converting to a {@link LanguageModelChatTool}.
+ */
+export abstract class BaseLanguageModelTool<T> implements LanguageModelTool<T> {
+  abstract readonly name: string;
+
+  abstract invoke(
+    options: LanguageModelToolInvocationOptions<T>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult>;
+
+  /**
+   * Invokes the tool and processes the result through the {@link ChatResponseStream}.
+   * This should be called when the model selects this tool in a {@link LanguageModelToolCallPart}.
+   */
+  abstract processInvocation(
+    request: ChatRequest,
+    stream: ChatResponseStream,
+    toolCall: LanguageModelToolCallPart,
+    token: CancellationToken,
+  ): Promise<LanguageModelChatMessage[]>;
+
+  /** Converts this tool to a {@link LanguageModelChatTool} for use in chat requests. */
+  toChatTool(): LanguageModelChatTool {
+    const packageJson = getExtensionContext().extension.packageJSON;
+    const registeredTool: LanguageModelToolContribution | undefined =
+      packageJson.contributes.languageModelTools!.find(
+        (tool: { name: string }) => tool.name === this.name,
+      );
+    if (!registeredTool) {
+      throw new Error(`Tool "${this.name}" not found in package.json`);
+    }
+    return {
+      name: this.name,
+      description: registeredTool.modelDescription,
+      inputSchema: registeredTool.inputSchema,
+    } as LanguageModelChatTool;
+  }
+}

--- a/src/chat/tools/listTemplates.test.ts
+++ b/src/chat/tools/listTemplates.test.ts
@@ -1,0 +1,40 @@
+import * as assert from "assert";
+import { inputTagsMatchSpecTags } from "./listTemplates";
+
+describe("chat/tools/listTemplates.ts inputTagsMatchSpecTags()", () => {
+  it("should return true if an input tag directly matches a spec tag", () => {
+    const inputTags = ["tag1"];
+    const specTags = ["tag1", "tag2"];
+
+    const result = inputTagsMatchSpecTags(inputTags, specTags);
+
+    assert.ok(result);
+  });
+
+  it("should return true if an input tag is contained within a spec tag", () => {
+    const inputTags = ["tag1"];
+    const specTags = ["tag2", "tag1-tag3"];
+
+    const result = inputTagsMatchSpecTags(inputTags, specTags);
+
+    assert.ok(result);
+  });
+
+  it("should return false if an input tag does not match any spec tags", () => {
+    const inputTags = ["tag1"];
+    const specTags = ["tag2", "tag3"];
+
+    const result = inputTagsMatchSpecTags(inputTags, specTags);
+
+    assert.ok(!result);
+  });
+
+  it("should return false if spec tags are not provided", () => {
+    const inputTags = ["tag1"];
+    const specTags = undefined;
+
+    const result = inputTagsMatchSpecTags(inputTags, specTags);
+
+    assert.ok(!result);
+  });
+});

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -44,7 +44,7 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
       }
       templateStrings.push(
         new LanguageModelTextPart(
-          `id="${spec.name}"; display_name="${spec.display_name}"; description="${spec.description}; inputOptions="${JSON.stringify(spec.options)}".`,
+          `id="${spec.name}"; display_name="${spec.display_name}"; description="${spec.description}"; inputOptions="${JSON.stringify(spec.options)}".`,
         ),
       );
     });

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -1,0 +1,78 @@
+import {
+  CancellationToken,
+  ChatRequest,
+  ChatResponseStream,
+  LanguageModelChatMessage,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolResult,
+} from "vscode";
+import { ScaffoldV1Template } from "../../clients/scaffoldingService";
+import { Logger } from "../../logging";
+import { getTemplatesList } from "../../scaffold";
+import { BaseLanguageModelTool } from "./base";
+
+const logger = new Logger("chat.tools.listTemplates");
+
+export interface IListTemplatesParameters {
+  tags: string[];
+}
+
+export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParameters> {
+  readonly name = "list_projectTemplates";
+
+  async invoke(
+    options: LanguageModelToolInvocationOptions<IListTemplatesParameters>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    const params = options.input;
+    logger.debug("params:", params);
+
+    const templateList = await getTemplatesList();
+    logger.debug("templateList:", templateList);
+
+    const templates = Array.from(templateList.data) as ScaffoldV1Template[];
+    const templateStrings: LanguageModelTextPart[] = templates.map((template) => {
+      const spec = template.spec!;
+      return new LanguageModelTextPart(
+        `${spec.name} ("${spec.display_name}"): ${spec.description}`,
+      );
+    });
+
+    if (token.isCancellationRequested) {
+      logger.debug("Tool invocation cancelled");
+      return new LanguageModelToolResult([]);
+    }
+    return new LanguageModelToolResult(templateStrings);
+  }
+
+  async processInvocation(
+    request: ChatRequest,
+    stream: ChatResponseStream,
+    toolCall: LanguageModelToolCallPart,
+    token: CancellationToken,
+  ): Promise<LanguageModelChatMessage[]> {
+    const parameters = toolCall.input as IListTemplatesParameters;
+
+    const result: LanguageModelToolResult = await this.invoke(
+      {
+        input: parameters,
+        toolInvocationToken: request.toolInvocationToken,
+      },
+      token,
+    );
+
+    const messages: LanguageModelChatMessage[] = [];
+    if (result.content && Array.isArray(result.content)) {
+      let message = `Available project templates:\n`;
+      for (const part of result.content as LanguageModelTextPart[]) {
+        message = `${message}\n\n${part.value}`;
+      }
+      messages.push(LanguageModelChatMessage.User(message, `${this.name}-result`));
+    } else {
+      throw new Error(`Unexpected result content structure: ${JSON.stringify(result)}`);
+    }
+    return messages;
+  }
+}

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -21,6 +21,7 @@ export interface IListTemplatesParameters {
 
 export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParameters> {
   readonly name = "list_projectTemplates";
+  readonly progressMessage = "Checking available project templates...";
 
   async invoke(
     options: LanguageModelToolInvocationOptions<IListTemplatesParameters>,
@@ -28,15 +29,23 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
   ): Promise<LanguageModelToolResult> {
     const params = options.input;
     logger.debug("params:", params);
+    const inputTagsPassed: boolean = Array.isArray(params.tags) && params.tags.length > 0;
 
     const templateList = await getTemplatesList();
     logger.debug("templateList:", templateList);
 
     const templates = Array.from(templateList.data) as ScaffoldV1Template[];
-    const templateStrings: LanguageModelTextPart[] = templates.map((template) => {
+    const templateStrings: LanguageModelTextPart[] = [];
+    templates.forEach((template) => {
       const spec = template.spec!;
-      return new LanguageModelTextPart(
-        `${spec.name} ("${spec.display_name}"): ${spec.description}`,
+      if (inputTagsPassed && !inputTagsMatchSpecTags(params.tags, spec.tags)) {
+        // skip any templates that don't match provided tags
+        return;
+      }
+      templateStrings.push(
+        new LanguageModelTextPart(
+          `id="${spec.name}"; display_name="${spec.display_name}"; description="${spec.description}; inputOptions="${JSON.stringify(spec.options)}".`,
+        ),
       );
     });
 
@@ -69,10 +78,38 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
       for (const part of result.content as LanguageModelTextPart[]) {
         message = `${message}\n\n${part.value}`;
       }
-      messages.push(LanguageModelChatMessage.User(message, `${this.name}-result`));
+      message = `${message}\n\nUse the display names and descriptions when responding to the user. Use the IDs when creating projects with templates.`;
+      messages.push(LanguageModelChatMessage.User(message, `tool:${this.name}:result`));
     } else {
-      throw new Error(`Unexpected result content structure: ${JSON.stringify(result)}`);
+      messages.push(
+        LanguageModelChatMessage.User(
+          `Unexpected result content structure: ${JSON.stringify(result)}`,
+          `tool:${this.name}:error`,
+        ),
+      );
     }
     return messages;
   }
+}
+
+export function inputTagsMatchSpecTags(
+  inputTags: string[],
+  specTags: string[] | undefined,
+): boolean {
+  if (!(Array.isArray(specTags) && specTags.length)) {
+    return false;
+  }
+
+  const inputTagsLower = inputTags.map((tag) => tag.toLowerCase());
+  const specTagsLower = specTags.map((tag) => tag.toLowerCase());
+  // spec tag directly matches an input tag, or input tag is contained within a spec tag
+  // (e.g. "flink" in "apache flink")
+  return specTagsLower.some((specTag) => {
+    for (const tag of inputTagsLower) {
+      if (specTag === tag || specTag.includes(tag)) {
+        return true;
+      }
+    }
+    return false;
+  });
 }

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -79,19 +79,17 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
         message = `${message}\n\n${part.value}`;
       }
       message = `${message}\n\nUse the display names and descriptions when responding to the user. Use the IDs when creating projects with templates.`;
-      messages.push(LanguageModelChatMessage.User(message, `tool:${this.name}:result`));
+      messages.push(this.toolMessage(message, "result"));
     } else {
-      messages.push(
-        LanguageModelChatMessage.User(
-          `Unexpected result content structure: ${JSON.stringify(result)}`,
-          `tool:${this.name}:error`,
-        ),
-      );
+      const errorMessage = `Unexpected result content structure: ${JSON.stringify(result)}`;
+      logger.error(errorMessage);
+      messages.push(this.toolMessage(errorMessage, "error"));
     }
     return messages;
   }
 }
 
+/** Check if `inputTags` match any of the `specTags`, either directly or as a substring. */
 export function inputTagsMatchSpecTags(
   inputTags: string[],
   specTags: string[] | undefined,

--- a/src/chat/tools/registration.ts
+++ b/src/chat/tools/registration.ts
@@ -1,0 +1,19 @@
+import { Disposable, lm } from "vscode";
+import { BaseLanguageModelTool } from "./base";
+import { ListTemplatesTool } from "./listTemplates";
+import { setToolMap } from "./toolMap";
+
+export function registerChatTools(): Disposable[] {
+  const disposables: Disposable[] = [];
+
+  const tools = new Map<string, BaseLanguageModelTool<any>>([
+    ["list_projectTemplates", new ListTemplatesTool()],
+  ]);
+
+  for (const [toolId, tool] of tools.entries()) {
+    disposables.push(lm.registerTool(toolId, tool));
+    setToolMap(toolId, tool);
+  }
+
+  return disposables;
+}

--- a/src/chat/tools/toolMap.ts
+++ b/src/chat/tools/toolMap.ts
@@ -1,0 +1,11 @@
+import { BaseLanguageModelTool } from "./base";
+
+const TOOL_MAP = new Map<string, BaseLanguageModelTool<any>>();
+
+export function setToolMap(toolId: string, tool: BaseLanguageModelTool<any>) {
+  TOOL_MAP.set(toolId, tool);
+}
+
+export function getToolMap() {
+  return TOOL_MAP;
+}

--- a/src/chat/tools/types.ts
+++ b/src/chat/tools/types.ts
@@ -1,5 +1,6 @@
 // NOTE: property descriptions below taken from package.json help text, not currently available at
 // https://code.visualstudio.com/api/references/contribution-points
+
 /** An object in the package.json `languageModelTools`. */
 export interface LanguageModelToolContribution {
   /**

--- a/src/chat/tools/types.ts
+++ b/src/chat/tools/types.ts
@@ -1,0 +1,43 @@
+// NOTE: property descriptions below taken from package.json help text, not currently available at
+// https://code.visualstudio.com/api/references/contribution-points
+/** An object in the package.json `languageModelTools`. */
+export interface LanguageModelToolContribution {
+  /**
+   * A unique name for this tool. This name must be a globally unique identifier, and is also used
+   * as a name when presenting this tool to a language model.
+   * @see https://code.visualstudio.com/api/extension-guides/tools#guidelines
+   */
+  name: string;
+  /**
+   * Condition which must be true for this tool to be enabled. Note that a tool may still be invoked
+   * by another extension even when its `when` condition is false.
+   * @see https://code.visualstudio.com/api/references/when-clause-contexts
+   */
+  when: string;
+  /** A human-readable name for this tool that may be used to describe it in the UI. */
+  displayName: string;
+  /** An icon that represents this tool. Either a file path, an object with file paths for dark and
+   * light themes, or a theme icon reference, like `$(zap)`. */
+  icon: string;
+  /**
+   * A set of tags that roughly describe the tool's capabilities. A tool user may use these to
+   * filter the set of tools to just ones that are relevant for the task at hand, or they may want
+   * to pick a tag that can be used to identify just the tools contributed by this extension.
+   */
+  tags?: string[];
+  /** If true, this tool shows up as an attachment that the user can add manually to their request.
+   * Chat participants will receive the tool in `ChatRequest#toolReferences`. */
+  canBeReferencedInPrompt: boolean;
+  /**
+   * If `canBeReferencedInPrompt` is enabled for this tool, the user may use '#' with this name to
+   * invoke the tool in a query. Otherwise, the name is not required. Name must not contain
+   * whitespace.
+   */
+  toolReferenceName: string;
+  /** A description of this tool that may be used by a language model to select it. */
+  modelDescription: string;
+  /** A JSON schema for the input this tool accepts. The input must be an object at the top level.
+   * A particular language model may not support all JSON schema features. See the documentation
+   * for the language model family you are using for more information. */
+  inputSchema: object;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { getCCloudAuthSession } from "./authn/utils";
 import { disableCCloudStatusPolling, enableCCloudStatusPolling } from "./ccloudStatus/polling";
 import { PARTICIPANT_ID } from "./chat/constants";
 import { chatHandler } from "./chat/participant";
+import { registerChatTools } from "./chat/tools/registration";
 import { registerCommandWithLogging } from "./commands";
 import { registerConnectionCommands } from "./commands/connections";
 import { registerDebugCommands } from "./commands/debugtools";
@@ -274,7 +275,7 @@ async function _activateExtension(
   // register the Copilot chat participant
   const chatParticipant = vscode.chat.createChatParticipant(PARTICIPANT_ID, chatHandler);
   chatParticipant.iconPath = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);
-  context.subscriptions.push(chatParticipant);
+  context.subscriptions.push(chatParticipant, ...registerChatTools());
 
   // track the status bar for CCloud notices (fetched from the Statuspage Status API)
   enableCCloudStatusPolling();

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -292,7 +292,7 @@ async function pickTemplate(
   });
 }
 
-async function getTemplatesList(): Promise<ScaffoldV1TemplateList> {
+export async function getTemplatesList(): Promise<ScaffoldV1TemplateList> {
   // TODO: fetch CCloud templates here once the sidecar supports authenticated template listing
 
   const client: TemplatesScaffoldV1Api = (await getSidecar()).getTemplatesApi();

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -767,7 +767,7 @@ describe("ResourceManager direct connection methods", function () {
     // make sure they exist
     let storedSpecs: DirectConnectionsById = await rm.getDirectConnections();
     assert.ok(storedSpecs);
-    assert.equal(storedSpecs.size, specs.length, JSON.stringify(storedSpecs, null, 2));
+    assert.equal(storedSpecs.size, specs.length, mapToString(storedSpecs));
 
     // delete all connections
     await rm.deleteDirectConnections();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR sets up some of the basic structures needed for our `@Confluent` Copilot chat participant to start using ["tools"](https://code.visualstudio.com/api/extension-guides/tools) based on lessons learned while collaborating with @Cerchie over https://github.com/confluentinc/vscode/pull/1458.

As part of this setup, the first tool exposes functionality **solely to the chat model** to allow it to list project templates from the scaffolding service by reusing [`getTemplatesList()`](https://github.com/confluentinc/vscode/blob/d1be37e68cd0d036dec3dc067ae5b486de71d864/src/scaffold.ts#L296C23-L296C39).


https://github.com/user-attachments/assets/6f424860-4fba-4f59-a6c4-71d310bc3156



Closes #1329, closes #1469.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Some other helpers are added here:
- [`messageTypes.ts`](https://github.com/confluentinc/vscode/blob/d1be37e68cd0d036dec3dc067ae5b486de71d864/src/chat/messageTypes.ts): the VS Code API is limited to `Assistant` and `User` messages but supports adding names to each, so we have to work within those confines to provide the right role/tone/"tag" based on what message contents need to be passed.
- [BaseLanguageModelTool](https://github.com/confluentinc/vscode/blob/d1be37e68cd0d036dec3dc067ae5b486de71d864/src/chat/tools/base.ts): base class providing some helper methods to make working with `LanguageModelTool`s easier, including a `toolMessage` method for reporting results/errors from tool invocations

> [!WARNING]  
> I've occasionally seen `Claude 3.5 Sonnet` respond with text hinting at listing templates, but then never actually invokes the tool call. I'm not sure how best to handle this, but I haven't seen the same behavior with other available models.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
