### PR TITLE
Describe user local timezone's GMT offset to Flink when submitting new statements.

### DIFF
--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -20,6 +20,7 @@ import {
   determineFlinkStatementName,
   FlinkSpecProperties,
   IFlinkStatementSubmitParameters,
+  localTimezoneOffset,
   submitFlinkStatement,
 } from "./utils/flinkStatements";
 
@@ -105,8 +106,7 @@ export async function submitFlinkStatementCommand(): Promise<void> {
     properties: new FlinkSpecProperties({
       currentDatabase,
       currentCatalog: computePool.environmentId,
-      // TODO get at the user's local timezone
-      // localTimezone: "GMT-04:00",
+      localTimezone: localTimezoneOffset(),
     }),
   };
 

--- a/src/commands/utils/flinkStatements.test.ts
+++ b/src/commands/utils/flinkStatements.test.ts
@@ -1,0 +1,37 @@
+import * as assert from "assert";
+import { localTimezoneOffset } from "./flinkStatements";
+
+describe("commands/utils/flinkStatements.ts localTimezoneOffset()", function () {
+  let originalTimezone: string | undefined;
+
+  beforeEach(() => {
+    originalTimezone = process.env.TZ;
+  });
+  afterEach(() => {
+    if (originalTimezone) {
+      process.env.TZ = originalTimezone;
+    } else {
+      delete process.env.TZ;
+    }
+  });
+
+  it("Should extract offset relative to GMT", async function () {
+    // Pin down timezone. May still be DST or not though based on the datetime.
+    // (Can only do this once; internals of Date will cache the timezone offset?)
+    process.env.TZ = "America/Los_Angeles";
+
+    // This should be GMT-0700 for EDT or GMT-0800 for EST
+    const offset = localTimezoneOffset();
+    assert.strictEqual(offset.startsWith("GMT"), true, "Offset should end with GMT");
+    // Fourth character should be + or -
+    assert.strictEqual(offset[3] === "+" || offset[3] === "-", true, "Offset should be + or -");
+
+    // Remainder will be either 0700 or 0800
+    assert.strictEqual(
+      offset.slice(4, 6) === "07" || offset.slice(4, 6) === "08",
+      true,
+      "Offset should be 0700 or 0800",
+    );
+    assert.strictEqual(offset.slice(6, 8) === "00", true, "Offset should be 00");
+  });
+});

--- a/src/commands/utils/flinkStatements.ts
+++ b/src/commands/utils/flinkStatements.ts
@@ -136,3 +136,12 @@ export async function submitFlinkStatement(
 
   return response;
 }
+
+/**
+ * Get the user's local timezone offset.
+ * @returns The local timezone offset in the format "GMT+/-HHMM", e.g. "GMT-0400" for EDT.
+ */
+export function localTimezoneOffset(): string {
+  const nowStr = new Date().toString();
+  return nowStr.match(/([A-Z]+[+-][0-9]+)/)![1];
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Obtain the user's timezone's current offset from GMT, augment Flink statement context.
- Matches CCloud Workspaces behavior when submitting statements.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-Closes #1579

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
