### PR TITLE
ignore hidden artifacts view pool

### DIFF
--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -8,7 +8,6 @@ import { Logger } from "../logging";
 import { Environment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { getConnectionLabel, isCCloud } from "../models/resource";
-import { FlinkArtifactsViewProvider } from "../viewProviders/flinkArtifacts";
 import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 import { QuickPickItemWithValue } from "./types";
 
@@ -79,8 +78,10 @@ export async function flinkComputePoolQuickPick(): Promise<CCloudFlinkComputePoo
   if (statementsPool) {
     focusedPools.push(statementsPool);
   }
-  const artifactsPool: CCloudFlinkComputePool | null =
-    FlinkArtifactsViewProvider.getInstance().computePool;
+  // TODO: uncomment this if/when we start working with the artifacts view again
+  // const artifactsPool: CCloudFlinkComputePool | null =
+  //   FlinkArtifactsViewProvider.getInstance().computePool;
+  const artifactsPool: CCloudFlinkComputePool | null = null;
   if (artifactsPool) {
     focusedPools.push(artifactsPool);
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes a minor UX issue where selecting a Flink compute pool from the Resources view will populate the (hidden) Flink Artifacts view with a "focused" pool, which will show multiple "focused" pools if the pool for the Flink (statements) view is changed after the selection from the Resources view.

![image](https://github.com/user-attachments/assets/62bbeea5-9231-4eda-a24f-c780bbc4576f)


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
