### PR TITLE
feat: add codelens for setting Flink statement catalog + database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this extension will be documented in this file.
 - Can submit new SQL statements to a Flink compute pool
 - Can view SQL statement results
 - Configurable default settings for `compute pool` and `database` for Flink operations
-- Codelenses for Flink SQL documents to support submitting statements, as well as signing in to
-  CCloud and setting a compute pool for the document
+- Codelenses for Flink SQL documents to support:
+  - submitting statements
+  - signing in to CCloud
+  - setting a compute pool
+  - setting a catalog and database
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -535,7 +535,7 @@
       },
       {
         "command": "confluent.document.flinksql.resetCCloudMetadata",
-        "icon": "$(x)",
+        "icon": "$(chrome-close)",
         "title": "Reset CCloud Flink Metadata",
         "category": "Confluent: Flink SQL"
       }

--- a/package.json
+++ b/package.json
@@ -535,7 +535,7 @@
       },
       {
         "command": "confluent.document.flinksql.resetCCloudMetadata",
-        "icon": "$(chrome-close)",
+        "icon": "Clear Settings",
         "title": "Reset CCloud Flink Metadata",
         "category": "Confluent: Flink SQL"
       }

--- a/package.json
+++ b/package.json
@@ -526,6 +526,12 @@
         "icon": "$(confluent-logo)",
         "title": "Set CCloud Flink Compute Pool for Flink Statement",
         "category": "Confluent: Flink SQL"
+      },
+      {
+        "command": "confluent.document.flinksql.setCCloudCatalogDatabase",
+        "icon": "$(confluent-logo)",
+        "title": "Set CCloud Catalog & Database for Flink Statement",
+        "category": "Confluent: Flink SQL"
       }
     ],
     "configuration": [
@@ -956,6 +962,10 @@
         },
         {
           "command": "confluent.document.flinksql.setCCloudComputePool",
+          "when": "false"
+        },
+        {
+          "command": "confluent.document.flinksql.setCCloudCatalogDatabase",
           "when": "false"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -532,6 +532,12 @@
         "icon": "$(confluent-logo)",
         "title": "Set CCloud Flink Database for Flink Statement",
         "category": "Confluent: Flink SQL"
+      },
+      {
+        "command": "confluent.document.flinksql.resetCCloudMetadata",
+        "icon": "$(x)",
+        "title": "Reset CCloud Flink Metadata",
+        "category": "Confluent: Flink SQL"
       }
     ],
     "configuration": [
@@ -966,6 +972,10 @@
         },
         {
           "command": "confluent.document.flinksql.setCCloudDatabase",
+          "when": "false"
+        },
+        {
+          "command": "confluent.document.flinksql.resetCCloudMetadata",
           "when": "false"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -528,9 +528,9 @@
         "category": "Confluent: Flink SQL"
       },
       {
-        "command": "confluent.document.flinksql.setCCloudCatalogDatabase",
+        "command": "confluent.document.flinksql.setCCloudDatabase",
         "icon": "$(confluent-logo)",
-        "title": "Set CCloud Catalog & Database for Flink Statement",
+        "title": "Set CCloud Flink Database for Flink Statement",
         "category": "Confluent: Flink SQL"
       }
     ],
@@ -965,7 +965,7 @@
           "when": "false"
         },
         {
-          "command": "confluent.document.flinksql.setCCloudCatalogDatabase",
+          "command": "confluent.document.flinksql.setCCloudDatabase",
           "when": "false"
         }
       ],

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -89,93 +89,93 @@ describe("codelens/flinkSqlProvider.ts", () => {
     assert.strictEqual(codeLenses[0].command?.title, "Sign in to Confluent Cloud");
   });
 
-  // for (const metadataPoolId of [undefined, "old-or-invalid-pool-id"]) {
-  //   it(`should provide 'Set Compute Pool' codelens when no pool is found matching stored metadata (${UriMetadataKeys.FLINK_COMPUTE_POOL_ID}=${metadataPoolId})`, async () => {
-  //     resourceManagerStub.getUriMetadata.resolves({
-  //       // undefined or something that won't match a valid pool
-  //       [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: metadataPoolId,
-  //     });
-  //     const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
-  //       ...TEST_CCLOUD_ENVIRONMENT,
-  //       flinkComputePools: [],
-  //     });
-  //     ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
+  for (const metadataPoolId of [undefined, "old-or-invalid-pool-id"]) {
+    it(`should provide 'Set Compute Pool' codelens when no pool is found matching stored metadata (${UriMetadataKeys.FLINK_COMPUTE_POOL_ID}=${metadataPoolId})`, async () => {
+      resourceManagerStub.getUriMetadata.resolves({
+        // undefined or something that won't match a valid pool
+        [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: metadataPoolId,
+      });
+      const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
+        ...TEST_CCLOUD_ENVIRONMENT,
+        flinkComputePools: [],
+      });
+      ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
 
-  //     const provider = FlinkSqlCodelensProvider.getInstance();
-  //     const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
+      const provider = FlinkSqlCodelensProvider.getInstance();
+      const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
 
-  //     assert.strictEqual(codeLenses.length, 3);
+      assert.strictEqual(codeLenses.length, 3);
 
-  //     const poolLens = codeLenses[0];
-  //     const dbLens = codeLenses[1];
-  //     const resetLens = codeLenses[2];
+      const poolLens = codeLenses[0];
+      const dbLens = codeLenses[1];
+      const resetLens = codeLenses[2];
 
-  //     assert.strictEqual(dbLens.command?.command, "confluent.document.flinksql.setCCloudDatabase");
-  //     assert.strictEqual(dbLens.command?.title, "Set Catalog & Database");
-  //     assert.deepStrictEqual(dbLens.command?.arguments, [fakeDocument.uri, undefined]);
+      assert.strictEqual(dbLens.command?.command, "confluent.document.flinksql.setCCloudDatabase");
+      assert.strictEqual(dbLens.command?.title, "Set Catalog & Database");
+      assert.deepStrictEqual(dbLens.command?.arguments, [fakeDocument.uri, undefined]);
 
-  //     assert.strictEqual(
-  //       poolLens.command?.command,
-  //       "confluent.document.flinksql.setCCloudComputePool",
-  //     );
-  //     assert.strictEqual(poolLens.command?.title, "Set Compute Pool");
-  //     assert.deepStrictEqual(poolLens.command?.arguments, [fakeDocument.uri, undefined]);
+      assert.strictEqual(
+        poolLens.command?.command,
+        "confluent.document.flinksql.setCCloudComputePool",
+      );
+      assert.strictEqual(poolLens.command?.title, "Set Compute Pool");
+      assert.deepStrictEqual(poolLens.command?.arguments, [fakeDocument.uri, undefined]);
 
-  //     assert.strictEqual(
-  //       resetLens.command?.command,
-  //       "confluent.document.flinksql.resetCCloudMetadata",
-  //     );
-  //     assert.strictEqual(resetLens.command?.title, "$(debug-restart)");
-  //     assert.deepStrictEqual(resetLens.command?.arguments, [fakeDocument.uri]);
-  //   });
-  // }
+      assert.strictEqual(
+        resetLens.command?.command,
+        "confluent.document.flinksql.resetCCloudMetadata",
+      );
+      assert.strictEqual(resetLens.command?.title, "Clear Settings");
+      assert.deepStrictEqual(resetLens.command?.arguments, [fakeDocument.uri]);
+    });
+  }
 
