### PR TITLE
Introduce completed state in results viewer

### DIFF
--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -40,6 +40,7 @@
                 data-on-click="this.handleStreamToggle(this.streamState())"
                 data-text="this.streamStateLabel()"
                 data-attr-title="this.streamStateTooltip()"
+                data-attr-disabled="this.streamState() === 'completed'"
               >
               </vscode-button>
             </div>

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -32,7 +32,7 @@ const resultLimitLabel = Object.fromEntries(
   labels.map((label, index) => [numbers[index], label]),
 ) as Record<string, ResultLimitType>;
 
-type StreamState = "running" | "paused" | "errored";
+type StreamState = "running" | "paused" | "errored" | "completed";
 
 /**
  * Top level view model for Flink Statement Results Viewer. It composes shared state and logic
@@ -320,6 +320,8 @@ class FlinkStatementResultsViewModel extends ViewModel {
         return "Pause";
       case "paused":
         return "Resume";
+      case "completed":
+        return "Completed";
     }
   });
   streamStateTooltip = this.derive(() => {
@@ -328,6 +330,8 @@ class FlinkStatementResultsViewModel extends ViewModel {
         return "Fetching results";
       case "paused":
         return "Result fetching is paused. Click to resume from last result received.";
+      case "completed":
+        return "All results have been fetched";
     }
   });
 
@@ -337,6 +341,8 @@ class FlinkStatementResultsViewModel extends ViewModel {
         return post("StreamPause", { timestamp: this.timestamp() });
       case "paused":
         return post("StreamResume", { timestamp: this.timestamp() });
+      case "completed":
+        return null; // No action for completed state
     }
   }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Introduces a new state called `Completed` in the results viewer, this will be shown for system statements that execute and stop.
- Also fixes #1602 -- notifying UI on pause/resume button click

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
