### PR TITLE
temporarily disable artifacts view

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,8 @@
         "command": "confluent.artifacts.flink-compute-pool.select",
         "icon": "$(confluent-flink-compute-pool)",
         "title": "Select Flink Compute Pool",
-        "category": "Confluent: Flink Artifacts"
+        "category": "Confluent: Flink Artifacts",
+        "enablement": "false"
       },
       {
         "command": "confluent.resources.search",

--- a/package.json
+++ b/package.json
@@ -623,7 +623,7 @@
           "name": "Flink Artifacts",
           "visibility": "collapsed",
           "icon": "$(confluent-logo)",
-          "when": "confluent.flinkEnabled",
+          "when": "false",
           "contextualTitle": "Confluent: Flink Artifacts"
         },
         {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We're focusing on statements for right now, and won't be getting around to Flink artifacts management until the statements UI/UX is in at least an MVP state. Disabling the view and its associated `confluent.artifacts.flink-compute-pool.select` command while keeping the underlying code available for when we revisit. (Or if we decide to go another direction and combine resources under a singular Flink Resources view, we can delete the artifacts-specific view+commands separately.)

Confirmed selecting pools from the Resources view still works fine and doesn't holler about `confluent.artifacts.flink-compute-pool.select` not being enabled:


https://github.com/user-attachments/assets/7891dba3-0855-4297-883e-44b8e6db0c29



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