-  // for (const metadataDatabaseId of [undefined, "old-or-invalid-db-id"]) {
-  //   it(`should provide 'Set Catalog & Database' codelens when no database is found matching stored metadata (${UriMetadataKeys.FLINK_DATABASE_ID}=${metadataDatabaseId})`, async () => {
-  //     const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-  //     // simulate stored compute pool metadata
-  //     resourceManagerStub.getUriMetadata.resolves({
-  //       [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: pool.id,
-  //       // undefined or something that won't match a valid catalog+db
-  //       [UriMetadataKeys.FLINK_DATABASE_ID]: metadataDatabaseId,
-  //     });
-  //     const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
-  //       ...TEST_CCLOUD_ENVIRONMENT,
-  //       flinkComputePools: [pool],
-  //     });
-  //     ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
+  for (const metadataDatabaseId of [undefined, "old-or-invalid-db-id"]) {
+    it(`should provide 'Set Catalog & Database' codelens when no database is found matching stored metadata (${UriMetadataKeys.FLINK_DATABASE_ID}=${metadataDatabaseId})`, async () => {
+      const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      // simulate stored compute pool metadata
+      resourceManagerStub.getUriMetadata.resolves({
+        [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: pool.id,
+        // undefined or something that won't match a valid catalog+db
+        [UriMetadataKeys.FLINK_DATABASE_ID]: metadataDatabaseId,
+      });
+      const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
+        ...TEST_CCLOUD_ENVIRONMENT,
+        flinkComputePools: [pool],
+      });
+      ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
 
-  //     const provider = FlinkSqlCodelensProvider.getInstance();
-  //     const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
+      const provider = FlinkSqlCodelensProvider.getInstance();
+      const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
 
-  //     assert.strictEqual(codeLenses.length, 3);
+      assert.strictEqual(codeLenses.length, 3);
 
-  //     const poolLens = codeLenses[0];
-  //     const dbLens = codeLenses[1];
-  //     const resetLens = codeLenses[2];
+      const poolLens = codeLenses[0];
+      const dbLens = codeLenses[1];
+      const resetLens = codeLenses[2];
 
-  //     assert.strictEqual(dbLens.command?.command, "confluent.document.flinksql.setCCloudDatabase");
-  //     assert.strictEqual(dbLens.command?.title, "Set Catalog & Database");
-  //     assert.deepStrictEqual(dbLens.command?.arguments, [
-  //       fakeDocument.uri,
-  //       TEST_CCLOUD_FLINK_COMPUTE_POOL,
-  //     ]);
+      assert.strictEqual(dbLens.command?.command, "confluent.document.flinksql.setCCloudDatabase");
+      assert.strictEqual(dbLens.command?.title, "Set Catalog & Database");
+      assert.deepStrictEqual(dbLens.command?.arguments, [
+        fakeDocument.uri,
+        TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      ]);
 
-  //     assert.strictEqual(
-  //       poolLens.command?.command,
-  //       "confluent.document.flinksql.setCCloudComputePool",
-  //     );
-  //     assert.strictEqual(poolLens.command?.title, pool.name);
-  //     assert.deepStrictEqual(poolLens.command?.arguments, [fakeDocument.uri, undefined]);
+      assert.strictEqual(
+        poolLens.command?.command,
+        "confluent.document.flinksql.setCCloudComputePool",
+      );
+      assert.strictEqual(poolLens.command?.title, pool.name);
+      assert.deepStrictEqual(poolLens.command?.arguments, [fakeDocument.uri, undefined]);
 
-  //     assert.strictEqual(
-  //       resetLens.command?.command,
-  //       "confluent.document.flinksql.resetCCloudMetadata",
-  //     );
-  //     assert.strictEqual(resetLens.command?.title, "$(debug-restart)");
-  //     assert.deepStrictEqual(resetLens.command?.arguments, [fakeDocument.uri]);
-  //   });
-  // }
+      assert.strictEqual(
+        resetLens.command?.command,
+        "confluent.document.flinksql.resetCCloudMetadata",
+      );
+      assert.strictEqual(resetLens.command?.title, "Clear Settings");
+      assert.deepStrictEqual(resetLens.command?.arguments, [fakeDocument.uri]);
+    });
+  }
 
   it("should provide 'Submit Statement' codelens when a compute pool and catalog+database are set", async () => {
     const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
@@ -221,7 +221,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       resetLens.command?.command,
       "confluent.document.flinksql.resetCCloudMetadata",
     );
-    assert.strictEqual(resetLens.command?.title, "$(debug-restart)");
+    assert.strictEqual(resetLens.command?.title, "Clear Settings");
     assert.deepStrictEqual(resetLens.command?.arguments, [fakeDocument.uri]);
   });
 });

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -126,7 +126,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       const provider = FlinkSqlCodelensProvider.getInstance();
       const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
 
-      assert.strictEqual(codeLenses.length, 3);
+      assert.strictEqual(codeLenses.length, 2);
 
       assert.strictEqual(
         codeLenses[0].command?.command,
@@ -184,8 +184,6 @@ describe("codelens/flinkSqlProvider.ts", () => {
     );
     assert.strictEqual(codeLenses[2].command?.title, pool.name);
     assert.deepStrictEqual(codeLenses[2].command?.arguments, [fakeDocument.uri]);
-
-    assert.strictEqual(codeLenses[3].command?.command, "confluent.document.setCCloudOrg");
   });
 
   it("should create codelenses at the top of the document", async () => {

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -94,7 +94,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
 
       assert.strictEqual(
         codeLenses[0].command?.command,
-        "confluent.document.flinksql.setCCloudCatalogDatabase",
+        "confluent.document.flinksql.setCCloudDatabase",
       );
       assert.strictEqual(codeLenses[0].command?.title, "Set Catalog & Database");
       assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri]);
