### PR TITLE
1596 flink database quickpick

### DIFF
--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -67,7 +67,7 @@ export async function submitFlinkStatementCommand(): Promise<void> {
     fileFilters,
   );
   if (!statementBodyUri) {
-    logger.info(
+    logger.debug(
       "sumbitFlinkStatementCommand",
       "Short circuiting return, no statement file chosen.",
     );
@@ -83,7 +83,7 @@ export async function submitFlinkStatementCommand(): Promise<void> {
   // 3. Choose the Flink cluster to send to
   const computePool = await flinkComputePoolQuickPick();
   if (!computePool) {
-    logger.error("sumbitFlinkStatementCommand", "computePool is undefined");
+    logger.error("submitFlinkStatementCommand", "computePool is undefined");
     return;
   }
 
@@ -92,7 +92,7 @@ export async function submitFlinkStatementCommand(): Promise<void> {
   const currentDatabaseKafkaCluster: KafkaCluster | undefined =
     await flinkDatabaseQuickpick(computePool);
   if (!currentDatabaseKafkaCluster) {
-    logger.error("sumbitFlinkStatementCommand: User canceled the default database quickpick");
+    logger.error("submitFlinkStatementCommand: User canceled the default database quickpick");
     return;
   }
   const currentDatabase = currentDatabaseKafkaCluster.name;

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -9,9 +9,9 @@ import {
 } from "../errors";
 import { Logger } from "../logging";
 import { FAILED_PHASE, FlinkStatement, restFlinkStatementToModel } from "../models/flinkStatement";
-import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
+import { KafkaCluster } from "../models/kafkaCluster";
 import { flinkComputePoolQuickPick } from "../quickpicks/flinkComputePools";
-import { kafkaClusterQuickPick } from "../quickpicks/kafkaClusters";
+import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
 import { uriQuickpick } from "../quickpicks/uris";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { getEditorOrFileContents } from "../utils/file";
@@ -87,25 +87,12 @@ export async function submitFlinkStatementCommand(): Promise<void> {
     return;
   }
 
-  // 4. Choose the current / default database / aka kafka cluster
-  // within the environment.
-  const currentDatabaseKafkaCluster: KafkaCluster | undefined = await kafkaClusterQuickPick({
-    placeHolder: "Select the Kafka cluster to use as the default database for the statement",
-    filter: (cluster: KafkaCluster) => {
-      if (cluster.environmentId !== computePool.environmentId) {
-        return false;
-      }
-      // Any survivors matching environmentId check should be CCloudKafkaClusters,
-      // since the compute pool is ccloud.
-      const ccloudCluster = cluster as CCloudKafkaCluster;
-      return (
-        ccloudCluster.provider === computePool.provider &&
-        ccloudCluster.region === computePool.region
-      );
-    },
-  });
+  // 4. Choose the current / default database for the expression to be evaluated against.
+  // (a kafka cluster in the same provider/region as the compute pool)
+  const currentDatabaseKafkaCluster: KafkaCluster | undefined =
+    await flinkDatabaseQuickpick(computePool);
   if (!currentDatabaseKafkaCluster) {
-    logger.error("sumbitFlinkStatementCommand", "currentDatabaseKafkaCluster is undefined");
+    logger.error("sumbitFlinkStatementCommand: User canceled the default database quickpick");
     return;
   }
   const currentDatabase = currentDatabaseKafkaCluster.name;

--- a/src/commands/utils/flinkStatements.ts
+++ b/src/commands/utils/flinkStatements.ts
@@ -68,6 +68,7 @@ export class FlinkSpecProperties {
  * Return a suitable (and unique) name for a Flink statement to submit.
  *
  * @param statement
+ * @returns string akin to "username-vscode-2023-10-01t12-00-00"
  */
 export async function determineFlinkStatementName(): Promise<string> {
   const parts: string[] = [];
@@ -84,6 +85,8 @@ export async function determineFlinkStatementName(): Promise<string> {
 
   parts.push(dateString);
 
+  // Can only be lowercase; probably to simplify the
+  // uniqueness check on the backend.
   const proposed = parts.join("-").toLocaleLowerCase();
 
   // TODO: Show the user the proposed name and let them edit it.

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -5,7 +5,8 @@ import { ContextValues, getContextValue } from "../context/values";
 import { ResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { Environment } from "../models/environment";
-import { KafkaCluster } from "../models/kafkaCluster";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
 import { getConnectionLabel, isCCloud, isDirect, isLocal } from "../models/resource";
 import { getTopicViewProvider } from "../viewProviders/topics";
 import { QuickPickItemWithValue } from "./types";
@@ -164,4 +165,34 @@ export async function kafkaClusterQuickPick(
       ignoreFocusOut: true,
     });
   return chosenClusterItem ? chosenClusterItem.value : undefined;
+}
+
+/**
+ * Quickpick for selecting a Kafka cluster to use as the default database for a Flink statement.
+ * @param computePool The compute pool to use as the context for the quickpick (limits to clusters in same cloud provider/region).
+ * @param placeholder Optionally override the placeholder text for the quickpick.
+ *                    Defaults to "Select the Kafka cluster to use as the default database for the statement".
+ * @returns chosen Kafka cluster or undefined if the user cancels the quickpick.
+ */
+export async function flinkDatabaseQuickpick(
+  computePool: CCloudFlinkComputePool,
+  placeholder: string = "Select the Kafka cluster to use as the default database for the statement",
+): Promise<KafkaCluster | undefined> {
+  return await kafkaClusterQuickPick({
+    placeHolder: placeholder,
+    filter: (cluster: KafkaCluster) => {
+      if (!isCCloud(cluster)) {
+        // Only CCloud clusters are supported for Flink compute pools.
+        return false;
+      }
+
+      // Include if the cluster is in the same provider + region as the compute pool.
+      // (Flink can query cross-environment, but not cross-provider/region.)
+      const ccloudCluster = cluster as CCloudKafkaCluster;
+      return (
+        ccloudCluster.provider === computePool.provider &&
+        ccloudCluster.region === computePool.region
+      );
+    },
+  });
 }

--- a/tests/unit/testResources/environments.ts
+++ b/tests/unit/testResources/environments.ts
@@ -36,5 +36,5 @@ export const TEST_LOCAL_ENVIRONMENT: LocalEnvironment = new LocalEnvironment({
 });
 
 // not tied to the CCloud Environment specifically, but used by CCloud Kafka clusters and Schema Registry
-export const TEST_CCLOUD_PROVIDER = "aws";
+export const TEST_CCLOUD_PROVIDER = "AWS";
 export const TEST_CCLOUD_REGION = "us-west-2";

--- a/tests/unit/testResources/kafkaCluster.ts
+++ b/tests/unit/testResources/kafkaCluster.ts
@@ -20,7 +20,7 @@ export const TEST_LOCAL_KAFKA_CLUSTER: LocalKafkaCluster = LocalKafkaCluster.cre
 export const TEST_CCLOUD_KAFKA_CLUSTER: CCloudKafkaCluster = CCloudKafkaCluster.create({
   id: "lkc-abc123",
   name: "test-ccloud-kafka-cluster",
-  provider: TEST_CCLOUD_PROVIDER.toUpperCase(),
+  provider: TEST_CCLOUD_PROVIDER,
   region: TEST_CCLOUD_REGION,
   bootstrapServers: `SASL_SSL://pkc-abc123.${TEST_CCLOUD_REGION}.${TEST_CCLOUD_PROVIDER}.confluent.cloud:443`,
   uri: `https://pkc-abc123.${TEST_CCLOUD_REGION}.${TEST_CCLOUD_PROVIDER}.confluent.cloud:443`,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Extract the kafka-cluster-as-Flink-default-database quickpick  inlined in submit statement code. Will filter for those matching the provider and region as indicated by the provided compute cluster (could in future devolve to anything providing `provider` and `region`, and/or undefined if we want open-ended picking). Current known use case wants only the kafka clusters appropriate for a given compute cluster, so API matches that need for now.
- Address the lower-hanging nits left-over from https://github.com/confluentinc/vscode/pull/1562 . #1599 will mop up the rest soon.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1596

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
