### PR TITLE
fix(test): `deleteDirectConnections() should delete all direct connections`

### DIFF
--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -771,7 +771,8 @@ describe("ResourceManager direct connection methods", function () {
     ];
     testConnectionIdsToCleanUp.add(id1);
     testConnectionIdsToCleanUp.add(id2);
-    await Promise.all(specs.map((spec) => rm.addDirectConnection(spec)));
+    await rm.addDirectConnection(specs[0]);
+    await rm.addDirectConnection(specs[1]);
 
     // make sure they exist
     let storedSpecs: DirectConnectionsById = await rm.getDirectConnections();

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { randomUUID } from "crypto";
 import { StorageManager } from ".";
 import {
   TEST_CCLOUD_ENVIRONMENT,
@@ -754,25 +755,29 @@ describe("ResourceManager direct connection methods", function () {
   });
 
   it("deleteDirectConnections() should delete all direct connections", async () => {
+    const id1 = `deleteme1-${randomUUID()}` as ConnectionId;
+    const id2 = `deleteme2-${randomUUID()}` as ConnectionId;
     // preload multiple connections
     const specs: CustomConnectionSpec[] = [
-      TEST_DIRECT_CONNECTION_FORM_SPEC,
-      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: "other-id" as ConnectionId },
-      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: "another-id" as ConnectionId },
+      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: id1 },
+      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: id2 },
     ];
     await Promise.all(specs.map((spec) => rm.addDirectConnection(spec)));
 
     // make sure they exist
     let storedSpecs: DirectConnectionsById = await rm.getDirectConnections();
     assert.ok(storedSpecs);
-    assert.equal(storedSpecs.size, specs.length);
+    assert.ok(storedSpecs.has(id1));
+    assert.ok(storedSpecs.has(id2));
 
     // delete all connections
     await rm.deleteDirectConnections();
 
-    // make sure they're gone
+    // make sure they're gone -- we aren't checking that `storedSpecs` is empty since other tests
+    // may be trying to work with other specs
     storedSpecs = await rm.getDirectConnections();
-    assert.deepStrictEqual(storedSpecs, new Map());
+    assert.ok(!storedSpecs.has(id1));
+    assert.ok(!storedSpecs.has(id2));
   });
 });
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -738,7 +738,10 @@ export class ResourceManager {
   }
 
   async deleteDirectConnections(): Promise<void> {
-    await this.storage.deleteSecret(SecretStorageKeys.DIRECT_CONNECTIONS);
+    const key = SecretStorageKeys.DIRECT_CONNECTIONS;
+    return await this.runWithMutex(key, async () => {
+      await this.storage.deleteSecret(key);
+    });
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Updates the `deleteDirectConnections() should delete all direct connections` test to set specific spec IDs that should be deleted during the `.deleteDirectConnections()` call and skips checking the map size. This is done because other tests may be creating/removing other connection specs at the same time and we may not end up with a truly empty map.

This also removes most of the `deleteDirectConnections()` use in test suites' `afterEach()` hook since that may have been contributing to the flakiness as well. Now the tests are keeping track of a set of ConnectionIds stored in each test and explicitly deleting them in `afterEach()`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