@@ -130,7 +130,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
 
       assert.strictEqual(
         codeLenses[0].command?.command,
-        "confluent.document.flinksql.setCCloudCatalogDatabase",
+        "confluent.document.flinksql.setCCloudDatabase",
       );
       assert.strictEqual(codeLenses[0].command?.title, "Set Catalog & Database");
       assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri]);
@@ -170,7 +170,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
 
     assert.strictEqual(
       codeLenses[1].command?.command,
-      "confluent.document.flinksql.setCCloudCatalogDatabase",
+      "confluent.document.flinksql.setCCloudDatabase",
     );
     assert.strictEqual(
       codeLenses[1].command?.title,

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -1,12 +1,13 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import { CodeLens, Position, Range, TextDocument, Uri } from "vscode";
-import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import { TEST_CCLOUD_ORGANIZATION } from "../../tests/unit/testResources/organization";
 import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { CCloudKafkaCluster } from "../models/kafkaCluster";
 import * as ccloud from "../sidecar/connections/ccloud";
 import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
@@ -73,75 +74,118 @@ describe("codelens/flinkSqlProvider.ts", () => {
     assert.strictEqual(codeLenses[0].command?.title, "Sign in to Confluent Cloud");
   });
 
-  it("should provide 'Set Compute Pool' codelens when no compute pool is set", async () => {
-    // simulate stored env metadata
-    const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
-      ...TEST_CCLOUD_ENVIRONMENT,
-      flinkComputePools: [],
+  for (const metadataPoolId of [undefined, "old-or-invalid-pool-id"]) {
+    it(`should provide 'Set Compute Pool' codelens when no pool is found matching stored metadata (${UriMetadataKeys.FLINK_COMPUTE_POOL_ID}=${metadataPoolId})`, async () => {
+      // simulate stored env metadata
+      const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
+        ...TEST_CCLOUD_ENVIRONMENT,
+        flinkComputePools: [],
+      });
+      ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
+      resourceManagerStub.getUriMetadata.resolves({
+        // undefined or something that won't match a valid pool
+        [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: metadataPoolId,
+      });
+
+      const provider = FlinkSqlCodelensProvider.getInstance();
+      const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
+
+      assert.strictEqual(codeLenses.length, 2);
+
+      assert.strictEqual(
+        codeLenses[0].command?.command,
+        "confluent.document.flinksql.setCCloudCatalogDatabase",
+      );
+      assert.strictEqual(codeLenses[0].command?.title, "Set Catalog & Database");
+      assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri]);
+
+      assert.strictEqual(
+        codeLenses[1].command?.command,
+        "confluent.document.flinksql.setCCloudComputePool",
+      );
+      assert.strictEqual(codeLenses[1].command?.title, "Set Compute Pool");
+      assert.deepStrictEqual(codeLenses[1].command?.arguments, [fakeDocument.uri]);
     });
-    ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
-    resourceManagerStub.getUriMetadata.resolves({});
+  }
 
-    const provider = FlinkSqlCodelensProvider.getInstance();
-    const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
+  for (const metadataDatabaseId of [undefined, "old-or-invalid-db-id"]) {
+    it(`should provide 'Set Catalog & Database' codelens when no database is found matching stored metadata (${UriMetadataKeys.FLINK_DATABASE_ID}=${metadataDatabaseId})`, async () => {
+      const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      // simulate stored env metadata
+      const envWithoutPool: CCloudEnvironment = new CCloudEnvironment({
+        ...TEST_CCLOUD_ENVIRONMENT,
+        flinkComputePools: [pool],
+      });
+      ccloudLoaderStub.getEnvironments.resolves([envWithoutPool]);
+      resourceManagerStub.getUriMetadata.resolves({
+        [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: pool.id,
+        // undefined or something that won't match a valid catalog+db
+        [UriMetadataKeys.FLINK_DATABASE_ID]: metadataDatabaseId,
+      });
 
-    assert.strictEqual(codeLenses.length, 1);
+      const provider = FlinkSqlCodelensProvider.getInstance();
+      const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
 
-    assert.strictEqual(
-      codeLenses[0].command?.command,
-      "confluent.document.flinksql.setCCloudComputePool",
-    );
-    assert.strictEqual(codeLenses[0].command?.title, "Set Compute Pool");
-    assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri]);
-  });
+      assert.strictEqual(codeLenses.length, 3);
 
-  it("should show 'Set Compute Pool' when pool metadata exists but compute pool is not found", async () => {
-    // simulate stored env + partially invalid compute pool metadata
-    const nonExistentPoolId = "non-existent-pool-id";
-    resourceManagerStub.getUriMetadata.resolves({
-      [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: nonExistentPoolId,
+      assert.strictEqual(
+        codeLenses[0].command?.command,
+        "confluent.document.flinksql.setCCloudCatalogDatabase",
+      );
+      assert.strictEqual(codeLenses[0].command?.title, "Set Catalog & Database");
+      assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri]);
+
+      assert.strictEqual(
+        codeLenses[1].command?.command,
+        "confluent.document.flinksql.setCCloudComputePool",
+      );
+      assert.strictEqual(codeLenses[1].command?.title, pool.name);
+      assert.deepStrictEqual(codeLenses[1].command?.arguments, [fakeDocument.uri]);
     });
+  }
 
