### PR TITLE
Statement results viewer - dynamic column sizes

### DIFF
--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -116,62 +116,53 @@
 
       <template data-if="this.hasResults()">
         <div class="grid-container">
-            <!-- Settings control positioned outside the grid -->
-            <div
-              class="grid-cell grid-column-header cell-text-overflow grid-settings-control settings-control"
-              popovertarget="columnSettings"
-              data-on-click="window.columnSettings.togglePopover()"
-              data-position="bottom-end"
-              tabindex="-1"
-            >
-              <span class="codicon codicon-gear"></span>
-            </div>
+          <!-- Settings control positioned outside the grid -->
+          <div class="grid-cell grid-column-header cell-text-overflow grid-settings-control"
+            popovertarget="columnSettings" data-on-click="window.columnSettings.togglePopover()"
+            data-position="bottom-end" tabindex="-1">
+            <span class="codicon codicon-gear"></span>
+          </div>
 
-            <table
-              class="grid"
-              cellpadding="0"
-cellspacing="0"
-data-prop-style="this.gridTemplateColumns()"
->
-          <thead class="sticky-table-header">
-            <tr class="grid-row">
-              <template data-for="column of this.visibleColumns() by column">
-                <th class="grid-cell grid-column-header cell-text-overflow" tabindex="-1">
-                  <span data-text="this.columns()[this.column()].title()"></span>
-                  <div class="resize-handler"
-                    data-on-pointerdown="this.handleStartResize(event, this.columns()[this.column()].index)"
-                    data-on-pointermove="this.handleMoveResize(event, this.columns()[this.column()].index)"
-                    data-on-pointerup="this.handleStopResize(event)"></div>
-                </th>
-              </template>
-            </tr>
-          </thead>
-
-          <section popover id="columnSettings" class="column-control">
-            <div class="flex-column" style="--gap: 0">
-              <label>Columns</label>
-              <template data-for="column of this.allColumns() by column">
-                <label class="checkbox">
-                  <input type="checkbox" data-prop-checked="this.isColumnVisible(this.columns()[this.column()].index)"
-                    data-on-change="event.preventDefault(); this.toggleColumnVisibility(this.columns()[this.column()].index)" />
-                  <span data-text="this.columns()[this.column()].title()"></span>
-                </label>
-              </template>
-            </div>
-          </section>
-
-          <tbody>
-            <template data-for="result of this.snapshot().results">
-              <tr class="grid-row" data-on-dblclick="this.previewResult(this.result())">
+          <table class="grid" cellpadding="0" cellspacing="0" data-prop-style="this.gridTemplateColumns()">
+            <thead class="sticky-table-header">
+              <tr class="grid-row">
                 <template data-for="column of this.visibleColumns() by column">
-                  <td class="grid-cell cell-text-overflow" tabindex="-1"
-                    data-children="((this.columns())[this.column()]).children(this.result())"
-                    data-prop-title="((this.columns())[this.column()]).title()"></td>
+                  <th class="grid-cell grid-column-header cell-text-overflow" tabindex="-1">
+                    <span data-text="this.columns()[this.column()].title()"></span>
+                    <div class="resize-handler"
+                      data-on-pointerdown="this.handleStartResize(event, this.columns()[this.column()].index)"
+                      data-on-pointermove="this.handleMoveResize(event, this.columns()[this.column()].index)"
+                      data-on-pointerup="this.handleStopResize(event)"></div>
+                  </th>
                 </template>
               </tr>
