### PR TITLE
MINOR cleanup: remove "Generate Project from Resource" from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -977,6 +977,10 @@
         {
           "command": "confluent.document.flinksql.resetCCloudMetadata",
           "when": "false"
+        },
+        {
+          "command": "confluent.resources.scaffold",
+          "when": "false"
         }
       ],
       "editor/title": [


### PR DESCRIPTION
Doesn't do anything when invoked since we fall through the `if`/`else` conditions and never end up calling `scaffoldProjectRequest()`: https://github.com/confluentinc/vscode/blob/13fe55f3eec273e01262432b43175c0a6804e6c1/src/scaffold.ts#L56-L92

Still appears on resources as expected:
<img width="370" alt="image" src="https://github.com/user-attachments/assets/5b1e2a4a-93e6-4550-8194-ee70384a6605" />