-    const provider = FlinkSqlCodelensProvider.getInstance();
-    const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
-
-    assert.strictEqual(codeLenses.length, 1);
-
-    assert.strictEqual(
-      codeLenses[0].command?.command,
-      "confluent.document.flinksql.setCCloudComputePool",
-    );
-    assert.strictEqual(codeLenses[0].command?.title, "Set Compute Pool");
-    assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri]);
-  });
-
-  it("should provide 'Submit Statement' codelens when a compute pool is set", async () => {
+  it("should provide 'Submit Statement' codelens when a compute pool and catalog+database are set", async () => {
     const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+    const database: CCloudKafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
     // simulate stored env + compute pool metadata
     const envWithPool: CCloudEnvironment = new CCloudEnvironment({
       ...TEST_CCLOUD_ENVIRONMENT,
+      kafkaClusters: [database],
       flinkComputePools: [pool],
     });
     ccloudLoaderStub.getEnvironments.resolves([envWithPool]);
     resourceManagerStub.getUriMetadata.resolves({
       [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: pool.id,
+      [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
     });
 
     const provider = FlinkSqlCodelensProvider.getInstance();
     const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
 
-    assert.strictEqual(codeLenses.length, 2);
+    assert.strictEqual(codeLenses.length, 3);
 
     assert.strictEqual(codeLenses[0].command?.command, "confluent.statements.create");
     assert.strictEqual(codeLenses[0].command?.title, "▶️ Submit Statement");
-    assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri, pool]);
+    assert.deepStrictEqual(codeLenses[0].command?.arguments, [fakeDocument.uri, pool, database]);
+
     assert.strictEqual(
       codeLenses[1].command?.command,
+      "confluent.document.flinksql.setCCloudCatalogDatabase",
+    );
+    assert.strictEqual(
+      codeLenses[1].command?.title,
+      `Catalog: ${TEST_CCLOUD_ENVIRONMENT.name}, Database: ${database.name}`,
+    );
+    assert.deepStrictEqual(codeLenses[1].command?.arguments, [fakeDocument.uri]);
+
+    assert.strictEqual(
+      codeLenses[2].command?.command,
       "confluent.document.flinksql.setCCloudComputePool",
     );
+    assert.strictEqual(codeLenses[2].command?.title, pool.name);
+    assert.deepStrictEqual(codeLenses[2].command?.arguments, [fakeDocument.uri]);
 
-    assert.strictEqual(codeLenses[1].command?.title, pool.name);
-    assert.deepStrictEqual(codeLenses[1].command?.arguments, [fakeDocument.uri]);
+    assert.strictEqual(codeLenses[3].command?.command, "confluent.document.setCCloudOrg");
   });
 
   it("should create codelenses at the top of the document", async () => {

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -80,76 +80,44 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
     // (as databases to match whatever the selected compute pool is, based on provider/region)
     const envs: CCloudEnvironment[] = await CCloudResourceLoader.getInstance().getEnvironments();
 
+    const computePool: CCloudFlinkComputePool | undefined = await getComputePoolFromMetadata(
+      uriMetadata,
+      envs,
+    );
+    const { catalog, database } = await getCatalogDatabaseFromMetadata(uriMetadata, envs);
+
     // codelens for selecting a compute pool, which we'll use to derive the rest of the properties
     // needed for various Flink operations (env ID, provider/region, etc)
-    const computePoolString: string | undefined =
-      uriMetadata?.[UriMetadataKeys.FLINK_COMPUTE_POOL_ID];
-    let computePool: CCloudFlinkComputePool | undefined;
-    if (computePoolString) {
-      // TODO: replace with dedicated loader method for looking up compute pool by ID
-      const env: CCloudEnvironment | undefined = envs.find((e) =>
-        e.flinkComputePools.some((pool) => pool.id === computePoolString),
-      );
-      const computePools: CCloudFlinkComputePool[] = env?.flinkComputePools || [];
-      computePool = computePools.find((p) => p.id === computePoolString);
-      if (computePool) {
-        // explicitly turn into a CCloudFlinkComputePool since `submitFlinkStatementCommand` checks
-        // for a CCloudFlinkComputePool instance
-        computePool = new CCloudFlinkComputePool({ ...computePool });
-      } else {
-        // no need to clear pool metadata since we'll show "Set Compute Pool" codelens
-        // and the user can choose a new one to update the stored metadata
-        logger.warn("compute pool not found from stored pool ID");
-      }
-    }
-
-    // codelens for selecting a database (and from it, a catalog)
-    const databaseId: string | undefined = uriMetadata?.[UriMetadataKeys.FLINK_DATABASE_ID];
-    let catalog: CCloudEnvironment | undefined;
-    let database: CCloudKafkaCluster | undefined;
-    if (databaseId) {
-      catalog = envs.find((e) => e.kafkaClusters.some((k) => k.id === databaseId));
-      if (catalog) {
-        database = catalog.kafkaClusters.find((k) => k.id === databaseId);
-        if (database) {
-          // finding a database by ID is not enough, we need to check that the provider/region
-          // match the compute pool (if one is selected)
-          if (
-            database.provider === computePool?.provider &&
-            database.region === computePool?.region
-          ) {
-            // explicitly turn into a CCloudKafkaCluster since `submitFlinkStatementCommand` checks
-            // for a CCloudKafkaCluster instance
-            database = CCloudKafkaCluster.create({ ...database });
-          }
-        } else {
-          // shouldn't happen since we just looked it up in order to get the catalog
-          logger.warn("database not found from stored database ID");
-        }
-      } else {
-        // no need to clear it since we'll show "Set Catalog & Database" codelens
-        logger.warn("catalog not found from stored database ID");
-      }
-    }
-
     const selectComputePoolCommand: Command = {
       title: computePool ? computePool.name : "Set Compute Pool",
       command: "confluent.document.flinksql.setCCloudComputePool",
-      tooltip: "Set CCloud Compute Pool for Flink Statement",
+      tooltip: computePool
+        ? `Compute Pool: ${computePool.name}`
+        : "Set CCloud Compute Pool for Flink Statement",
       arguments: [document.uri, database],
     };
     const computePoolLens = new CodeLens(range, selectComputePoolCommand);
 
+    // codelens for selecting a database (and from it, a catalog)
     const selectDatabaseCommand: Command = {
-      title:
+      title: catalog && database ? `${catalog.name}, ${database.name}` : "Set Catalog & Database",
+      command: "confluent.document.flinksql.setCCloudDatabase",
+      tooltip:
         catalog && database
           ? `Catalog: ${catalog.name}, Database: ${database.name}`
-          : "Set Catalog & Database",
-      command: "confluent.document.flinksql.setCCloudDatabase",
-      tooltip: "Set Catalog & Database for Flink Statement",
+          : "Set Catalog & Database for Flink Statement",
       arguments: [document.uri, computePool],
     };
     const databaseLens = new CodeLens(range, selectDatabaseCommand);
+
+    // codelens for resetting the metadata for the document
+    const resetCommand: Command = {
+      title: "$(debug-restart)",
+      command: "confluent.document.flinksql.resetCCloudMetadata",
+      tooltip: "Clear Selected CCloud Resources for Flink Statement",
+      arguments: [document.uri],
+    };
+    const resetLens = new CodeLens(range, resetCommand);
 
     if (computePool && database) {
       const submitCommand: Command = {
@@ -159,13 +127,112 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
         arguments: [document.uri, computePool, database],
       };
       const submitLens = new CodeLens(range, submitCommand);
-      // show the "Submit Statement" | <current catalog+db> | <current pool> codelenses
-      codeLenses.push(submitLens, databaseLens, computePoolLens);
+      // show the "Submit Statement" | <current pool> | <current catalog+db> codelenses
+      codeLenses.push(submitLens, computePoolLens, databaseLens, resetLens);
     } else {
       // don't show the submit codelens if we don't have a compute pool and database
-      codeLenses.push(databaseLens, computePoolLens);
+      codeLenses.push(computePoolLens, databaseLens, resetLens);
     }
 
     return codeLenses;
   }
+}
+
+/**
+ * Get the compute pool from the metadata stored in the document.
+ * @param metadata The metadata stored in the document.
+ * @param envs The environments to look up the compute pool.
+ * @returns The compute pool.
+ */
+async function getComputePoolFromMetadata(
+  metadata: UriMetadata | undefined,
+  envs: CCloudEnvironment[],
+): Promise<CCloudFlinkComputePool | undefined> {
+  const computePoolString: string | undefined = metadata?.[UriMetadataKeys.FLINK_COMPUTE_POOL_ID];
+  if (!computePoolString) {
+    return;
+  }
+
+  let computePool: CCloudFlinkComputePool | undefined;
+  // TODO: replace with dedicated loader method for looking up compute pool by ID
+  const env: CCloudEnvironment | undefined = envs.find((e) =>
+    e.flinkComputePools.some((pool) => pool.id === computePoolString),
+  );
+  const computePools: CCloudFlinkComputePool[] = env?.flinkComputePools || [];
+  computePool = computePools.find((p) => p.id === computePoolString);
+  if (computePool) {
+    // explicitly turn into a CCloudFlinkComputePool since `submitFlinkStatementCommand` checks
+    // for a CCloudFlinkComputePool instance
+    computePool = new CCloudFlinkComputePool({ ...computePool });
+  } else {
+    // no need to clear pool metadata since we'll show "Set Compute Pool" codelens
+    // and the user can choose a new one to update the stored metadata
+    logger.warn("compute pool not found from stored pool ID");
+  }
+
+  return computePool;
+}
+
+interface CatalogDatabase {
+  catalog?: CCloudEnvironment;
+  database?: CCloudKafkaCluster;
+}
+
+/**
+ * Get the catalog and database from the metadata stored in the document.
+ * @param metadata The metadata stored in the document.
+ * @param envs The environments to look up the catalog and database.
+ * @param computePool Optional: the compute pool to match provider/region against the database.
+ * @returns The catalog and database.
+ */
+async function getCatalogDatabaseFromMetadata(
+  metadata: UriMetadata | undefined,
+  envs: CCloudEnvironment[],
+  computePool?: CCloudFlinkComputePool,
+): Promise<CatalogDatabase> {
+  let catalogDatabase: CatalogDatabase = { catalog: undefined, database: undefined };
+  const databaseId: string | undefined = metadata?.[UriMetadataKeys.FLINK_DATABASE_ID];
+  if (!databaseId) {
+    return catalogDatabase;
+  }
+
+  const catalog: CCloudEnvironment | undefined = envs.find((e) =>
+    e.kafkaClusters.some((k) => k.id === databaseId),
+  );
+  if (!catalog) {
+    // no need to clear it since we'll show "Set Catalog & Database" codelens
+    logger.warn("catalog not found from stored database ID");
+    return catalogDatabase;
+  }
+
+  const cluster: CCloudKafkaCluster | undefined = catalog.kafkaClusters.find(
+    (k) => k.id === databaseId,
+  );
+  if (!cluster) {
+    // shouldn't happen since we just looked it up in order to get the catalog
+    logger.warn("database not found from stored database ID");
+    return catalogDatabase;
+  }
+
+  // finding a database by ID is not enough, we need to check that the provider/region
+  // match the compute pool (if one is selected)
+  let database: CCloudKafkaCluster | undefined;
+  if (computePool) {
+    if (cluster.provider === computePool.provider && cluster.region === computePool?.region) {
+      // explicitly turn into a CCloudKafkaCluster since `submitFlinkStatementCommand` checks
+      // for a CCloudKafkaCluster instance
+      database = CCloudKafkaCluster.create({ ...cluster });
+    } else {
+      logger.warn("database provider/region does not match compute pool provider/region", {
+        database,
+        computePool,
+      });
+    }
+  } else {
+    // no compute pool selected, so we can use the database as-is
+    database = CCloudKafkaCluster.create({ ...cluster });
+  }
+
+  catalogDatabase = { catalog, database };
+  return catalogDatabase;
 }

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -102,13 +102,6 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
         logger.warn("compute pool not found from stored pool ID");
       }
     }
