### PR TITLE
[v1.2.x] fix: `No current organization found`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this extension will be documented in this file.
 
 - If the route call fails while fetching Schema Registry subject names while populating the topics
   view, show a warning but continue on with no schema associations for the topics.
+- Selecting resources from a quickpick should no longer throw a "No current organization found"
+  error when the user is not logged into Confluent Cloud.
 
 ## 1.2.0
 

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -1,7 +1,9 @@
 import assert from "assert";
 import * as sinon from "sinon";
 
+import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { TEST_CCLOUD_ORGANIZATION } from "../../tests/unit/testResources/organization";
 import {
   SqlV1StatementList,
   SqlV1StatementListApiVersionEnum,
@@ -11,7 +13,10 @@ import {
   SqlV1StatementListKindEnum,
   StatementsSqlV1Api,
 } from "../clients/flinkSql";
+import * as graphqlEnvs from "../graphql/environments";
+import * as graphqlOrgs from "../graphql/organizations";
 import * as sidecar from "../sidecar";
+import { ResourceManager } from "../storage/resourceManager";
 import { CCloudResourceLoader } from "./ccloudResourceLoader";
 
 describe("CCloudResourceLoader", () => {
@@ -173,4 +178,64 @@ describe("CCloudResourceLoader", () => {
       };
     }
   }); // getFlinkStatements
+
+  describe("doLoadCoarseResources", () => {
+    let resourceLoader: CCloudResourceLoader;
+
+    let sandbox: sinon.SinonSandbox;
+    let stubbedResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
+    let getEnvironmentsStub: sinon.SinonStub;
+    let getCurrentOrganizationStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+
+      resourceLoader = CCloudResourceLoader.getInstance();
+      stubbedResourceManager = sandbox.createStubInstance(ResourceManager);
+      sandbox.stub(ResourceManager, "getInstance").returns(stubbedResourceManager);
+
+      getEnvironmentsStub = sandbox.stub(graphqlEnvs, "getEnvironments");
+      getCurrentOrganizationStub = sandbox.stub(graphqlOrgs, "getCurrentOrganization");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should not throw any errors when no CCloud org is available", async () => {
+      getEnvironmentsStub.resolves([]);
+      getCurrentOrganizationStub.resolves(undefined);
+
+      await resourceLoader["doLoadCoarseResources"]();
+
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      sinon.assert.calledOnce(getCurrentOrganizationStub);
+      assert.strictEqual(resourceLoader["organizationId"], null);
+      sinon.assert.calledOnceWithExactly(stubbedResourceManager.setCCloudEnvironments, []);
+      sinon.assert.calledOnceWithExactly(stubbedResourceManager.setCCloudKafkaClusters, []);
+      sinon.assert.calledOnceWithExactly(stubbedResourceManager.setCCloudSchemaRegistries, []);
+    });
+
+    it("should set CCloud resources when available", async () => {
+      getEnvironmentsStub.resolves([TEST_CCLOUD_ENVIRONMENT]);
+      getCurrentOrganizationStub.resolves(TEST_CCLOUD_ORGANIZATION);
+
+      await resourceLoader["doLoadCoarseResources"]();
+
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      sinon.assert.calledOnce(getCurrentOrganizationStub);
+      assert.strictEqual(resourceLoader["organizationId"], TEST_CCLOUD_ORGANIZATION.id);
+      sinon.assert.calledOnceWithExactly(stubbedResourceManager.setCCloudEnvironments, [
+        TEST_CCLOUD_ENVIRONMENT,
+      ]);
+      sinon.assert.calledOnceWithExactly(
+        stubbedResourceManager.setCCloudKafkaClusters,
+        TEST_CCLOUD_ENVIRONMENT.kafkaClusters, // empty array by default
+      );
+      sinon.assert.calledOnceWithExactly(
+        stubbedResourceManager.setCCloudSchemaRegistries,
+        TEST_CCLOUD_ENVIRONMENT.schemaRegistry ? [TEST_CCLOUD_ENVIRONMENT.schemaRegistry] : [],
+      );
+    });
+  });
 }); // CCloudResourceLoader

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -283,7 +283,7 @@ export class CCloudResourceLoader extends ResourceLoader {
    *
    * @returns The current organization ID.
    */
-  public async getOrganizationId(): Promise<string> {
+  public async getOrganizationId(): Promise<string | undefined> {
     if (this.organizationId) {
       return this.organizationId;
     }
@@ -294,7 +294,6 @@ export class CCloudResourceLoader extends ResourceLoader {
       return this.organizationId;
     }
     logger.error("getOrganizationId(): No current organization found.");
-    throw new Error("No current organization found.");
   }
 
   /**
@@ -305,7 +304,11 @@ export class CCloudResourceLoader extends ResourceLoader {
   public async determineFlinkQueryables(
     resource: CCloudEnvironment | CCloudFlinkComputePool,
   ): Promise<IFlinkQueryable[]> {
-    const orgId = await this.getOrganizationId();
+    const orgId: string | undefined = await this.getOrganizationId();
+    if (!orgId) {
+      return [];
+    }
+
     if (resource instanceof CCloudFlinkComputePool) {
       // If we have a single compute pool, just reexpress it.
       return [


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We recently started seeing `No current organization found` errors that mainly came from trying to load CCloud resources from quickpicks (like the Kafka cluster quickpick) when the user wasn't signed in to CCloud:
![image](https://github.com/user-attachments/assets/3971d941-4b6f-4a7a-9662-a74378ec37ec)

This PR removes the error-throwing and instead skips returning any (mainly Flink) resources if we get the CCloud org.

New tests with previous behavior:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/b9a425be-fd77-4a8e-b338-3d3d36b84617" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
