### PR TITLE
🍒 [main] fix: use the LaunchDarkly Node SDK for remote environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to this extension will be documented in this file.
   [`1.97.0`](https://code.visualstudio.com/updates/v1_97) to help development efforts and integrate
   with newer VS Code APIs.
 
+### Fixed
+
+- The LaunchDarkly client will now use the Node SDK instead of the Electron SDK for remote
+  environments, which previously prevented the extension from activating properly.
+
 ## 1.1.1
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "graphql": "^16.8.2",
         "inertial": "^0.4.1",
         "launchdarkly-electron-client-sdk": "^1.7.0",
+        "launchdarkly-node-client-sdk": "^3.3.0",
         "opentelemetry-instrumentation-fetch-node": "^1.2.3",
         "rotating-file-stream": "^3.2.6",
         "tail": "^2.2.6",
@@ -79,7 +80,7 @@
         "typescript-eslint": "^8.25.0"
       },
       "engines": {
-        "vscode": "^1.87.0"
+        "vscode": "^1.97.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -9475,6 +9476,15 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/launchdarkly-eventsource": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.3.tgz",
+      "integrity": "sha512-VhFjppK7jXlcEKaS7bxdoibB5j01NKyeDR7a8XfssdDGNWCTsbF0/5IExSmPi44eDncPhkoPNxlSZhEZvrbD5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/launchdarkly-js-client-sdk": {
       "version": "2.24.2",
       "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-2.24.2.tgz",
@@ -9506,6 +9516,37 @@
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
         "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.4.0.tgz",
+      "integrity": "sha512-Kb3SDcB6S0HUpFNBZgtEt0YUV/fVkyg+gODfaOCJQ0Y0ApxLKNmmJBZOrPE2qIdzw536u4BqEjtaJdqJWCEElg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "fast-deep-equal": "^2.0.1",
+        "uuid": "^8.0.0"
+      }
+    },
+    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "license": "MIT"
+    },
+    "node_modules/launchdarkly-node-client-sdk": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/launchdarkly-node-client-sdk/-/launchdarkly-node-client-sdk-3.3.0.tgz",
+      "integrity": "sha512-AVuJxWAE4So+fj8HBPpzIEwAHtpgYhlYGY/B0ig0BGLE49jLnuFppm0eW/YYMNoDqQ2crU0MGASSEdi/8m+MuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "launchdarkly-eventsource": "2.0.3",
+        "launchdarkly-js-sdk-common": "5.4.0",
+        "node-localstorage": "^1.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/lazystream": {
@@ -10881,6 +10922,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "dependencies": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/node-releases": {
@@ -12840,6 +12892,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/slugify": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
@@ -13962,7 +14023,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14357,6 +14417,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/package.json
+++ b/package.json
@@ -1553,6 +1553,7 @@
     "graphql": "^16.8.2",
     "inertial": "^0.4.1",
     "launchdarkly-electron-client-sdk": "^1.7.0",
+    "launchdarkly-node-client-sdk": "^3.3.0",
     "opentelemetry-instrumentation-fetch-node": "^1.2.3",
     "rotating-file-stream": "^3.2.6",
     "tail": "^2.2.6",

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -174,7 +174,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
         userInfo: authenticatedConnection.status.authentication.user,
         session: undefined,
       });