-    const selectComputePoolCommand: Command = {
-      title: computePool ? computePool.name : "Set Compute Pool",
-      command: "confluent.document.flinksql.setCCloudComputePool",
-      tooltip: "Set CCloud Compute Pool for Flink Statement",
-      arguments: [document.uri],
-    };
-    const computePoolLens = new CodeLens(range, selectComputePoolCommand);
 
     // codelens for selecting a database (and from it, a catalog)
     const databaseId: string | undefined = uriMetadata?.[UriMetadataKeys.FLINK_DATABASE_ID];
@@ -138,6 +131,15 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
         logger.warn("catalog not found from stored database ID");
       }
     }
+
+    const selectComputePoolCommand: Command = {
+      title: computePool ? computePool.name : "Set Compute Pool",
+      command: "confluent.document.flinksql.setCCloudComputePool",
+      tooltip: "Set CCloud Compute Pool for Flink Statement",
+      arguments: [document.uri, database],
+    };
+    const computePoolLens = new CodeLens(range, selectComputePoolCommand);
+
     const selectDatabaseCommand: Command = {
       title:
         catalog && database
@@ -145,7 +147,7 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
           : "Set Catalog & Database",
       command: "confluent.document.flinksql.setCCloudDatabase",
       tooltip: "Set Catalog & Database for Flink Statement",
-      arguments: [document.uri],
+      arguments: [document.uri, computePool],
     };
     const databaseLens = new CodeLens(range, selectDatabaseCommand);
 

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -112,7 +112,7 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
 
     // codelens for resetting the metadata for the document
     const resetCommand: Command = {
-      title: "$(debug-restart)",
+      title: "$(chrome-close)",
       command: "confluent.document.flinksql.resetCCloudMetadata",
       tooltip: "Clear Selected CCloud Resources for Flink Statement",
       arguments: [document.uri],

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -112,7 +112,7 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
 
     // codelens for resetting the metadata for the document
     const resetCommand: Command = {
-      title: "$(chrome-close)",
+      title: "Clear Settings",
       command: "confluent.document.flinksql.resetCCloudMetadata",
       tooltip: "Clear Selected CCloud Resources for Flink Statement",
       arguments: [document.uri],

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -143,7 +143,7 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
         catalog && database
           ? `Catalog: ${catalog.name}, Database: ${database.name}`
           : "Set Catalog & Database",
-      command: "confluent.document.flinksql.setCCloudCatalogDatabase",
+      command: "confluent.document.flinksql.setCCloudDatabase",
       tooltip: "Set Catalog & Database for Flink Statement",
       arguments: [document.uri],
     };

--- a/src/commands/documents.test.ts
+++ b/src/commands/documents.test.ts
@@ -1,12 +1,17 @@
 import * as sinon from "sinon";
 import { Uri } from "vscode";
+import { TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import { uriMetadataSet } from "../emitters";
-import * as notifications from "../notifications";
 import * as flinkComputePoolsQuickPick from "../quickpicks/flinkComputePools";
+import * as flinkDatabaseQuickpick from "../quickpicks/kafkaClusters";
 import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
-import { setCCloudComputePoolForUriCommand } from "./documents";
+import {
+  resetCCloudMetadataForUriCommand,
+  setCCloudComputePoolForUriCommand,
+  setCCloudDatabaseForUriCommand,
+} from "./documents";
 
 describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
   let sandbox: sinon.SinonSandbox;
@@ -14,7 +19,6 @@ describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
   let stubResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
   let flinkComputePoolQuickPickStub: sinon.SinonStub;
   let uriMetadataSetFireStub: sinon.SinonStub;
-  let showErrorNotificationWithButtonsStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -27,10 +31,6 @@ describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
       "flinkComputePoolQuickPick",
     );
     uriMetadataSetFireStub = sandbox.stub(uriMetadataSet, "fire");
-    showErrorNotificationWithButtonsStub = sandbox.stub(
-      notifications,
-      "showErrorNotificationWithButtons",
-    );
   });
 
   afterEach(() => {
@@ -44,7 +44,6 @@ describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
     sinon.assert.notCalled(flinkComputePoolQuickPickStub);
     sinon.assert.notCalled(stubResourceManager.setUriMetadataValue);
     sinon.assert.notCalled(uriMetadataSetFireStub);
-    sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
   });
 
   it("should do nothing when compute pool quickpick is cancelled", async () => {
@@ -57,7 +56,6 @@ describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
     sinon.assert.called(flinkComputePoolQuickPickStub);
     sinon.assert.notCalled(stubResourceManager.setUriMetadataValue);
     sinon.assert.notCalled(uriMetadataSetFireStub);
-    sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
   });
 
   it("should set the compute pool metadata and fire event when compute pool is selected", async () => {
@@ -68,7 +66,6 @@ describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
     await setCCloudComputePoolForUriCommand(testUri);
 
     sinon.assert.calledOnce(flinkComputePoolQuickPickStub);
-    sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
     sinon.assert.calledOnce(stubResourceManager.setUriMetadataValue);
     // all metadata should be derived from the chosen compute pool
     sinon.assert.calledWithExactly(
@@ -77,6 +74,134 @@ describe("commands/documents.ts setCCloudComputePoolForUriCommand()", () => {
       UriMetadataKeys.FLINK_COMPUTE_POOL_ID,
       TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
     );
+    sinon.assert.calledOnce(uriMetadataSetFireStub);
+    sinon.assert.calledOnceWithExactly(uriMetadataSetFireStub, testUri);
+  });
+});
+
+describe("commands/documents.ts setCCloudDatabaseForUriCommand()", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  let stubResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
+  let flinkComputePoolQuickPickStub: sinon.SinonStub;
+  let flinkDatabaseQuickpickStub: sinon.SinonStub;
+  let uriMetadataSetFireStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    stubResourceManager = sandbox.createStubInstance(ResourceManager);
+    sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
+
+    flinkComputePoolQuickPickStub = sandbox.stub(
+      flinkComputePoolsQuickPick,
+      "flinkComputePoolQuickPick",
+    );
+    flinkDatabaseQuickpickStub = sandbox.stub(flinkDatabaseQuickpick, "flinkDatabaseQuickpick");
+    uriMetadataSetFireStub = sandbox.stub(uriMetadataSet, "fire");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should do nothing when no Uri is provided", async () => {
+    // no uri argument passed here:
+    await setCCloudDatabaseForUriCommand();
+
+    sinon.assert.notCalled(flinkComputePoolQuickPickStub);
+    sinon.assert.notCalled(stubResourceManager.setUriMetadataValue);
+    sinon.assert.notCalled(uriMetadataSetFireStub);
+  });
+
+  it("should do nothing when compute pool quickpick is cancelled", async () => {
+    // simulate user cancelling the quick pick
+    flinkComputePoolQuickPickStub.resolves(undefined);
+
+    const testUri = Uri.parse("file:///path/to/test.sql");
+    await setCCloudDatabaseForUriCommand(testUri);
+
+    sinon.assert.called(flinkComputePoolQuickPickStub);
+    sinon.assert.notCalled(stubResourceManager.setUriMetadataValue);
+    sinon.assert.notCalled(uriMetadataSetFireStub);
+  });
+
+  it("should set the database ID metadata and fire event when database is selected", async () => {
+    // simulate user selecting a compute pool and database
+    flinkComputePoolQuickPickStub.resolves(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+    flinkDatabaseQuickpickStub.resolves(TEST_CCLOUD_KAFKA_CLUSTER);
+    const testUri = Uri.parse("file:///path/to/test.sql");
+
+    await setCCloudDatabaseForUriCommand(testUri);
+
+    sinon.assert.calledOnce(flinkComputePoolQuickPickStub);
+    sinon.assert.calledOnce(stubResourceManager.setUriMetadataValue);
+    // all metadata should be derived from the chosen compute pool
+    sinon.assert.calledWithExactly(
+      stubResourceManager.setUriMetadataValue,
+      testUri,
+      UriMetadataKeys.FLINK_DATABASE_ID,
+      TEST_CCLOUD_KAFKA_CLUSTER.id,
+    );
+    sinon.assert.calledOnce(uriMetadataSetFireStub);
+    sinon.assert.calledOnceWithExactly(uriMetadataSetFireStub, testUri);
+  });
+
+  it("should skip the compute pool quickpick when a pool is provided", async () => {
+    // simulate user selecting a database
+    flinkDatabaseQuickpickStub.resolves(TEST_CCLOUD_KAFKA_CLUSTER);
+    const testUri = Uri.parse("file:///path/to/test.sql");
+
+    await setCCloudDatabaseForUriCommand(testUri, TEST_CCLOUD_FLINK_COMPUTE_POOL);
+
+    sinon.assert.notCalled(flinkComputePoolQuickPickStub);
+    sinon.assert.calledOnce(stubResourceManager.setUriMetadataValue);
+    // all metadata should be derived from the chosen compute pool
+    sinon.assert.calledWithExactly(
+      stubResourceManager.setUriMetadataValue,
+      testUri,
+      UriMetadataKeys.FLINK_DATABASE_ID,
+      TEST_CCLOUD_KAFKA_CLUSTER.id,
+    );
+    sinon.assert.calledOnce(uriMetadataSetFireStub);
+    sinon.assert.calledOnceWithExactly(uriMetadataSetFireStub, testUri);
+  });
+});
+
+describe("commands/documents.ts resetCCloudMetadataForUriCommand()", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  let stubResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
+  let uriMetadataSetFireStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    stubResourceManager = sandbox.createStubInstance(ResourceManager);
+    sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
+
+    uriMetadataSetFireStub = sandbox.stub(uriMetadataSet, "fire");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should do nothing when no Uri is provided", async () => {
+    // no uri argument passed here:
+    await resetCCloudMetadataForUriCommand();
+
+    sinon.assert.notCalled(stubResourceManager.deleteUriMetadata);
+    sinon.assert.notCalled(uriMetadataSetFireStub);
+  });
+
+  it("should reset the metadata and fire event when a Uri is provided", async () => {
+    const testUri = Uri.parse("file:///path/to/test.sql");
+
+    await resetCCloudMetadataForUriCommand(testUri);
+
+    sinon.assert.calledOnce(stubResourceManager.deleteUriMetadata);
+    sinon.assert.calledWithExactly(stubResourceManager.deleteUriMetadata, testUri);
     sinon.assert.calledOnce(uriMetadataSetFireStub);
     sinon.assert.calledOnceWithExactly(uriMetadataSetFireStub, testUri);
   });

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -79,6 +79,24 @@ export async function setCCloudDatabaseForUriCommand(uri?: Uri, pool?: CCloudFli
   uriMetadataSet.fire(uri);
 }
 
