### PR TITLE
#1537: add collection id to telemetry evt

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -112,6 +112,7 @@ export const scaffoldProjectRequest = async (templateRequestOptions?: PrefilledT
     status: "template picked",
     templateId: pickedTemplate.spec!.name,
     templateName: pickedTemplate.spec!.display_name,
+    collectionId: pickedTemplate.spec!.template_collection,
     itemType: telemetrySource,
   });
 
@@ -178,6 +179,7 @@ export const scaffoldProjectRequest = async (templateRequestOptions?: PrefilledT
           status: "form submitted",
           templateId: templateSpec.name,
           templateName: templateSpec.display_name,
+          collectionId: templateSpec.template_collection,
           itemType: telemetrySource,
         });
         let res: PostResponse = { success: false, message: "Failed to apply template." };
@@ -233,6 +235,7 @@ export async function applyTemplate(
         status: "cancelled before save",
         templateId: pickedTemplate.spec!.name,
         templateName: pickedTemplate.spec!.display_name,
+        collectionId: pickedTemplate.spec!.template_collection,
         itemType: telemetrySource,
       });
       vscode.window.showInformationMessage("Project generation cancelled");
@@ -246,6 +249,7 @@ export async function applyTemplate(
       status: "project generated",
       templateId: pickedTemplate.spec!.name,
       templateName: pickedTemplate.spec!.display_name,
+      collectionId: pickedTemplate.spec!.template_collection,
       itemType: telemetrySource,
     });
     // Notify the user that the project was generated successfully
@@ -264,6 +268,7 @@ export async function applyTemplate(
         status: "project folder opened",
         templateId: pickedTemplate.spec!.name,
         templateName: pickedTemplate.spec!.display_name,
+        collectionId: pickedTemplate.spec!.template_collection,
         keepsExistingWindow,
         itemType: telemetrySource,
       });
@@ -408,6 +413,7 @@ export async function handleProjectScaffoldUri(
         logUsage(UserEvent.ProjectScaffoldingAction, {
           status: "URI handling failed",
           templateId: template,
+          collectionId: collection,
           itemType: "uri",
         });
       }


### PR DESCRIPTION
## Summary of Changes

Adds the collectionid to telemetry so we can tell which collection each event stems from 

## Any additional details or context that should be provided?
<img width="1184" alt="Screenshot 2025-04-23 at 7 35 58 AM" src="https://github.com/user-attachments/assets/d284ed76-a1a2-4614-bf60-4d517b49e424" />

>Note: this adds the whole object. Might make sense to drill down on just the id. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
