### PR TITLE
add basic `copilot-instructions.md` to help with testing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Testing
 
-This VS Code extension use the Mocha BDD interface and the "sinon" and "assert" packages for
+This VS Code extension uses the Mocha BDD interface and the "sinon" and "assert" packages for
 testing.
 
 Always use a `SinonSandbox` instance when setting up stubs, spies, or fakes to ensure proper
@@ -16,4 +16,4 @@ the class.
 
 Fixtures are in the `test/unit/testResources` directory and represent instances of our data models
 in `src/models` solely used for test purposes. Use these fixtures as needed, only creating new
-instances when slight variations are necessary or a when a fixture is missing entirely.
+instances when slight variations are necessary or when a fixture is missing entirely.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Testing
+
+This VS Code extension use the Mocha BDD interface and the "sinon" and "assert" packages for
+testing.
+
+Always use a `SinonSandbox` instance when setting up stubs, spies, or fakes to ensure proper
+cleanup. Use the sinon Assert API for assertions involving the behavior of stubs, spies, or fakes.
+(For example, use `sinon.assert.called(stub)` instead of
+`assert.equal(stub.called, true, "stub should be called, but wasn't")`.) This allows for more
+concise code and provides better feedback in case of test failures.
+
+When working with a class instance where methods need to be stubbed, use the
+`sandbox.createStubInstance(ClassNameHere)` method to create a `SinonStubbedInstance` of the class.
+This will ensure that all methods are stubbed and that the instance behaves like a real instance of
+the class.
+
+Fixtures are in the `test/unit/testResources` directory and represent instances of our data models
+in `src/models` solely used for test purposes. Use these fixtures as needed, only creating new
+instances when slight variations are necessary or a when a fixture is missing entirely.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR sets up some basic instructions to help Copilot suggest better test practices, which will in turn help other contributors that are newer to the repo.

In future PRs, we can add some additional sections describing the overall architecture of the extension repo, sidecar interaction context, `src/clients` generation, `gulp` and `rollup` nuances, etc.

Context: https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot?tool=vscode

### Without instructions
- uses chai/jest/expect instead of sinon and assert
![image](https://github.com/user-attachments/assets/c49c1ecc-4ed6-4fde-ad1d-9254088e5a61)

### With `copilot-instructions.md` 
- loads `copilot-instructions.md` context by default
- suggests using `sinon` and `assert`, with sandboxes and stubs if appropriate
![image](https://github.com/user-attachments/assets/b2265ae5-507a-4dcb-9b70-6fac61db5a5b)