### PR TITLE
Prevent uriQuickpick() from resolving too soon when external file is chosen

### DIFF
--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -65,7 +65,7 @@ export async function submitFlinkStatementCommand(): Promise<void> {
   );
   if (!statementBodyUri) {
     logger.debug(
-      "sumbitFlinkStatementCommand",
+      "submitFlinkStatementCommand",
       "Short circuiting return, no statement file chosen.",
     );
     return;

--- a/src/commands/utils/flinkStatements.test.ts
+++ b/src/commands/utils/flinkStatements.test.ts
@@ -20,7 +20,7 @@ describe("commands/utils/flinkStatements.ts localTimezoneOffset()", function () 
     // (Can only do this once; internals of Date will cache the timezone offset?)
     process.env.TZ = "America/Los_Angeles";
 
-    // This should be GMT-0700 for EDT or GMT-0800 for EST
+    // This should be GMT-0700 for PDT or GMT-0800 for PST
     const offset = localTimezoneOffset();
     assert.strictEqual(offset.startsWith("GMT"), true, "Offset should end with GMT");
     // Fourth character should be + or -

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -115,9 +115,15 @@ export async function uriQuickpick(
 
   return new Promise<Uri | undefined>((resolve) => {
     let resolved = false;
+    let qpHidden = false;
     let usingFileChooser = false;
 
     function resolver(uri: Uri | undefined) {
+      if (!qpHidden) {
+        qpHidden = true;
+        quickPick.hide();
+      }
+
       // Only really resolve once.
       if (!resolved) {
         resolved = true;

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -114,11 +114,22 @@ export async function uriQuickpick(
   }
 
   return new Promise<Uri | undefined>((resolve) => {
+    let resolved = false;
+    let usingFileChooser = false;
+
+    function resolver(uri: Uri | undefined) {
+      // Only really resolve once.
+      if (!resolved) {
+        resolved = true;
+        resolve(uri);
+      }
+    }
+
     quickPick.onDidAccept(() => {
       const selection = quickPick.selectedItems[0];
-      quickPick.hide();
 
       if (selection.label === selectFileLabel) {
+        usingFileChooser = true;
         window
           .showOpenDialog({
             openLabel: "Select a file",
@@ -128,16 +139,27 @@ export async function uriQuickpick(
             filters: fileFilters,
           })
           .then((uri) => {
-            resolve(uri ? uri[0] : undefined);
+            resolver(uri ? uri[0] : undefined);
           });
       } else if (filenameUriMap.has(selection.label)) {
-        resolve(filenameUriMap.get(selection.label));
+        resolver(filenameUriMap.get(selection.label));
       } else {
-        resolve(undefined);
+        resolver(undefined);
       }
     });
 
-    quickPick.onDidHide(() => resolve(undefined));
+    quickPick.onDidHide(() => {
+      // The call to window.showOpenDialog() as well as any of the resolver() / resolve() calls above
+      // will implicitly close the quickpick and cause onDidHide() to fire, but we don't want to resolve
+      // or falsely re-resolve our promise in those cases.
+
+      // We only want to resolve in this codepath if the quickpick was escape closed by the user.
+      if (!usingFileChooser && !resolved) {
+        resolver(undefined);
+      }
+    });
+
+    // Let the plinko games begin!
     quickPick.show();
   });
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- #1615 caused by the nuance needed when using the `window.createQuickPick()` API and our subsequent need to sometimes open up `window.showOpenDialog()`.
- In buggy code spelling, the immediate explicit call to `quickpick.hide()` would cause the `onDidHide()` handler to fire _before_ the `window.showOpenDialog().then()` handler had a chance to be called, leaving us with `resolve(undefined)` from the  `onDidHide()` handler --- "prematurely." Any subsequent `resolve()` with the file picker's URI was moot. _That ship done sailed_.
- Moreover, even with the explicit `quickpick.hide()` removed, the `onDidHide()` is _implicitly_ fired when we make the `window.showOpenDialog()` call, so need to work around that by recording if we're going down that codepath.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1615 
- Leaving #1627 as future work.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