-            </template>
-          </tbody>
-        </table>
+            </thead>
+
+            <section popover id="columnSettings" class="column-control">
+              <div class="flex-column" style="--gap: 0">
+                <label>Columns</label>
+                <template data-for="column of this.allColumns() by column">
+                  <label class="checkbox">
+                    <input type="checkbox" data-prop-checked="this.isColumnVisible(this.columns()[this.column()].index)"
+                      data-on-change="event.preventDefault(); this.toggleColumnVisibility(this.columns()[this.column()].index)" />
+                    <span data-text="this.columns()[this.column()].title()"></span>
+                  </label>
+                </template>
+              </div>
+            </section>
+
+            <tbody>
+              <template data-for="result of this.snapshot().results">
+                <tr class="grid-row" data-on-dblclick="this.previewResult(this.result())">
+                  <template data-for="column of this.visibleColumns() by column">
+                    <td class="grid-cell cell-text-overflow" tabindex="-1"
+                      data-children="((this.columns())[this.column()]).children(this.result())"
+                      data-prop-title="((this.columns())[this.column()]).title()"></td>
+                  </template>
+                </tr>
+              </template>
+            </tbody>
+          </table>
       </template>
     </section>
 
@@ -369,24 +360,27 @@ data-prop-style="this.gridTemplateColumns()"
       font-size: 28px;
       color: var(--vscode-progressBar-background);
     }
-.grid-container {
-        position: relative;
-      }
-      .grid {
-        padding-left: 26px; /* padding for the settings control width */
-      }
+
+    .grid-container {
+      position: relative;
+    }
+
+    .grid {
+      padding-left: 26px;
+      /* padding for the settings control width */
+    }
 
     .grid-settings-control {
       position: absolute;
-        top: 0;
-        left: 0;
-        width: 26px;
-        height: 26px;
-        display: flex;
-        align-items: center;
+      top: 0;
+      left: 0;
+      width: 26px;
+      height: 26px;
+      display: flex;
+      align-items: center;
       justify-content: center;
       cursor: pointer;
-z-index: 2;
+      z-index: 2;
     }
 
     .grid-settings-control:hover {

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -115,7 +115,24 @@
       </template>
 
       <template data-if="this.hasResults()">
-        <table class="grid" cellpadding="0" cellspacing="0" data-prop-style="this.gridTemplateColumns()">
+        <div class="grid-container">
+            <!-- Settings control positioned outside the grid -->
+            <div
+              class="grid-cell grid-column-header cell-text-overflow grid-settings-control settings-control"
+              popovertarget="columnSettings"
+              data-on-click="window.columnSettings.togglePopover()"
+              data-position="bottom-end"
+              tabindex="-1"
+            >
+              <span class="codicon codicon-gear"></span>
+            </div>
+
+            <table
+              class="grid"
+              cellpadding="0"
+cellspacing="0"
+data-prop-style="this.gridTemplateColumns()"
+>
           <thead class="sticky-table-header">
             <tr class="grid-row">
               <template data-for="column of this.visibleColumns() by column">
@@ -127,12 +144,6 @@
                     data-on-pointerup="this.handleStopResize(event)"></div>
                 </th>
               </template>
-
-              <th class="grid-cell grid-column-header cell-text-overflow grid-settings-control"
-                popovertarget="columnSettings" data-on-click="window.columnSettings.togglePopover()"
-                data-position="bottom-end" tabindex="-1">
-                <span class="codicon codicon-gear"></span>
-              </th>
             </tr>
           </thead>
 
@@ -358,12 +369,24 @@
       font-size: 28px;
       color: var(--vscode-progressBar-background);
     }
+.grid-container {
+        position: relative;
+      }
+      .grid {
+        padding-left: 26px; /* padding for the settings control width */
+      }
 
     .grid-settings-control {
-      grid-column: -1;
-      grid-row: 1;
-      justify-self: end;
+      position: absolute;
+        top: 0;
+        left: 0;
+        width: 26px;
+        height: 26px;
+        display: flex;
+        align-items: center;
+      justify-content: center;
       cursor: pointer;
+z-index: 2;
     }
 
     .grid-settings-control:hover {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Update column width code to allow for dynamic number of columns
- Move the settings gear to the left of table & adjust stuff so it fits there

## Any additional details or context that should be provided?
- You should be able to resize and show/hide columns 
- It's a little jumpy while the results are streaming in & updating the `DOM`; works better when Paused

### Resize
https://github.com/user-attachments/assets/3df8f773-0909-411a-86e7-92899dab88aa

### Show/Hide

https://github.com/user-attachments/assets/61bbf6a7-cf7f-4142-a94e-830a619a3c02

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
