### PR TITLE
MINOR fix(testing): create stub instances from the sandboxes

### DIFF
--- a/src/authn/ccloudStateHandling.test.ts
+++ b/src/authn/ccloudStateHandling.test.ts
@@ -179,7 +179,7 @@ describe("authn/ccloudStateHangling.ts reactToCCloudAuthState()", () => {
 
     nonInvalidTokenStatusFireStub = sandbox.stub(nonInvalidTokenStatus, "fire");
 
-    stubResourceManager = sinon.createStubInstance(ResourceManager);
+    stubResourceManager = sandbox.createStubInstance(ResourceManager);
     sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
   });
 

--- a/src/directConnect.test.ts
+++ b/src/directConnect.test.ts
@@ -1,15 +1,18 @@
-import * as vscode from "vscode";
 import * as assert from "assert";
-import { parseTestResult, getConnectionSpecFromFormData, deepMerge } from "./directConnect";
+import sinon from "sinon";
+import * as vscode from "vscode";
 import {
   TEST_DIRECT_CONNECTION,
   TEST_DIRECT_CONNECTION_FORM_SPEC,
 } from "../tests/unit/testResources/connection";
 import { ConnectedState, Status } from "./clients/sidecar";
-import { CustomConnectionSpec } from "./storage/resourceManager";
-import sinon from "sinon";
-import { ResourceManager } from "./storage/resourceManager";
-import { handleConnectionChange } from "./directConnect";
+import {
+  deepMerge,
+  getConnectionSpecFromFormData,
+  handleConnectionChange,
+  parseTestResult,
+} from "./directConnect";
+import { CustomConnectionSpec, ResourceManager } from "./storage/resourceManager";
 
 describe("directConnect.ts", () => {
   describe("getConnectionSpecFromFormData", () => {
@@ -530,7 +533,7 @@ describe("directConnect.ts", () => {
       mockShowInformationMessage = sandbox.stub(vscode.window, "showInformationMessage");
 
       // Mock resource manager with required methods
-      stubResourceManager = sinon.createStubInstance(ResourceManager);
+      stubResourceManager = sandbox.createStubInstance(ResourceManager);
       sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
     });
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Noticed we had some references creating stubs/`SinonStubInstance`s off of `sinon` instead of the `sandbox`es, which is problematic since we don't use `sinon.restore()` anywhere in the test suites.

This _may_ be affecting some of the test flakiness (on windows agents in CI) we've seen with ResourceManager methods, but neither of the affect suites mess with direct connection storage/deletion, so my confidence isn't super high that the flaky behavior will cease. Regardless, this is necessary cleanup for consistency.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
