### PR TITLE
MINOR: add `platform`/`arch` and VS Code `env.remoteName` to observability context

### DIFF
--- a/src/context/observability.ts
+++ b/src/context/observability.ts
@@ -18,6 +18,13 @@ import { Status } from "../clients/sidecar";
  */
 class ObservabilityContext {
   constructor(
+    /** The OS platform */
+    public platform: string = process.platform,
+    /** The OS CPU architecture */
+    public arch: string = process.arch,
+    /** Indicator that the extension is running in WSL or another remote host. */
+    public remoteName: string = env.remoteName ?? "",
+
     /** The version of VS Code (or variant) in use. */
     public productVersion: string = ideVersion,
     /** The name of the VS Code (or variant) in use. */

--- a/src/context/observability.ts
+++ b/src/context/observability.ts
@@ -23,7 +23,7 @@ class ObservabilityContext {
     /** The OS CPU architecture */
     public arch: string = process.arch,
     /** Indicator that the extension is running in WSL or another remote host. */
-    public remoteName: string = env.remoteName ?? "",
+    public remoteName: string | undefined = env.remoteName,
 
     /** The version of VS Code (or variant) in use. */
     public productVersion: string = ideVersion,

--- a/src/telemetry/telemetryLogger.ts
+++ b/src/telemetry/telemetryLogger.ts
@@ -116,6 +116,7 @@ export function preparePropertiesForTrack(
     currentSidecarVersion: ideSidecar.version,
     platform: platform(),
     arch: arch(),
+    remoteName: vscode.env.remoteName ?? "", // "wsl", "ssh-remote", etc.
     ...data, // VSCode Common properties in data includes the extension version
   };
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We get some of this automatically when sending errors to Sentry, but we won't get them for support requests. 

(We also previously [set platform/arch](https://github.com/confluentinc/vscode/pull/1225) in the telemetry logger, but didn't have `remoteName`.)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
