### PR TITLE
Client for FlinkSQL language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this extension will be documented in this file.
 
 ### Added
 
+- Intellisense features for FlinkSQL language documents, provided by a connection to Confluent
+  Cloud's Flink Language Server
 - Can submit new SQL statements to a Flink compute pool
 - Can view SQL statement results
 - Configurable default settings for `compute pool` and `database` for Flink operations

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "undici": "^6.19.8",
         "unzipit": "^1.4.3",
         "vscode-json-languageservice": "^5.4.2",
+        "vscode-languageclient": "^9.0.1",
+        "vscode-languageserver": "^9.0.1",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -14377,6 +14379,58 @@
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.17.5",
         "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {

--- a/package.json
+++ b/package.json
@@ -722,13 +722,14 @@
           "confluent.flink.computePoolId": {
             "type": "string",
             "default": "",
-            "order": 1,
-            "description": "ID for the CCloud compute pool to use as default for Flink SQL operations."
+            "order": 2,
+            "description": "ID for the compute pool to use as a default in Confluent Cloud for Apache Flink® SQL operations."
           },
           "confluent.flink.database": {
             "type": "string",
+            "order": 3,
             "default": "",
-            "description": "Name or ID for CCloud Kafka® cluster to use as the default Flink SQL database."
+            "description": "Name or ID for Apache Kafka® cluster in Confluent to use as the default Confluent Cloud for Apache Flink® SQL database."
           },
           "confluent.flink.updateComputePoolIdFromCodelens": {
             "markdownDescription": "Controls whether or not to update `#confluent.flink.computePoolId#` after selecting a compute pool from the 'Set Compute Pool' codelens.",

--- a/package.json
+++ b/package.json
@@ -1861,6 +1861,7 @@
     "undici": "^6.19.8",
     "unzipit": "^1.4.3",
     "vscode-json-languageservice": "^5.4.2",
+    "vscode-languageclient": "^9.0.1",
     "vscode-languageserver": "^9.0.1",
     "ws": "^8.18.0"
   }

--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
           "confluent.flink.database": {
             "type": "string",
             "default": "",
-            "description": "Name or ID for CCloud Kafka® cluster to use as the default Flink SQL database"
+            "description": "Name or ID for CCloud Kafka® cluster to use as the default Flink SQL database."
           },
           "confluent.flink.updateComputePoolIdFromCodelens": {
             "markdownDescription": "Controls whether or not to update `#confluent.flink.computePoolId#` after selecting a compute pool from the 'Set Compute Pool' codelens.",

--- a/package.json
+++ b/package.json
@@ -1861,6 +1861,7 @@
     "undici": "^6.19.8",
     "unzipit": "^1.4.3",
     "vscode-json-languageservice": "^5.4.2",
+    "vscode-languageserver": "^9.0.1",
     "ws": "^8.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -723,12 +723,12 @@
             "type": "string",
             "default": "",
             "order": 1,
-            "description": "ID for the default CCloud compute pool to use for Flink SQL operations."
+            "description": "ID for the CCloud compute pool to use as default for Flink SQL operations."
           },
           "confluent.flink.database": {
             "type": "string",
             "default": "",
-            "description": "Name or ID for default CCloud database (topic) to use for Flink SQL operations"
+            "description": "Name or ID for CCloud Kafka® cluster to use as the default Flink SQL database"
           },
           "confluent.flink.updateComputePoolIdFromCodelens": {
             "markdownDescription": "Controls whether or not to update `#confluent.flink.computePoolId#` after selecting a compute pool from the 'Set Compute Pool' codelens.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ import {
   checkForExtensionDisabledReason,
   showExtensionDisabledNotification,
 } from "./featureFlags/evaluation";
-import { initializeFlinkConfigManager } from "./flinkSql/flinkConfigManager";
+import { initializeFlinkLanguageClientManager } from "./flinkSql/flinkLanguageClientManager";
 import { FlinkStatementManager } from "./flinkSql/flinkStatementManager";
 import { activateFlinkStatementResultsViewer } from "./flinkStatementResults";
 import { constructResourceLoaderSingletons } from "./loaders";
