### PR TITLE
chore(CI): set up block-level PR status checks

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -11,6 +11,7 @@ codeowners:
   enable: true
 semaphore:
   enable: true
+  status_level: block
   pipeline_enable: false
   triggers: ["branches", "pull_requests"]
 sonarqube:


### PR DESCRIPTION
Should help us only require certain blocks to pass for release branches, and have generally better visibility around which block(s) may be failing builds/tests/etc.