### PR TITLE
Refactor custom `FlinkStatement` model to use API generated models

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../clients/flinkSql";
 import * as sidecar from "../sidecar";
 import { CCloudResourceLoader } from "./ccloudResourceLoader";
+import { OrganizationId } from "../models/resource";
 
 describe("CCloudResourceLoader", () => {
   describe("getFlinkStatements", () => {
@@ -33,7 +34,7 @@ describe("CCloudResourceLoader", () => {
       mockSidecarHandle.getFlinkSqlStatementsApi.returns(flinkStatementsApiStub);
       sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
 
-      sandbox.stub(resourceLoader, "getOrganizationId").resolves(testOrgId);
+      sandbox.stub(resourceLoader, "getOrganizationId").resolves(testOrgId as OrganizationId);
     });
 
     afterEach(() => {

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -1,11 +1,6 @@
 import { Disposable } from "vscode";
 
-import {
-  ListSqlv1StatementsRequest,
-  SqlV1StatementListDataInner,
-  SqlV1StatementSpec,
-  SqlV1StatementTraits,
-} from "../clients/flinkSql";
+import { ListSqlv1StatementsRequest, SqlV1StatementListDataInner } from "../clients/flinkSql";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudConnected } from "../emitters";

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -280,7 +280,7 @@ export class CCloudResourceLoader extends ResourceLoader {
 
     const organization = await getCurrentOrganization();
     if (organization) {
-      this.organizationId = organization.id as unknown as OrganizationId;
+      this.organizationId = organization.id;
       return this.organizationId;
     }
     logger.error("getOrganizationId(): No current organization found.");

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -8,7 +8,6 @@ import {
 import { IconNames } from "../constants";
 import {
   FlinkStatement,
-  FlinkStatementStatus,
   FlinkStatementTreeItem,
   STATUS_BLUE,
   STATUS_GRAY,
@@ -18,6 +17,7 @@ import {
 } from "./flinkStatement";
 import { CustomMarkdownString, KeyValuePairArray } from "./main";
 import { EnvironmentId } from "./resource";
+import { SqlV1Statement, SqlV1StatementStatus } from "../clients/flinkSql";
 
 describe("FlinkStatement", () => {
   it("uses name as id", () => {
@@ -151,6 +151,6 @@ describe("FlinkStatementTreeItem", () => {
   });
 });
 
-function makeStatus(phase: string): FlinkStatementStatus {
+function makeStatus(phase: string): SqlV1StatementStatus {
   return createFlinkStatement({ phase: phase }).status;
 }

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./flinkStatement";
 import { CustomMarkdownString, KeyValuePairArray } from "./main";
 import { EnvironmentId } from "./resource";
-import { SqlV1Statement, SqlV1StatementStatus } from "../clients/flinkSql";
+import { SqlV1StatementStatus } from "../clients/flinkSql";
 
 describe("FlinkStatement", () => {
   it("uses name as id", () => {

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -2,7 +2,18 @@ import { ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscod
 import { ConnectionType } from "../clients/sidecar";
 import { IconNames, UTM_SOURCE_VSCODE } from "../constants";
 import { CustomMarkdownString, IdItem } from "./main";
-import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import {
+  ConnectionId,
+  EnvironmentId,
+  IResourceBase,
+  ISearchable,
+  OrganizationId,
+} from "./resource";
+import {
+  SqlV1StatementMetadata,
+  SqlV1StatementSpec,
+  SqlV1StatementStatus,
+} from "../clients/flinkSql";
 
 /**
  * Model for a Flink statement.
@@ -11,23 +22,32 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   connectionId!: ConnectionId;
   connectionType!: ConnectionType;
   environmentId!: EnvironmentId;
+  organizationId!: OrganizationId;
 
   name: string;
-  metadata: FlinkStatementMetadata;
-  status: FlinkStatementStatus;
-  spec: FlinkStatementSpec;
+  metadata: SqlV1StatementMetadata;
+  status: SqlV1StatementStatus;
+  spec: SqlV1StatementSpec;
 
   // TODO: add more properties as needed
 
   constructor(
     props: Pick<
       FlinkStatement,
-      "connectionId" | "connectionType" | "environmentId" | "spec" | "name" | "metadata" | "status"
+      | "connectionId"
+      | "connectionType"
+      | "environmentId"
+      | "organizationId"
+      | "spec"
+      | "name"
+      | "metadata"
+      | "status"
     >,
   ) {
     this.connectionId = props.connectionId;
     this.connectionType = props.connectionType;
     this.environmentId = props.environmentId;
+    this.organizationId = props.organizationId;
     this.spec = props.spec;
     this.name = props.name;
     this.metadata = props.metadata;
@@ -40,11 +60,11 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
 
   /** The flink compute pool that maybe is running/ran the statement. */
   get computePoolId(): string | undefined {
-    return this.spec.computePoolId;
+    return this.spec.compute_pool_id;
   }
 
   get sqlStatement(): string | undefined {
-    return this.spec.sqlStatement;
+    return this.spec.statement;
   }
 
   /**
@@ -64,15 +84,15 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   }
 
   get sqlKindDisplay(): string | undefined {
-    return this.status.traits?.sqlKindDisplay;
+    return this.status.traits?.sql_kind?.replace(/_/g, " ");
   }
 
   get createdAt(): Date | undefined {
-    return this.metadata.createdAt;
+    return this.metadata.created_at;
   }
 
   get updatedAt(): Date | undefined {
-    return this.metadata.updatedAt;
+    return this.metadata.updated_at;
   }
 }
 
@@ -85,71 +105,6 @@ export class FlinkStatementMetadata {
   constructor(props: Pick<FlinkStatementMetadata, "createdAt" | "updatedAt">) {
     this.createdAt = props.createdAt;
     this.updatedAt = props.updatedAt;
-  }
-}
-
-/** Model for the `status` subfield of a Flink statement. */
-export class FlinkStatementStatus {
-  phase: string;
-  detail: string | undefined;
-  traits?: FlinkStatementTraits;
-  // TODO refine in the future.
-  scalingStatus!: any;
-
-  constructor(props: Pick<FlinkStatementStatus, "phase" | "detail" | "traits" | "scalingStatus">) {
-    this.phase = props.phase;
-    this.detail = props.detail;
-    this.traits = props.traits;
-    this.scalingStatus = props.scalingStatus;
-  }
-}
-
-export class FlinkStatementTraits {
-  sqlKind?: string; // CREATE_TABLE_AS, SELECT, ...
-  bounded?: boolean;
-  appendOnly?: boolean;
-  schema: any; // todo flesh out
-
-  constructor(props: Pick<FlinkStatementTraits, "sqlKind" | "bounded" | "appendOnly" | "schema">) {
-    this.sqlKind = props.sqlKind;
-    this.bounded = props.bounded;
-    this.appendOnly = props.appendOnly;
-    this.schema = props.schema;
-  }
-
-  /** "CREATE_TABLE_AS" -> "CREATE TABLE AS" */
-  get sqlKindDisplay(): string | undefined {
-    // "FAILED" phase statements may not have a sqlKind, as far as
-    // have observed so far.
-    return this.sqlKind?.replace(/_/g, " ");
-  }
-}
-
-export class FlinkStatementSpec {
-  computePoolId?: string;
-  principal?: string;
-  authorizedPrincipals?: string[];
-  sqlStatement?: string;
-  stopped?: boolean;
-  properties?: Record<string, string>;
-
-  constructor(
-    props: Pick<
-      FlinkStatementSpec,
-      | "computePoolId"
-      | "principal"
-      | "authorizedPrincipals"
-      | "sqlStatement"
-      | "stopped"
-      | "properties"
-    >,
-  ) {
-    this.computePoolId = props.computePoolId;
-    this.principal = props.principal;
-    this.authorizedPrincipals = props.authorizedPrincipals;
-    this.sqlStatement = props.sqlStatement;
-    this.stopped = props.stopped;
-    this.properties = props.properties;
   }
 }
 
@@ -199,21 +154,21 @@ export class FlinkStatementTreeItem extends TreeItem {
    */
   getThemeIcon(): ThemeIcon {
     switch (this.resource.phase.toUpperCase()) {
-      case "FAILED":
-      case "FAILING":
+      case FAILED_PHASE:
+      case FAILING_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_FAILED, STATUS_RED);
-      case "DEGRADED":
+      case DEGRADED_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_DEGRADED, STATUS_YELLOW);
-      case "RUNNING":
+      case RUNNING_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_RUNNING, STATUS_GREEN);
-      case "COMPLETED":
+      case COMPLETED_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_COMPLETED, STATUS_GRAY);
-      case "DELETING":
-      case "STOPPING":
+      case DELETING_PHASE:
+      case STOPPING_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_DELETING, STATUS_GRAY);
-      case "STOPPED":
+      case STOPPED_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_STOPPED, STATUS_BLUE);
-      case "PENDING":
+      case PENDING_PHASE:
         return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_PENDING, STATUS_BLUE);
       default:
         return new ThemeIcon(IconNames.FLINK_STATEMENT);
@@ -230,3 +185,16 @@ export const STATUS_BLUE = new ThemeColor("notificationsInfoIcon.foreground");
 // there aren't as many green or gray options to choose from without using `chart` colors
 export const STATUS_GREEN = new ThemeColor("charts.green");
 export const STATUS_GRAY = new ThemeColor("charts.lines");
+
+// Statement phases
+export const RUNNING_PHASE = "RUNNING";
+export const DEGRADED_PHASE = "DEGRADED";
+export const COMPLETED_PHASE = "COMPLETED";
+export const STOPPING_PHASE = "STOPPING";
+export const STOPPED_PHASE = "STOPPED";
+export const FAILED_PHASE = "FAILED";
+export const FAILING_PHASE = "FAILING";
+export const DELETING_PHASE = "DELETING";
+export const PENDING_PHASE = "PENDING";
+
+export const TERMINAL_PHASES = [COMPLETED_PHASE, FAILED_PHASE, STOPPED_PHASE];

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,7 +1,8 @@
 import { Data, type Require as Enforced } from "dataclass";
+import { OrganizationId } from "./resource";
 
 export class CCloudOrganization extends Data {
-  id!: Enforced<string>;
+  id!: Enforced<OrganizationId>;
   name!: Enforced<string>;
   current!: Enforced<boolean>;
   jit_enabled!: Enforced<boolean>;

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -7,6 +7,8 @@ export type ConnectionId = string & { readonly brand: unique symbol };
 /** Likewise for environment ids. Note that Direct Connection ids also double as environment ids. */
 export type EnvironmentId = string & { readonly brand: unique symbol };
 
+export type OrganizationId = string & { readonly brand: unique symbol };
+
 // Function to convert a ConnectionId to a ConnectionType, because we can always
 // go from one to the other.
 export function connectionIdToType(id: ConnectionId): ConnectionType {
@@ -91,7 +93,7 @@ export interface IEnvProviderRegion {
  **/
 export interface IFlinkQueryable extends IEnvProviderRegion {
   /** The organization ID for the resource. */
-  organizationId: string;
+  organizationId: OrganizationId;
   /** Limit to a specific compute pool? */
   computePoolId?: string;
 }

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -14,10 +14,7 @@ import { ContextValues } from "../context/values";
 import { ccloudConnected } from "../emitters";
 import { CCloudResourceLoader, ResourceLoader } from "../loaders";
 import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
-import {
-  FlinkStatement,
-  FlinkStatementTreeItem,
-} from "../models/flinkStatement";
+import { FlinkStatement, FlinkStatementTreeItem } from "../models/flinkStatement";
 import { BaseViewProvider } from "./base";
 import { SqlV1StatementStatus } from "../clients/flinkSql";
 

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -16,10 +16,10 @@ import { CCloudResourceLoader, ResourceLoader } from "../loaders";
 import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import {
   FlinkStatement,
-  FlinkStatementStatus,
   FlinkStatementTreeItem,
 } from "../models/flinkStatement";
 import { BaseViewProvider } from "./base";
+import { SqlV1StatementStatus } from "../clients/flinkSql";
 
 /** Sample view provider subclass for testing {@link BaseViewProvider}. */
 class TestViewProvider extends BaseViewProvider<FlinkComputePool, FlinkStatement> {
@@ -395,6 +395,6 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   });
 });
 
-function makeStatus(phase: string): FlinkStatementStatus {
+function makeStatus(phase: string): SqlV1StatementStatus {
   return createFlinkStatement({ phase: phase }).status;
 }

--- a/tests/unit/testResources/flinkStatement.ts
+++ b/tests/unit/testResources/flinkStatement.ts
@@ -27,7 +27,7 @@ export function createFlinkStatement(overrides: CreateFlinkStatementArgs = {}): 
     connectionId: CCLOUD_CONNECTION_ID,
     connectionType: ConnectionType.Ccloud,
     environmentId: overrides.environmentId || TEST_CCLOUD_ENVIRONMENT_ID,
-    organizationId: overrides.organizationId || TEST_CCLOUD_ORGANIZATION.id as unknown as OrganizationId,
+    organizationId: overrides.organizationId || TEST_CCLOUD_ORGANIZATION.id,
     name: overrides.name || "statement0",
     metadata: {
       self: null,

--- a/tests/unit/testResources/flinkStatement.ts
+++ b/tests/unit/testResources/flinkStatement.ts
@@ -2,14 +2,11 @@ import { ConnectionType } from "../../../src/clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../../../src/constants";
 import {
   FlinkStatement,
-  FlinkStatementMetadata,
-  FlinkStatementSpec,
-  FlinkStatementStatus,
-  FlinkStatementTraits,
 } from "../../../src/models/flinkStatement";
-import { EnvironmentId } from "../../../src/models/resource";
+import { EnvironmentId, OrganizationId } from "../../../src/models/resource";
 import { TEST_CCLOUD_ENVIRONMENT_ID } from "./environments";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL_ID } from "./flinkComputePool";
+import { TEST_CCLOUD_ORGANIZATION } from "./organization";
 
 export const TEST_CCLOUD_FLINK_STATEMENT = createFlinkStatement();
 
@@ -21,6 +18,7 @@ export interface CreateFlinkStatementArgs {
   sqlStatement?: string;
 
   environmentId?: EnvironmentId;
+  organizationId?: OrganizationId;
   computePoolId?: string;
 }
 
@@ -29,33 +27,35 @@ export function createFlinkStatement(overrides: CreateFlinkStatementArgs = {}): 
     connectionId: CCLOUD_CONNECTION_ID,
     connectionType: ConnectionType.Ccloud,
     environmentId: overrides.environmentId || TEST_CCLOUD_ENVIRONMENT_ID,
+    organizationId: overrides.organizationId || TEST_CCLOUD_ORGANIZATION.id as unknown as OrganizationId,
     name: overrides.name || "statement0",
-    metadata: new FlinkStatementMetadata({
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    }),
-    status: new FlinkStatementStatus({
+    metadata: {
+      self: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    },
+    status: {
       phase: overrides.phase || "RUNNING",
       detail: overrides.detail || "Running",
-      traits: new FlinkStatementTraits({
-        sqlKind: overrides.sqlKind || "SELECT",
-        bounded: true,
-        appendOnly: true,
+      traits: {
+        sql_kind: overrides.sqlKind || "SELECT",
+        is_bounded: true,
+        is_append_only: true,
         schema: {},
-      }),
-      scalingStatus: {},
-    }),
-    spec: new FlinkStatementSpec({
-      computePoolId: overrides.computePoolId || TEST_CCLOUD_FLINK_COMPUTE_POOL_ID,
-      sqlStatement: overrides.sqlStatement || "SELECT * FROM test_table",
+      },
+      scaling_status: {}
+    },
+    spec: {
+      compute_pool_id: overrides.computePoolId || TEST_CCLOUD_FLINK_COMPUTE_POOL_ID,
+      statement: overrides.sqlStatement || "SELECT * FROM test_table",
       principal: "test-principal",
-      authorizedPrincipals: [],
+      authorized_principals: [],
       properties: {
         "sql.current-catalog": "custom-data-env",
         "sql.current-database": "Custom Data Dedicated Replica",
         "sql.local-time-zone": "GMT-04:00",
       },
       stopped: false,
-    }),
+    },
   });
 }

--- a/tests/unit/testResources/organization.ts
+++ b/tests/unit/testResources/organization.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "crypto";
 import { CCloudOrganization } from "../../../src/models/organization";
+import { OrganizationId } from "../../../src/models/resource";
 
 export const TEST_CCLOUD_ORGANIZATION = CCloudOrganization.create({
-  id: randomUUID(),
+  id: randomUUID() as OrganizationId,
   current: true,
   name: "test-ccloud-org",
   jit_enabled: false,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->


- Introduces a typed `OrganizationId` into the `FlinkStatement` model, this is used by the following PR #1565.
- Also introduces exported constants for the Flink statement phase.
- Use API generated types instead of custom types for most fields of `FlinkStatement`. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

This PR extracts refactorings made as part of #1565.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
