### PR TITLE
Eagerly fetch + cache users's ccloud organization ID as a "coarse resource"

### DIFF
--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -54,7 +54,7 @@ export class FlinkStatementsViewProvider
         },
       );
 
-      // Repopulate this.subjectsInTreeView from getSubjects() result.
+      // Repopulate this.resourcesInTreeView from getFlinkStatements() result.
       statements.forEach((r: FlinkStatement) => this.resourcesInTreeView.set(r.id, r));
     }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Have CCloud loader also fetch (and cache) the user's organization id concurrently with the fetch for the Confluent Cloud environments.
- Makes fetching the first Flink resources (statements, artifacts) go one step faster because organization id will already be known. We can't use the Flink API clients until we know the organization ID -- is part of the API paths.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- The original ticket thought that this could be done by watching websocket connection events, and that the organization id will be pushed to us. Alas:
   - Even though the organization id field is in the spec, it was optional and doesn't seem to be populated when we get a ccloud connection change event pushed to us.
   - Even if it were present, we won't always get this event (say, second workspace coming online _after_ sidecar already had a ccloud connection).

  - While here, fix comment copypasta left over from #1452.

  - Closes #1446
## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
