### PR TITLE
Flink settings followup: better db picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -593,7 +593,7 @@
         }
       },
       {
-        "title": "Flink SQL",
+        "title": "Flink SQL Defaults",
         "properties": {
           "confluent.preview.enableFlink": {
             "type": "boolean",

--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -1,0 +1,77 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import * as quickpicks from "../quickpicks/flinkComputePools";
+import * as kafkaQuickpicks from "../quickpicks/kafkaClusters";
+import * as commandsModule from "./flinkComputePools";
+import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../constants";
+
+describe.only("configureFlinkDefaults command", () => {
+  let sandbox: sinon.SinonSandbox;
+  let flinkComputePoolQuickPickStub: sinon.SinonStub;
+  let flinkDatabaseQuickpickStub: sinon.SinonStub;
+  // HELP: Not sure how to rewrite to avoid this unused var warning... we are stubbing this so internal update can call it
+  let getConfigurationStub: sinon.SinonStub;
+  let updateStub: sinon.SinonStub;
+  let showInformationMessageStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    flinkComputePoolQuickPickStub = sandbox.stub(quickpicks, "flinkComputePoolQuickPick");
+    flinkDatabaseQuickpickStub = sandbox.stub(kafkaQuickpicks, "flinkDatabaseQuickpick");
+    updateStub = sandbox.stub();
+    getConfigurationStub = sandbox.stub(vscode.workspace, "getConfiguration").returns({
+      update: updateStub,
+      get: sandbox.stub().callsFake((section: string, defaultValue?: unknown) => defaultValue),
+      has: sandbox.stub(),
+      inspect: sandbox.stub(),
+    });
+    showInformationMessageStub = sandbox
+      .stub(vscode.window, "showInformationMessage")
+      .resolves(undefined);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return early if no compute pool is selected", async () => {
+    flinkComputePoolQuickPickStub.resolves(undefined);
+
+    await commandsModule.configureFlinkDefaults();
+
+    assert.ok(updateStub.notCalled);
+    assert.ok(flinkDatabaseQuickpickStub.notCalled);
+  });
+
+  it("should update config and show info message after pool and database are selected", async () => {
+    const pool = { id: "pool1" };
+    const cluster = { name: "db1" };
+    flinkComputePoolQuickPickStub.resolves(pool);
+    flinkDatabaseQuickpickStub.resolves(cluster);
+
+    await commandsModule.configureFlinkDefaults();
+
+    assert.ok(updateStub.calledWith(FLINK_CONFIG_COMPUTE_POOL, pool.id, false));
+    assert.ok(updateStub.calledWith(FLINK_CONFIG_DATABASE, cluster.name, false));
+    assert.ok(showInformationMessageStub.calledOnce);
+  });
+
+  it("should open settings if user selects 'View' in info message", async () => {
+    const pool = { id: "pool1" };
+    const cluster = { name: "db1" };
+    flinkComputePoolQuickPickStub.resolves(pool);
+    flinkDatabaseQuickpickStub.resolves(cluster);
+    showInformationMessageStub.resolves("View");
+    const executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
+
+    await commandsModule.configureFlinkDefaults();
+
+    assert.ok(
+      executeCommandStub.calledWith(
+        "workbench.action.openSettings",
+        "@ext:confluentinc.vscode-confluent flink",
+      ),
+    );
+  });
+});

--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -10,8 +10,8 @@ describe.only("configureFlinkDefaults command", () => {
   let sandbox: sinon.SinonSandbox;
   let flinkComputePoolQuickPickStub: sinon.SinonStub;
   let flinkDatabaseQuickpickStub: sinon.SinonStub;
-  // HELP: Not sure how to rewrite to avoid this unused var warning... we are stubbing this so internal update can call it
-  let getConfigurationStub: sinon.SinonStub;
+  // We use this to stub the getConfiguration().update() method, see below
+  let getConfigurationStub: sinon.SinonStub; // eslint-disable-line @typescript-eslint/no-unused-vars
   let updateStub: sinon.SinonStub;
   let showInformationMessageStub: sinon.SinonStub;
 

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -11,7 +11,10 @@ import {
 } from "../quickpicks/flinkComputePools";
 import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../constants";
 import { KafkaCluster } from "../models/kafkaCluster";
-import { flinkDatabaseQuickpick, logger } from "../quickpicks/kafkaClusters";
+import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
+import { Logger } from "../logging";
+
+const logger = new Logger("commands.flinkComputePools");
 
 /**
  * Select a {@link FlinkComputePool} from the "Resources" view to focus both the "Statements" and

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -136,7 +136,11 @@ export class FlinkConfigurationManager implements Disposable {
       // Load available compute pools to verify the configured pool exists
       const resourceManager = getResourceManager();
       const environments = await resourceManager.getCCloudEnvironments();
-
+      // Avoid warning if we haven't loaded the envs yet (happens if user already has setting on activation)
+      if (!environments || environments.length === 0) {
+        logger.warn("No CCloud environments found");
+        return;
+      }
       // Check if the configured compute pool exists in any environment
       let poolFound = false;
       for (const env of environments) {

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -138,7 +138,7 @@ export class FlinkConfigurationManager implements Disposable {
       const environments = await resourceManager.getCCloudEnvironments();
       // Avoid warning if we haven't loaded the envs yet (happens if user already has setting on activation)
       if (!environments || environments.length === 0) {
-        logger.warn("No CCloud environments found");
+        logger.debug("No CCloud environments found");
         return;
       }
       // Check if the configured compute pool exists in any environment

--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -1,4 +1,4 @@
-import { commands, QuickPickItemKind, ThemeIcon, window } from "vscode";
+import { commands, QuickPickItemKind, ThemeIcon, window, workspace } from "vscode";
 import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "../authn/constants";
 import { IconNames } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
@@ -52,6 +52,9 @@ export async function flinkComputePoolQuickPick(): Promise<CCloudFlinkComputePoo
     }
   }
 
+  const config = workspace.getConfiguration("confluent.flink");
+  const defaultComputePoolId = config.get<string>("computePoolId");
+
   if (computePools.length === 0) {
     let login: string = "";
     if (!getContextValue(ContextValues.ccloudConnectionAvailable)) {
@@ -84,6 +87,13 @@ export async function flinkComputePoolQuickPick(): Promise<CCloudFlinkComputePoo
   const artifactsPool: CCloudFlinkComputePool | null = null;
   if (artifactsPool) {
     focusedPools.push(artifactsPool);
+  }
+  // Add default compute pool to focused pools if it exists
+  if (defaultComputePoolId) {
+    const defaultPool = computePools.find((pool) => pool.id === defaultComputePoolId);
+    if (defaultPool && !focusedPools.some((pool) => pool.id === defaultComputePoolId)) {
+      focusedPools.push(defaultPool);
+    }
   }
   for (const focusedPool of focusedPools) {
     const focusedPoolIndex: number = computePools.findIndex((pool) => focusedPool.id === pool.id);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Reuse code from @jlrobins recent PR - smart kafka cluster picker instead of a text field for the Flink default database
- Update copy in a couple places to make the "default" aspect of these settings clear

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
