### PR TITLE
ON HOLD: add `no-floating-promises` eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default [
       "no-undef": "off",
       "no-unused-vars": "off",
       "no-redeclare": "off",
-      "require-await": "error",
+      "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-unused-vars": "warn",
       // Some untyped things may require extra effort to be fixed
       "@typescript-eslint/no-explicit-any": "off",
@@ -48,6 +48,10 @@ export default [
         ...globals.builtin,
         ...globals.browser,
         ...globals.node,
+      },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default [
       "no-undef": "off",
       "no-unused-vars": "off",
       "no-redeclare": "off",
+      "require-await": "error",
       "@typescript-eslint/no-unused-vars": "warn",
       // Some untyped things may require extra effort to be fixed
       "@typescript-eslint/no-explicit-any": "off",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Top level PR for any calls returning a `Promise` that aren't `await`ed. This should cause a lot of failures (100+) during `gulp lint`, but we can create some PRs based on this one to slowly chip away at the different offenders either through adding the [`void` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void), `await`ing the promise, or adding the following above an offending line:
```
// eslint-disable-next-line @typescript-eslint/no-floating-promises
```

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
