### PR TITLE
chore: Testing scaffold resource

### DIFF
--- a/src/scaffold.test.ts
+++ b/src/scaffold.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./clients/scaffoldingService";
 import * as scaffold from "./scaffold";
 
-describe.only("scaffoldProjectRequest", () => {
+describe("scaffoldProjectRequest", () => {
   let sandbox: sinon.SinonSandbox;
   let getTemplatesStub: sinon.SinonStub;
   let quickPickStub: sinon.SinonStub;

--- a/src/scaffold.test.ts
+++ b/src/scaffold.test.ts
@@ -1,187 +1,122 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import { TEST_LOCAL_KAFKA_CLUSTER, TEST_LOCAL_KAFKA_TOPIC } from "../tests/unit/testResources";
-import { getTestExtensionContext } from "../tests/unit/testUtils";
-import * as errors from "./errors";
-import { CCloudResourceLoader } from "./loaders/ccloudResourceLoader";
-import { CCloudFlinkComputePool } from "./models/flinkComputePool";
-import { CCloudKafkaCluster } from "./models/kafkaCluster";
-import { EnvironmentId, OrganizationId } from "./models/resource";
-import { KafkaTopic } from "./models/topic";
+import * as vscode from "vscode";
+import {
+  ScaffoldV1TemplateListApiVersionEnum,
+  ScaffoldV1TemplateListDataInner,
+  ScaffoldV1TemplateListDataInnerApiVersionEnum,
+  ScaffoldV1TemplateListDataInnerKindEnum,
+  ScaffoldV1TemplateListKindEnum,
+} from "./clients/scaffoldingService";
 import * as scaffold from "./scaffold";
-import * as resourceManager from "./storage/resourceManager";
 
-describe.only("resourceScaffoldProjectRequest tests", () => {
+describe.only("scaffoldProjectRequest", () => {
   let sandbox: sinon.SinonSandbox;
-  let scaffoldProjectRequestStub: sinon.SinonStub;
-  let mockResourceManager: any;
-  let getClusterForTopicStub: sinon.SinonStub;
-  let showErrorNotificationStub: sinon.SinonStub;
-  let ccloudResourceLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
-  let getOrganizationIdStub: sinon.SinonStub;
+  let getTemplatesStub: sinon.SinonStub;
+  let quickPickStub: sinon.SinonStub;
 
-  const testOrgId = "test-org-id" as OrganizationId;
-
-  before(async () => {
-    await getTestExtensionContext();
-  });
-
-  beforeEach(() => {
+  beforeEach(async () => {
     sandbox = sinon.createSandbox();
 
-    // Stub scaffoldProjectRequest
-    scaffoldProjectRequestStub = sandbox.stub(scaffold, "scaffoldProjectRequest").resolves();
+    const templateData: ScaffoldV1TemplateListDataInner[] = [
+      {
+        api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
+        kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
+        metadata: { self: undefined },
+        spec: {
+          name: "kafka-js",
+          display_name: "Kafka Client In JavaScript",
+          description: "A simple JavaScript project",
+          tags: ["producer", "consumer", "javascript"],
+        },
+      },
+      {
+        api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
+        kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
+        metadata: { self: undefined },
+        spec: {
+          name: "flink-sql",
+          display_name: "Flink SQL Application",
+          description: "A Flink SQL application",
+          tags: ["apache flink", "table api"],
+        },
+      },
+      {
+        api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
+        kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
+        metadata: { self: undefined },
+        spec: {
+          name: "other-template",
+          display_name: "Other Template",
+          description: "Another template",
+          tags: ["other"],
+        },
+      },
+    ];
 
-    // Stub resource manager
-    mockResourceManager = {
-      getClusterForTopic: sandbox.stub(),
+    const mockTemplates = {
+      api_version: ScaffoldV1TemplateListApiVersionEnum.ScaffoldV1,
+      kind: ScaffoldV1TemplateListKindEnum.TemplateList,
+      metadata: {
+        first: true,
+        last: true,
+        total_size: 3,
+      },
+      data: new Set(templateData),
     };
-    sandbox.stub(resourceManager, "getResourceManager").returns(mockResourceManager);
-    getClusterForTopicStub = mockResourceManager.getClusterForTopic;
 
-    // Stub error notification
-    showErrorNotificationStub = sandbox.stub(errors, "showErrorNotificationWithButtons");
-
-    // Stub CCloudResourceLoader
-    ccloudResourceLoaderStub = sandbox.createStubInstance(CCloudResourceLoader);
-    sandbox.stub(CCloudResourceLoader, "getInstance").returns(ccloudResourceLoaderStub);
-    getOrganizationIdStub = ccloudResourceLoaderStub.getOrganizationId.resolves(testOrgId);
+    getTemplatesStub = sandbox.stub(scaffold, "getTemplatesList").resolves(mockTemplates);
+    quickPickStub = sandbox.stub(vscode.window, "showQuickPick").resolves(undefined);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  describe("KafkaCluster tests", () => {
-    it("should call scaffoldProjectRequest with correct parameters for KafkaCluster", async () => {
-      // Create a test CCloudKafkaCluster
-      const testCluster = CCloudKafkaCluster.create({
-        ...TEST_LOCAL_KAFKA_CLUSTER,
-        bootstrapServers: "kafka:9092",
-        provider: "GCP",
-        region: "us-east-1",
-        environmentId: "test-env-id" as EnvironmentId,
-      });
-
-      // Call the function
-      await scaffold.resourceScaffoldProjectRequest(testCluster);
-
-      // Check that scaffoldProjectRequest was called with the correct parameters
-      assert.strictEqual(scaffoldProjectRequestStub.calledOnce, true);
-      assert.deepStrictEqual(scaffoldProjectRequestStub.firstCall.args[0], {
-        bootstrap_server: "kafka:9092-without-protocol",
-        cc_bootstrap_server: "kafka:9092-without-protocol",
-        templateType: "kafka",
-      });
-    });
+  it("filters templates by kafka tags when templateType is kafka", async () => {
+    await scaffold.scaffoldProjectRequest({ templateType: "kafka" });
+    const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
+    assert.ok(quickPickItems.length > 0, "Should have at least one Kafka template");
+    assert.ok(
+      quickPickItems.every(
+        (item) => item.description?.includes("producer") || item.description?.includes("consumer"),
+      ),
+      "All items should be Kafka related",
+    );
   });
 
-  describe("KafkaTopic tests", () => {
-    it("should call scaffoldProjectRequest with correct parameters for KafkaTopic with associated cluster", async () => {
-      // Create a test KafkaTopic
-      const testTopic = KafkaTopic.create({
-        ...TEST_LOCAL_KAFKA_TOPIC,
-        name: "test-topic",
-      });
-
-      // Create a test CCloudKafkaCluster that will be returned by getClusterForTopic
-      const testCluster = CCloudKafkaCluster.create({
-        ...TEST_LOCAL_KAFKA_CLUSTER,
-        bootstrapServers: "kafka:9092",
-        provider: "AWS",
-        region: "us-west-2",
-        environmentId: "test-env-id" as EnvironmentId,
-      });
-
-      // Configure getClusterForTopic to return the test cluster
-      getClusterForTopicStub.withArgs(testTopic).resolves(testCluster);
-
-      // Call the function
-      await scaffold.resourceScaffoldProjectRequest(testTopic);
-
-      // Check that getClusterForTopic was called with the correct parameter
-      assert.strictEqual(getClusterForTopicStub.calledOnce, true);
-      assert.strictEqual(getClusterForTopicStub.firstCall.args[0], testTopic);
-
-      // Check that scaffoldProjectRequest was called with the correct parameters
-      assert.strictEqual(scaffoldProjectRequestStub.calledOnce, true);
-      assert.deepStrictEqual(scaffoldProjectRequestStub.firstCall.args[0], {
-        bootstrap_server: "kafka:9092-without-protocol",
-        cc_bootstrap_server: "kafka:9092-without-protocol",
-        cc_topic: "test-topic",
-        topic: "test-topic",
-        templateType: "kafka",
-      });
-
-      // Verify the error notification was not shown
-      assert.strictEqual(showErrorNotificationStub.called, false);
-    });
-
-    it("should show error notification when no cluster is found for KafkaTopic", async () => {
-      // Create a test KafkaTopic
-      const testTopic = KafkaTopic.create({
-        ...TEST_LOCAL_KAFKA_TOPIC,
-        name: "test-topic-no-cluster",
-      });
-
-      // Configure getClusterForTopic to return null (no cluster found)
-      getClusterForTopicStub.withArgs(testTopic).resolves(null);
-
-      // Call the function
-      await scaffold.resourceScaffoldProjectRequest(testTopic);
-
-      // Check that getClusterForTopic was called with the correct parameter
-      assert.strictEqual(getClusterForTopicStub.calledOnce, true);
-      assert.strictEqual(getClusterForTopicStub.firstCall.args[0], testTopic);
-
-      // Verify scaffoldProjectRequest was not called
-      assert.strictEqual(scaffoldProjectRequestStub.called, false);
-
-      // Verify the error notification was shown with the correct message
-      assert.strictEqual(showErrorNotificationStub.calledOnce, true);
-      assert.strictEqual(
-        showErrorNotificationStub.firstCall.args[0],
-        'Unable to find Kafka cluster for topic "test-topic-no-cluster".',
-      );
-    });
+  it("filters templates by flink tags when templateType is flink", async () => {
+    await scaffold.scaffoldProjectRequest({ templateType: "flink" });
+    const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
+    assert.ok(quickPickItems.length > 0, "Should have at least one Flink template");
+    assert.ok(
+      quickPickItems.every(
+        (item) =>
+          item.description?.includes("apache flink") || item.description?.includes("table api"),
+      ),
+      "All items should be Flink related",
+    );
   });
 
-  describe("CCloudFlinkComputePool tests", () => {
-    it("should call scaffoldProjectRequest with correct parameters for CCloudFlinkComputePool", async () => {
-      // Create a test CCloudFlinkComputePool
-      const testComputePool: CCloudFlinkComputePool = new CCloudFlinkComputePool({
-        id: "test-compute-pool-id",
-        name: "Test Compute Pool",
-        environmentId: "test-env-id" as EnvironmentId,
-        region: "us-west-2",
-        provider: "AWS",
-        maxCfu: 5,
-      });
-
-      // Call the function
-      await scaffold.resourceScaffoldProjectRequest(testComputePool);
-
-      // Check that getOrganizationId was called
-      assert.strictEqual(getOrganizationIdStub.calledOnce, true);
-
-      // Check that scaffoldProjectRequest was called with the correct parameters
-      assert.strictEqual(scaffoldProjectRequestStub.calledOnce, true);
-      assert.deepStrictEqual(scaffoldProjectRequestStub.firstCall.args[0], {
-        cc_environment_id: "test-env-id",
-        cc_organization_id: testOrgId,
-        cloud_region: "us-west-2",
-        cloud_provider: "AWS",
-        cc_compute_pool_id: "test-compute-pool-id",
-        templateType: "flink",
-      });
+  it("returns undefined when no templates are available", async () => {
+    getTemplatesStub.resolves({
+      api_version: ScaffoldV1TemplateListApiVersionEnum.ScaffoldV1,
+      kind: ScaffoldV1TemplateListKindEnum.TemplateList,
+      metadata: { first: true, last: true, total_size: 0 },
+      data: new Set([]),
     });
+
+    const result = await scaffold.scaffoldProjectRequest({ templateType: "kafka" });
+    assert.strictEqual(result, undefined);
   });
 
-  it("should not call scaffoldProjectRequest when no item is provided", async () => {
-    // Call the function with no item
-    await scaffold.resourceScaffoldProjectRequest();
+  it("finds specific template when templateName is provided", async () => {
+    await scaffold.scaffoldProjectRequest({
+      templateName: "kafka-js",
+      templateType: "kafka",
+    });
 
-    // Verify scaffoldProjectRequest was not called
-    assert.strictEqual(scaffoldProjectRequestStub.called, false);
+    const quickPickItems = quickPickStub.firstCall?.args[0] as vscode.QuickPickItem[];
+    assert.ok(!quickPickItems, "QuickPick should not be shown when template is specified");
   });
 });

--- a/src/scaffold.test.ts
+++ b/src/scaffold.test.ts
@@ -1,0 +1,187 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { TEST_LOCAL_KAFKA_CLUSTER, TEST_LOCAL_KAFKA_TOPIC } from "../tests/unit/testResources";
+import { getTestExtensionContext } from "../tests/unit/testUtils";
+import * as errors from "./errors";
+import { CCloudResourceLoader } from "./loaders/ccloudResourceLoader";
+import { CCloudFlinkComputePool } from "./models/flinkComputePool";
+import { CCloudKafkaCluster } from "./models/kafkaCluster";
+import { EnvironmentId, OrganizationId } from "./models/resource";
+import { KafkaTopic } from "./models/topic";
+import * as scaffold from "./scaffold";
+import * as resourceManager from "./storage/resourceManager";
+
+describe.only("resourceScaffoldProjectRequest tests", () => {
+  let sandbox: sinon.SinonSandbox;
+  let scaffoldProjectRequestStub: sinon.SinonStub;
+  let mockResourceManager: any;
+  let getClusterForTopicStub: sinon.SinonStub;
+  let showErrorNotificationStub: sinon.SinonStub;
+  let ccloudResourceLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+  let getOrganizationIdStub: sinon.SinonStub;
+
+  const testOrgId = "test-org-id" as OrganizationId;
+
+  before(async () => {
+    await getTestExtensionContext();
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // Stub scaffoldProjectRequest
+    scaffoldProjectRequestStub = sandbox.stub(scaffold, "scaffoldProjectRequest").resolves();
+
+    // Stub resource manager
+    mockResourceManager = {
+      getClusterForTopic: sandbox.stub(),
+    };
+    sandbox.stub(resourceManager, "getResourceManager").returns(mockResourceManager);
+    getClusterForTopicStub = mockResourceManager.getClusterForTopic;
+
+    // Stub error notification
+    showErrorNotificationStub = sandbox.stub(errors, "showErrorNotificationWithButtons");
+
+    // Stub CCloudResourceLoader
+    ccloudResourceLoaderStub = sandbox.createStubInstance(CCloudResourceLoader);
+    sandbox.stub(CCloudResourceLoader, "getInstance").returns(ccloudResourceLoaderStub);
+    getOrganizationIdStub = ccloudResourceLoaderStub.getOrganizationId.resolves(testOrgId);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("KafkaCluster tests", () => {
+    it("should call scaffoldProjectRequest with correct parameters for KafkaCluster", async () => {
+      // Create a test CCloudKafkaCluster
+      const testCluster = CCloudKafkaCluster.create({
+        ...TEST_LOCAL_KAFKA_CLUSTER,
+        bootstrapServers: "kafka:9092",
+        provider: "GCP",
+        region: "us-east-1",
+        environmentId: "test-env-id" as EnvironmentId,
+      });
+
+      // Call the function
+      await scaffold.resourceScaffoldProjectRequest(testCluster);
+
+      // Check that scaffoldProjectRequest was called with the correct parameters
+      assert.strictEqual(scaffoldProjectRequestStub.calledOnce, true);
+      assert.deepStrictEqual(scaffoldProjectRequestStub.firstCall.args[0], {
+        bootstrap_server: "kafka:9092-without-protocol",
+        cc_bootstrap_server: "kafka:9092-without-protocol",
+        templateType: "kafka",
+      });
+    });
+  });
+
+  describe("KafkaTopic tests", () => {
+    it("should call scaffoldProjectRequest with correct parameters for KafkaTopic with associated cluster", async () => {
+      // Create a test KafkaTopic
+      const testTopic = KafkaTopic.create({
+        ...TEST_LOCAL_KAFKA_TOPIC,
+        name: "test-topic",
+      });
+
+      // Create a test CCloudKafkaCluster that will be returned by getClusterForTopic
+      const testCluster = CCloudKafkaCluster.create({
+        ...TEST_LOCAL_KAFKA_CLUSTER,
+        bootstrapServers: "kafka:9092",
+        provider: "AWS",
+        region: "us-west-2",
+        environmentId: "test-env-id" as EnvironmentId,
+      });
+
+      // Configure getClusterForTopic to return the test cluster
+      getClusterForTopicStub.withArgs(testTopic).resolves(testCluster);
+
+      // Call the function
+      await scaffold.resourceScaffoldProjectRequest(testTopic);
+
+      // Check that getClusterForTopic was called with the correct parameter
+      assert.strictEqual(getClusterForTopicStub.calledOnce, true);
+      assert.strictEqual(getClusterForTopicStub.firstCall.args[0], testTopic);
+
+      // Check that scaffoldProjectRequest was called with the correct parameters
+      assert.strictEqual(scaffoldProjectRequestStub.calledOnce, true);
+      assert.deepStrictEqual(scaffoldProjectRequestStub.firstCall.args[0], {
+        bootstrap_server: "kafka:9092-without-protocol",
+        cc_bootstrap_server: "kafka:9092-without-protocol",
+        cc_topic: "test-topic",
+        topic: "test-topic",
+        templateType: "kafka",
+      });
+
+      // Verify the error notification was not shown
+      assert.strictEqual(showErrorNotificationStub.called, false);
+    });
+
+    it("should show error notification when no cluster is found for KafkaTopic", async () => {
+      // Create a test KafkaTopic
+      const testTopic = KafkaTopic.create({
+        ...TEST_LOCAL_KAFKA_TOPIC,
+        name: "test-topic-no-cluster",
+      });
+
+      // Configure getClusterForTopic to return null (no cluster found)
+      getClusterForTopicStub.withArgs(testTopic).resolves(null);
+
+      // Call the function
+      await scaffold.resourceScaffoldProjectRequest(testTopic);
+
+      // Check that getClusterForTopic was called with the correct parameter
+      assert.strictEqual(getClusterForTopicStub.calledOnce, true);
+      assert.strictEqual(getClusterForTopicStub.firstCall.args[0], testTopic);
+
+      // Verify scaffoldProjectRequest was not called
+      assert.strictEqual(scaffoldProjectRequestStub.called, false);
+
+      // Verify the error notification was shown with the correct message
+      assert.strictEqual(showErrorNotificationStub.calledOnce, true);
+      assert.strictEqual(
+        showErrorNotificationStub.firstCall.args[0],
+        'Unable to find Kafka cluster for topic "test-topic-no-cluster".',
+      );
+    });
+  });
+
+  describe("CCloudFlinkComputePool tests", () => {
+    it("should call scaffoldProjectRequest with correct parameters for CCloudFlinkComputePool", async () => {
+      // Create a test CCloudFlinkComputePool
+      const testComputePool: CCloudFlinkComputePool = new CCloudFlinkComputePool({
+        id: "test-compute-pool-id",
+        name: "Test Compute Pool",
+        environmentId: "test-env-id" as EnvironmentId,
+        region: "us-west-2",
+        provider: "AWS",
+        maxCfu: 5,
+      });
+
+      // Call the function
+      await scaffold.resourceScaffoldProjectRequest(testComputePool);
+
+      // Check that getOrganizationId was called
+      assert.strictEqual(getOrganizationIdStub.calledOnce, true);
+
+      // Check that scaffoldProjectRequest was called with the correct parameters
+      assert.strictEqual(scaffoldProjectRequestStub.calledOnce, true);
+      assert.deepStrictEqual(scaffoldProjectRequestStub.firstCall.args[0], {
+        cc_environment_id: "test-env-id",
+        cc_organization_id: testOrgId,
+        cloud_region: "us-west-2",
+        cloud_provider: "AWS",
+        cc_compute_pool_id: "test-compute-pool-id",
+        templateType: "flink",
+      });
+    });
+  });
+
+  it("should not call scaffoldProjectRequest when no item is provided", async () => {
+    // Call the function with no item
+    await scaffold.resourceScaffoldProjectRequest();
+
+    // Verify scaffoldProjectRequest was not called
+    assert.strictEqual(scaffoldProjectRequestStub.called, false);
+  });
+});

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -51,7 +51,7 @@ export function registerProjectGenerationCommands(): vscode.Disposable[] {
   ];
 }
 
-async function resourceScaffoldProjectRequest(
+export async function resourceScaffoldProjectRequest(
   item?: KafkaCluster | KafkaTopic | CCloudFlinkComputePool,
 ) {
   if (item instanceof KafkaCluster) {

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -51,7 +51,7 @@ export function registerProjectGenerationCommands(): vscode.Disposable[] {
   ];
 }
 
-export async function resourceScaffoldProjectRequest(
+async function resourceScaffoldProjectRequest(
   item?: KafkaCluster | KafkaTopic | CCloudFlinkComputePool,
 ) {
   if (item instanceof KafkaCluster) {


### PR DESCRIPTION
## Summary of Changes

This one is similar to #1592 but doesn't test `resourceScaffoldProjectRequest` directly (would need input on the contexts to import for that) but it does test the results of calling `scaffoldProjectRequest`  by resource type, which `resourceScaffoldProjectRequest` pretty much is a wrapper on. 

-

## Any additional details or context that should be provided?

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
