### PR TITLE
FlinkStatement.update(other)

### DIFF
--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -25,13 +25,13 @@ const ONE_DAY_MILLIS = 24 * 60 * 60 * 1000;
  */
 export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   // Immutable foreign reference properties
-  connectionId!: ConnectionId;
-  connectionType!: ConnectionType;
-  environmentId!: EnvironmentId;
-  organizationId!: OrganizationId;
+  readonly connectionId!: ConnectionId;
+  readonly connectionType!: ConnectionType;
+  readonly environmentId!: EnvironmentId;
+  readonly organizationId!: OrganizationId;
 
   // Immutable name
-  name: string;
+  readonly name: string;
 
   // Mutable properties
   metadata: SqlV1StatementMetadata | undefined;

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -24,12 +24,16 @@ const ONE_DAY_MILLIS = 24 * 60 * 60 * 1000;
  * Model for a Flink statement.
  */
 export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
+  // Immutable foreign reference properties
   connectionId!: ConnectionId;
   connectionType!: ConnectionType;
   environmentId!: EnvironmentId;
   organizationId!: OrganizationId;
 
+  // Immutable name
   name: string;
+
+  // Mutable properties
   metadata: SqlV1StatementMetadata | undefined;
   status: SqlV1StatementStatus;
   spec: SqlV1StatementSpec;
