### PR TITLE
store Flink statement compute pool ID and database on document load

### DIFF
--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -87,7 +87,11 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
       uriMetadata,
       envs,
     );
-    const { catalog, database } = await getCatalogDatabaseFromMetadata(uriMetadata, envs);
+    const { catalog, database } = await getCatalogDatabaseFromMetadata(
+      uriMetadata,
+      envs,
+      computePool,
+    );
 
     // codelens for selecting a compute pool, which we'll use to derive the rest of the properties
     // needed for various Flink operations (env ID, provider/region, etc)
@@ -219,20 +223,20 @@ export async function getCatalogDatabaseFromMetadata(
   }
 
   const catalog: CCloudEnvironment | undefined = envs.find((e) =>
-    e.kafkaClusters.some((k) => k.id === databaseId),
+    e.kafkaClusters.some((k) => k.id === databaseId || k.name === databaseId),
   );
   if (!catalog) {
     // no need to clear it since we'll show "Set Catalog & Database" codelens
-    logger.warn("catalog not found from stored database ID");
+    logger.warn("catalog not found from stored database ID/name", { database: databaseId });
     return catalogDatabase;
   }
 
   const cluster: CCloudKafkaCluster | undefined = catalog.kafkaClusters.find(
-    (k) => k.id === databaseId,
+    (k) => k.id === databaseId || k.name === databaseId,
   );
   if (!cluster) {
     // shouldn't happen since we just looked it up in order to get the catalog
-    logger.warn("database not found from stored database ID");
+    logger.warn("database not found from stored database ID/name", { database: databaseId });
     return catalogDatabase;
   }
 

--- a/src/commands/flinkStatement.test.ts
+++ b/src/commands/flinkStatement.test.ts
@@ -2,19 +2,24 @@ import assert from "assert";
 import sinon from "sinon";
 import * as vscode from "vscode";
 
+import { TextDocument } from "vscode-json-languageservice";
 import { createFlinkStatement } from "../../tests/unit/testResources/flinkStatement";
 import { FlinkStatementDocumentProvider } from "../documentProviders/flinkStatement";
 import { FlinkStatement } from "../models/flinkStatement";
+import { UriMetadataKeys } from "../storage/constants";
+import { ResourceManager } from "../storage/resourceManager";
 import { viewStatementSqlCommand } from "./flinkStatements";
 
