### PR TITLE
fix(test): swap stub for flaky test on Windows agent

### DIFF
--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -151,22 +151,23 @@ describe("ResourceViewProvider loading functions", () => {
   it("loadCCloudResources() should load CCloud resources under the Confluent Cloud container tree item when connected to CCloud", async () => {
     sandbox.stub(ccloudConnections, "hasCCloudAuthSession").returns(true);
     sandbox.stub(org, "getCurrentOrganization").resolves(TEST_CCLOUD_ORGANIZATION);
-    sandbox
+    const envStub = sandbox
       .stub(resourceManager.getResourceManager(), "getCCloudEnvironments")
       .resolves([TEST_CCLOUD_ENVIRONMENT]);
 
     const result: ContainerTreeItem<CCloudEnvironment> = await loadCCloudResources();
 
+    sinon.assert.calledOnce(envStub);
     assert.ok(result instanceof ContainerTreeItem);
     assert.equal(result.label, ConnectionLabel.CCLOUD);
     assert.equal(result.id, `ccloud-connected-${EXTENSION_VERSION}`);
+    assert.deepStrictEqual(result.children, [TEST_CCLOUD_ENVIRONMENT]);
     assert.equal(
       result.collapsibleState,
       TreeItemCollapsibleState.Expanded,
       `Tree item should be expanded, but was ${result.collapsibleState === TreeItemCollapsibleState.Collapsed ? "collapsed" : "none"}:\n\n${JSON.stringify(result, null, 2)}`,
     );
     assert.equal(result.description, TEST_CCLOUD_ORGANIZATION.name);
-    assert.deepStrictEqual(result.children, [TEST_CCLOUD_ENVIRONMENT]);
   });
 
   it("loadCCloudResources() should return a CCloud placeholder item when not connected", async () => {

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -160,7 +160,11 @@ describe("ResourceViewProvider loading functions", () => {
     assert.ok(result instanceof ContainerTreeItem);
     assert.equal(result.label, ConnectionLabel.CCLOUD);
     assert.equal(result.id, `ccloud-connected-${EXTENSION_VERSION}`);
-    assert.equal(result.collapsibleState, TreeItemCollapsibleState.Expanded);
+    assert.equal(
+      result.collapsibleState,
+      TreeItemCollapsibleState.Expanded,
+      `Tree item should be expanded, but was ${result.collapsibleState === TreeItemCollapsibleState.Collapsed ? "collapsed" : "none"}:\n\n${JSON.stringify(result, null, 2)}`,
+    );
     assert.equal(result.description, TEST_CCLOUD_ORGANIZATION.name);
     assert.deepStrictEqual(result.children, [TEST_CCLOUD_ENVIRONMENT]);
   });

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -152,7 +152,7 @@ describe("ResourceViewProvider loading functions", () => {
     sandbox.stub(ccloudConnections, "hasCCloudAuthSession").returns(true);
     sandbox.stub(org, "getCurrentOrganization").resolves(TEST_CCLOUD_ORGANIZATION);
     const envStub = sandbox
-      .stub(resourceManager.getResourceManager(), "getCCloudEnvironments")
+      .stub(CCloudResourceLoader.getInstance(), "getEnvironments")
       .resolves([TEST_CCLOUD_ENVIRONMENT]);
 
     const result: ContainerTreeItem<CCloudEnvironment> = await loadCCloudResources();


### PR DESCRIPTION
Closes #1655:
![image](https://github.com/user-attachments/assets/10451827-3980-4fb7-970e-7e92d36dce5e)

The main problem was:
- the test would fail, claiming the tree item had the wrong collapsible state (`0=none`,`2=expanded`)
- the test didn't fail on the `id` assertion, even though `id` is set after the collapsible state: https://github.com/confluentinc/vscode/blob/7d9d11a654838f3e3eccc60f985992405729c534/src/viewProviders/resources.ts#L587-L596
- this means something about the stubbing was not behaving correctly in the Windows environment, suggesting the `ResourceManager.getCCloudEnvironments()` method wasn't being called
- [`CCloudResourceLoader.getEnvironments()` is called](https://github.com/confluentinc/vscode/blob/7d9d11a654838f3e3eccc60f985992405729c534/src/viewProviders/resources.ts#L574) more closely to all the logic with these tree views, even though the loader's `getEnvironments()` calls into ResourceManager's `getCCloudEnvironments()`: https://github.com/confluentinc/vscode/blob/7d9d11a654838f3e3eccc60f985992405729c534/src/loaders/ccloudResourceLoader.ts#L190-L193