@@ -109,6 +113,27 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable {
   /** All statements but background statements can have results */
   get canHaveResults(): boolean {
     return !this.isBackground;
+  }
+
+  /**
+   * Update this FlinkStatement with metadata, status, spec from another FlinkStatement.
+   *
+   * (Needed because statements within the view controller must be retained by reference,
+   *  but statements mutate over time.)
+   *
+   * @param other The other FlinkStatement to update this one with.
+   * @throws Error if the other statement has a different name or environmentId
+   */
+  update(other: FlinkStatement): void {
+    if (this.name !== other.name || this.environmentId !== other.environmentId) {
+      throw new Error(
+        `Cannot update FlinkStatement "${this.name}" with instance with different name ${other.id} or environmentId ${other.environmentId}`,
+      );
+    }
+
+    this.metadata = other.metadata;
+    this.status = other.status;
+    this.spec = other.spec;
   }
 
   /**

--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -40,7 +40,7 @@ describe("FlinkStatementsViewProvider", () => {
       resourcesClearStub = sandbox.stub(viewProvider["resourcesInTreeView"], "clear");
     });
 
-    it("refresh() when no resource is selected", async () => {
+    it("clears when no resource is selected", async () => {
       // Should clear the resource map and fire the change event.
       await viewProvider.refresh();
 
@@ -48,7 +48,7 @@ describe("FlinkStatementsViewProvider", () => {
       sinon.assert.calledOnce(resourcesClearStub);
     });
 
-    it("refresh() when a resource is selected fetches new statements", async () => {
+    it("fetches new statements when a resource is selected", async () => {
       const resourceLoader = sinon.createStubInstance(CCloudResourceLoader);
       sandbox.stub(ResourceLoader, "getInstance").returns(resourceLoader);
       const windowWithProgressStub = sandbox
@@ -74,14 +74,14 @@ describe("FlinkStatementsViewProvider", () => {
   });
 
   describe("getChildren()", () => {
-    it("getChildren returns empty array when resourcesInTreeView is empty", async () => {
+    it("returns empty array when resourcesInTreeView is empty", async () => {
       resourcesInTreeView.clear();
       const children = await viewProvider.getChildren();
 
       assert.deepStrictEqual(children, []);
     });
 
-    describe("getChildren with resourcesInTreeView populated", () => {
+    describe("behavior with resourcesInTreeView populated", () => {
       const oldestStatement = createFlinkStatement({
         name: "papa", // bear ommitted to test filtering.
         createdAt: new Date("2023-01-01"),
@@ -103,12 +103,12 @@ describe("FlinkStatementsViewProvider", () => {
         }
       });
 
-      it("getChildren returns sorted array of FlinkStatement unfiltered", async () => {
+      it("returns sorted array of FlinkStatement unfiltered", async () => {
         const children = await viewProvider.getChildren();
         assert.deepStrictEqual(children, [youngestStatement, middleStatement, oldestStatement]);
       });
 
-      it("getChildren returns sorted array of FlinkStatement filtered by name", async () => {
+      it("returns sorted array of FlinkStatement filtered by name", async () => {
         viewProvider.itemSearchString = "bear";
         const children = await viewProvider.getChildren();
         // papa's last name isnt bear.
@@ -118,7 +118,7 @@ describe("FlinkStatementsViewProvider", () => {
   });
 
   describe("focus()", () => {
-    it("focus() calls treeView.reveal() with the correct statement", async () => {
+    it("calls treeView.reveal() with the correct statement", async () => {
       const statement = createFlinkStatement();
       resourcesInTreeView.set(statement.id, statement);
       const revealStub = sandbox.stub(viewProvider["treeView"], "reveal");
@@ -127,7 +127,7 @@ describe("FlinkStatementsViewProvider", () => {
       sinon.assert.calledWith(revealStub, statement, { focus: true, select: true });
     });
 
-    it("focus() throws if reveal() fails", async () => {
+    it("throws if reveal() fails", async () => {
       const statement = createFlinkStatement();
       resourcesInTreeView.set(statement.id, statement);
       const revealStub = sandbox.stub(viewProvider["treeView"], "reveal").throws();
@@ -144,7 +144,7 @@ describe("FlinkStatementsViewProvider", () => {
       sinon.assert.calledWith(revealStub, statement, { focus: true, select: true });
     });
 
-    it("focus() throws error if statement not found", async () => {
+    it("throws error if statement not found", async () => {
       const statementId = "non-existent-statement-id";
       assert.rejects(
         async () => {
@@ -159,14 +159,14 @@ describe("FlinkStatementsViewProvider", () => {
   });
 
   describe("getParent()", () => {
-    it("getParent returns null", () => {
+    it("always returns null", () => {
       const parent = viewProvider.getParent();
       assert.strictEqual(parent, null);
     });
   });
 
   describe("getTreeItem()", () => {
-    it("getTreeItem returns FlinkStatementTreeItem", () => {
+    it("returns FlinkStatementTreeItem", () => {
       const statement = createFlinkStatement();
       const treeItem = viewProvider.getTreeItem(statement);
       assert.strictEqual(treeItem.label, statement.name);
@@ -174,18 +174,18 @@ describe("FlinkStatementsViewProvider", () => {
   });
 
   describe("get computePool()", () => {
-    it("get computePool returns null if no resource set", () => {
+    it("returns null if no resource set", () => {
       const computePool = viewProvider.computePool;
       assert.strictEqual(computePool, null);
     });
 
-    it("get computePool returns returns null if resource set to an environment", () => {
+    it("returns returns null if resource set to an environment", () => {
       viewProvider["resource"] = TEST_CCLOUD_ENVIRONMENT;
       const computePool = viewProvider.computePool;
       assert.strictEqual(computePool, null);
     });
 
-    it("get computePool returns CCloudFlinkComputePool if resource set to a compute pool", () => {
+    it("returns CCloudFlinkComputePool if resource set to a compute pool", () => {
       const computePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       viewProvider["resource"] = computePool;
       const result = viewProvider.computePool;

--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -179,7 +179,7 @@ describe("FlinkStatementsViewProvider", () => {
       assert.strictEqual(computePool, null);
     });
 
-    it("returns returns null if resource set to an environment", () => {
+    it("returns null if resource set to an environment", () => {
       viewProvider["resource"] = TEST_CCLOUD_ENVIRONMENT;
       const computePool = viewProvider.computePool;
       assert.strictEqual(computePool, null);

--- a/tests/unit/testResources/flinkStatement.ts
+++ b/tests/unit/testResources/flinkStatement.ts
@@ -20,6 +20,7 @@ export interface CreateFlinkStatementArgs {
   computePoolId?: string;
 
   createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export function createFlinkStatement(overrides: CreateFlinkStatementArgs = {}): FlinkStatement {
@@ -32,7 +33,7 @@ export function createFlinkStatement(overrides: CreateFlinkStatementArgs = {}): 
     metadata: {
       self: null,
       created_at: overrides.createdAt || new Date(),
-      updated_at: new Date(),
+      updated_at: overrides.updatedAt || new Date(),
     },
     status: {
       phase: overrides.phase || "RUNNING",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Method to update the mutable fields of a `FlinkStatement` given a reference to an updated representation of the same statement.
- Will be used for doing piecemeal updates of non-terminal-state statements within the statement view in #1589.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Simplify test names for `FlinkStatementsViewProvider`, dregs from #1666 PR comments.
- Closes #1709.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
