### PR TITLE
update project scaffolding telemetry for URI handling

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -110,6 +110,7 @@ export const scaffoldProjectRequest = async (templateRequestOptions?: PrefilledT
   }
   logUsage(UserEvent.ProjectScaffoldingAction, {
     status: "template picked",
+    templateId: pickedTemplate.spec!.name,
     templateName: pickedTemplate.spec!.display_name,
     itemType: telemetrySource,
   });
@@ -175,6 +176,7 @@ export const scaffoldProjectRequest = async (templateRequestOptions?: PrefilledT
       case "Submit": {
         logUsage(UserEvent.ProjectScaffoldingAction, {
           status: "form submitted",
+          templateId: templateSpec.name,
           templateName: templateSpec.display_name,
           itemType: telemetrySource,
         });
@@ -229,6 +231,7 @@ export async function applyTemplate(
       // This means the user cancelled @ save dialog. Show a message and return
       logUsage(UserEvent.ProjectScaffoldingAction, {
         status: "cancelled before save",
+        templateId: pickedTemplate.spec!.name,
         templateName: pickedTemplate.spec!.display_name,
         itemType: telemetrySource,
       });
@@ -241,6 +244,7 @@ export async function applyTemplate(
     await extractZipContents(arrayBuffer, destination);
     logUsage(UserEvent.ProjectScaffoldingAction, {
       status: "project generated",
+      templateId: pickedTemplate.spec!.name,
       templateName: pickedTemplate.spec!.display_name,
       itemType: telemetrySource,
     });
@@ -258,6 +262,7 @@ export async function applyTemplate(
       const keepsExistingWindow = selection.title === "Open in New Window";
       logUsage(UserEvent.ProjectScaffoldingAction, {
         status: "project folder opened",
+        templateId: pickedTemplate.spec!.name,
         templateName: pickedTemplate.spec!.display_name,
         keepsExistingWindow,
         itemType: telemetrySource,
@@ -402,7 +407,7 @@ export async function handleProjectScaffoldUri(
         );
         logUsage(UserEvent.ProjectScaffoldingAction, {
           status: "URI handling failed",
-          templateName: template,
+          templateId: template,
           itemType: "uri",
         });
       }
@@ -411,7 +416,7 @@ export async function handleProjectScaffoldUri(
     } else {
       logUsage(UserEvent.ProjectScaffoldingAction, {
         status: "URI handling succeeded",
-        templateName: template,
+        templateId: template,
         itemType: "uri",
       });
     }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

No user-facing changes here, just adding more telemetry logging for handling URIs:
<img width="1629" alt="image" src="https://github.com/user-attachments/assets/b3ceebd6-e314-4d66-81a7-1e25d2e80698" />

Worth noting this also adds `templateId` (as the template spec `name`) to the data sent back since we don't have the template spec `display_name` of the template at the time of handling the URIs.

Closes #1503.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
