### PR TITLE
swap file extension used for Flink SQL documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -677,7 +677,7 @@
       {
         "id": "flinksql",
         "extensions": [
-          ".flinksql"
+          ".flink.sql"
         ],
         "aliases": [
           "Flink SQL",

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -5,6 +5,7 @@ import {
   FlinkStatementDocumentProvider,
 } from "../documentProviders/flinkStatement";
 import { extractResponseBody, isResponseError, logError } from "../errors";
+import { FLINK_SQL_FILE_EXTENSIONS, FLINK_SQL_LANGUAGE_ID } from "../flinkSql/constants";
 import { Logger } from "../logging";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { FAILED_PHASE, FlinkStatement, restFlinkStatementToModel } from "../models/flinkStatement";
@@ -161,9 +162,9 @@ export async function submitFlinkStatementCommand(
 
   // 1. Choose the document with the SQL to submit
   const uriSchemes = ["file", "untitled", FLINKSTATEMENT_URI_SCHEME];
-  const languageIds = ["plaintext", "flinksql", "sql"];
+  const languageIds = ["plaintext", FLINK_SQL_LANGUAGE_ID, "sql"];
   const fileFilters = {
-    "FlinkSQL files": [".flinksql", ".sql"],
+    "FlinkSQL files": [...FLINK_SQL_FILE_EXTENSIONS, ".sql"],
   };
   const validUriProvided: boolean = uri instanceof vscode.Uri && uriSchemes.includes(uri.scheme);
   const statementBodyUri: vscode.Uri | undefined = validUriProvided

--- a/src/flinkSql/constants.ts
+++ b/src/flinkSql/constants.ts
@@ -1,0 +1,8 @@
+/** The identifier for the Flink SQL document language. */
+export const FLINK_SQL_LANGUAGE_ID = "flinksql";
+
+/** File extensions supporting the {@linkcode FLINK_SQL_LANGUAGE_ID} document language. */
+export const FLINK_SQL_FILE_EXTENSIONS = [".flink.sql"];
+
+/** Primary/default file extension supporting the {@linkcode FLINK_SQL_LANGUAGE_ID} document language. */
+export const DEFAULT_FLINK_SQL_FILE_EXTENSION = FLINK_SQL_FILE_EXTENSIONS[0];

--- a/tests/e2e/specs/flinkStatement.spec.ts
+++ b/tests/e2e/specs/flinkStatement.spec.ts
@@ -1,4 +1,5 @@
 import { Page } from "@playwright/test";
+import { DEFAULT_FLINK_SQL_FILE_EXTENSION } from "../../../src/flinkSql/constants";
 import { test } from "./base";
 import { login } from "./utils/confluentCloud";
 
@@ -29,7 +30,8 @@ test.describe("Flink statements and statement results", () => {
     // First, login to Confluent Cloud
     await login(page, electronApp, process.env.E2E_USERNAME!, process.env.E2E_PASSWORD!);
 
-    // Open a new file, save it and call it `test.flinksql`
+    // Open a new file, save it and call it `select.flink.sql`
+    const fileName = `select${DEFAULT_FLINK_SQL_FILE_EXTENSION}`;
 
     // Enable Flink
     await enableFlink(page);
@@ -41,7 +43,7 @@ test.describe("Flink statements and statement results", () => {
     await (await page.getByText("AWS.us-east-1")).click();
 
     await page.keyboard.press("ControlOrMeta+P");
-    await page.keyboard.type("select.flinksql");
+    await page.keyboard.type(fileName);
     await page.keyboard.press("Enter");
 
     // Move the mouse and hover over Flink Statements
@@ -51,7 +53,7 @@ test.describe("Flink statements and statement results", () => {
     await (await page.getByLabel("Submit Flink Statement")).click();
 
     // Choose the select.flinksql file
-    await page.keyboard.type("select.flinksql");
+    await page.keyboard.type(fileName);
     await page.keyboard.press("Enter");
 
     // Select the first compute pool


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

From `.flinksql` to `.flink.sql` (leaving the `flinksql` language ID alone).

Closes #1663.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
