### PR TITLE
MINOR: use CCloud authentication session's `label` (email) instead of `id`

### DIFF
--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -1,12 +1,12 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
+import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../constants";
 import * as quickpicks from "../quickpicks/flinkComputePools";
 import * as kafkaQuickpicks from "../quickpicks/kafkaClusters";
 import * as commandsModule from "./flinkComputePools";
-import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../constants";
 
-describe.only("configureFlinkDefaults command", () => {
+describe("configureFlinkDefaults command", () => {
   let sandbox: sinon.SinonSandbox;
   let flinkComputePoolQuickPickStub: sinon.SinonStub;
   let flinkDatabaseQuickpickStub: sinon.SinonStub;

--- a/src/commands/utils/flinkStatements.test.ts
+++ b/src/commands/utils/flinkStatements.test.ts
@@ -57,14 +57,16 @@ describe("determineFlinkStatementName()", function () {
 
   it("Should return a unique name for a Flink statement", async function () {
     // will be lowercased, reduced to 'joe'
-    getCCloudAuthSessionStub.resolves({ account: { id: "Joe+spam@confluent.io" } });
+    getCCloudAuthSessionStub.resolves({
+      account: { label: "Joe+spam@confluent.io", id: "u-abc123" },
+    });
 
     const statementName = await determineFlinkStatementName();
     assert.strictEqual(statementName, `joe-vscode-${expectedDatePart}`);
   });
 
   it("Works with degenerate ccloud username", async function () {
-    getCCloudAuthSessionStub.resolves({ account: { id: "simple" } });
+    getCCloudAuthSessionStub.resolves({ account: { label: "simple", id: "u-abc123" } });
 
     const statementName = await determineFlinkStatementName();
     assert.strictEqual(statementName, `simple-vscode-${expectedDatePart}`);

--- a/src/commands/utils/flinkStatements.ts
+++ b/src/commands/utils/flinkStatements.ts
@@ -76,7 +76,7 @@ export async function determineFlinkStatementName(): Promise<string> {
 
   // If we're creating flink statements, then we're ccloud authed. Use their
   // ccloud account name as primary part of the statement name.
-  const ccloudAccountName = (await getCCloudAuthSession())?.account.id;
+  const ccloudAccountName = (await getCCloudAuthSession())?.account.label;
   if (ccloudAccountName) {
     let userNamePart = ccloudAccountName.split("@")[0];
     // strip anything to the right of any '+' character if present, don't want their


### PR DESCRIPTION
Before:
<img width="389" alt="image" src="https://github.com/user-attachments/assets/48e3542f-44f6-4ef6-8d92-fa6c14703373" />

After:
<img width="389" alt="image" src="https://github.com/user-attachments/assets/072ac70e-2db8-4e13-9c84-c59a6442e8ae" />