+export async function resetCCloudMetadataForUriCommand(uri?: Uri) {
+  if (!(uri instanceof Uri)) {
+    return;
+  }
+  if (!hasCCloudAuthSession()) {
+    // shouldn't happen since callers shouldn't be able to call this command without a valid CCloud
+    // connection, but just in case
+    logger.warn("not resetting metadata for URI: no CCloud auth session");
+    return;
+  }
+
+  logger.debug("resetting metadata for URI", {
+    uri: uri.toString(),
+  });
+  await getResourceManager().deleteUriMetadata(uri);
+  uriMetadataSet.fire(uri);
+}
+
 export function registerDocumentCommands(): Disposable[] {
   return [
     registerCommandWithLogging(
@@ -88,6 +106,10 @@ export function registerDocumentCommands(): Disposable[] {
     registerCommandWithLogging(
       "confluent.document.flinksql.setCCloudDatabase",
       setCCloudDatabaseForUriCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.document.flinksql.resetCCloudMetadata",
+      resetCCloudMetadataForUriCommand,
     ),
   ];
 }

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -3,7 +3,7 @@ import { registerCommandWithLogging } from ".";
 import { uriMetadataSet } from "../emitters";
 import { Logger } from "../logging";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
-import { KafkaCluster } from "../models/kafkaCluster";
+import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
 import { flinkComputePoolQuickPick } from "../quickpicks/flinkComputePools";
 import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
@@ -12,7 +12,7 @@ import { getResourceManager } from "../storage/resourceManager";
 
 const logger = new Logger("commands.documents");
 
-export async function setCCloudComputePoolForUriCommand(uri?: Uri) {
+export async function setCCloudComputePoolForUriCommand(uri?: Uri, database?: CCloudKafkaCluster) {
   if (!(uri instanceof Uri)) {
     return;
   }
@@ -23,7 +23,12 @@ export async function setCCloudComputePoolForUriCommand(uri?: Uri) {
     return;
   }
 
-  const pool: CCloudFlinkComputePool | undefined = await flinkComputePoolQuickPick();
+  // if a database is provided, we need to match provider/region when showing the pool quickpick
+  const filter = database
+    ? (pool: CCloudFlinkComputePool) =>
+        pool.provider === database.provider && pool.region === database.region
+    : undefined;
+  const pool: CCloudFlinkComputePool | undefined = await flinkComputePoolQuickPick(filter);
   if (!pool) {
     return;
   }

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -40,17 +40,14 @@ export async function setCCloudComputePoolForUriCommand(uri?: Uri) {
   uriMetadataSet.fire(uri);
 }
 
-export async function setCCloudCatalogDatabaseForUriCommand(
-  uri?: Uri,
-  pool?: CCloudFlinkComputePool,
-) {
+export async function setCCloudDatabaseForUriCommand(uri?: Uri, pool?: CCloudFlinkComputePool) {
   if (!(uri instanceof Uri)) {
     return;
   }
   if (!hasCCloudAuthSession()) {
     // shouldn't happen since callers shouldn't be able to call this command without a valid CCloud
     // connection, but just in case
-    logger.warn("not setting compute pool for URI: no CCloud auth session");
+    logger.warn("not setting database for URI: no CCloud auth session");
     return;
   }
 
@@ -84,8 +81,8 @@ export function registerDocumentCommands(): Disposable[] {
       setCCloudComputePoolForUriCommand,
     ),
     registerCommandWithLogging(
-      "confluent.document.flinksql.setCCloudCatalogDatabase",
-      setCCloudCatalogDatabaseForUriCommand,
+      "confluent.document.flinksql.setCCloudDatabase",
+      setCCloudDatabaseForUriCommand,
     ),
   ];
 }

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -3,7 +3,9 @@ import { registerCommandWithLogging } from ".";
 import { uriMetadataSet } from "../emitters";
 import { Logger } from "../logging";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { KafkaCluster } from "../models/kafkaCluster";
 import { flinkComputePoolQuickPick } from "../quickpicks/flinkComputePools";
+import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { UriMetadataKeys } from "../storage/constants";
 import { getResourceManager } from "../storage/resourceManager";
@@ -38,11 +40,52 @@ export async function setCCloudComputePoolForUriCommand(uri?: Uri) {
   uriMetadataSet.fire(uri);
 }
 
+export async function setCCloudCatalogDatabaseForUriCommand(
+  uri?: Uri,
+  pool?: CCloudFlinkComputePool,
+) {
+  if (!(uri instanceof Uri)) {
+    return;
+  }
+  if (!hasCCloudAuthSession()) {
+    // shouldn't happen since callers shouldn't be able to call this command without a valid CCloud
+    // connection, but just in case
+    logger.warn("not setting compute pool for URI: no CCloud auth session");
+    return;
+  }
+
+  const computePool: CCloudFlinkComputePool | undefined =
+    pool instanceof CCloudFlinkComputePool ? pool : await flinkComputePoolQuickPick();
+  if (!computePool) {
+    return;
+  }
+
+  const database: KafkaCluster | undefined = await flinkDatabaseQuickpick(computePool);
+  if (!database) {
+    return;
+  }
+
+  logger.debug("setting metadata for URI", {
+    uri: uri.toString(),
+    [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
+  });
+  await getResourceManager().setUriMetadataValue(
+    uri,
+    UriMetadataKeys.FLINK_DATABASE_ID,
+    database.id,
+  );
+  uriMetadataSet.fire(uri);
+}
+
 export function registerDocumentCommands(): Disposable[] {
   return [
     registerCommandWithLogging(
       "confluent.document.flinksql.setCCloudComputePool",
       setCCloudComputePoolForUriCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.document.flinksql.setCCloudCatalogDatabase",
+      setCCloudCatalogDatabaseForUriCommand,
     ),
   ];
 }

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -9,7 +9,7 @@ import { extractResponseBody, isResponseError, logError } from "../errors";
 import { Logger } from "../logging";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { FAILED_PHASE, FlinkStatement, restFlinkStatementToModel } from "../models/flinkStatement";
-import { KafkaCluster } from "../models/kafkaCluster";
+import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
 import { showErrorNotificationWithButtons } from "../notifications";
 import { flinkComputePoolQuickPick } from "../quickpicks/flinkComputePools";
 import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
@@ -136,8 +136,8 @@ export async function viewStatementSqlCommand(statement: FlinkStatement): Promis
  *     preferring the current foreground editor
  *  2) Create **statement name** (auto-generated from template pattern, but user can override)
  *  3) (If no `pool` is passed): show a quickpick to **choose a Flink compute pool** to send the statement
- *  4) Show a quickpick to **choose a database** (Kafka cluster) to submit along with the
- *     **catalog name** (the environment, inferable from the chosen database).
+ *  4) (if no `database` is passed): show a quickpick to **choose a database** (Kafka cluster) to
+ *     submit along with the **catalog name** (the environment, inferable from the chosen database).
  *  5) Submit!
  *  6) Show error notification for any submission errors.
  *  7) Refresh the statements view if the view is focused on the chosen compute pool.
