### PR TITLE
Make determineFlinkStatementName() use the ccloud username

### DIFF
--- a/src/commands/utils/flinkStatements.test.ts
+++ b/src/commands/utils/flinkStatements.test.ts
@@ -63,6 +63,13 @@ describe("determineFlinkStatementName()", function () {
     assert.strictEqual(statementName, `joe-vscode-${expectedDatePart}`);
   });
 
+  it("Works with degenerate ccloud username", async function () {
+    getCCloudAuthSessionStub.resolves({ account: { id: "simple" } });
+
+    const statementName = await determineFlinkStatementName();
+    assert.strictEqual(statementName, `simple-vscode-${expectedDatePart}`);
+  });
+
   it("Handles crazy case if ccloud isn't authenticated", async function () {
     getCCloudAuthSessionStub.resolves(undefined);
     const statementName = await determineFlinkStatementName();

--- a/src/commands/utils/flinkStatements.ts
+++ b/src/commands/utils/flinkStatements.ts
@@ -1,3 +1,4 @@
+import { getCCloudAuthSession } from "../../authn/utils";
 import {
   CreateSqlv1Statement201Response,
   CreateSqlv1StatementOperationRequest,
@@ -73,16 +74,24 @@ export class FlinkSpecProperties {
 export async function determineFlinkStatementName(): Promise<string> {
   const parts: string[] = [];
 
-  const userName = process.env.USER || process.env.USERNAME;
-  if (userName) {
-    parts.push(userName);
+  // If we're creating flink statements, then we're ccloud authed. Use their
+  // ccloud account name as primary part of the statement name.
+  const ccloudAccountName = (await getCCloudAuthSession())?.account.id;
+  if (ccloudAccountName) {
+    let userNamePart = ccloudAccountName.split("@")[0];
+    // strip anything to the right of any '+' character if present, don't want their
+    // email buckets involved.
+    userNamePart = userNamePart.split("+")[0];
+
+    parts.push(userNamePart);
+  } else {
+    // Wacky. Not ccloud authed?
+    parts.push("unknownuser");
   }
 
   parts.push("vscode");
 
-  const date = new Date();
-  const dateString = date.toISOString().replace(/:/g, "-").replace(/\..*$/, "");
-
+  const dateString = new Date().toISOString().replace(/:/g, "-").replace(/\..*$/, "");
   parts.push(dateString);
 
   // Can only be lowercase; probably to simplify the


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Use ccloud username as prefix for flink statements, not local username.
- Tests.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1604

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