@@ -245,7 +245,7 @@ async function _activateExtension(
     uriHandler,
     WebsocketManager.getInstance(),
     FlinkStatementManager.getInstance(),
-    initializeFlinkConfigManager(),
+    initializeFlinkLanguageClientManager(),
     ...authProviderDisposables,
     ...viewProviderDisposables,
     ...registeredCommands,

--- a/src/flinkSql/flinkConfigManager.test.ts
+++ b/src/flinkSql/flinkConfigManager.test.ts
@@ -1,9 +1,15 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { FlinkConfigurationManager } from "./flinkConfigManager";
 import * as vscode from "vscode";
+import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import * as contextValues from "../context/values";
+import * as environmentsModule from "../graphql/environments";
+import { CCloudResourceLoader } from "../loaders";
+import { CCloudEnvironment } from "../models/environment";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import * as ccloud from "../sidecar/connections/ccloud";
+import { FlinkConfigurationManager } from "./flinkConfigManager";
 
 describe("FlinkConfigurationManager", () => {
   let sandbox: sinon.SinonSandbox;
@@ -11,13 +17,12 @@ describe("FlinkConfigurationManager", () => {
   let contextValueStub: sinon.SinonStub;
   let hasCCloudAuthSessionStub: sinon.SinonStub;
   let flinkManager: FlinkConfigurationManager;
+  let ccloudLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+  let getEnvironmentsStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    // Reset the FlinkConfigurationManager instance
     FlinkConfigurationManager["instance"] = null;
-
-    // Stub the external methods (context, ccould auth, config)
     configStub = sandbox.stub(vscode.workspace, "getConfiguration");
     const configMock = {
       get: sandbox.stub(),
@@ -27,109 +32,158 @@ describe("FlinkConfigurationManager", () => {
     hasCCloudAuthSessionStub = sandbox.stub(ccloud, "hasCCloudAuthSession");
     hasCCloudAuthSessionStub.returns(false);
 
-    // Create instance and replace internal methods with spies
+    ccloudLoaderStub = sandbox.createStubInstance(CCloudResourceLoader);
+    sandbox.stub(CCloudResourceLoader, "getInstance").returns(ccloudLoaderStub);
+
+    getEnvironmentsStub = sandbox.stub(environmentsModule, "getEnvironments");
+
     flinkManager = FlinkConfigurationManager.getInstance();
     sandbox.stub(flinkManager, "promptChooseDefaultComputePool" as any).resolves();
     sandbox.stub(flinkManager, "checkFlinkResourcesAvailability" as any).resolves();
   });
-
   afterEach(() => {
     sandbox.restore();
     FlinkConfigurationManager["instance"] = null;
   });
 
   describe("validateFlinkSettings", () => {
-    it("should return early if already prompted for settings", async () => {
-      (flinkManager as any).hasPromptedForSettings = true;
-      await flinkManager.validateFlinkSettings();
-      // Verify none of the methods were called
-      assert.strictEqual(contextValueStub.called, false);
-      assert.strictEqual(configStub.called, false);
-      assert.strictEqual((flinkManager as any).promptChooseDefaultComputePool.called, false);
-    });
-
-    it("should return early if Flink is disabled", async () => {
+    it("should return false if Flink is disabled", async () => {
       contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(false);
-      await flinkManager.validateFlinkSettings();
+      const result = await flinkManager.validateFlinkSettings();
+
       // Verify only method called was check for Flink enabled status
       assert.strictEqual(contextValueStub.called, true);
       assert.strictEqual(configStub.called, false);
-      assert.strictEqual((flinkManager as any).promptChooseDefaultComputePool.called, false);
+      assert.strictEqual(result, false);
     });
 
-    it("should prompt for settings when computePoolId and database are missing", async () => {
+    it("should return false when computePoolId is missing", async () => {
       // Set up mocks -> Flink is enabled but no settings set
       contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns(undefined);
-      configMock.get.withArgs("database").returns(undefined);
+      configMock.get.withArgs("computePoolId").returns("");
+      configMock.get.withArgs("database").returns("");
       configStub.returns(configMock);
 
-      await flinkManager.validateFlinkSettings();
-      // Verify prompt was called and flag was set
-      assert.strictEqual((flinkManager as any).promptChooseDefaultComputePool.calledOnce, true);
-      assert.strictEqual((flinkManager as any).hasPromptedForSettings, true);
+      const result = await flinkManager.validateFlinkSettings();
+      assert.strictEqual(result, false);
     });
 
-    it("should prompt for settings when only computePoolId is missing", async () => {
-      // Set up mocks --> Flink is enabled but computePoolId is missing
+    it("should return false when compute pool is invalid", async () => {
+      // Set up mocks -> Flink is enabled with invalid compute pool
       contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns(undefined);
-      configMock.get.withArgs("database").returns("test-database");
+      configMock.get.withArgs("computePoolId").returns("invalid-pool-id");
       configStub.returns(configMock);
 
-      await flinkManager.validateFlinkSettings();
-      // Verify prompt was called & hasPromtedForSettings was set to true
-      assert.strictEqual((flinkManager as any).promptChooseDefaultComputePool.calledOnce, true);
-      assert.strictEqual((flinkManager as any).hasPromptedForSettings, true);
+      (flinkManager as any).checkFlinkResourcesAvailability.resolves(false);
+
+      const result = await flinkManager.validateFlinkSettings();
+
+      sinon.assert.calledOnceWithExactly(
+        (flinkManager as any).checkFlinkResourcesAvailability,
+        "invalid-pool-id",
+      );
+      assert.strictEqual(result, false);
     });
 
-    it("should check resources availability when all settings are configured", async () => {
+    it("should return true when compute pool is valid", async () => {
+      // Set up mocks -> Flink is enabled with valid compute pool
+      contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
+      const configMock = {
+        get: sandbox.stub(),
+      };
+      configMock.get.withArgs("computePoolId").returns("valid-pool-id");
+      configStub.returns(configMock);
+      (flinkManager as any).checkFlinkResourcesAvailability.resolves(true);
+
+      const result = await flinkManager.validateFlinkSettings();
+
+      sinon.assert.calledOnceWithExactly(
+        (flinkManager as any).checkFlinkResourcesAvailability,
+        "valid-pool-id",
+      );
+      assert.strictEqual(result, true);
+    });
+
+    it("should check resources availability when compute pool is set", async () => {
       // Set up mocks to indicate Flink is enabled with all settings
       contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
       const configMock = {
         get: sandbox.stub(),
       };
       configMock.get.withArgs("computePoolId").returns("test-pool-id");
-      configMock.get.withArgs("database").returns("test-database");
       configStub.returns(configMock);
+      (flinkManager as any).checkFlinkResourcesAvailability.resolves(true);
 
-      await flinkManager.validateFlinkSettings();
+      const result = await flinkManager.validateFlinkSettings();
 
-      // Verify resource check was called, but user not prompted for settings
-      assert.strictEqual((flinkManager as any).promptChooseDefaultComputePool.called, false);
-      assert.strictEqual((flinkManager as any).checkFlinkResourcesAvailability.calledOnce, true);
-      assert.strictEqual((flinkManager as any).hasPromptedForSettings, false);
-    });
-  });
-
-  describe("checkAuthenticationState", () => {
-    it("should validate Flink settings when user is authenticated", async () => {
-      hasCCloudAuthSessionStub.returns(true);
-      const validateStub = sandbox.stub(flinkManager, "validateFlinkSettings").resolves();
-      await flinkManager.checkAuthenticationState();
-      assert.strictEqual(validateStub.calledOnce, true);
-    });
-
-    it("should not validate Flink settings when user is not authenticated", async () => {
-      hasCCloudAuthSessionStub.returns(false);
-      const validateStub = sandbox.stub(flinkManager, "validateFlinkSettings").resolves();
-      await flinkManager.checkAuthenticationState();
-      assert.strictEqual(validateStub.called, false);
+      sinon.assert.calledOnceWithExactly(
+        (flinkManager as any).checkFlinkResourcesAvailability,
+        "test-pool-id",
+      );
+      assert.strictEqual(result, true);
     });
   });
 
   describe("checkFlinkResourcesAvailability", () => {
-    it("should return early if not authenticated with CCloud", async () => {
-      hasCCloudAuthSessionStub.returns(false);
-      const getResourceManagerStub = sandbox.stub().throws(new Error("Should not be called"));
-      await (flinkManager as any).checkFlinkResourcesAvailability();
-      assert.strictEqual(getResourceManagerStub.called, false);
+    beforeEach(() => {
+      // Restore the stub to test the actual implementation
+      (flinkManager as any).checkFlinkResourcesAvailability.restore();
+
+      // Create stub for lookupComputePoolInfo
+      sandbox.stub(flinkManager as any, "lookupComputePoolInfo").resolves({
+        organizationId: "test-org",
+        environmentId: "test-env",
+        region: "us-west-1",
+        provider: "aws",
+      });
+    });
+
+    it("should return false if no environments found", async () => {
+      getEnvironmentsStub.resolves([]);
+
+      const result = await (flinkManager as any).checkFlinkResourcesAvailability("test-pool-id");
+
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return true if compute pool is found in environments", async () => {
+      const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      const envWithPool: CCloudEnvironment = new CCloudEnvironment({
+        ...TEST_CCLOUD_ENVIRONMENT,
+        flinkComputePools: [pool],
+      });
+      getEnvironmentsStub.resolves([envWithPool]);
+      const result = await (flinkManager as any).checkFlinkResourcesAvailability(
+        TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
+      );
+
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return false if compute pool is not found in any environment", async () => {
+      getEnvironmentsStub.resolves([TEST_CCLOUD_ENVIRONMENT]);
+
+      const result = await (flinkManager as any).checkFlinkResourcesAvailability("test-pool-id");
+
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if error occurs during check", async () => {
+      getEnvironmentsStub.rejects(new Error("Network error"));
+
+      const result = await (flinkManager as any).checkFlinkResourcesAvailability("test-pool-id");
+
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      assert.strictEqual(result, false);
     });
   });
 });

--- a/src/flinkSql/flinkConfigManager.test.ts
+++ b/src/flinkSql/flinkConfigManager.test.ts
@@ -8,6 +8,7 @@ import * as environmentsModule from "../graphql/environments";
 import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../preferences/constants";
 import * as ccloud from "../sidecar/connections/ccloud";
 import { FlinkConfigurationManager } from "./flinkConfigManager";
 
@@ -63,8 +64,8 @@ describe("FlinkConfigurationManager", () => {
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns("");
-      configMock.get.withArgs("database").returns("");
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("");
+      configMock.get.withArgs(FLINK_CONFIG_DATABASE).returns("");
       configStub.returns(configMock);
 
       const result = await flinkManager.validateFlinkSettings();
@@ -77,7 +78,7 @@ describe("FlinkConfigurationManager", () => {
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns("invalid-pool-id");
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("invalid-pool-id");
       configStub.returns(configMock);
 
       (flinkManager as any).checkFlinkResourcesAvailability.resolves(false);
@@ -97,7 +98,7 @@ describe("FlinkConfigurationManager", () => {
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns("valid-pool-id");
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("valid-pool-id");
       configStub.returns(configMock);
       (flinkManager as any).checkFlinkResourcesAvailability.resolves(true);
 
@@ -116,7 +117,7 @@ describe("FlinkConfigurationManager", () => {
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns("test-pool-id");
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("test-pool-id");
       configStub.returns(configMock);
       (flinkManager as any).checkFlinkResourcesAvailability.resolves(true);
 

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -2,7 +2,7 @@ import { Disposable, commands, window, workspace } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
-import { ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
+import { ccloudConnected } from "../emitters";
 import { getEnvironments } from "../graphql/environments";
 import { getCurrentOrganization } from "../graphql/organizations";
 import { Logger } from "../logging";
@@ -33,7 +33,7 @@ export interface FlinkSqlSettings {
 export class FlinkConfigurationManager implements Disposable {
   private static instance: FlinkConfigurationManager | null = null;
   private disposables: Disposable[] = [];
-  private hasPromptedForSettings = false;
+  // private hasPromptedForSettings = false;
   private languageClient: LanguageClient | null = null;
   private lastWebSocketUrl: string | null = null;
 
@@ -46,8 +46,6 @@ export class FlinkConfigurationManager implements Disposable {
 
   private constructor() {
     this.registerListeners();
-    // Check immediately in case we're already authenticated
-    this.checkAuthenticationState();
   }
 
   private registerListeners(): void {
@@ -55,25 +53,19 @@ export class FlinkConfigurationManager implements Disposable {
     this.disposables.push(
       workspace.onDidOpenTextDocument(async (document) => {
         if (document.languageId === "flinksql") {
-          await this.validateFlinkSettings();
-          await this.initLanguageClient();
+          await this.maybeStartLanguageClient();
         }
       }),
     );
 
     // Listen for CCloud authentication
     this.disposables.push(
-      ccloudAuthSessionInvalidated.event(() => {
-        logger.debug("CCloud auth session invalidated, resetting prompt state");
-        this.hasPromptedForSettings = false;
-        this.languageClient?.dispose();
-        this.languageClient = null;
-        this.lastWebSocketUrl = null;
-      }),
-      ccloudConnected.event(async () => {
-        await this.validateFlinkSettings();
-        if (workspace.textDocuments.some((doc) => doc.languageId === "flinksql")) {
-          this.initLanguageClient();
+      ccloudConnected.event(async (connected) => {
+        if (connected) {
+          await this.maybeStartLanguageClient();
+        } else {
+          logger.debug("CCloud auth session invalidated, stopping Flink language client");
+          this.maybeStopLanguageClient();
         }
       }),
     );
@@ -82,7 +74,7 @@ export class FlinkConfigurationManager implements Disposable {
     this.disposables.push(
       workspace.onDidChangeConfiguration(async (e) => {
         if (e.affectsConfiguration("confluent.flink")) {
-          await this.handleFlinkConfigChange();
+          await this.notifyConfigChanged();
         }
       }),
     );
@@ -93,10 +85,10 @@ export class FlinkConfigurationManager implements Disposable {
         if (e.affectsConfiguration(ENABLE_FLINK)) {
           const isFlinkEnabled = getContextValue(ContextValues.flinkEnabled);
           if (isFlinkEnabled) {
-            this.hasPromptedForSettings = false;
-            await this.validateFlinkSettings();
+            await this.maybeStartLanguageClient();
           } else {
-            logger.debug("Flink was disabled, no further actions needed");
+            logger.debug("Flink is disabled in settings, stopping language client");
+            this.maybeStopLanguageClient();
           }
         }
       }),
@@ -108,7 +100,7 @@ export class FlinkConfigurationManager implements Disposable {
         logger.info("Received language client restart event");
         if (this.lastWebSocketUrl) {
           logger.info(`Attempting to reconnect language client to ${this.lastWebSocketUrl}`);
-          await this.initLanguageClient();
+          await this.maybeStartLanguageClient();
         } else {
           logger.warn("Cannot reconnect language client - no previous WebSocket URL stored");
         }
@@ -116,54 +108,7 @@ export class FlinkConfigurationManager implements Disposable {
     );
   }
 
-  private async handleFlinkConfigChange(): Promise<void> {
-    logger.debug("Flink configuration changed");
-    await this.checkFlinkResourcesAvailability();
-
-    // We have a lang client, send the updated settings
-    if (this.languageClient) {
-      const { database, computePoolId } = this.getFlinkSqlSettings();
-      if (!computePoolId) {
-        logger.debug("No compute pool ID configured, not sending configuration update");
-        return;
-      }
-      const poolInfo = await this.lookupComputePoolInfo(computePoolId);
-      const environmentId = poolInfo?.environmentId;
-
-      // Don't send with undefined settings, server will delete existing settings if sent with empty/undefined values
-      if (environmentId && database && computePoolId) {
-        logger.debug("Sending complete configuration to language server", {
-          computePoolId,
-          environmentId,
-          database,
-        });
-
-        this.languageClient.sendNotification("workspace/didChangeConfiguration", {
-          settings: {
-            AuthToken: "{{ ccloud.data_plane_token }}",
-            Catalog: environmentId,
-            Database: database,
-            ComputePoolId: computePoolId,
-          },
-        });
-      } else {
-        logger.debug("Incomplete settings, not sending configuration update", {
-          hasComputePool: !!computePoolId,
-          hasEnvironment: !!environmentId,
-          hasDatabase: !!database,
-        });
-      }
-    }
-  }
-
-  public async checkAuthenticationState(): Promise<void> {
-    if (hasCCloudAuthSession()) {
-      logger.debug("User is authenticated with CCloud, checking Flink settings");
-      await this.validateFlinkSettings();
-    } else {
-      logger.debug("User is not authenticated with CCloud");
-    }
-  }
+  /** Get the global/workspace settings for Flink, if any */
   public getFlinkSqlSettings(): FlinkSqlSettings {
     const config = workspace.getConfiguration("confluent.flink");
     return {
@@ -171,51 +116,45 @@ export class FlinkConfigurationManager implements Disposable {
       computePoolId: config.get<string>("computePoolId", ""),
     };
   }
-  /** Verify if the user has the required settings
-   * - If not, prompt the user to select at least default compute pool
-   * - If flink disabled or already prompted, skip the prompt
-   * - If the user has a compute pool set, see if it is OK
-   */
-  public async validateFlinkSettings(): Promise<void> {
-    if (this.hasPromptedForSettings) {
-      logger.debug("Already prompted for Flink settings this session, skipping");
-      return;
-    }
+
+  /** Verify that Flink is enabled + the compute pool id setting exists and is in an environment we know about */
+  public async validateFlinkSettings(): Promise<boolean> {
+    // if (this.hasPromptedForSettings) {
+    //   logger.debug("Already prompted for Flink settings this session, skipping");
+    //   // return;
+    // }
     const isFlinkEnabled = getContextValue(ContextValues.flinkEnabled);
     if (!isFlinkEnabled) {
       logger.debug("Flink is not enabled in settings, skipping configuration prompt");
-      return;
-    }
-    const { computePoolId, database } = this.getFlinkSqlSettings();
-    // If default settings are missing, prompt the user
-    if (!computePoolId || !database) {
-      // TODO NC: should we skip as long as compute pool set? Branch off for DB?
-      logger.debug("Flink settings not fully configured, prompting user");
-      await this.promptChooseDefaultComputePool();
-      this.hasPromptedForSettings = true;
-    } else {
-      logger.debug("Flink settings are configured", { computePoolId, database });
-      await this.checkFlinkResourcesAvailability();
-    }
-  }
-
-  private async checkFlinkResourcesAvailability(): Promise<void> {
-    if (!hasCCloudAuthSession()) {
-      return; // This method should not be called if not authenticated
+      return false;
     }
     const { computePoolId } = this.getFlinkSqlSettings();
     if (!computePoolId) {
-      return;
+      logger.debug("Flink settings not fully configured");
+      // await this.promptChooseDefaultComputePool(); // TODO NC where does this go now?
+      // this.hasPromptedForSettings = true;
+      return false;
     }
 
+    logger.debug("Flink compute pool is:", computePoolId);
+    const computeValid = await this.checkFlinkResourcesAvailability(computePoolId);
+    if (!computeValid) {
+      // logger.debug("Flink compute pool is not valid, prompting user");
+      // await this.promptChooseDefaultComputePool();
+      return false;
+    }
+    logger.debug("Flink compute pool is valid");
+    return true;
+  }
+
+  /** Does the compute pool id exist in an available ccloud environment? */
+  private async checkFlinkResourcesAvailability(computePoolId: string): Promise<boolean> {
     try {
       // Load available compute pools to verify the configured pool exists
-      // const resourceManager = getResourceManager();
-      const environments = await getEnvironments(); //resourceManager.getCCloudEnvironments();
-      // Avoid warning if we haven't loaded the envs yet (happens if user already has setting on activation)
+      const environments = await getEnvironments();
       if (!environments || environments.length === 0) {
         logger.debug("No CCloud environments found");
-        return;
+        return false;
       }
       // Check if the configured compute pool exists in any environment
       let poolFound = false;
@@ -226,30 +165,24 @@ export class FlinkConfigurationManager implements Disposable {
         }
       }
 
-      if (!poolFound) {
+      if (poolFound) {
+        return true;
+      } else {
         logger.warn(
           `Configured Flink compute pool ${computePoolId} not found in available resources`,
         );
-        window
-          .showWarningMessage(
-            `The configured Flink compute pool (${computePoolId}) is not available. Please check your configuration.`,
-            "Update Flink Settings",
-          )
-          .then((selection) => {
-            if (selection === "Update Flink Settings") {
-              commands.executeCommand("confluent.flink.configureFlinkDefaults");
-            }
-          });
+        return false;
       }
     } catch (error) {
       logger.error("Error checking Flink resources availability", error);
+      return false;
     }
   }
 
   /**
-   * Finds compute pool information across all environments
-   * @param computePoolId The ID of the compute pool to find
-   * @returns Object containing pool info and environment, or null if not found
+   * Compiles compute pool details across all known environments
+   * @param computePoolId The ID of the compute pool to look up
+   * @returns Object {organizationId, environmentId, region, provider} or null if not found
    */
   private async lookupComputePoolInfo(computePoolId: string): Promise<{
     organizationId: string;
@@ -257,10 +190,6 @@ export class FlinkConfigurationManager implements Disposable {
     region: string;
     provider: string;
   } | null> {
-    if (!computePoolId) {
-      return null;
-    }
-
     try {
       // Get the current org
       const currentOrg = await getCurrentOrganization();
@@ -317,42 +246,33 @@ export class FlinkConfigurationManager implements Disposable {
 
   /**
    * Ensures the language client is initialized if prerequisites are met
+   * Prerequisites:
+   * - User is authenticated with CCloud
+   * - User has selected a compute pool to use for websocket connection (language server route is region/provider specific)
+   * - User has opened a Flink SQL file
+   * - User has not disabled Flink in settings
    */
-  private async initLanguageClient(): Promise<void> {
-    // If we already have a client and it's healthy, just update settings
-    if (this.languageClient) {
-      try {
-        if (isLanguageClientConnected()) {
-          logger.debug("Language client connection confirmed active");
-          await this.handleFlinkConfigChange();
-          return;
-        }
-        throw new Error("Language client is not in running state");
-      } catch (error) {
-        logger.warn("Language client appears to be disconnected, will reinitialize", error);
-        try {
-          await this.languageClient.stop();
-        } catch (e) {
-          logger.error("Error stopping disconnected language client", e);
-        }
-        this.languageClient = null;
-      }
+  private async maybeStartLanguageClient(): Promise<void> {
+    // If we already have a client and it's healthy we're cool
+    if (this.languageClient && isLanguageClientConnected()) {
+      logger.debug("Language client connection confirmed active");
+      return;
     }
-
+    // Otherwise, we need to check if the prerequisites are met
     const isFlinkEnabled = getContextValue(ContextValues.flinkEnabled);
     if (!isFlinkEnabled) {
       logger.debug("Flink is not enabled, not initializing language client");
       return;
     }
-
     if (!hasCCloudAuthSession()) {
-      logger.debug("No CCloud auth session, not initializing language client");
+      logger.debug("User is not authenticated with CCloud, not initializing language client");
       return;
     }
-
     const { computePoolId } = this.getFlinkSqlSettings();
-    if (!computePoolId) {
-      logger.debug("No compute pool ID configured, not initializing language client");
+    const isPoolOk = await this.validateFlinkSettings();
+    // TODO NC: refactor to validate & return setting in one?
+    if (!computePoolId || !isPoolOk) {
+      logger.debug("No valid compute pool; not initializing language client");
       return;
     }
 
@@ -365,27 +285,79 @@ export class FlinkConfigurationManager implements Disposable {
       } else {
         url = await this.buildFlinkSqlWebSocketUrl(computePoolId).catch((error) => {
           logger.error("Failed to build WebSocket URL:", error);
-          window.showErrorMessage(
-            `Failed to initialize Flink SQL language client: ${error instanceof Error ? error.message : String(error)}`,
-          );
           return undefined;
         });
       }
-
       if (!url) return;
-
       // Initialize the client with the URL
       this.languageClient = await initializeLanguageClient(url);
       if (this.languageClient) {
         this.disposables.push(this.languageClient);
         logger.info("Flink SQL language client successfully initialized");
-        this.handleFlinkConfigChange(); // Send settings right away
+        // this.notifyConfigChanged(); // Send settings right away... or no?
       }
     } catch (error) {
       logger.error("Failed to initialize Flink SQL language client:", error);
-      window.showErrorMessage(
-        `Failed to initialize Flink SQL language client: ${error instanceof Error ? error.message : String(error)}`,
-      );
+    }
+  }
+
+  private async maybeStopLanguageClient(): Promise<void> {
+    try {
+      if (this.languageClient) {
+        logger.debug("Stopping language client");
+        await this.languageClient.stop();
+        this.languageClient = null;
+      }
+      if (this.lastWebSocketUrl) {
+        logger.debug("Clearing cached WebSocket URL");
+        this.lastWebSocketUrl = null;
+      }
+    } catch (error) {
+      logger.error("Error stopping language client:", error);
+      return;
+    }
+  }
+
+  /** Verifies and sends workspace settings to the language server via
+   * `workspace/didChangeConfiguration` notification
+   */
+  private async notifyConfigChanged(): Promise<void> {
+    logger.debug("Flink configuration changed");
+    // await this.checkFlinkResourcesAvailability();
+
+    // We have a lang client, send the updated settings
+    if (this.languageClient) {
+      const { database, computePoolId } = this.getFlinkSqlSettings();
+      if (!computePoolId) {
+        logger.debug("No compute pool ID configured, not sending configuration update");
+        return;
+      }
+      const poolInfo = await this.lookupComputePoolInfo(computePoolId);
+      const environmentId = poolInfo?.environmentId;
+
+      // Don't send with undefined settings, server will override existing settings with empty/undefined values
+      if (environmentId && database && computePoolId) {
+        logger.debug("Sending complete configuration to language server", {
+          computePoolId,
+          environmentId,
+          database,
+        });
+
+        this.languageClient.sendNotification("workspace/didChangeConfiguration", {
+          settings: {
+            AuthToken: "{{ ccloud.data_plane_token }}",
+            Catalog: environmentId,
+            Database: database,
+            ComputePoolId: computePoolId,
+          },
+        });
+      } else {
+        logger.debug("Incomplete settings, not sending configuration update", {
+          hasComputePool: !!computePoolId,
+          hasEnvironment: !!environmentId,
+          hasDatabase: !!database,
+        });
+      }
     }
   }
 

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -305,6 +305,9 @@ export class FlinkConfigurationManager implements Disposable {
    * Show notification for user to select default compute pool, database
    */
   private async promptChooseDefaultComputePool(): Promise<void> {
+if (!hasCCloudAuthSession()) {
+      return; // This method should not be called if not authenticated
+    }
     const selection = await window.showInformationMessage(
       "Choose your CCloud Flink Compute Pool and other defaults to quickly run & view Flink SQL queries.",
       "Update Flink Settings",

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -1,4 +1,4 @@
-import { Disposable, commands, window, workspace } from "vscode";
+import { Disposable, WorkspaceConfiguration, commands, window, workspace } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
@@ -7,7 +7,11 @@ import { getEnvironments } from "../graphql/environments";
 import { getCurrentOrganization } from "../graphql/organizations";
 import { Logger } from "../logging";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
-import { ENABLE_FLINK } from "../preferences/constants";
+import {
+  ENABLE_FLINK,
+  FLINK_CONFIG_COMPUTE_POOL,
+  FLINK_CONFIG_DATABASE,
+} from "../preferences/constants";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { SIDECAR_PORT } from "../sidecar/constants";
 import { initializeLanguageClient, isLanguageClientConnected } from "./languageClient";
@@ -93,10 +97,13 @@ export class FlinkConfigurationManager implements Disposable {
 
   /** Get the global/workspace settings for Flink, if any */
   public getFlinkSqlSettings(): FlinkSqlSettings {
-    const config = workspace.getConfiguration("confluent.flink");
+    const config: WorkspaceConfiguration = workspace.getConfiguration();
+    const defaultPoolId: string = config.get(FLINK_CONFIG_COMPUTE_POOL, "");
+    const defaultDatabase: string = config.get(FLINK_CONFIG_DATABASE, "");
+    logger.info("pool/db =>", defaultPoolId, defaultDatabase);
     return {
-      database: config.get<string>("database", ""),
-      computePoolId: config.get<string>("computePoolId", ""),
+      database: defaultDatabase,
+      computePoolId: defaultPoolId,
     };
   }
 

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -1,4 +1,5 @@
 import { Disposable, commands, window, workspace } from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ContextValues, getContextValue } from "../context/values";
 import { ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
@@ -29,7 +30,7 @@ export class FlinkConfigurationManager implements Disposable {
   static instance: FlinkConfigurationManager | null = null;
   private disposables: Disposable[] = [];
   private hasPromptedForSettings = false;
-  private languageClientInitialized = false;
+  private languageClient: LanguageClient | null = null;
 
   static getInstance(): FlinkConfigurationManager {
     if (!FlinkConfigurationManager.instance) {
@@ -50,7 +51,7 @@ export class FlinkConfigurationManager implements Disposable {
       workspace.onDidOpenTextDocument(async (document) => {
         if (document.languageId === "flinksql") {
           await this.validateFlinkSettings();
-          await this.ensureLanguageClientInitialized();
+          await this.initLanguageClient();
         }
       }),
     );
@@ -60,10 +61,12 @@ export class FlinkConfigurationManager implements Disposable {
       ccloudAuthSessionInvalidated.event(() => {
         logger.debug("CCloud auth session invalidated, resetting prompt state");
         this.hasPromptedForSettings = false;
+        this.languageClient?.dispose();
+        this.languageClient = null;
       }),
       ccloudConnected.event(async () => {
         await this.validateFlinkSettings();
-        await this.ensureLanguageClientInitialized();
+        await this.initLanguageClient();
       }),
     );
 
@@ -71,8 +74,7 @@ export class FlinkConfigurationManager implements Disposable {
     this.disposables.push(
       workspace.onDidChangeConfiguration(async (e) => {
         if (e.affectsConfiguration("confluent.flink")) {
-          logger.debug("Flink configuration changed");
-          await this.checkFlinkResourcesAvailability();
+          await this.handleFlinkConfigChange(e);
         }
       }),
     );
@@ -85,13 +87,32 @@ export class FlinkConfigurationManager implements Disposable {
           if (isFlinkEnabled) {
             this.hasPromptedForSettings = false;
             await this.validateFlinkSettings();
-            await this.ensureLanguageClientInitialized();
+            await this.initLanguageClient();
           } else {
             logger.debug("Flink was disabled, no further actions needed");
           }
         }
       }),
     );
+  }
+
+  private async handleFlinkConfigChange(e: any): Promise<void> {
+    logger.debug("Flink configuration changed");
+    await this.checkFlinkResourcesAvailability();
+    // Reset language client if compute pool changes, or update workspace settings in client
+    if (this.languageClient) {
+      const settings = this.getFlinkSqlSettings();
+      this.languageClient.sendNotification("workspace/didChangeConfiguration", {
+        settings: {
+          workspaceSettings: {
+            AuthToken: "{{ ccloud.data_plane_token }}",
+            // Catalog: settings.catalog, // Uncomment if catalog is part of settings
+            Database: settings.database,
+            ComputePoolId: settings.computePoolId,
+          },
+        },
+      });
+    }
   }
 
   public async checkAuthenticationState(): Promise<void> {
@@ -254,8 +275,8 @@ export class FlinkConfigurationManager implements Disposable {
   /**
    * Ensures the language client is initialized if prerequisites are met
    */
-  private async ensureLanguageClientInitialized(): Promise<void> {
-    if (this.languageClientInitialized) {
+  private async initLanguageClient(): Promise<void> {
+    if (this.languageClient) {
       return;
     }
 
@@ -287,10 +308,9 @@ export class FlinkConfigurationManager implements Disposable {
         return;
       });
       if (!url) return;
-      const client = await initializeLanguageClient(url);
-      if (client) {
-        this.languageClientInitialized = true;
-        this.disposables.push(client);
+      this.languageClient = await initializeLanguageClient(url);
+      if (this.languageClient) {
+        this.disposables.push(this.languageClient);
         logger.info("Flink SQL language client successfully initialized");
       }
     } catch (error) {
@@ -305,7 +325,7 @@ export class FlinkConfigurationManager implements Disposable {
    * Show notification for user to select default compute pool, database
    */
   private async promptChooseDefaultComputePool(): Promise<void> {
-if (!hasCCloudAuthSession()) {
+    if (!hasCCloudAuthSession()) {
       return; // This method should not be called if not authenticated
     }
     const selection = await window.showInformationMessage(

--- a/src/flinkSql/flinkConfigManager.ts
+++ b/src/flinkSql/flinkConfigManager.ts
@@ -66,7 +66,9 @@ export class FlinkConfigurationManager implements Disposable {
       }),
       ccloudConnected.event(async () => {
         await this.validateFlinkSettings();
-        await this.initLanguageClient();
+        if (workspace.textDocuments.some((doc) => doc.languageId === "flinksql")) {
+          this.initLanguageClient();
+        }
       }),
     );
 
@@ -87,8 +89,7 @@ export class FlinkConfigurationManager implements Disposable {
           if (isFlinkEnabled) {
             this.hasPromptedForSettings = false;
             await this.validateFlinkSettings();
-            await this.initLanguageClient();
-          } else {
+                      } else {
             logger.debug("Flink was disabled, no further actions needed");
           }
         }

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -10,20 +10,20 @@ import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../preferences/constants";
 import * as ccloud from "../sidecar/connections/ccloud";
-import { FlinkConfigurationManager } from "./flinkConfigManager";
+import { FlinkLanguageClientManager } from "./flinkLanguageClientManager";
 
-describe("FlinkConfigurationManager", () => {
+describe("FlinkLanguageClientManager", () => {
   let sandbox: sinon.SinonSandbox;
   let configStub: sinon.SinonStub;
   let contextValueStub: sinon.SinonStub;
   let hasCCloudAuthSessionStub: sinon.SinonStub;
-  let flinkManager: FlinkConfigurationManager;
+  let flinkManager: FlinkLanguageClientManager;
   let ccloudLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
   let getEnvironmentsStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    FlinkConfigurationManager["instance"] = null;
+    FlinkLanguageClientManager["instance"] = null;
     configStub = sandbox.stub(vscode.workspace, "getConfiguration");
     const configMock = {
       get: sandbox.stub(),
@@ -38,13 +38,14 @@ describe("FlinkConfigurationManager", () => {
 
     getEnvironmentsStub = sandbox.stub(environmentsModule, "getEnvironments");
 
-    flinkManager = FlinkConfigurationManager.getInstance();
+    flinkManager = FlinkLanguageClientManager.getInstance();
     sandbox.stub(flinkManager, "promptChooseDefaultComputePool" as any).resolves();
     sandbox.stub(flinkManager, "checkFlinkResourcesAvailability" as any).resolves();
   });
+
   afterEach(() => {
     sandbox.restore();
-    FlinkConfigurationManager["instance"] = null;
+    FlinkLanguageClientManager["instance"] = null;
   });
 
   describe("validateFlinkSettings", () => {

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -3,7 +3,6 @@ import sinon from "sinon";
 import * as vscode from "vscode";
 import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
-import * as contextValues from "../context/values";
 import * as environmentsModule from "../graphql/environments";
 import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
@@ -15,7 +14,6 @@ import { FlinkLanguageClientManager } from "./flinkLanguageClientManager";
 describe("FlinkLanguageClientManager", () => {
   let sandbox: sinon.SinonSandbox;
   let configStub: sinon.SinonStub;
-  let contextValueStub: sinon.SinonStub;
   let hasCCloudAuthSessionStub: sinon.SinonStub;
   let flinkManager: FlinkLanguageClientManager;
   let ccloudLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
@@ -29,7 +27,6 @@ describe("FlinkLanguageClientManager", () => {
       get: sandbox.stub(),
     };
     configStub.returns(configMock);
-    contextValueStub = sandbox.stub(contextValues, "getContextValue");
     hasCCloudAuthSessionStub = sandbox.stub(ccloud, "hasCCloudAuthSession");
     hasCCloudAuthSessionStub.returns(false);
 
@@ -50,18 +47,18 @@ describe("FlinkLanguageClientManager", () => {
 
   describe("validateFlinkSettings", () => {
     it("should return false if Flink is disabled", async () => {
-      contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(false);
+      sandbox.stub(flinkManager, "getIsFlinkEnabled").returns(false);
       const result = await flinkManager.validateFlinkSettings();
 
       // Verify only method called was check for Flink enabled status
-      assert.strictEqual(contextValueStub.called, true);
+      sinon.assert.calledOnce(flinkManager.getIsFlinkEnabled as sinon.SinonStub);
       assert.strictEqual(configStub.called, false);
       assert.strictEqual(result, false);
     });
 
     it("should return false when computePoolId is missing", async () => {
       // Set up mocks -> Flink is enabled but no settings set
-      contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
+      sandbox.stub(flinkManager, "getIsFlinkEnabled").returns(true);
       const configMock = {
         get: sandbox.stub(),
       };
@@ -75,7 +72,7 @@ describe("FlinkLanguageClientManager", () => {
 
     it("should return false when compute pool is invalid", async () => {
       // Set up mocks -> Flink is enabled with invalid compute pool
-      contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
+      sandbox.stub(flinkManager, "getIsFlinkEnabled").returns(true);
       const configMock = {
         get: sandbox.stub(),
       };
@@ -95,7 +92,7 @@ describe("FlinkLanguageClientManager", () => {
 
     it("should return true when compute pool is valid", async () => {
       // Set up mocks -> Flink is enabled with valid compute pool
-      contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
+      sandbox.stub(flinkManager, "getIsFlinkEnabled").returns(true);
       const configMock = {
         get: sandbox.stub(),
       };
@@ -114,7 +111,7 @@ describe("FlinkLanguageClientManager", () => {
 
     it("should check resources availability when compute pool is set", async () => {
       // Set up mocks to indicate Flink is enabled with all settings
-      contextValueStub.withArgs(contextValues.ContextValues.flinkEnabled).returns(true);
+      sandbox.stub(flinkManager, "getIsFlinkEnabled").returns(true);
       const configMock = {
         get: sandbox.stub(),
       };

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -119,7 +119,7 @@ export async function initializeLanguageClient(
           },
           errorHandler: {
             error: (error: Error, message: Message): ErrorHandlerResult => {
-              vscode.window.showErrorMessage(`Language server error: ${message}`); // FIXME do we want to show this to users?
+              logger.error(`Language server error: ${message}`);
               return {
                 action: ErrorAction.Continue,
                 message: `${message ?? error.message}`,
@@ -146,7 +146,7 @@ export async function initializeLanguageClient(
 
         await languageClient.start();
         logger.debug("FlinkSQL Language Server started");
-        languageClient.setTrace(Trace.Verbose);
+        languageClient.setTrace(Trace.Compact);
         resolve(languageClient);
       } catch (e) {
         logger.error(`Error starting FlinkSQL language server: ${e}`);

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -66,11 +66,9 @@ export async function initializeLanguageClient(
               // Clear diagnostics when document changes, so user sees only latest issues
               const diagnostics = vscode.languages.getDiagnostics(event.document.uri);
               if (diagnostics.length > 0) {
-                vscode.languages.getDiagnostics().forEach(([uri, diags]) => {
-                  if (uri.toString() === event.document.uri.toString()) {
-                    vscode.languages.createDiagnosticCollection("flinksql").delete(uri);
-                  }
-                });
+                const diagnosticCollection =
+                  vscode.languages.createDiagnosticCollection("flinksql");
+                diagnosticCollection.delete(event.document.uri);
               }
               return next(event);
             },

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -24,7 +24,7 @@ let languageClient: LanguageClient | null = null;
  * - User is authenticated with CCloud
  * - User has selected a compute pool
  */
-export async function initializeLanguageClient(url: string): Promise<vscode.Disposable | null> {
+export async function initializeLanguageClient(url: string): Promise<LanguageClient | null> {
   if (!hasCCloudAuthSession()) {
     logger.warn("Cannot initialize language client: User not authenticated with CCloud");
     return null;

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -30,9 +30,8 @@ export async function initializeLanguageClient(
     SecretStorageKeys.SIDECAR_AUTH_TOKEN,
   );
   if (!accessToken) {
-    logger.error("No access token found");
-    vscode.window.showErrorMessage(
-      "Failed to initialize Flink SQL language client: No access token found",
+    logger.error(
+      "Failed to initialize Flink SQL language client: No access token found for language client",
     );
     return null;
   }
@@ -42,7 +41,7 @@ export async function initializeLanguageClient(
     });
     ws.onerror = (error) => {
       logger.error(`WebSocket connection error: ${error}`);
-      reject(new Error("Failed to connect to Flink SQL language server"));
+      reject(new Error("Failed to connect to Flink SQL language server")); //FIXME here's one error that surfaces to users
     };
     ws.onopen = async () => {
       logger.debug("WebSocket connection opened");
@@ -59,7 +58,6 @@ export async function initializeLanguageClient(
           ],
           middleware: {
             didOpen: (document, next) => {
-              logger.info(`FlinkSQL document opened: ${document.uri}`);
               return next(document);
             },
             didChange: (event, next) => {
@@ -121,7 +119,7 @@ export async function initializeLanguageClient(
           },
           errorHandler: {
             error: (error: Error, message: Message): ErrorHandlerResult => {
-              vscode.window.showErrorMessage(`Language server error: ${message}`);
+              vscode.window.showErrorMessage(`Language server error: ${message}`); // FIXME do we want to show this to users?
               return {
                 action: ErrorAction.Continue,
                 message: `${message ?? error.message}`,
@@ -147,7 +145,7 @@ export async function initializeLanguageClient(
         );
 
         await languageClient.start();
-        logger.info("FlinkSQL Language Server started");
+        logger.debug("FlinkSQL Language Server started");
         languageClient.setTrace(Trace.Verbose);
         resolve(languageClient);
       } catch (e) {

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -33,11 +33,6 @@ export const languageClientRestartNeeded = new vscode.EventEmitter<void>();
  * - User has selected a compute pool
  */
 export async function initializeLanguageClient(url: string): Promise<LanguageClient | null> {
-  if (!hasCCloudAuthSession()) {
-    logger.warn("Cannot initialize language client: User not authenticated with CCloud");
-    return null;
-  }
-
   // Reset reconnect counter on new initialization
   reconnectCounter = 0;
 
@@ -57,24 +52,24 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
     return null;
   }
   return new Promise((resolve, reject) => {
-    const conn = new WebSocket(url, {
+    const ws = new WebSocket(url, {
       headers: { authorization: `Bearer ${accessToken}` },
     });
-    conn.onerror = (error) => {
+    ws.onerror = (error) => {
       logger.error(`WebSocket connection error: ${error}`);
       reject(new Error("Failed to connect to Flink SQL language server"));
     };
-    conn.onopen = async () => {
-      logger.info("FlinkSQL WebSocket connection opened");
+    ws.onopen = async () => {
+      logger.debug("WebSocket connection opened");
       try {
-        const transport = new WebsocketTransport(conn);
+        const transport = new WebsocketTransport(ws);
         const serverOptions = () => {
           return Promise.resolve(transport);
         };
         const clientOptions: LanguageClientOptions = {
           documentSelector: [
             { scheme: "file", language: "flinksql" },
-            { scheme: "untitled", language: "flinksql" }, // TODO NC: We may want to use a different file extension
+            { scheme: "untitled", language: "flinksql" },
           ],
           middleware: {
             didOpen: (document, next) => {
@@ -153,7 +148,7 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
         reject(e);
       }
     };
-    conn.onclose = async (event) => {
+    ws.onclose = async (event) => {
       const reason = event.reason || "Unknown reason";
       const code = event.code;
       logger.warn(`WebSocket connection closed: Code ${code}, Reason: ${reason}`);
@@ -177,10 +172,7 @@ async function handleWebSocketDisconnect(url: string): Promise<void> {
   if (reconnectCounter >= MAX_RECONNECT_ATTEMPTS) {
     logger.error(`Failed to reconnect after ${MAX_RECONNECT_ATTEMPTS} attempts`);
     vscode.window
-      .showErrorMessage(
-        "Connection to Flink SQL server lost. Please try reopening your Flink SQL files.",
-        "Retry Now",
-      )
+      .showErrorMessage("Connection to Flink SQL language server lost.", "Retry Now")
       .then((selection) => {
         if (selection === "Retry Now") {
           // Reset counter and try again immediately

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -6,6 +6,7 @@ import {
   LanguageClient,
   LanguageClientOptions,
   Message,
+  Trace,
 } from "vscode-languageclient/node";
 import { WebSocket } from "ws";
 import { Logger } from "../logging";
@@ -133,12 +134,15 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
 
         await languageClient.start();
         logger.info("FlinkSQL Language Server started");
+        languageClient.setTrace(Trace.Verbose);
         resolve(languageClient);
       } catch (e) {
         logger.error(`Error starting FlinkSQL language server: ${e}`);
         reject(e);
       }
     };
+    // TODO NC (after sidecar changes) handle conn.onclose
+    // reconnect counter and logic to check connection health/status
   });
 }
 

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -96,7 +96,6 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
               return next(document, positionToUse, context, token);
             },
             sendRequest: (type, params, token, next) => {
-              if (type === "textDocument/completion") {
                 // Server does not accept line positions > 0, so we need to convert them to single-line
                 if (params && (params as any).position && (params as any).textDocument?.uri) {
                   const uri = (params as any).textDocument.uri;
@@ -112,8 +111,6 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
                   }
                 }
 
-                return next(type, params, token);
-              }
               return next(type, params, token);
             },
           },

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -1,0 +1,277 @@
+import * as vscode from "vscode";
+import {
+  CloseAction,
+  ErrorAction,
+  ErrorHandlerResult,
+  LanguageClient,
+  LanguageClientOptions,
+  Message,
+} from "vscode-languageclient/node";
+import { WebSocket } from "ws";
+import { Logger } from "../logging";
+import { WebsocketTransport } from "./websocketTransport";
+import { CCLOUD_CONNECTION_ID } from "../constants";
+import { getStorageManager } from "../storage";
+import { SecretStorageKeys } from "../storage/constants";
+import { SIDECAR_PORT } from "../sidecar/constants";
+import { getResourceManager } from "../storage/resourceManager";
+import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { getCurrentOrganization } from "../graphql/organizations";
+
+const logger = new Logger("flinkSql.languageClient");
+
+let languageClient: LanguageClient | null = null;
+export interface FlinkSqlSettings {
+  database: string;
+  computePoolId: string;
+}
+export function getFlinkSqlSettings(): FlinkSqlSettings {
+  const config = vscode.workspace.getConfiguration("confluent.flink");
+  return {
+    database: config.get<string>("database", ""),
+    computePoolId: config.get<string>("computePoolId", ""),
+  };
+}
+
+/**
+ * Builds the WebSocket URL for the Flink SQL Language Server based on current settings
+ * @param computePoolId - The ID of the compute pool used to determine URL query params
+ * @returns The WebSocket URL for the Flink SQL Language Server
+ * @throws Error if the environment or organization ID cannot be found
+ * @throws Error if the compute pool ID is not found in any environment
+ */
+export async function buildFlinkSqlWebSocketUrl(computePoolId: string): Promise<string> {
+  let organizationId = "";
+  let environmentId = "";
+  let region = "";
+  let provider = "";
+  // Get the current org
+  const currentOrg = await getCurrentOrganization();
+  organizationId = currentOrg?.id ?? "";
+  // Find the environment containing this compute pool
+  const resourceManager = getResourceManager();
+  const environments = await resourceManager.getCCloudEnvironments();
+  for (const env of environments) {
+    const foundPool = env.flinkComputePools.find(
+      (pool: CCloudFlinkComputePool) => pool.id === computePoolId,
+    );
+    if (foundPool) {
+      environmentId = env.id;
+      region = foundPool.region;
+      provider = foundPool.provider;
+      break;
+    }
+  }
+  if (!environmentId || !organizationId) {
+    throw new Error(`Could not find environment containing compute pool ${computePoolId}`);
+  }
+  return `ws://localhost:${SIDECAR_PORT}/flsp?connectionId=${CCLOUD_CONNECTION_ID}&region=${region}&provider=${provider}&environmentId=${environmentId}&organizationId=${organizationId}`;
+}
+
+/** Initialize the FlinkSQL language client and connect to the language server websocket
+ * @returns A promise that resolves to the language client, or null if initialization failed
+ * Prerequisites:
+ * - User is authenticated with CCloud
+ * - User has selected a compute pool
+ */
+export async function initializeLanguageClient(): Promise<vscode.Disposable | null> {
+  if (!hasCCloudAuthSession()) {
+    logger.warn("Cannot initialize language client: User not authenticated with CCloud");
+    return null;
+  }
+
+  if (languageClient) {
+    logger.info("Language client already initialized");
+    return languageClient;
+  }
+
+  const settings = getFlinkSqlSettings();
+  if (!settings.computePoolId) {
+    logger.warn("Cannot initialize language client: No compute pool configured");
+    return null;
+  }
+
+  let addr: string;
+  try {
+    addr = await buildFlinkSqlWebSocketUrl(settings.computePoolId);
+  } catch (error) {
+    logger.error("Failed to build WebSocket URL:", error);
+    vscode.window.showErrorMessage(
+      `Failed to initialize Flink SQL language client: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+
+  let accessToken: string | undefined = await getStorageManager().getSecret(
+    SecretStorageKeys.SIDECAR_AUTH_TOKEN,
+  );
+  if (!accessToken) {
+    logger.error("No access token found");
+    vscode.window.showErrorMessage(
+      "Failed to initialize Flink SQL language client: No access token found",
+    );
+    return null;
+  }
+  return new Promise((resolve, reject) => {
+    const conn = new WebSocket(addr, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    conn.onerror = (error) => {
+      logger.error(`WebSocket connection error: ${error}`);
+      reject(new Error("Failed to connect to Flink SQL language server"));
+    };
+    conn.onopen = async () => {
+      logger.info("FlinkSQL WebSocket connection opened");
+      try {
+        const transport = new WebsocketTransport(conn);
+        const serverOptions = () => {
+          return Promise.resolve(transport);
+        };
+        const clientOptions: LanguageClientOptions = {
+          documentSelector: [
+            { scheme: "file", language: "flinksql" },
+            { scheme: "untitled", language: "flinksql" }, // TODO NC: We may want to use a different file extension
+          ],
+          middleware: {
+            didOpen: (document, next) => {
+              logger.info(`FlinkSQL document opened: ${document.uri}`);
+              // TODO NC send config when document opens. Must handle empty values to avoid closing connection. (See UI)
+              // Maybe in flinkConfigManager.ts?
+              return next(document);
+            },
+            didChange: (event, next) => {
+              // Clear diagnostics when document changes, so user sees only relevant (new) issues
+              const diagnostics = languageClient?.diagnostics;
+              if (diagnostics) {
+                diagnostics.delete(event.document.uri);
+              }
+              return next(event);
+            },
+            provideCompletionItem: (document, position, context, token, next) => {
+              // Server adds backticks to all Entities, so we need to see
+              // if the character before the word range start is a backtick & if so, adjust the position
+              const range = document.getWordRangeAtPosition(position);
+              const line = document.lineAt(position.line).text;
+              let positionToUse = position;
+              if (range) {
+                const charBeforeWordStart =
+                  range.start.character > 0 ? line.charAt(range.start.character - 1) : "";
+                if (charBeforeWordStart === "`") {
+                  positionToUse = new vscode.Position(position.line, range.start.character - 1);
+                }
+              }
+              return next(document, positionToUse, context, token);
+            },
+            sendRequest: (type, params, token, next) => {
+              if (type === "textDocument/completion") {
+                // Server does not accept line positions > 0, so we need to convert them to single-line
+                if (params && (params as any).position && (params as any).textDocument?.uri) {
+                  const uri = (params as any).textDocument.uri;
+                  const document = vscode.workspace.textDocuments.find(
+                    (doc) => doc.uri.toString() === uri,
+                  );
+                  if (document) {
+                    const originalPosition = (params as any).position;
+                    (params as any).position = convertToSingleLinePosition(
+                      document,
+                      new vscode.Position(originalPosition.line, originalPosition.character),
+                    );
+                  }
+                }
+
+                return next(type, params, token);
+              }
+              return next(type, params, token);
+            },
+          },
+          errorHandler: {
+            error: (error: Error, message: Message): ErrorHandlerResult => {
+              vscode.window.showErrorMessage(`Language server error: ${message}`);
+              return { action: ErrorAction.Continue, message: `${message ?? error.message}` };
+            },
+            closed: () => {
+              vscode.window.showWarningMessage("Language server connection closed");
+              return { action: CloseAction.Restart };
+            },
+          },
+        };
+
+        languageClient = new LanguageClient(
+          "confluent.flinksqlLanguageServer",
+          "ConfluentFlinkSQL",
+          serverOptions,
+          clientOptions,
+        );
+
+        await languageClient.start();
+        logger.info("FlinkSQL Language Server started");
+        resolve(languageClient);
+      } catch (e) {
+        logger.error(`Error starting FlinkSQL language server: ${e}`);
+        reject(e);
+      }
+    };
+  });
+}
+
+// TODO NC Maybe move to flinkConfigManager.ts
+// export async function registerFlinkSqlConfigListener(): Promise<vscode.Disposable> {
+//   // The CCloud UI defaults to the currently selected catalog and database from the dropdown
+//   // & waits until all settings are updated, instead of sending intermittent updates (i.e. catalog changes, then db)
+//   return vscode.workspace.onDidChangeConfiguration(async (event) => {
+//     if (event.affectsConfiguration("confluent.flink")) {
+//       logger.info("Flink SQL configuration changed");
+//       try {
+//         const settings = getFlinkSqlSettings();
+//         languageClient?.sendNotification("workspace/didChangeConfiguration", {
+//           settings: {
+//             workspaceSettings: {
+//               AuthToken: "{{ ccloud.data_plane_token }}",
+//               Catalog: settings.catalog,
+//               Database: settings.database,
+//               ComputePoolId: settings.computePoolId,
+//             },
+//           },
+//         });
+//       } catch (error) {
+//         logger.error(`Failed to send configuration update to language server: ${error}`);
+//       }
+
+//       /** We need special handling for region/provider/env/org changes, which affect the WebSocket URL
+//        * These would require a full client/socket restart
+//        * */
+//       // if (
+//       //   event.affectsConfiguration("confluent.flink.region") ||
+//       //   event.affectsConfiguration("confluent.flink.provider")
+//       // ) {
+//       //   logger.info("Region or provider changed - restarting language client");
+//       //   try {
+//       //     await startOrRestartLanguageClient(context, CCLOUD_CONNECTION_ID);
+//       //   } catch (error) {
+//       //     logger.error(`Failed to restart Flink SQL language client: ${error}`);
+//       //   }
+//       // } else {
+//       //   // For any other settings, just send log or notification, e.g.
+//       //   updateLanguageServerSettings();
+//       // }
+//     }
+//   });
+// }
+
+/** Helper to convert vscode.Position to always have {line: 0...},
+ * since CCloud Flink Language Server does not support multi-line completions at this time */
+function convertToSingleLinePosition(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+): vscode.Position {
+  const text = document.getText();
+  const lines = text.split("\n");
+  let singleLinePosition = 0;
+
+  for (let i = 0; i < position.line; i++) {
+    singleLinePosition += lines[i].length + 1; // +1 for the newline character
+  }
+  singleLinePosition += position.character;
+  return new vscode.Position(0, singleLinePosition);
+}

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -111,7 +111,11 @@ export async function initializeLanguageClient(
           errorHandler: {
             error: (error: Error, message: Message): ErrorHandlerResult => {
               vscode.window.showErrorMessage(`Language server error: ${message}`);
-              return { action: ErrorAction.Continue, message: `${message ?? error.message}` };
+              return {
+                action: ErrorAction.Continue,
+                message: `${message ?? error.message}`,
+                handled: true,
+              };
             },
             closed: () => {
               logger.warn("Language server connection closed by the client's error handler");

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -19,7 +19,7 @@ const logger = new Logger("flinkSql.languageClient");
 
 let languageClient: LanguageClient | null = null;
 let reconnectCounter = 0;
-const MAX_RECONNECT_ATTEMPTS = 2;
+const MAX_RECONNECT_ATTEMPTS = 5;
 
 /** Initialize the FlinkSQL language client and connect to the language server websocket
  * @returns A promise that resolves to the language client, or null if initialization failed
@@ -164,7 +164,7 @@ async function handleWebSocketDisconnect(url: string): Promise<void> {
     return;
   }
 
-  // If we've reached max attempts, show a notification to the user
+  // If we've reached max attempts, stop trying to reconnect
   if (reconnectCounter >= MAX_RECONNECT_ATTEMPTS) {
     logger.error(`Failed to reconnect after ${MAX_RECONNECT_ATTEMPTS} attempts`);
     return;

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -97,18 +97,24 @@ export async function initializeLanguageClient(
               return [];
             },
             sendRequest: (type, params, token, next) => {
-              // Server does not accept line positions > 0, so we need to convert them to single-line
-              if (params && (params as any).position && (params as any).textDocument?.uri) {
-                const uri = (params as any).textDocument.uri;
-                const document = vscode.workspace.textDocuments.find(
-                  (doc) => doc.uri.toString() === uri,
-                );
-                if (document) {
-                  const originalPosition = (params as any).position;
-                  (params as any).position = convertToSingleLinePosition(
-                    document,
-                    new vscode.Position(originalPosition.line, originalPosition.character),
+              // Server does not accept line positions > 0 for completions, so we need to convert them to single-line
+              if (
+                typeof type === "object" &&
+                type.method &&
+                type.method === "textDocument/completion"
+              ) {
+                if (params && (params as any).position && (params as any).textDocument?.uri) {
+                  const uri = (params as any).textDocument.uri;
+                  const document = vscode.workspace.textDocuments.find(
+                    (doc) => doc.uri.toString() === uri,
                   );
+                  if (document) {
+                    const originalPosition = (params as any).position;
+                    (params as any).position = convertToSingleLinePosition(
+                      document,
+                      new vscode.Position(originalPosition.line, originalPosition.character),
+                    );
+                  }
                 }
               }
 

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -19,7 +19,7 @@ const logger = new Logger("flinkSql.languageClient");
 
 let languageClient: LanguageClient | null = null;
 let reconnectCounter = 0;
-const MAX_RECONNECT_ATTEMPTS = 5;
+const MAX_RECONNECT_ATTEMPTS = 2;
 
 /** Initialize the FlinkSQL language client and connect to the language server websocket
  * @returns A promise that resolves to the language client, or null if initialization failed
@@ -63,8 +63,9 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
         };
         const clientOptions: LanguageClientOptions = {
           documentSelector: [
-            { scheme: "file", language: "flinksql" },
+            { language: "flinksql" },
             { scheme: "untitled", language: "flinksql" },
+            { pattern: "**/*.flink.sql" },
           ],
           middleware: {
             didOpen: (document, next) => {

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -10,64 +10,13 @@ import {
 import { WebSocket } from "ws";
 import { Logger } from "../logging";
 import { WebsocketTransport } from "./websocketTransport";
-import { CCLOUD_CONNECTION_ID } from "../constants";
 import { getStorageManager } from "../storage";
 import { SecretStorageKeys } from "../storage/constants";
-import { SIDECAR_PORT } from "../sidecar/constants";
-import { getResourceManager } from "../storage/resourceManager";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
-import { CCloudFlinkComputePool } from "../models/flinkComputePool";
-import { getCurrentOrganization } from "../graphql/organizations";
 
 const logger = new Logger("flinkSql.languageClient");
 
 let languageClient: LanguageClient | null = null;
-export interface FlinkSqlSettings {
-  database: string;
-  computePoolId: string;
-}
-export function getFlinkSqlSettings(): FlinkSqlSettings {
-  const config = vscode.workspace.getConfiguration("confluent.flink");
-  return {
-    database: config.get<string>("database", ""),
-    computePoolId: config.get<string>("computePoolId", ""),
-  };
-}
-
-/**
- * Builds the WebSocket URL for the Flink SQL Language Server based on current settings
- * @param computePoolId - The ID of the compute pool used to determine URL query params
- * @returns The WebSocket URL for the Flink SQL Language Server
- * @throws Error if the environment or organization ID cannot be found
- * @throws Error if the compute pool ID is not found in any environment
- */
-export async function buildFlinkSqlWebSocketUrl(computePoolId: string): Promise<string> {
-  let organizationId = "";
-  let environmentId = "";
-  let region = "";
-  let provider = "";
-  // Get the current org
-  const currentOrg = await getCurrentOrganization();
-  organizationId = currentOrg?.id ?? "";
-  // Find the environment containing this compute pool
-  const resourceManager = getResourceManager();
-  const environments = await resourceManager.getCCloudEnvironments();
-  for (const env of environments) {
-    const foundPool = env.flinkComputePools.find(
-      (pool: CCloudFlinkComputePool) => pool.id === computePoolId,
-    );
-    if (foundPool) {
-      environmentId = env.id;
-      region = foundPool.region;
-      provider = foundPool.provider;
-      break;
-    }
-  }
-  if (!environmentId || !organizationId) {
-    throw new Error(`Could not find environment containing compute pool ${computePoolId}`);
-  }
-  return `ws://localhost:${SIDECAR_PORT}/flsp?connectionId=${CCLOUD_CONNECTION_ID}&region=${region}&provider=${provider}&environmentId=${environmentId}&organizationId=${organizationId}`;
-}
 
 /** Initialize the FlinkSQL language client and connect to the language server websocket
  * @returns A promise that resolves to the language client, or null if initialization failed
@@ -75,7 +24,7 @@ export async function buildFlinkSqlWebSocketUrl(computePoolId: string): Promise<
  * - User is authenticated with CCloud
  * - User has selected a compute pool
  */
-export async function initializeLanguageClient(): Promise<vscode.Disposable | null> {
+export async function initializeLanguageClient(url: string): Promise<vscode.Disposable | null> {
   if (!hasCCloudAuthSession()) {
     logger.warn("Cannot initialize language client: User not authenticated with CCloud");
     return null;
@@ -84,23 +33,6 @@ export async function initializeLanguageClient(): Promise<vscode.Disposable | nu
   if (languageClient) {
     logger.info("Language client already initialized");
     return languageClient;
-  }
-
-  const settings = getFlinkSqlSettings();
-  if (!settings.computePoolId) {
-    logger.warn("Cannot initialize language client: No compute pool configured");
-    return null;
-  }
-
-  let addr: string;
-  try {
-    addr = await buildFlinkSqlWebSocketUrl(settings.computePoolId);
-  } catch (error) {
-    logger.error("Failed to build WebSocket URL:", error);
-    vscode.window.showErrorMessage(
-      `Failed to initialize Flink SQL language client: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return null;
   }
 
   let accessToken: string | undefined = await getStorageManager().getSecret(
@@ -114,7 +46,7 @@ export async function initializeLanguageClient(): Promise<vscode.Disposable | nu
     return null;
   }
   return new Promise((resolve, reject) => {
-    const conn = new WebSocket(addr, {
+    const conn = new WebSocket(url, {
       headers: { authorization: `Bearer ${accessToken}` },
     });
     conn.onerror = (error) => {
@@ -149,7 +81,7 @@ export async function initializeLanguageClient(): Promise<vscode.Disposable | nu
               return next(event);
             },
             provideCompletionItem: (document, position, context, token, next) => {
-              // Server adds backticks to all Entities, so we need to see
+              // Server adds backticks to all Entity completions, so we check
               // if the character before the word range start is a backtick & if so, adjust the position
               const range = document.getWordRangeAtPosition(position);
               const line = document.lineAt(position.line).text;

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -126,8 +126,8 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
             closed: () => {
               logger.warn("Language server connection closed by the client's error handler");
               // This will trigger our own reconnection logic
-              languageClientRestartNeeded.fire();
-              return { action: CloseAction.DoNotRestart };
+              handleWebSocketDisconnect(url);
+              return { action: CloseAction.Restart, handled: true };
             },
           },
         };
@@ -152,7 +152,6 @@ export async function initializeLanguageClient(url: string): Promise<LanguageCli
       const reason = event.reason || "Unknown reason";
       const code = event.code;
       logger.warn(`WebSocket connection closed: Code ${code}, Reason: ${reason}`);
-      await handleWebSocketDisconnect(url);
     };
   });
 }

--- a/src/flinkSql/websocketTransport.test.ts
+++ b/src/flinkSql/websocketTransport.test.ts
@@ -254,30 +254,5 @@ describe("WebsocketTransport", () => {
       // Verify that end was called on writer
       sinon.assert.calledOnce(writerEndSpy);
     });
-
-    it("should handle errors during writer.end() gracefully", async () => {
-      const transport = new WebsocketTransport(mockSocket);
-
-      // Need to get the writer instance to stub end
-      const writer = transport.writer as any;
-      const testError = new Error("End failed");
-
-      // Directly set up the stub to call the error logger when the catch handler runs
-      sandbox.stub(writer, "end").callsFake(() => {
-        const promise = Promise.reject(testError);
-        // Force the promise to be "handled" to avoid unhandled rejection warnings
-        promise.catch(() => {});
-        return promise;
-      });
-
-      // Should not throw when disposing
-      transport.dispose();
-
-      // We need to wait for the promise rejection to be processed
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      // Should log the error
-      sinon.assert.called(loggerStub.error);
-    });
   });
 });

--- a/src/flinkSql/websocketTransport.test.ts
+++ b/src/flinkSql/websocketTransport.test.ts
@@ -1,0 +1,283 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { Message, RequestMessage } from "vscode-languageclient/node";
+import { WebSocket } from "ws";
+import { Logger } from "../logging";
+import { WebsocketTransport } from "./websocketTransport";
+
+describe("WebsocketTransport", () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockSocket: any;
+  let loggerStub: any;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    // Create a mock WebSocket
+    mockSocket = {
+      on: sandbox.stub(),
+      send: sandbox.stub(),
+      close: sandbox.stub(),
+      readyState: WebSocket.OPEN,
+    };
+
+    // Stub the logger to avoid real logging during tests
+    loggerStub = {
+      debug: sandbox.stub(),
+      info: sandbox.stub(),
+      error: sandbox.stub(),
+      warn: sandbox.stub(),
+    };
+    sandbox.stub(Logger.prototype, "debug").callsFake(loggerStub.debug);
+    sandbox.stub(Logger.prototype, "error").callsFake(loggerStub.error);
+    sandbox.stub(Logger.prototype, "info").callsFake(loggerStub.info);
+    sandbox.stub(Logger.prototype, "warn").callsFake(loggerStub.warn);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("WebsocketMessageReader", () => {
+    it("should register event listeners on WebSocket constructor", () => {
+      // Creating a transport will create a reader which registers listeners
+      new WebsocketTransport(mockSocket);
+
+      // The reader should register message, close, and error listeners
+      sinon.assert.calledWith(mockSocket.on, "message", sinon.match.func);
+      sinon.assert.calledWith(mockSocket.on, "close", sinon.match.func);
+      sinon.assert.calledWith(mockSocket.on, "error", sinon.match.func);
+    });
+
+    it("should parse messages and emit them", () => {
+      const transport = new WebsocketTransport(mockSocket);
+      const callback = sandbox.stub();
+
+      // Register a message listener
+      transport.reader.listen(callback);
+
+      // Get the message handler that was registered
+      const messageHandler = mockSocket.on.args.find((args: any) => args[0] === "message")?.[1];
+      assert.ok(messageHandler, "Message handler not registered");
+
+      // Simulate receiving a message
+      const testMessage = { jsonrpc: "2.0", method: "test", params: {} };
+      messageHandler(JSON.stringify(testMessage));
+
+      // Verify the callback was called with the parsed message
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithMatch(callback, testMessage);
+    });
+
+    it("should handle buffer data", () => {
+      const transport = new WebsocketTransport(mockSocket);
+      const callback = sandbox.stub();
+
+      // Register a message listener
+      transport.reader.listen(callback);
+
+      // Get the message handler
+      const messageHandler = mockSocket.on.args.find((args: any) => args[0] === "message")?.[1];
+      assert.ok(messageHandler, "Message handler not registered");
+
+      // Simulate receiving a message as Buffer
+      const testMessage = { jsonrpc: "2.0", method: "test", params: {} };
+      const messageBuffer = Buffer.from(JSON.stringify(testMessage), "utf8");
+      messageHandler(messageBuffer);
+
+      // Verify the callback was called with the parsed message
+      sinon.assert.calledOnce(callback);
+      sinon.assert.calledWithMatch(callback, testMessage);
+    });
+
+    it("should emit errors on parse failure", () => {
+      const transport = new WebsocketTransport(mockSocket);
+      const errorHandler = sandbox.stub();
+
+      // Register an error listener
+      transport.reader.onError(errorHandler);
+
+      // Get the message handler
+      const messageHandler = mockSocket.on.args.find((args: any) => args[0] === "message")?.[1];
+      assert.ok(messageHandler, "Message handler not registered");
+
+      // Simulate receiving invalid JSON
+      messageHandler("this is not valid JSON");
+
+      // Verify an error was emitted
+      sinon.assert.calledOnce(errorHandler);
+      sinon.assert.called(loggerStub.error);
+    });
+
+    it("should emit close event when socket closes", () => {
+      const transport = new WebsocketTransport(mockSocket);
+      const closeHandler = sandbox.stub();
+
+      // Register a close listener
+      transport.reader.onClose(closeHandler);
+
+      // Get the close handler
+      const socketCloseHandler = mockSocket.on.args.find((args: any) => args[0] === "close")?.[1];
+      assert.ok(socketCloseHandler, "Close handler not registered");
+
+      // Simulate socket close
+      socketCloseHandler();
+
+      // Verify close was emitted
+      sinon.assert.calledOnce(closeHandler);
+      sinon.assert.called(loggerStub.debug);
+    });
+  });
+
+  describe("WebsocketMessageWriter", () => {
+    it("should send messages as JSON strings", async () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      // Configure the send stub to call its callback with no error
+      mockSocket.send.callsFake((data: any, callback: () => void) => {
+        if (callback) callback();
+      });
+
+      // Create a test message
+      const message: Message = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "testMethod",
+        params: { test: true },
+      } as Message;
+
+      // Send the message
+      await transport.writer.write(message);
+
+      // Verify the message was sent correctly
+      sinon.assert.calledOnce(mockSocket.send);
+      sinon.assert.calledWithMatch(mockSocket.send, JSON.stringify(message), sinon.match.func);
+    });
+
+    it("should reject the promise if send fails", async () => {
+      const transport = new WebsocketTransport(mockSocket);
+      const testError = new Error("Send failed");
+
+      // Configure the send stub to call its callback with an error
+      mockSocket.send.callsFake((data: string | Buffer, callback: (err?: Error) => void) => {
+        if (callback) callback(testError);
+      });
+      // Create a test message
+      const message: RequestMessage = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "testMethod",
+        params: {},
+      };
+
+      // Send the message and expect rejection
+      await assert.rejects(async () => {
+        await transport.writer.write(message);
+      });
+
+      // Verify that send was called
+      sinon.assert.calledOnce(mockSocket.send);
+      sinon.assert.called(loggerStub.error);
+    });
+
+    it("should not attempt to send if socket is closed", async () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      // Set readyState to CLOSED
+      mockSocket.readyState = WebSocket.CLOSED;
+
+      // Create a test message
+      const message: RequestMessage = {
+        jsonrpc: "2.0",
+        method: "testMethod",
+        id: 1,
+        params: {},
+      };
+
+      // Send the message
+      await transport.writer.write(message);
+
+      // Verify that send was not called
+      sinon.assert.notCalled(mockSocket.send);
+      sinon.assert.called(loggerStub.warn);
+    });
+
+    it("should close the socket gracefully on end()", async () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      // Need to get the writer instance to call end directly
+      const writer = transport.writer as any;
+      await writer.end();
+
+      // Verify that socket.close was called with normal closure code
+      sinon.assert.calledOnce(mockSocket.close);
+      sinon.assert.calledWithMatch(mockSocket.close, 1000, sinon.match.string);
+    });
+  });
+
+  describe("WebsocketTransport class", () => {
+    it("should create reader and writer on construction", () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      assert.ok(transport.reader, "Reader should be created");
+      assert.ok(transport.writer, "Writer should be created");
+    });
+
+    it("should dispose reader, writer and close socket on dispose", () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      // Create spies for reader and writer dispose methods
+      const readerDisposeSpy = sandbox.spy(transport.reader, "dispose");
+      const writerDisposeSpy = sandbox.spy(transport.writer, "dispose");
+
+      // Dispose the transport
+      transport.dispose();
+
+      // Verify that dispose was called on reader and writer
+      sinon.assert.calledOnce(readerDisposeSpy);
+      sinon.assert.calledOnce(writerDisposeSpy);
+
+      // Verify socket.close was called
+      sinon.assert.called(mockSocket.close);
+    });
+
+    it("should attempt to end the writer before disposing", () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      // Need to get the writer instance to spy on end
+      const writer = transport.writer as any;
+      const writerEndSpy = sandbox.stub(writer, "end").resolves();
+
+      // Dispose the transport
+      transport.dispose();
+
+      // Verify that end was called on writer
+      sinon.assert.calledOnce(writerEndSpy);
+    });
+
+    it("should handle errors during writer.end() gracefully", async () => {
+      const transport = new WebsocketTransport(mockSocket);
+
+      // Need to get the writer instance to stub end
+      const writer = transport.writer as any;
+      const testError = new Error("End failed");
+
+      // Directly set up the stub to call the error logger when the catch handler runs
+      sandbox.stub(writer, "end").callsFake(() => {
+        const promise = Promise.reject(testError);
+        // Force the promise to be "handled" to avoid unhandled rejection warnings
+        promise.catch(() => {});
+        return promise;
+      });
+
+      // Should not throw when disposing
+      transport.dispose();
+
+      // We need to wait for the promise rejection to be processed
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Should log the error
+      sinon.assert.called(loggerStub.error);
+    });
+  });
+});

--- a/src/flinkSql/websocketTransport.ts
+++ b/src/flinkSql/websocketTransport.ts
@@ -1,0 +1,142 @@
+import {
+  MessageTransports,
+  MessageReader,
+  MessageWriter,
+  Message,
+  PartialMessageInfo,
+  DataCallback,
+} from "vscode-languageclient/node";
+import { EventEmitter, Event, Disposable } from "vscode";
+import { Logger } from "../logging";
+import { WebSocket } from "ws";
+
+const logger = new Logger("websocketTransport");
+
+/** Create a WebSocket that reads/writes messages in Language Server Protocol + JSON-RPC
+ * Used by the FlinkSQL LanguageClient to communicate with the ccloud language server
+ */
+class WebsocketMessageReader implements MessageReader {
+  private socket: WebSocket;
+  private messageEmitter = new EventEmitter<Message>();
+  private errorEmitter = new EventEmitter<Error>();
+  private closeEmitter = new EventEmitter<void>();
+  private partialMessageEmitter = new EventEmitter<PartialMessageInfo>();
+
+  constructor(socket: WebSocket) {
+    this.socket = socket;
+
+    this.socket.on("message", (data: Buffer | string) => {
+      try {
+        const strData = typeof data === "string" ? data : data.toString("utf8");
+        logger.debug(`Received message from language server: ${strData}`);
+        const message = JSON.parse(strData);
+        this.messageEmitter.fire(message);
+        logger.debug("Message emitted to language client");
+      } catch (e) {
+        logger.error(`Error parsing LSP message: ${e}`);
+        this.errorEmitter.fire(e as Error);
+      }
+    });
+
+    this.socket.on("close", () => {
+      logger.debug("WebSocket connection closed");
+      this.closeEmitter.fire();
+    });
+
+    this.socket.on("error", (error) => {
+      logger.error(`WebSocket error: ${error}`);
+      this.errorEmitter.fire(error);
+    });
+  }
+
+  public onError: Event<Error> = this.errorEmitter.event;
+  public onClose: Event<void> = this.closeEmitter.event;
+  public onPartialMessage: Event<PartialMessageInfo> = this.partialMessageEmitter.event;
+
+  public listen(callback: DataCallback): Disposable {
+    return this.messageEmitter.event((event) => {
+      logger.debug(`Calling callback with message: ${JSON.stringify(event)}`);
+      callback(event);
+    });
+  }
+
+  public dispose(): void {
+    this.messageEmitter.dispose();
+    this.errorEmitter.dispose();
+    this.closeEmitter.dispose();
+    this.partialMessageEmitter.dispose();
+  }
+}
+
+class WebsocketMessageWriter implements MessageWriter {
+  private socket: WebSocket;
+  private errorEmitter = new EventEmitter<[Error, Message | undefined, number | undefined]>();
+  private closeEmitter = new EventEmitter<void>();
+
+  constructor(socket: WebSocket) {
+    this.socket = socket;
+    this.socket.on("close", () => {
+      this.closeEmitter.fire();
+    });
+
+    this.socket.on("error", (error) => {
+      this.errorEmitter.fire([error, undefined, undefined]);
+    });
+  }
+
+  public async write(message: Message): Promise<void> {
+    try {
+      const messageStr = JSON.stringify(message);
+      logger.debug(`Sending message to language server: ${messageStr}`);
+
+      return new Promise<void>((resolve, reject) => {
+        this.socket.send(messageStr, (error) => {
+          if (error) {
+            logger.error(`Failed to send message: ${error}`);
+            this.errorEmitter.fire([error, message, undefined]);
+            reject(error);
+          } else {
+            logger.debug("Message sent successfully");
+            resolve();
+          }
+        });
+      });
+    } catch (error) {
+      logger.error(`Error preparing message: ${error}`);
+      this.errorEmitter.fire([error as Error, message, undefined]);
+      throw error;
+    }
+  }
+
+  public onError: Event<[Error, Message | undefined, number | undefined]> = this.errorEmitter.event;
+  public onClose: Event<void> = this.closeEmitter.event;
+
+  public async end(): Promise<void> {
+    // Close the WebSocket connection gently if needed
+    if (this.socket.readyState === WebSocket.OPEN) {
+      this.socket.close(1000, "Client closed connection");
+    }
+  }
+
+  public dispose(): void {
+    this.errorEmitter.dispose();
+    this.closeEmitter.dispose();
+  }
+}
+
+export class WebsocketTransport implements MessageTransports {
+  public reader: MessageReader;
+  public writer: MessageWriter;
+
+  constructor(socket: WebSocket) {
+    logger.debug("Creating websocket transport");
+    this.reader = new WebsocketMessageReader(socket);
+    this.writer = new WebsocketMessageWriter(socket);
+  }
+
+  public dispose(): void {
+    logger.debug("Disposing websocket transport");
+    this.reader.dispose();
+    this.writer.dispose();
+  }
+}


### PR DESCRIPTION
## Summary of Changes

- Adds intellisense features with a new ✨ Language Client ✨ that connects to Confluent Cloud's Flink Language Server via `ide-sidecar`'s websocket proxy
- Closes https://github.com/confluentinc/vscode/issues/1493

## Any additional details or context that should be provided?
Just the initial setup and happy path here. 🌞 Full implementation to be done in separate PRs w/ remaining tasks listed in [this issue](https://github.com/confluentinc/vscode/issues/1401).

It currently maintains a single connection for all files, so depends on a single compute pool/region for now. Future work will allow it to make multiple connections for different regions.

## How to test
- User Settings required: Flink features enabled, (valid) global compute pool id set
- Sign in to CCloud and open a file that is `flinksql` language. You should see completions from the CCloud service. 

#### ⚠️ There are some known issues for fast follow-up in https://github.com/confluentinc/vscode/issues/1401. This will remain under a the Flink Enabled `Preview` flag in the meantime

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [X] Updated existing
- [X] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