-describe("viewStatementSqlCommand", () => {
+describe("commands/flinkStatements.ts viewStatementSqlCommand", () => {
   let sandbox: sinon.SinonSandbox;
 
   let showTextDocumentStub: sinon.SinonStub;
+  let setUriMetadataStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     showTextDocumentStub = sandbox.stub(vscode.window, "showTextDocument");
+    setUriMetadataStub = sandbox.stub(ResourceManager.getInstance(), "setUriMetadata");
   });
 
   afterEach(() => {
@@ -39,8 +44,27 @@ describe("viewStatementSqlCommand", () => {
 
     await viewStatementSqlCommand(statement);
 
-    assert.strictEqual(showTextDocumentStub.callCount, 1);
-    assert.strictEqual(showTextDocumentStub.firstCall.args[0].uri.toString(), uri.toString());
-    assert.strictEqual(showTextDocumentStub.firstCall.args[1].preview, false);
+    sinon.assert.calledOnce(showTextDocumentStub);
+    const document: TextDocument = showTextDocumentStub.firstCall.args[0];
+    assert.strictEqual(document.uri.toString(), uri.toString());
+    sinon.assert.calledWithExactly(showTextDocumentStub, document, { preview: false });
+  });
+
+  it("should set Uri metadata before opening the document", async () => {
+    const statement = createFlinkStatement({
+      sqlStatement: "SELECT * FROM my_test_flink_statement_table",
+    });
+    const uri = FlinkStatementDocumentProvider.getStatementDocumentUri(statement);
+
+    await viewStatementSqlCommand(statement);
+
+    sinon.assert.calledOnce(setUriMetadataStub);
+    const callArgs = setUriMetadataStub.firstCall.args;
+    assert.strictEqual(callArgs.length, 2);
+    assert.strictEqual(callArgs[0].toString(), uri.toString());
+    assert.deepStrictEqual(callArgs[1], {
+      [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: statement.computePoolId,
+      [UriMetadataKeys.FLINK_DATABASE_ID]: statement.database,
+    });
   });
 });

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -15,6 +15,8 @@ import { flinkComputePoolQuickPick } from "../quickpicks/flinkComputePools";
 import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
 import { uriQuickpick } from "../quickpicks/uris";
 import { getSidecar } from "../sidecar";
+import { UriMetadataKeys } from "../storage/constants";
+import { ResourceManager } from "../storage/resourceManager";
 import { UserEvent, logUsage } from "../telemetry/events";
 import { getEditorOrFileContents } from "../utils/file";
 import { selectPoolForStatementsViewCommand } from "./flinkComputePools";
@@ -123,6 +125,14 @@ export async function viewStatementSqlCommand(statement: FlinkStatement): Promis
   }
 
   const uri = FlinkStatementDocumentProvider.getStatementDocumentUri(statement);
+
+  // make sure any relevant metadata for the Uri is set
+  const rm = ResourceManager.getInstance();
+  await rm.setUriMetadata(uri, {
+    [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: statement.computePoolId,
+    [UriMetadataKeys.FLINK_DATABASE_ID]: statement.database,
+  });
+
   const doc = await vscode.workspace.openTextDocument(uri);
   vscode.languages.setTextDocumentLanguage(doc, "flinksql");
   await vscode.window.showTextDocument(doc, { preview: false });

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -130,6 +130,16 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
       [RUNNING_PHASE, COMPLETED_PHASE].includes(this.phase)
     );
   }
+
+  /** @see https://docs.confluent.io/cloud/current/api.html#tag/Statements-(sqlv1)/The-Statements-Model */
+  get catalog(): string | undefined {
+    return this.spec.properties?.["sql.current-catalog"];
+  }
+
+  /** @see https://docs.confluent.io/cloud/current/api.html#tag/Statements-(sqlv1)/The-Statements-Model */
+  get database(): string | undefined {
+    return this.spec.properties?.["sql.current-database"];
+  }
 }
 
 /** Model for the interesting bits of the `metadata` subfield of Flink statement. */

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -756,7 +756,12 @@ export class ResourceManager {
     });
   }
 
-  /** Set the metadata for a specific {@link Uri}. */
+  /**
+   * Set the metadata for a specific {@link Uri}.
+   *
+   * This will merge with any existing metadata, overwriting any preexisting keys with (new) values
+   * provided in `metadata`.
+   */
   async setUriMetadata(uri: Uri, metadata: UriMetadata): Promise<void> {
     const key = WorkspaceStorageKeys.URI_METADATA;
     await this.runWithMutex(key, async () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR adds a step before opening any `flinksql` document from the Flink Statements view to ensure its associated compute pool ID and database property as stored in extension state. This allows the codelens provider to pre-populate the last values used and helps the user skip the quickpicks and easily resubmit (or change something and then resubmit without having to start from scratch):


https://github.com/user-attachments/assets/c6d13667-c75a-4828-88a4-df59c167e36b


Closes #1661.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

This also loosens up our catalog/database matching since CCloud may store the names of resources instead of the ids:
https://github.com/confluentinc/vscode/blob/bf354e9ba6f8bfb1cf702316a601898147eada9a/src/codelens/flinkSqlProvider.ts#L216-L218
https://github.com/confluentinc/vscode/blob/bf354e9ba6f8bfb1cf702316a601898147eada9a/src/codelens/flinkSqlProvider.ts#L225-L227

https://docs.confluent.io/cloud/current/api.html#tag/Statements-(sqlv1)/The-Statements-Model:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/0173e145-f18b-4424-bf2e-1059795b4a0c" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
