### PR TITLE
set default `typescript` configs under `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.formatOnType": false,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  }
+}


### PR DESCRIPTION
We've had some issues with `gulp lint` catching formatting-related issues that can usually be addressed with `gulp format`, but handling that before each commit can be tedious. This PR adds some basic repo-level settings to use https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode and auto-format when a file is saved.

> [!NOTE]  
> These are definitely up for discussion/feedback, since they're mainly the settings I use and have shared with other folks that ran into the above linting issues.