-      getLaunchDarklyClient()?.identify({
+      (await getLaunchDarklyClient())?.identify({
         key: authenticatedConnection.status.authentication.user.id,
         email: authenticatedConnection.status.authentication.user.username,
       });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,7 +15,7 @@ export function registerCommandWithLogging(
   const wrappedCommand = async (...args: any[]) => {
     // if the extension was disabled, we need to prevent any commands from running and show an error
     // notification to the user
-    const disabledMessage: string | undefined = checkForExtensionDisabledReason();
+    const disabledMessage: string | undefined = await checkForExtensionDisabledReason();
     if (disabledMessage) {
       showExtensionDisabledNotification(disabledMessage);
       return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -389,7 +389,7 @@ async function setupFeatureFlags(): Promise<void> {
   // the local defaults from `setFlagDefaults()`
   resetFlagDefaults();
 
-  const client = getLaunchDarklyClient();
+  const client = await getLaunchDarklyClient();
   if (client) {
     // wait a few seconds for the LD client to initialize for the first time, because if we
     // continue to use the client before it's ready, it will return the default values for all flags
@@ -406,7 +406,7 @@ async function setupFeatureFlags(): Promise<void> {
     logger.info(`Feature flag client initialization ${initialized ? "completed" : "failed"}`);
   }
 
-  const disabledMessage: string | undefined = checkForExtensionDisabledReason();
+  const disabledMessage: string | undefined = await checkForExtensionDisabledReason();
   if (disabledMessage) {
     showExtensionDisabledNotification(disabledMessage);
     throw new Error(disabledMessage);
@@ -460,7 +460,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
       userInfo: undefined,
       session: cloudSession,
     });
-    getLaunchDarklyClient()?.identify({
+    (await getLaunchDarklyClient())?.identify({
       key: cloudSession.account.id,
       email: cloudSession.account.label,
     });

--- a/src/featureFlags/client.ts
+++ b/src/featureFlags/client.ts
@@ -1,4 +1,4 @@
-import { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDClientBase } from "launchdarkly-js-sdk-common";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { FEATURE_FLAG_DEFAULTS, FeatureFlags } from "./constants";
@@ -14,7 +14,7 @@ const logger = new Logger("featureFlags.client");
  * However, we're using the Electron client SDK instead of the Node.js SDK:
  * @see https://launchdarkly.com/docs/sdk/client-side/electron#why-use-this-instead-of-the-nodejs-sdk
  */
-let client: LDElectronMainClient | undefined = undefined;
+let client: LDClientBase | undefined = undefined;
 
 /**
  * Returns the singleton LaunchDarkly client. If the client is not initialized, it will attempt to
@@ -24,13 +24,13 @@ let client: LDElectronMainClient | undefined = undefined;
  * If the client fails to initialize, it will log an error and return `undefined`, and any feature
  * flag lookups will return the local defaults.
  */
-export function getLaunchDarklyClient(): LDElectronMainClient | undefined {
+export async function getLaunchDarklyClient(): Promise<LDClientBase | undefined> {
   if (client) {
     return client;
   }
 
   try {
-    client = clientInit();
+    client = await clientInit();
     if (!client) {
       return;
     }

--- a/src/featureFlags/evaluation.ts
+++ b/src/featureFlags/evaluation.ts
@@ -1,4 +1,4 @@
-import { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDClientBase } from "launchdarkly-js-sdk-common";
 import { commands, env } from "vscode";
 import { EXTENSION_ID, EXTENSION_VERSION } from "../constants";
 import { showErrorNotificationWithButtons } from "../errors";
@@ -15,9 +15,9 @@ const logger = new Logger("featureFlags.evaluation");
  * If the client is not able to communicate with LaunchDarkly, it will return the last value applied
  * to {@link FeatureFlags} (which may be the default from {@link FEATURE_FLAG_DEFAULTS} if offline).
  */
-export function getFlagValue<T>(flag: FeatureFlag): T | undefined {
+export async function getFlagValue<T>(flag: FeatureFlag): Promise<T | undefined> {
   // try to re-initialize if we don't have a client
-  const ldClient: LDElectronMainClient | undefined = getLaunchDarklyClient();
+  const ldClient: LDClientBase | undefined = await getLaunchDarklyClient();
   const backupValue: T | undefined = FeatureFlags[flag];
   let value: T | undefined = ldClient?.variation(flag) ?? backupValue;
   return value;
@@ -32,9 +32,9 @@ export function getFlagValue<T>(flag: FeatureFlag): T | undefined {
  * block the command from being run and show an error notification to the user if the extension is
  * disabled.
  */
-export function checkForExtensionDisabledReason(): string | undefined {
+export async function checkForExtensionDisabledReason(): Promise<string | undefined> {
   // first check if the extension is enabled at all
-  const globalEnabled: boolean | undefined = getFlagValue(FeatureFlag.GLOBAL_ENABLED);
+  const globalEnabled: boolean | undefined = await getFlagValue(FeatureFlag.GLOBAL_ENABLED);
   if (globalEnabled === undefined) {
     return;
   }
@@ -43,7 +43,7 @@ export function checkForExtensionDisabledReason(): string | undefined {
   }
 
   // then make sure the version of the extension is not disabled
-  const disabledVersions: DisabledVersion[] | undefined = getFlagValue(
+  const disabledVersions: DisabledVersion[] | undefined = await getFlagValue(
     FeatureFlag.GLOBAL_DISABLED_VERSIONS,
   );
   if (disabledVersions === undefined || !Array.isArray(disabledVersions)) {

--- a/src/featureFlags/handlers.ts
+++ b/src/featureFlags/handlers.ts
@@ -1,8 +1,4 @@
-import {
-  LDElectronMainClient,
-  LDFlagChangeset,
-  LDFlagValue,
-} from "launchdarkly-electron-client-sdk";
+import type { LDClientBase, LDFlagChangeset, LDFlagValue } from "launchdarkly-js-sdk-common";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { FEATURE_FLAG_DEFAULTS, FeatureFlags } from "./constants";
@@ -11,7 +7,7 @@ const logger = new Logger("featureFlags.handlers");
 
 /** Callback function for handling "ready" events from the LD stream, which sets up the initial
  * feature flag values from LaunchDarkly, overriding any default values set during activation. */
-export async function handleClientReady(client: LDElectronMainClient) {
+export async function handleClientReady(client: LDClientBase) {
   logger.debug("client ready event, setting flags...");
   // set starting values
   for (const [flag, defaultValue] of Object.entries(FEATURE_FLAG_DEFAULTS)) {

--- a/src/featureFlags/init.ts
+++ b/src/featureFlags/init.ts
@@ -24,12 +24,9 @@ export async function clientInit(): Promise<LDClientBase | undefined> {
       logger.debug("using Node client SDK");
       return nodeClient;
     } catch (error) {
-      logError(
-        error,
-        "Failed to initialize Node LaunchDarkly client",
-        { remoteName: env.remoteName },
-        true,
-      );
+      logError(error, "Failed to initialize Node LaunchDarkly client", {
+        extra: { remoteName: env.remoteName },
+      });
       return;
     }
   }

--- a/src/featureFlags/init.ts
+++ b/src/featureFlags/init.ts
@@ -1,10 +1,46 @@
-import { LDElectronMainClient, initializeInMain } from "launchdarkly-electron-client-sdk";
+import type { LDElectronMainClient } from "launchdarkly-electron-client-sdk";
+import type { LDClientBase } from "launchdarkly-js-sdk-common";
+import type { LDClient } from "launchdarkly-node-client-sdk";
+import { env } from "vscode";
+import { logError } from "../errors";
+import { Logger } from "../logging";
 import { LD_CLIENT_ID, LD_CLIENT_OPTIONS, LD_CLIENT_USER_INIT } from "./constants";
 
+const logger = new Logger("featureFlags.init");
+
 /** Initializes the LaunchDarkly client. Wraps the SDK's initializeInMain for easier testing. */
-export function clientInit(): LDElectronMainClient | undefined {
+export async function clientInit(): Promise<LDClientBase | undefined> {
   if (!LD_CLIENT_ID) {
     return;
   }
-  return initializeInMain(LD_CLIENT_ID, LD_CLIENT_USER_INIT, LD_CLIENT_OPTIONS);
+
+  if (env.remoteName) {
+    // use the Node client SDK if we're running in a remote environment since Electron isn't
+    // available there, see:
+    // https://code.visualstudio.com/api/advanced-topics/remote-extensions#using-native-node.js-modules
+    try {
+      const { initialize } = await import("launchdarkly-node-client-sdk");
+      const nodeClient: LDClient = initialize(LD_CLIENT_ID, LD_CLIENT_USER_INIT, LD_CLIENT_OPTIONS);
+      logger.debug("using Node client SDK");
+      return nodeClient;
+    } catch (error) {
+      logError(
+        error,
+        "Failed to initialize Node LaunchDarkly client",
+        { remoteName: env.remoteName },
+        true,
+      );
+      return;
+    }
+  }
+
+  // running in Electron, so use the Electron client SDK
+  const { initializeInMain } = await import("launchdarkly-electron-client-sdk");
+  const electronClient: LDElectronMainClient = initializeInMain(
+    LD_CLIENT_ID,
+    LD_CLIENT_USER_INIT,
+    LD_CLIENT_OPTIONS,
+  );
+  logger.debug("using Electron client SDK");
+  return electronClient;
 }


### PR DESCRIPTION
https://github.com/confluentinc/vscode/pull/1512 to `main`, with a slight adjustment for the `logError` call since it accepts slightly different args (#1457)
https://github.com/confluentinc/vscode/blob/d58fe0d8781f2fb148e0fc360953bd4322dda2e3/src/featureFlags/init.ts#L27-L29