@@ -146,6 +146,7 @@ export async function viewStatementSqlCommand(statement: FlinkStatement): Promis
 export async function submitFlinkStatementCommand(
   uri?: vscode.Uri,
   pool?: CCloudFlinkComputePool,
+  database?: CCloudKafkaCluster,
 ): Promise<void> {
   const funcLogger = logger.withCallpoint("submitFlinkStatementCommand");
 
@@ -155,10 +156,10 @@ export async function submitFlinkStatementCommand(
   const fileFilters = {
     "FlinkSQL files": [".flinksql", ".sql"],
   };
-  const statementBodyUri: vscode.Uri | undefined =
-    uri instanceof vscode.Uri && uriSchemes.includes(uri.scheme)
-      ? uri
-      : await uriQuickpick(uriSchemes, languageIds, fileFilters);
+  const validUriProvided: boolean = uri instanceof vscode.Uri && uriSchemes.includes(uri.scheme);
+  const statementBodyUri: vscode.Uri | undefined = validUriProvided
+    ? uri
+    : await uriQuickpick(uriSchemes, languageIds, fileFilters);
   if (!statementBodyUri) {
     funcLogger.debug("User canceled the URI quickpick");
     return;
@@ -180,8 +181,13 @@ export async function submitFlinkStatementCommand(
 
   // 4. Choose the current / default database for the expression to be evaluated against.
   // (a kafka cluster in the same provider/region as the compute pool)
-  const currentDatabaseKafkaCluster: KafkaCluster | undefined =
-    await flinkDatabaseQuickpick(computePool);
+  const validDatabaseProvided: boolean =
+    database instanceof CCloudKafkaCluster &&
+    database.provider === computePool.provider &&
+    database.region === computePool.region;
+  const currentDatabaseKafkaCluster: KafkaCluster | undefined = validDatabaseProvided
+    ? database
+    : await flinkDatabaseQuickpick(computePool);
   if (!currentDatabaseKafkaCluster) {
     funcLogger.debug("User canceled the default database quickpick");
     return;

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -201,7 +201,7 @@ export async function submitFlinkStatementCommand(
     computePool,
     properties: new FlinkSpecProperties({
       currentDatabase,
-      currentCatalog: computePool.environmentId,
+      currentCatalog: currentDatabaseKafkaCluster.environmentId,
       localTimezone: localTimezoneOffset(),
     }),
   };

--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -40,7 +40,9 @@ export async function flinkComputePoolQuickPickWithViewProgress(
  * ---------------------------------- Confluent Cloud: env2
  * ccloud-pool3 (lfcp-id3)
  */
-export async function flinkComputePoolQuickPick(): Promise<CCloudFlinkComputePool | undefined> {
+export async function flinkComputePoolQuickPick(
+  filterPredicate?: (pool: CCloudFlinkComputePool) => boolean,
+): Promise<CCloudFlinkComputePool | undefined> {
   const loader = CCloudResourceLoader.getInstance();
   const environments: Environment[] = await loader.getEnvironments();
   const computePools: CCloudFlinkComputePool[] = [];
@@ -106,6 +108,9 @@ export async function flinkComputePoolQuickPick(): Promise<CCloudFlinkComputePoo
 
   let lastSeparator: string = "";
   for (const pool of computePools) {
+    if (filterPredicate && !filterPredicate(pool)) {
+      continue;
+    }
     const environment: Environment | undefined = environments.find(
       (env) => env.id === pool.environmentId,
     );

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -34,6 +34,7 @@ export enum WorkspaceStorageKeys {
 /** Keys for use within UriMetadata records */
 export enum UriMetadataKeys {
   FLINK_COMPUTE_POOL_ID = "flinkComputePoolId",
+  FLINK_DATABASE_ID = "flinkDatabaseId",
 }
 
 export enum SecretStorageKeys {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to https://github.com/confluentinc/vscode/pull/1595 to allow setting the database (Kafka cluster with the same cloud provider+region as the chosen Flink compute pool) from a codelens in a `flinksql` document:

<img width="544" alt="image" src="https://github.com/user-attachments/assets/b65f6556-c629-4c85-b877-e74cb9336fe8" />

Closes #1644.

> [!NOTE]  
> Similar to #1595, this is mainly for generic functionality and smaller copy/UI branches will be done as follow-up work to this, which may include consolidating some of the codelenses and improving the overall flow.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Since we handle some "make sure the compute pool and catalog+db match CCloud provider+region" logic here, we ended up in a situation where:
- if you set the compute pool first (via unfiltered quickpick), which then filters the catalog+db quickpick based on the pool's cloud provider/region
- if you set the catalog+db first (via unfiltered quickpick), which then filters the compute pool quickpick based on the catalog+db cloud provider/region

Setting both would lock in the filtering for each, so we needed a way to clear it out:
<img width="655" alt="image" src="https://github.com/user-attachments/assets/970e315e-cba9-4552-9b8a-d4f2e125a381" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
