### PR TITLE
fix: prevent non-`CCloudEnvironment` arguments from being used in command

### DIFF
--- a/src/commands/environments.ts
+++ b/src/commands/environments.ts
@@ -6,32 +6,21 @@ import { flinkCcloudEnvironmentQuickPick } from "../quickpicks/environments";
 import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 
 async function setFlinkStatementsEnvironmentCommand(item?: CCloudEnvironment): Promise<void> {
-  // the user gestured either from a ccloud environment in the Resources view, flink statements
-  // titlebar, or used the command palette
-
-  if (!item) {
-    // the user either used the command palette or the icon in the flink statements titlebar
-    // to select a new environment
-
-    // (ccloudEnvironmentQuickPick currently does deep fetch every time (and is slow), so
-    //  show progress while it is loading)
-    item = await FlinkStatementsViewProvider.getInstance().withProgress(
-      "Select Environment",
-      flinkCcloudEnvironmentQuickPick,
-    );
-    if (!item) {
-      // aborted the quickpick.
-      return;
-    }
-  }
-
-  if (!(item instanceof CCloudEnvironment)) {
-    throw new Error("Called with something other than a CCloudEnvironment");
+  // ensure whatever was passed in is a CCloudEnvironment; if not, prompt the user to pick one
+  const env: CCloudEnvironment | undefined =
+    item instanceof CCloudEnvironment
+      ? item
+      : await FlinkStatementsViewProvider.getInstance().withProgress(
+          "Select Environment",
+          flinkCcloudEnvironmentQuickPick,
+        );
+  if (!env) {
+    return;
   }
 
   // Inform the Flink Statements view that the user has selected a new environment.
   // This will cause the view to repaint itself with the new environment's statements.
-  currentFlinkStatementsResourceChanged.fire(item);
+  currentFlinkStatementsResourceChanged.fire(env);
 
   // Focus the Flink Statements view.
   await vscode.commands.executeCommand("confluent-flink-statements.focus");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fix for the scenario where a `FlinkStatement` is focused/selected in the view and the command is invoked through the view nav action:
![image](https://github.com/user-attachments/assets/b83c1dc7-20cc-4737-a92b-87575bad5f60)

Similar handling to our other nav actions, like the compute pool selection: https://github.com/confluentinc/vscode/blob/e27716e4c45fe2d755252d8b55102a908ee7b025/src/commands/flinkComputePools.ts#L18-L26

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
