### PR TITLE
Attempt to deflake through being able to bulk-add the setup direct co…

### DIFF
--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -731,13 +731,13 @@ describe("ResourceManager direct connection methods", function () {
 
   it("deleteDirectConnection() should correctly delete a direct connection and not touch existing connections", async () => {
     // preload two connections
-    const connId1: ConnectionId = TEST_DIRECT_CONNECTION_ID;
+    const connId1: ConnectionId = "new-connection-id" as ConnectionId;
     const connId2: ConnectionId = "other-id" as ConnectionId;
     const specs: CustomConnectionSpec[] = [
-      TEST_DIRECT_CONNECTION_FORM_SPEC,
+      { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: connId1 },
       { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: connId2 },
     ];
-    await Promise.all(specs.map((spec) => rm.addDirectConnection(spec)));
+    await rm.addDirectConnections(...specs);
 
     // make sure they exist
     let storedSpecs: DirectConnectionsById = await rm.getDirectConnections();
@@ -762,7 +762,7 @@ describe("ResourceManager direct connection methods", function () {
       { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: "bar2" as ConnectionId },
       { ...TEST_DIRECT_CONNECTION_FORM_SPEC, id: "baz3" as ConnectionId },
     ];
-    await Promise.all(specs.map((spec) => rm.addDirectConnection(spec)));
+    await rm.addDirectConnections(...specs);
 
     // make sure they exist
     let storedSpecs: DirectConnectionsById = await rm.getDirectConnections();


### PR DESCRIPTION
…nnections.

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Alternative method ResourceManager.
- Maybe closes #1506

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
