### PR TITLE
[v1.1.x] fix: use the LaunchDarkly Node SDK for remote environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- The LaunchDarkly client will now use the Node SDK instead of the Electron SDK for remote
+  environments, which previously prevented the extension from activating properly.
+
 ## 1.1.1
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "graphql": "^16.8.2",
         "inertial": "^0.4.1",
         "launchdarkly-electron-client-sdk": "^1.7.0",
+        "launchdarkly-node-client-sdk": "^3.3.0",
         "opentelemetry-instrumentation-fetch-node": "^1.2.3",
         "rotating-file-stream": "^3.2.6",
         "tail": "^2.2.6",
@@ -79,7 +80,7 @@
         "typescript-eslint": "^8.25.0"
       },
       "engines": {
-        "vscode": "^1.87.0"
+        "vscode": "^1.97.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -9475,6 +9476,15 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/launchdarkly-eventsource": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.3.tgz",
+      "integrity": "sha512-VhFjppK7jXlcEKaS7bxdoibB5j01NKyeDR7a8XfssdDGNWCTsbF0/5IExSmPi44eDncPhkoPNxlSZhEZvrbD5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/launchdarkly-js-client-sdk": {
       "version": "2.24.2",
       "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.24.2.tgz",
@@ -9506,6 +9516,37 @@
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.4.0.tgz",
+      "integrity": "sha512-Kb3SDcB6S0HUpFNBZgtEt0YUV/fVkyg+gODfaOCJQ0Y0ApxLKNmmJBZOrPE2qIdzw536u4BqEjtaJdqJWCEElg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^8.0.0"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
+    "node_modules/launchdarkly-node-client-sdk": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-node-client-sdk/-/launchdarkly-node-client-sdk-3.3.0.tgz",
+      "integrity": "sha512-AVuJxWAE4So+fj8HBPpzIEwAHtpgYhlYGY/B0ig0BGLE49jLnuFppm0eW/YYMNoDqQ2crU0MGASSEdi/8m+MuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "launchdarkly-eventsource": "2.0.3",
+        "launchdarkly-js-sdk-common": "5.4.0",
+        "node-localstorage": "^1.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/lazystream": {
@@ -10881,6 +10922,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "dependencies": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/node-releases": {
@@ -12840,6 +12892,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/slugify": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
@@ -13962,7 +14023,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14357,6 +14417,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1390,6 +1390,7 @@
     "graphql": "^16.8.2",
     "inertial": "^0.4.1",
     "launchdarkly-electron-client-sdk": "^1.7.0",
+    "launchdarkly-node-client-sdk": "^3.3.0",
     "opentelemetry-instrumentation-fetch-node": "^1.2.3",
     "rotating-file-stream": "^3.2.6",
     "tail": "^2.2.6",

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -174,7 +174,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
         userInfo: authenticatedConnection.status.authentication.user,
         session: undefined,
       });
-      getLaunchDarklyClient()?.identify({
+      (await getLaunchDarklyClient())?.identify({
         key: authenticatedConnection.status.authentication.user.id,
         email: authenticatedConnection.status.authentication.user.username,
       });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,7 +15,7 @@ export function registerCommandWithLogging(
   const wrappedCommand = async (...args: any[]) => {
     // if the extension was disabled, we need to prevent any commands from running and show an error
     // notification to the user
-    const disabledMessage: string | undefined = checkForExtensionDisabledReason();
+    const disabledMessage: string | undefined = await checkForExtensionDisabledReason();
     if (disabledMessage) {
       showExtensionDisabledNotification(disabledMessage);
       return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -363,7 +363,7 @@ async function setupFeatureFlags(): Promise<void> {
   // the local defaults from `setFlagDefaults()`
   resetFlagDefaults();
 
-  const client = getLaunchDarklyClient();
+  const client = await getLaunchDarklyClient();
   if (client) {
     // wait a few seconds for the LD client to initialize for the first time, because if we
     // continue to use the client before it's ready, it will return the default values for all flags
@@ -380,7 +380,7 @@ async function setupFeatureFlags(): Promise<void> {
     logger.info(`Feature flag client initialization ${initialized ? "completed" : "failed"}`);
   }
 
-  const disabledMessage: string | undefined = checkForExtensionDisabledReason();
+  const disabledMessage: string | undefined = await checkForExtensionDisabledReason();
   if (disabledMessage) {
     showExtensionDisabledNotification(disabledMessage);
     throw new Error(disabledMessage);
@@ -434,7 +434,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
       userInfo: undefined,
       session: cloudSession,
     });
-    getLaunchDarklyClient()?.identify({
+    (await getLaunchDarklyClient())?.identify({
       key: cloudSession.account.id,
       email: cloudSession.account.label,
     });

--- a/src/featureFlags/client.ts
+++ b/src/featureFlags/client.ts
@@ -1,5 +1,4 @@
-import type { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
-import type { LDClient } from "launchdarkly-node-client-sdk";
+import type { LDClientBase } from "launchdarkly-js-sdk-common";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { FEATURE_FLAG_DEFAULTS, FeatureFlags } from "./constants";
@@ -15,7 +14,7 @@ const logger = new Logger("featureFlags.client");
  * However, we're using the Electron client SDK instead of the Node.js SDK:
  * @see https://launchdarkly.com/docs/sdk/client-side/electron#why-use-this-instead-of-the-nodejs-sdk
  */
-let client: LDElectronMainClient | LDClient | undefined = undefined;
+let client: LDClientBase | undefined = undefined;
 
 /**
  * Returns the singleton LaunchDarkly client. If the client is not initialized, it will attempt to
@@ -25,9 +24,7 @@ let client: LDElectronMainClient | LDClient | undefined = undefined;
  * If the client fails to initialize, it will log an error and return `undefined`, and any feature
  * flag lookups will return the local defaults.
  */
-export async function getLaunchDarklyClient(): Promise<
-  LDElectronMainClient | LDClient | undefined
-> {
+export async function getLaunchDarklyClient(): Promise<LDClientBase | undefined> {
   if (client) {
     return client;
   }

--- a/src/featureFlags/client.ts
+++ b/src/featureFlags/client.ts
@@ -1,4 +1,5 @@
-import { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDClient } from "launchdarkly-node-client-sdk";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { FEATURE_FLAG_DEFAULTS, FeatureFlags } from "./constants";
@@ -14,7 +15,7 @@ const logger = new Logger("featureFlags.client");
  * However, we're using the Electron client SDK instead of the Node.js SDK:
  * @see https://launchdarkly.com/docs/sdk/client-side/electron#why-use-this-instead-of-the-nodejs-sdk
  */
-let client: LDElectronMainClient | undefined = undefined;
+let client: LDElectronMainClient | LDClient | undefined = undefined;
 
 /**
  * Returns the singleton LaunchDarkly client. If the client is not initialized, it will attempt to
@@ -24,13 +25,15 @@ let client: LDElectronMainClient | undefined = undefined;
  * If the client fails to initialize, it will log an error and return `undefined`, and any feature
  * flag lookups will return the local defaults.
  */
-export function getLaunchDarklyClient(): LDElectronMainClient | undefined {
+export async function getLaunchDarklyClient(): Promise<
+  LDElectronMainClient | LDClient | undefined
+> {
   if (client) {
     return client;
   }
 
   try {
-    client = clientInit();
+    client = await clientInit();
     if (!client) {
       return;
     }

--- a/src/featureFlags/evaluation.ts
+++ b/src/featureFlags/evaluation.ts
@@ -1,5 +1,4 @@
-import { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
-import { LDClient } from "launchdarkly-node-client-sdk";
+import type { LDClientBase } from "launchdarkly-js-sdk-common";
 import { commands, env } from "vscode";
 import { EXTENSION_ID, EXTENSION_VERSION } from "../constants";
 import { showErrorNotificationWithButtons } from "../errors";
@@ -18,7 +17,7 @@ const logger = new Logger("featureFlags.evaluation");
  */
 export async function getFlagValue<T>(flag: FeatureFlag): Promise<T | undefined> {
   // try to re-initialize if we don't have a client
-  const ldClient: LDElectronMainClient | LDClient | undefined = await getLaunchDarklyClient();
+  const ldClient: LDClientBase | undefined = await getLaunchDarklyClient();
   const backupValue: T | undefined = FeatureFlags[flag];
   let value: T | undefined = ldClient?.variation(flag) ?? backupValue;
   return value;

--- a/src/featureFlags/handlers.ts
+++ b/src/featureFlags/handlers.ts
@@ -1,9 +1,4 @@
-import type {
-  LDElectronMainClient,
-  LDFlagChangeset,
-  LDFlagValue,
-} from "launchdarkly-electron-client-sdk";
-import type { LDClient } from "launchdarkly-node-client-sdk";
+import type { LDClientBase, LDFlagChangeset, LDFlagValue } from "launchdarkly-js-sdk-common";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { FEATURE_FLAG_DEFAULTS, FeatureFlags } from "./constants";
@@ -12,7 +7,7 @@ const logger = new Logger("featureFlags.handlers");
 
 /** Callback function for handling "ready" events from the LD stream, which sets up the initial
  * feature flag values from LaunchDarkly, overriding any default values set during activation. */
-export async function handleClientReady(client: LDElectronMainClient | LDClient) {
+export async function handleClientReady(client: LDClientBase) {
   logger.debug("client ready event, setting flags...");
   // set starting values
   for (const [flag, defaultValue] of Object.entries(FEATURE_FLAG_DEFAULTS)) {

--- a/src/featureFlags/handlers.ts
+++ b/src/featureFlags/handlers.ts
@@ -1,8 +1,9 @@
-import {
+import type {
   LDElectronMainClient,
   LDFlagChangeset,
   LDFlagValue,
 } from "launchdarkly-electron-client-sdk";
+import type { LDClient } from "launchdarkly-node-client-sdk";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { FEATURE_FLAG_DEFAULTS, FeatureFlags } from "./constants";
@@ -11,7 +12,7 @@ const logger = new Logger("featureFlags.handlers");
 
 /** Callback function for handling "ready" events from the LD stream, which sets up the initial
  * feature flag values from LaunchDarkly, overriding any default values set during activation. */
-export async function handleClientReady(client: LDElectronMainClient) {
+export async function handleClientReady(client: LDElectronMainClient | LDClient) {
   logger.debug("client ready event, setting flags...");
   // set starting values
   for (const [flag, defaultValue] of Object.entries(FEATURE_FLAG_DEFAULTS)) {

--- a/src/featureFlags/init.ts
+++ b/src/featureFlags/init.ts
@@ -1,10 +1,42 @@
-import { LDElectronMainClient, initializeInMain } from "launchdarkly-electron-client-sdk";
+import type { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDClient } from "launchdarkly-node-client-sdk";
+import { env } from "vscode";
+import { logError } from "../errors";
+import { Logger } from "../logging";
 import { LD_CLIENT_ID, LD_CLIENT_OPTIONS, LD_CLIENT_USER_INIT } from "./constants";
 
+const logger = new Logger("featureFlags.init");
+
 /** Initializes the LaunchDarkly client. Wraps the SDK's initializeInMain for easier testing. */
-export function clientInit(): LDElectronMainClient | undefined {
+export async function clientInit(): Promise<LDElectronMainClient | LDClient | undefined> {
   if (!LD_CLIENT_ID) {
     return;
   }
-  return initializeInMain(LD_CLIENT_ID, LD_CLIENT_USER_INIT, LD_CLIENT_OPTIONS);
+
+  if (env.remoteName) {
+    // use the Node client SDK if we're running in a remote environment since Electron isn't
+    // available there, see:
+    // https://code.visualstudio.com/api/advanced-topics/remote-extensions#using-native-node.js-modules
+    try {
+      const { initialize } = await import("launchdarkly-node-client-sdk");
+      const nodeClient: LDClient = initialize(LD_CLIENT_ID, LD_CLIENT_USER_INIT, LD_CLIENT_OPTIONS);
+      logger.debug("using Node client SDK");
+      return nodeClient;
+    } catch (error) {
+      logError(error, "Failed to initialize Node LaunchDarkly client", {
+        extra: { remoteName: env.remoteName },
+      });
+      return;
+    }
+  }
+
+  // running in Electron, so use the Electron client SDK
+  const { initializeInMain } = await import("launchdarkly-electron-client-sdk");
+  const electronClient: LDElectronMainClient = initializeInMain(
+    LD_CLIENT_ID,
+    LD_CLIENT_USER_INIT,
+    LD_CLIENT_OPTIONS,
+  );
+  logger.debug("using Electron client SDK");
+  return electronClient;
 }

--- a/src/featureFlags/init.ts
+++ b/src/featureFlags/init.ts
@@ -24,9 +24,12 @@ export async function clientInit(): Promise<LDClientBase | undefined> {
       logger.debug("using Node client SDK");
       return nodeClient;
     } catch (error) {
-      logError(error, "Failed to initialize Node LaunchDarkly client", {
-        extra: { remoteName: env.remoteName },
-      });
+      logError(
+        error,
+        "Failed to initialize Node LaunchDarkly client",
+        { remoteName: env.remoteName },
+        true,
+      );
       return;
     }
   }

--- a/src/featureFlags/init.ts
+++ b/src/featureFlags/init.ts
@@ -1,4 +1,5 @@
 import type { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDClientBase } from "launchdarkly-js-sdk-common";
 import type { LDClient } from "launchdarkly-node-client-sdk";
 import { env } from "vscode";
 import { logError } from "../errors";
@@ -8,7 +9,7 @@ import { LD_CLIENT_ID, LD_CLIENT_OPTIONS, LD_CLIENT_USER_INIT } from "./constant
 const logger = new Logger("featureFlags.init");
 
 /** Initializes the LaunchDarkly client. Wraps the SDK's initializeInMain for easier testing. */
-export async function clientInit(): Promise<LDElectronMainClient | LDClient | undefined> {
+export async function clientInit(): Promise<LDClientBase | undefined> {
   if (!LD_CLIENT_ID) {
     return;
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

https://github.com/confluentinc/vscode/pull/1166 unfortunately broke the extension for WSL users due to the added LaunchDarkly Electron Client SDK requiring the `electron` package. Remote instances attempting to run this extension quietly threw an error (visible in the `Extension Host (Remote)` output channel) and failed to even start activation due to https://code.visualstudio.com/api/advanced-topics/remote-extensions#using-native-node.js-modules
> However, VS Code Server runs a standard (non-Electron) version of Node.js, which can cause binaries to fail when used remotely.

Thankfully, LaunchDarkly makes it easy to use both the [Node client SDK](https://launchdarkly.com/docs/sdk/client-side/node-js) and the [Electron client SDK](https://launchdarkly.com/docs/sdk/client-side/electron#why-use-this-instead-of-the-nodejs-sdk), so this PR really just checks:
- if we have a `remoteName` in the VS Code `env`, use the Node client
- otherwise, use the Electron client
https://github.com/confluentinc/vscode/blob/209ca68ed2af09178c29d1b55a12c721fe2ef5fb/src/featureFlags/init.ts#L17-L24

Closes https://github.com/confluentinc/vscode/issues/1509.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Unfortunately, this means we have to make the `clientInit()` function async since we can't use `require()` in the `env.remoteName` check and have to use the `await import( ... )` pattern. This then cascaded to needing a lot more `async`/`await` throughout the rest of the feature flag related code.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
