### PR TITLE
1476 filterable environment quickpick

### DIFF
--- a/src/commands/environments.ts
+++ b/src/commands/environments.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { currentFlinkStatementsResourceChanged } from "../emitters";
 import { CCloudEnvironment } from "../models/environment";
-import { environmentQuickPick as ccloudEnvironmentQuickPick } from "../quickpicks/environments";
+import { flinkCcloudEnvironmentQuickPick } from "../quickpicks/environments";
 import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 
 async function setFlinkStatementsEnvironmentCommand(item?: CCloudEnvironment): Promise<void> {
@@ -17,7 +17,7 @@ async function setFlinkStatementsEnvironmentCommand(item?: CCloudEnvironment): P
     //  show progress while it is loading)
     item = await FlinkStatementsViewProvider.getInstance().withProgress(
       "Select Environment",
-      ccloudEnvironmentQuickPick,
+      flinkCcloudEnvironmentQuickPick,
     );
     if (!item) {
       // aborted the quickpick.

--- a/src/quickpicks/environments.test.ts
+++ b/src/quickpicks/environments.test.ts
@@ -1,0 +1,159 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { IconNames } from "../constants";
+import { CCloudResourceLoader } from "../loaders";
+import { CCloudEnvironment } from "../models/environment";
+import { EnvironmentId } from "../models/resource";
+import * as connections from "../sidecar/connections/ccloud";
+import { ccloudEnvironmentQuickPick, flinkCcloudEnvironmentQuickPick } from "./environments";
+
+describe("quickpicks/environments.ts ccloudEnvironmentQuickPick() / flinkCcloudEnvironmentQuickPick()", function () {
+  let sandbox: sinon.SinonSandbox;
+
+  let showQuickPickStub: sinon.SinonStub;
+  let showInfoStub: sinon.SinonStub;
+  let hasCCloudAuthSessionStub: sinon.SinonStub;
+  let getInstanceStub: sinon.SinonStub;
+
+  let loaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+
+  // No flink compute pools.
+  const noFlinkEnvironment = TEST_CCLOUD_ENVIRONMENT;
+
+  const flinkableEnvironment = new CCloudEnvironment({
+    ...TEST_CCLOUD_ENVIRONMENT,
+    id: "flinkable-env" as EnvironmentId,
+    name: "flinkable-env",
+    flinkComputePools: [TEST_CCLOUD_FLINK_COMPUTE_POOL],
+  });
+
+  const testEnvironments = [noFlinkEnvironment, flinkableEnvironment];
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+
+    // vscode stubs
+    showQuickPickStub = sandbox.stub(vscode.window, "showQuickPick");
+    showInfoStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
+
+    // Other stubs
+    hasCCloudAuthSessionStub = sandbox.stub(connections, "hasCCloudAuthSession").returns(true);
+
+    loaderStub = sandbox.createStubInstance(CCloudResourceLoader);
+    getInstanceStub = sandbox.stub(CCloudResourceLoader, "getInstance").returns(loaderStub);
+    loaderStub.getEnvironments.resolves(testEnvironments);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should show information message and return undefined when not authenticated", async function () {
+    hasCCloudAuthSessionStub.returns(false);
+
+    const result = await ccloudEnvironmentQuickPick(undefined);
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.calledOnce(showInfoStub);
+    sinon.assert.calledWithExactly(showInfoStub, "No Confluent Cloud connection found.");
+    sinon.assert.notCalled(showQuickPickStub);
+  });
+
+  it("should show information message and return undefined when no environments are found", async function () {
+    loaderStub.getEnvironments.resolves([]);
+
+    const result = await ccloudEnvironmentQuickPick(undefined);
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.calledOnce(showInfoStub);
+    sinon.assert.calledWithExactly(showInfoStub, "No Confluent Cloud environments found.");
+    sinon.assert.notCalled(showQuickPickStub);
+  });
+
+  it("should correctly set quickpick options", async function () {
+    await ccloudEnvironmentQuickPick(undefined);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    const options = showQuickPickStub.firstCall.args[1];
+    assert.strictEqual(options.placeHolder, "Select an environment");
+  });
+
+  it("should get environments from the CCloudResourceLoader", async function () {
+    await ccloudEnvironmentQuickPick(undefined);
+
+    sinon.assert.calledOnce(getInstanceStub);
+    sinon.assert.calledOnce(loaderStub.getEnvironments);
+  });
+
+  it("should show quickpick with environments and appropriate icons", async function () {
+    await ccloudEnvironmentQuickPick(undefined);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+
+    const quickPickItems: vscode.QuickPickItem[] = showQuickPickStub.firstCall.args[0];
+    assert.strictEqual(quickPickItems.length, 2);
+
+    // Check the first environment
+    assert.strictEqual(quickPickItems[0].label, noFlinkEnvironment.name);
+    assert.strictEqual(quickPickItems[0].description, noFlinkEnvironment.id);
+    assert.strictEqual(
+      (quickPickItems[0].iconPath as vscode.ThemeIcon).id,
+      IconNames.CCLOUD_ENVIRONMENT,
+    );
+
+    // Check the second environment
+    assert.strictEqual(quickPickItems[1].label, flinkableEnvironment.name);
+    assert.strictEqual(quickPickItems[1].description, flinkableEnvironment.id);
+    assert.strictEqual(
+      (quickPickItems[1].iconPath as vscode.ThemeIcon).id,
+      IconNames.CCLOUD_ENVIRONMENT,
+    );
+  });
+
+  it("should return the selected environment", async function () {
+    showQuickPickStub.resolves({
+      label: noFlinkEnvironment.name,
+      description: noFlinkEnvironment.id,
+    });
+
+    const result = await ccloudEnvironmentQuickPick(undefined);
+
+    assert.strictEqual(result, noFlinkEnvironment);
+  });
+
+  it("should return undefined if no environment is selected", async function () {
+    // User cancels the quickpick
+    showQuickPickStub.resolves(undefined);
+
+    const result = await ccloudEnvironmentQuickPick(undefined);
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("should apply filter function when provided", async function () {
+    const filter = (env: CCloudEnvironment) => env.flinkComputePools.length > 0;
+
+    await ccloudEnvironmentQuickPick(filter);
+
+    sinon.assert.calledOnce(showQuickPickStub);
+
+    // Should have only offered the flinkable environment.
+    const quickPickItems: vscode.QuickPickItem[] = showQuickPickStub.firstCall.args[0];
+    assert.strictEqual(quickPickItems.length, 1);
+    assert.strictEqual(quickPickItems[0].label, flinkableEnvironment.name);
+  });
+
+  it("flinkCcloudEnvironmentQuickPick() should call ccloudEnvironmentQuickPick with filter", async function () {
+    await flinkCcloudEnvironmentQuickPick();
+
+    sinon.assert.calledOnce(showQuickPickStub);
+
+    // Should have only offered the flinkable environemnt.
+    const quickPickItems: vscode.QuickPickItem[] = showQuickPickStub.firstCall.args[0];
+    assert.strictEqual(quickPickItems.length, 1);
+    assert.strictEqual(quickPickItems[0].label, flinkableEnvironment.name);
+  });
+});

--- a/src/quickpicks/environments.test.ts
+++ b/src/quickpicks/environments.test.ts
@@ -151,7 +151,7 @@ describe("quickpicks/environments.ts ccloudEnvironmentQuickPick() / flinkCcloudE
 
     sinon.assert.calledOnce(showQuickPickStub);
 
-    // Should have only offered the flinkable environemnt.
+    // Should have only offered the flinkable environment.
     const quickPickItems: vscode.QuickPickItem[] = showQuickPickStub.firstCall.args[0];
     assert.strictEqual(quickPickItems.length, 1);
     assert.strictEqual(quickPickItems[0].label, flinkableEnvironment.name);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Generalize `ccloudEnvironmentQuickPick()` to take an optional filter function to use to filter the possible environments.

- Make convenience variant, `flinkCcloudEnvironmentQuickPick()`, only offering the flinkable environments as determined at this time by the presence of at least one flink cluster, wired up into the command for picking the environment to show flink statements for.

- While here,  make`ccloudEnvironmentQuickPick()` consult the CCLoudResourceLoader cached environments, not deep-graphql-fetch every time.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

<img width="702" alt="image" src="https://github.com/user-attachments/assets/1fdbd484-40af-4e8a-a81d-09022fa7261c" />


- Closes #1476
- Closes #1466

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
