### PR TITLE
allow optional `collection` arg when listing templates and set `templateCollection` for telemetry events

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -97,8 +97,8 @@ export const scaffoldProjectRequest = async (templateRequestOptions?: PrefilledT
           },
         });
         showErrorNotificationWithButtons(errMsg);
+        return;
       }
-      return;
     } else {
       // If no arguments are passed, show all templates
       pickedTemplate = await pickTemplate(templateList);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Updated telemetry with user notification in the event the template collection + name don't jive.
<img width="945" alt="image" src="https://github.com/user-attachments/assets/e27bf1a9-da4e-4ff6-8a34-3d642ae2acbb" />

<img width="906" alt="image" src="https://github.com/user-attachments/assets/137e7606-a3bb-478f-8600-f41b08dab896" />


Closes #1536, closes #1537.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Also includes a minor typo fix for the "user canceled" result message.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
