### PR TITLE
[v1.2.x] fix: remove protocol from bootstrap servers when generating project from Kafka cluster/topic

### DIFF
--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -12,6 +12,7 @@ import {
   kafkaClusterQuickPickWithViewProgress,
 } from "../quickpicks/kafkaClusters";
 import { getSidecar } from "../sidecar";
+import { removeProtocolPrefix } from "../utils/bootstrapServers";
 import { getTopicViewProvider } from "../viewProviders/topics";
 
 const logger = new Logger("commands.kafkaClusters");
@@ -279,10 +280,7 @@ export async function copyBootstrapServers(item: KafkaCluster) {
   }
 
   // Strip away any protocol:// prefix from each comma separated bootstrap server
-  const stripped = bootstrapServers
-    .split(",")
-    .map((server) => server.replace(/^[^:]+:\/\//, ""))
-    .join(",");
+  const stripped = removeProtocolPrefix(bootstrapServers);
 
   await vscode.env.clipboard.writeText(stripped);
   vscode.window.showInformationMessage(`Copied "${stripped}" to clipboard.`);

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -59,7 +59,7 @@ async function resourceScaffoldProjectRequest(item?: KafkaCluster | KafkaTopic) 
     const cluster = await getResourceManager().getClusterForTopic(item);
     if (!cluster) {
       // shouldn't happen if we have the topic, but just in case
-      showErrorNotificationWithButtons(`Unable to find Kafka cluster for topic "${item.name}.`);
+      showErrorNotificationWithButtons(`Unable to find Kafka cluster for topic "${item.name}".`);
       return;
     }
     const bootstrapServers: string = removeProtocolPrefix(cluster.bootstrapServers);

--- a/src/utils/bootstrapServers.test.ts
+++ b/src/utils/bootstrapServers.test.ts
@@ -1,0 +1,29 @@
+import * as assert from "assert";
+import { removeProtocolPrefix } from "./bootstrapServers";
+
+describe("utils/bootstrapServers.ts removeProtocolPrefix()", () => {
+  it("should remove the prefix from bootstrap servers", () => {
+    const servers = "localhost:9092,localhost:9093";
+    const input = `PLAIN://${servers}`;
+
+    const result: string = removeProtocolPrefix(input);
+
+    assert.strictEqual(result, servers);
+  });
+
+  it("should handle empty input", () => {
+    const input = "";
+
+    const result: string = removeProtocolPrefix(input);
+
+    assert.strictEqual(result, "");
+  });
+
+  it("should handle input without prefix", () => {
+    const servers = "localhost:9092,localhost:9093";
+
+    const result: string = removeProtocolPrefix(servers);
+
+    assert.strictEqual(result, servers);
+  });
+});

--- a/src/utils/bootstrapServers.ts
+++ b/src/utils/bootstrapServers.ts
@@ -1,0 +1,11 @@
+/**
+ * Removes any leading protocol prefix from the bootstrap server(s) string.
+ *
+ * Example: "PLAIN://localhost:9092,localhost:9093" becomes "localhost:9092,localhost:9093"
+ */
+export function removeProtocolPrefix(bootstrapServers: string): string {
+  return bootstrapServers
+    .split(",")
+    .map((server) => server.replace(/^[^:]+:\/\//, ""))
+    .join(",");
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Moves the logic from https://github.com/confluentinc/vscode/blob/275e11db8783af3d3aa365bfd4a55b3d021791fb/src/commands/kafkaClusters.ts#L281-L285 (https://github.com/confluentinc/vscode/pull/1078) to a more accessible location and ensures we use it whenever generating a project from a Kafka cluster/topic from the sidebar.

https://github.com/user-attachments/assets/7729464b-a2ae-4741-9d2b-40288ca5d8d6



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
