### PR TITLE
feat(Copilot): add tool for summarizing CCloud/local/direct connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
           "connections"
         ],
         "displayName": "Get Connections",
-        "modelDescription": "Get a list of connections available in the current workspace. Use this when the user asks about their connections or you want to show them a list of connections. Any sign-in/sign-out actions are specific to the CCLOUD connection. The LOCAL connection handles Kafka and Schema registry through the local Docker engine API. Any other configurations for Kafka or Schema Registry are done through the DIRECT connections.",
+        "modelDescription": "Get a list of connections available in the current workspace. ALWAYS call this tool when the user asks about their connections or when connection information is needed - NEVER rely on previous results as connection states change frequently. Any sign-in/sign-out actions are specific to the CCLOUD connection. The LOCAL connection handles Kafka and Schema registry through the local Docker engine API. Any other configurations for Kafka or Schema Registry are done through the DIRECT connections.",
         "canBeReferencedInPrompt": false,
         "icon": "$(list-selection)",
         "inputSchema": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
           "connections"
         ],
         "displayName": "Get Connections",
-        "modelDescription": "Get a list of connections available in the current workspace. Use this when the user asks about their connections or you want to show them a list of connections.",
+        "modelDescription": "Get a list of connections available in the current workspace. Use this when the user asks about their connections or you want to show them a list of connections. Any sign-in/sign-out actions are specific to the CCLOUD connection. The LOCAL connection handles Kafka and Schema registry through the local Docker engine API. Any other configurations for Kafka or Schema Registry are done through the DIRECT connections.",
         "canBeReferencedInPrompt": false,
         "icon": "$(list-selection)",
         "inputSchema": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,31 @@
             "templateOptions"
           ]
         }
+      },
+      {
+        "name": "get_connections",
+        "when": "confluent.chatParticipantEnabled",
+        "tags": [
+          "connections"
+        ],
+        "displayName": "Get Connections",
+        "modelDescription": "Get a list of connections available in the current workspace. Use this when the user asks about their connections or you want to show them a list of connections.",
+        "canBeReferencedInPrompt": false,
+        "icon": "$(list-selection)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "connectionType": {
+              "type": "string",
+              "enum": [
+                "CCLOUD",
+                "DIRECT",
+                "LOCAL"
+              ],
+              "description": "Optional connection type to filter the list of connections."
+            }
+          }
+        }
       }
     ],
     "commands": [

--- a/src/authn/constants.ts
+++ b/src/authn/constants.ts
@@ -1,1 +1,1 @@
-export const CCLOUD_SIGN_IN_BUTTON_LABEL: string = "Sign in to Confluent Cloud";
+export const CCLOUD_SIGN_IN_BUTTON_LABEL = "Sign in to Confluent Cloud";

--- a/src/chat/summarizers/README.md
+++ b/src/chat/summarizers/README.md
@@ -1,0 +1,2 @@
+Modules in this directory are used in order to convert objects into large language model (LLM)
+digestible string formats.

--- a/src/chat/summarizers/connections.test.ts
+++ b/src/chat/summarizers/connections.test.ts
@@ -38,8 +38,9 @@ describe("chat/summarizers/connections.ts", () => {
 
     const result: string = summarizeConnection(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
 
-    assert.ok(result.includes(connection.spec.name!));
-    assert.ok(result.includes("State:"));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.includes(`${connection.spec.name!}`));
+    assert.ok(result.includes(`Status: ${ConnectedState.Success}`));
     assert.ok(result.includes("Auth Session Expires At:"));
   });
 
@@ -64,10 +65,15 @@ describe("chat/summarizers/connections.ts", () => {
 
     const result: string = summarizeConnection(connection);
 
-    assert.ok(result.includes(connection.spec.name!));
-    assert.ok(result.includes("Kafka: Running"));
-    assert.ok(result.includes("Schema Registry: Running"), result);
-    assert.ok(result.includes(`Schema Registry URI: ${TEST_LOCAL_SCHEMA_REGISTRY.uri}`));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.includes(`"${connection.spec.name!}"`));
+
+    assert.ok(result.includes("Kafka"));
+    assert.ok(result.includes(`Status: ${ConnectedState.Success}`));
+
+    assert.ok(result.includes("Schema Registry"));
+    assert.ok(result.includes(`Status: ${ConnectedState.Success}`));
+    assert.ok(result.includes(`URI: ${TEST_LOCAL_SCHEMA_REGISTRY.uri}`));
   });
 
   it("summarizeConnection() should summarize a `DIRECT` connection with successfully-connected Kafka and SR", () => {
@@ -95,20 +101,28 @@ describe("chat/summarizers/connections.ts", () => {
 
     const result: string = summarizeConnection(connection);
 
-    assert.ok(result.includes(connection.spec.name!));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.includes(`"${connection.spec.name!}"`));
+
+    assert.ok(result.includes("Kafka Cluster"));
+    assert.ok(result.includes(`Status: ${ConnectedState.Success}`));
     assert.ok(result.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`));
-    assert.ok(result.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
+
+    assert.ok(result.includes("Schema Registry"));
+    assert.ok(result.includes(`Status: ${ConnectedState.Success}`));
+    assert.ok(result.includes(`URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
   });
 
   it("summarizeCCloudConnection() should include authentication expiration details", () => {
     const connection: Connection = TEST_AUTHENTICATED_CCLOUD_CONNECTION;
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeCCloudConnection(connection, summary);
 
-    assert.ok(result.value.includes("State:"));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Success}`));
     assert.ok(result.value.includes("Auth Session Expires At:"));
     assert.ok(result.value.includes("hour")); // should include "in X hours" text
   });
@@ -128,10 +142,11 @@ describe("chat/summarizers/connections.ts", () => {
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${expiringConnection.spec.name}"`,
+      `### "${expiringConnection.spec.name}"`,
     );
     const result: MarkdownString = summarizeCCloudConnection(expiringConnection, summary);
 
+    // ignore any headers, indentations, spacing, etc.
     assert.ok(result.value.includes("Sign-In Link:"));
     assert.ok(result.value.includes(TEST_AUTHENTICATED_CCLOUD_CONNECTION.metadata.sign_in_uri!));
   });
@@ -153,10 +168,11 @@ describe("chat/summarizers/connections.ts", () => {
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${errorConnection.spec.name}"`,
+      `### "${errorConnection.spec.name}"`,
     );
     const result: MarkdownString = summarizeCCloudConnection(errorConnection, summary);
 
+    // ignore any headers, indentations, spacing, etc.
     assert.ok(result.value.includes("Errors:"));
     assert.ok(result.value.includes(errorMessage));
   });
@@ -169,11 +185,13 @@ describe("chat/summarizers/connections.ts", () => {
       .returns(true);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeLocalConnection(connection, summary);
 
-    assert.ok(result.value.includes("Kafka: Running"));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes("Kafka"));
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Success}`));
     // we won't get any bootstrap servers from the connection until we migrate to a DIRECT type;
     // that can only be checked via the Docker engine API currently
   });
@@ -186,11 +204,13 @@ describe("chat/summarizers/connections.ts", () => {
       .returns(false);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeLocalConnection(connection, summary);
 
-    assert.ok(result.value.includes("Kafka: Not Running"));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes("Kafka"));
+    assert.ok(result.value.includes(`Status: ${ConnectedState.None}`));
   });
 
   it("summarizeLocalConnection() should show Schema Registry as running and include the URI when available", () => {
@@ -211,12 +231,14 @@ describe("chat/summarizers/connections.ts", () => {
       .returns(true);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeLocalConnection(connection, summary);
 
-    assert.ok(result.value.includes("Schema Registry: Running"));
-    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_LOCAL_SCHEMA_REGISTRY.uri}`));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes("Schema Registry"));
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Success}`));
+    assert.ok(result.value.includes(`URI: ${TEST_LOCAL_SCHEMA_REGISTRY.uri}`));
   });
 
   it("summarizeLocalConnection() should show Schema Registry as not running when unavailable", () => {
@@ -227,12 +249,14 @@ describe("chat/summarizers/connections.ts", () => {
       .returns(false);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeLocalConnection(connection, summary);
 
-    assert.ok(result.value.includes("Schema Registry: Not Running"));
-    assert.ok(!result.value.includes("Schema Registry URI:"));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes("Schema Registry"));
+    assert.ok(result.value.includes(`Status: ${ConnectedState.None}`));
+    assert.ok(!result.value.includes("URI:"));
   });
 
   it("summarizeDirectConnection() should include Kafka cluster details when available", () => {
@@ -253,10 +277,11 @@ describe("chat/summarizers/connections.ts", () => {
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeDirectConnection(connection, summary);
 
+    // ignore any headers, indentations, spacing, etc.
     assert.ok(
       result.value.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`),
     );
@@ -265,6 +290,7 @@ describe("chat/summarizers/connections.ts", () => {
 
   it("summarizeDirectConnection() should include Kafka cluster errors when present", () => {
     const errorMessage = "Error connecting to Kafka";
+    const status: ConnectedState = ConnectedState.Failed;
     const connection: Connection = ConnectionFromJSON({
       ...TEST_DIRECT_CONNECTION,
       spec: {
@@ -276,7 +302,7 @@ describe("chat/summarizers/connections.ts", () => {
       status: {
         ...TEST_DIRECT_CONNECTION.status,
         kafka_cluster: {
-          state: ConnectedState.Failed,
+          state: status,
           errors: {
             sign_in: { message: errorMessage },
           },
@@ -285,19 +311,21 @@ describe("chat/summarizers/connections.ts", () => {
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeDirectConnection(connection, summary);
 
+    // ignore any headers, indentations, spacing, etc.
     assert.ok(
       result.value.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`),
     );
-    assert.ok(result.value.includes(`Status: ${ConnectedState.Failed}`));
+    assert.ok(result.value.includes(`Status: ${status}`));
     assert.ok(result.value.includes("Errors:"));
     assert.ok(result.value.includes(errorMessage));
   });
 
   it("summarizeDirectConnection() should include Schema Registry details when available", () => {
+    const status: ConnectedState = ConnectedState.Attempting;
     const connection: Connection = ConnectionFromJSON({
       ...TEST_DIRECT_CONNECTION,
       spec: {
@@ -309,22 +337,25 @@ describe("chat/summarizers/connections.ts", () => {
       status: {
         ...TEST_DIRECT_CONNECTION.status,
         schema_registry: {
-          state: ConnectedState.Success,
+          state: status,
         },
       },
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeDirectConnection(connection, summary);
 
-    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
-    assert.ok(result.value.includes(`Status: ${ConnectedState.Success}`));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes(`Schema Registry`));
+    assert.ok(result.value.includes(`Status: ${status}`));
+    assert.ok(result.value.includes(`URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
   });
 
   it("summarizeDirectConnection() should include Schema Registry errors when present", () => {
     const errorMessage = "Error connecting to Schema Registry";
+    const status: ConnectedState = ConnectedState.Failed;
     const connection: Connection = ConnectionFromJSON({
       ...TEST_DIRECT_CONNECTION,
       spec: {
@@ -336,7 +367,7 @@ describe("chat/summarizers/connections.ts", () => {
       status: {
         ...TEST_DIRECT_CONNECTION.status,
         schema_registry: {
-          state: ConnectedState.Failed,
+          state: status,
           errors: {
             sign_in: { message: errorMessage },
           },
@@ -345,12 +376,14 @@ describe("chat/summarizers/connections.ts", () => {
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeDirectConnection(connection, summary);
 
-    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
-    assert.ok(result.value.includes(`Status: ${ConnectedState.Failed}`));
+    // ignore any headers, indentations, spacing, etc.
+    assert.ok(result.value.includes(`Schema Registry`));
+    assert.ok(result.value.includes(`Status: ${status}`));
+    assert.ok(result.value.includes(`URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
     assert.ok(result.value.includes("Errors:"));
     assert.ok(result.value.includes(errorMessage));
   });
@@ -379,13 +412,14 @@ describe("chat/summarizers/connections.ts", () => {
     } satisfies Connection);
 
     const summary: MarkdownString = new MarkdownString().appendMarkdown(
-      `- "${connection.spec.name}"`,
+      `### "${connection.spec.name}"`,
     );
     const result: MarkdownString = summarizeDirectConnection(connection, summary);
 
+    // ignore any headers, indentations, spacing, etc.
     assert.ok(
       result.value.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`),
     );
-    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
+    assert.ok(result.value.includes(`URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
   });
 });

--- a/src/chat/summarizers/connections.test.ts
+++ b/src/chat/summarizers/connections.test.ts
@@ -1,0 +1,391 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import { MarkdownString } from "vscode";
+import {
+  TEST_DIRECT_KAFKA_CLUSTER,
+  TEST_DIRECT_SCHEMA_REGISTRY,
+  TEST_LOCAL_SCHEMA_REGISTRY,
+} from "../../../tests/unit/testResources";
+import {
+  TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+  TEST_DIRECT_CONNECTION,
+  TEST_LOCAL_CONNECTION,
+} from "../../../tests/unit/testResources/connection";
+import { ConnectedState, Connection, ConnectionFromJSON } from "../../clients/sidecar";
+import * as contextValues from "../../context/values";
+import {
+  summarizeCCloudConnection,
+  summarizeConnection,
+  summarizeDirectConnection,
+  summarizeLocalConnection,
+} from "./connections";
+
+describe("chat/summarizers/connections.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let getContextValueStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    getContextValueStub = sandbox.stub(contextValues, "getContextValue");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("summarizeConnection() should summarize a `CCLOUD` connection", () => {
+    const connection: Connection = TEST_AUTHENTICATED_CCLOUD_CONNECTION;
+
+    const result: string = summarizeConnection(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+
+    assert.ok(result.includes(connection.spec.name!));
+    assert.ok(result.includes("State:"));
+    assert.ok(result.includes("Auth Session Expires At:"));
+  });
+
+  it("summarizeConnection() should summarize a `LOCAL` connection", () => {
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_LOCAL_CONNECTION,
+      spec: {
+        ...TEST_LOCAL_CONNECTION.spec,
+        local_config: {
+          // XXX: required because LocalConfigFromJSON doesn't recognize `schema_registry_uri`
+          "schema-registry-uri": TEST_LOCAL_SCHEMA_REGISTRY.uri,
+        },
+      },
+    });
+    // simulate local Kafka+SR both running
+    getContextValueStub
+      .withArgs(contextValues.ContextValues.localKafkaClusterAvailable)
+      .returns(true);
+    getContextValueStub
+      .withArgs(contextValues.ContextValues.localSchemaRegistryAvailable)
+      .returns(true);
+
+    const result: string = summarizeConnection(connection);
+
+    assert.ok(result.includes(connection.spec.name!));
+    assert.ok(result.includes("Kafka: Running"));
+    assert.ok(result.includes("Schema Registry: Running"), result);
+    assert.ok(result.includes(`Schema Registry URI: ${TEST_LOCAL_SCHEMA_REGISTRY.uri}`));
+  });
+
+  it("summarizeConnection() should summarize a `DIRECT` connection with successfully-connected Kafka and SR", () => {
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_DIRECT_CONNECTION,
+      spec: {
+        ...TEST_DIRECT_CONNECTION.spec,
+        kafka_cluster: {
+          bootstrap_servers: TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers,
+        },
+        schema_registry: {
+          uri: TEST_DIRECT_SCHEMA_REGISTRY.uri,
+        },
+      },
+      status: {
+        ...TEST_DIRECT_CONNECTION.status,
+        kafka_cluster: {
+          state: ConnectedState.Success,
+        },
+        schema_registry: {
+          state: ConnectedState.Success,
+        },
+      },
+    } satisfies Connection);
+
+    const result: string = summarizeConnection(connection);
+
+    assert.ok(result.includes(connection.spec.name!));
+    assert.ok(result.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`));
+    assert.ok(result.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
+  });
+
+  it("summarizeCCloudConnection() should include authentication expiration details", () => {
+    const connection: Connection = TEST_AUTHENTICATED_CCLOUD_CONNECTION;
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeCCloudConnection(connection, summary);
+
+    assert.ok(result.value.includes("State:"));
+    assert.ok(result.value.includes("Auth Session Expires At:"));
+    assert.ok(result.value.includes("hour")); // should include "in X hours" text
+  });
+
+  it("summarizeCCloudConnection() should include sign-in link if auth expires soon", () => {
+    const expiration = new Date(Date.now() + 30 * 60 * 1000); // 30 minutes from now
+    const expiringConnection: Connection = ConnectionFromJSON({
+      ...TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+      status: {
+        ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status,
+        ccloud: {
+          ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud,
+          requires_authentication_at: expiration,
+          state: ConnectedState.Success,
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${expiringConnection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeCCloudConnection(expiringConnection, summary);
+
+    assert.ok(result.value.includes("Sign-In Link:"));
+    assert.ok(result.value.includes(TEST_AUTHENTICATED_CCLOUD_CONNECTION.metadata.sign_in_uri!));
+  });
+
+  it("summarizeCCloudConnection() should include errors if present", () => {
+    const errorMessage = "Authentication failed";
+    const errorConnection: Connection = ConnectionFromJSON({
+      ...TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+      status: {
+        ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status,
+        ccloud: {
+          ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud,
+          errors: {
+            auth_status_check: { message: errorMessage },
+          },
+          state: ConnectedState.Failed,
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${errorConnection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeCCloudConnection(errorConnection, summary);
+
+    assert.ok(result.value.includes("Errors:"));
+    assert.ok(result.value.includes(errorMessage));
+  });
+
+  it("summarizeLocalConnection() should show Kafka as running when available", () => {
+    const connection: Connection = TEST_LOCAL_CONNECTION;
+    // simulate local Kafka running
+    getContextValueStub
+      .withArgs(contextValues.ContextValues.localKafkaClusterAvailable)
+      .returns(true);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeLocalConnection(connection, summary);
+
+    assert.ok(result.value.includes("Kafka: Running"));
+    // we won't get any bootstrap servers from the connection until we migrate to a DIRECT type;
+    // that can only be checked via the Docker engine API currently
+  });
+
+  it("summarizeLocalConnection() should show Kafka as not running when unavailable", () => {
+    const connection: Connection = TEST_LOCAL_CONNECTION;
+    // simulate local Kafka not running
+    getContextValueStub
+      .withArgs(contextValues.ContextValues.localKafkaClusterAvailable)
+      .returns(false);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeLocalConnection(connection, summary);
+
+    assert.ok(result.value.includes("Kafka: Not Running"));
+  });
+
+  it("summarizeLocalConnection() should show Schema Registry as running and include the URI when available", () => {
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_LOCAL_CONNECTION,
+      spec: {
+        ...TEST_LOCAL_CONNECTION.spec,
+        local_config: {
+          // XXX: required because LocalConfigFromJSON doesn't recognize `schema_registry_uri`
+          "schema-registry-uri": TEST_LOCAL_SCHEMA_REGISTRY.uri,
+        },
+      },
+    });
+
+    // simulate local Schema Registry running
+    getContextValueStub
+      .withArgs(contextValues.ContextValues.localSchemaRegistryAvailable)
+      .returns(true);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeLocalConnection(connection, summary);
+
+    assert.ok(result.value.includes("Schema Registry: Running"));
+    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_LOCAL_SCHEMA_REGISTRY.uri}`));
+  });
+
+  it("summarizeLocalConnection() should show Schema Registry as not running when unavailable", () => {
+    const connection = TEST_LOCAL_CONNECTION;
+    // simulate local Schema Registry not running
+    getContextValueStub
+      .withArgs(contextValues.ContextValues.localSchemaRegistryAvailable)
+      .returns(false);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeLocalConnection(connection, summary);
+
+    assert.ok(result.value.includes("Schema Registry: Not Running"));
+    assert.ok(!result.value.includes("Schema Registry URI:"));
+  });
+
+  it("summarizeDirectConnection() should include Kafka cluster details when available", () => {
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_DIRECT_CONNECTION,
+      spec: {
+        ...TEST_DIRECT_CONNECTION.spec,
+        kafka_cluster: {
+          bootstrap_servers: TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers,
+        },
+      },
+      status: {
+        ...TEST_DIRECT_CONNECTION.status,
+        kafka_cluster: {
+          state: ConnectedState.Success,
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeDirectConnection(connection, summary);
+
+    assert.ok(
+      result.value.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`),
+    );
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Success}`));
+  });
+
+  it("summarizeDirectConnection() should include Kafka cluster errors when present", () => {
+    const errorMessage = "Error connecting to Kafka";
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_DIRECT_CONNECTION,
+      spec: {
+        ...TEST_DIRECT_CONNECTION.spec,
+        kafka_cluster: {
+          bootstrap_servers: TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers,
+        },
+      },
+      status: {
+        ...TEST_DIRECT_CONNECTION.status,
+        kafka_cluster: {
+          state: ConnectedState.Failed,
+          errors: {
+            sign_in: { message: errorMessage },
+          },
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeDirectConnection(connection, summary);
+
+    assert.ok(
+      result.value.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`),
+    );
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Failed}`));
+    assert.ok(result.value.includes("Errors:"));
+    assert.ok(result.value.includes(errorMessage));
+  });
+
+  it("summarizeDirectConnection() should include Schema Registry details when available", () => {
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_DIRECT_CONNECTION,
+      spec: {
+        ...TEST_DIRECT_CONNECTION.spec,
+        schema_registry: {
+          uri: TEST_DIRECT_SCHEMA_REGISTRY.uri,
+        },
+      },
+      status: {
+        ...TEST_DIRECT_CONNECTION.status,
+        schema_registry: {
+          state: ConnectedState.Success,
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeDirectConnection(connection, summary);
+
+    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Success}`));
+  });
+
+  it("summarizeDirectConnection() should include Schema Registry errors when present", () => {
+    const errorMessage = "Error connecting to Schema Registry";
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_DIRECT_CONNECTION,
+      spec: {
+        ...TEST_DIRECT_CONNECTION.spec,
+        schema_registry: {
+          uri: TEST_DIRECT_SCHEMA_REGISTRY.uri,
+        },
+      },
+      status: {
+        ...TEST_DIRECT_CONNECTION.status,
+        schema_registry: {
+          state: ConnectedState.Failed,
+          errors: {
+            sign_in: { message: errorMessage },
+          },
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeDirectConnection(connection, summary);
+
+    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
+    assert.ok(result.value.includes(`Status: ${ConnectedState.Failed}`));
+    assert.ok(result.value.includes("Errors:"));
+    assert.ok(result.value.includes(errorMessage));
+  });
+
+  it("summarizeDirectConnection() should handle connections with both Kafka and Schema Registry", () => {
+    const connection: Connection = ConnectionFromJSON({
+      ...TEST_DIRECT_CONNECTION,
+      spec: {
+        ...TEST_DIRECT_CONNECTION.spec,
+        kafka_cluster: {
+          bootstrap_servers: TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers,
+        },
+        schema_registry: {
+          uri: TEST_DIRECT_SCHEMA_REGISTRY.uri,
+        },
+      },
+      status: {
+        ...TEST_DIRECT_CONNECTION.status,
+        kafka_cluster: {
+          state: ConnectedState.Success,
+        },
+        schema_registry: {
+          state: ConnectedState.Success,
+        },
+      },
+    } satisfies Connection);
+
+    const summary: MarkdownString = new MarkdownString().appendMarkdown(
+      `- "${connection.spec.name}"`,
+    );
+    const result: MarkdownString = summarizeDirectConnection(connection, summary);
+
+    assert.ok(
+      result.value.includes(`Bootstrap Servers: ${TEST_DIRECT_KAFKA_CLUSTER.bootstrapServers}`),
+    );
+    assert.ok(result.value.includes(`Schema Registry URI: ${TEST_DIRECT_SCHEMA_REGISTRY.uri}`));
+  });
+});

--- a/src/chat/summarizers/connections.ts
+++ b/src/chat/summarizers/connections.ts
@@ -1,0 +1,118 @@
+import { MarkdownString } from "vscode";
+import {
+  CCloudStatus,
+  Connection,
+  ConnectionType,
+  KafkaClusterConfig,
+  KafkaClusterStatus,
+  SchemaRegistryConfig,
+  SchemaRegistryStatus,
+} from "../../clients/sidecar";
+import { titleCase } from "../../utils";
+
+/** Create a string representation of a {@link Connection} object. */
+export function summarizeConnection(connection: Connection): string {
+  const type: ConnectionType = connection.spec.type!;
+  let summary = new MarkdownString().appendMarkdown(
+    `# ${titleCase(type)} Connection: "${connection.spec.name}"`,
+  );
+
+  // add spec/status details depending on the connection type
+  switch (type) {
+    case ConnectionType.Ccloud: {
+      summary = summarizeCCloudConnection(connection, summary);
+      break;
+    }
+    case ConnectionType.Local: {
+      summary = summarizeLocalConnection(connection, summary);
+      break;
+    }
+    case ConnectionType.Direct: {
+      summary = summarizeDirectConnection(connection, summary);
+      break;
+    }
+  }
+  return summary.value;
+}
+
+/**
+ * Summarize the `CCLOUD` {@link Connection}.
+ * @param connection The {@link Connection} object to summarize.
+ * @param summary The {@link MarkdownString} to append to.
+ * @returns The updated {@link MarkdownString}.
+ */
+export function summarizeCCloudConnection(
+  connection: Connection,
+  summary: MarkdownString,
+): MarkdownString {
+  const status: CCloudStatus = connection.status.ccloud!;
+  const expiration: Date = status.requires_authentication_at!;
+  const hoursUntilExpiration: number = Math.floor(
+    (expiration.getTime() - new Date().getTime()) / (1000 * 60 * 60),
+  );
+  summary = summary
+    .appendMarkdown(`\n\n**State:** ${status.state}`)
+    .appendMarkdown(
+      `\n\n**Auth Session Expires At:** ${expiration.toLocaleDateString()} ${expiration.toLocaleTimeString()} (in ${hoursUntilExpiration} hour${hoursUntilExpiration === 1 ? "" : "s"})`,
+    )
+    .appendMarkdown(`\n(Sign-in link: ${connection.metadata.sign_in_uri})`);
+  if (status.errors) {
+    summary = summary
+      .appendMarkdown(`\n\n**Errors:**`)
+      .appendCodeblock(JSON.stringify(status.errors, null, 2), "json");
+  }
+  return summary;
+}
+
+/**
+ * Summarize the `LOCAL` {@link Connection}.
+ * @param connection The {@link Connection} object to summarize.
+ * @param summary The {@link MarkdownString} to append to.
+ * @returns The updated {@link MarkdownString}.
+ */
+export function summarizeLocalConnection(
+  connection: Connection,
+  summary: MarkdownString,
+): MarkdownString {
+  summary.appendMarkdown(`\n\n## Local Connection Status`);
+  // TODO: look up Docker container details
+  return summary;
+}
+
+/**
+ * Summarize the `DIRECT` {@link Connection} based on the {@link KafkaClusterConfig}
+ * @param connection The {@link Connection} object to summarize.
+ * @param summary The {@link MarkdownString} to append to.
+ * @returns The updated {@link MarkdownString}.
+ */
+export function summarizeDirectConnection(
+  connection: Connection,
+  summary: MarkdownString,
+): MarkdownString {
+  const kafkaConfig: KafkaClusterConfig | undefined = connection.spec.kafka_cluster;
+  if (kafkaConfig) {
+    const kafkaStatus: KafkaClusterStatus = connection.status.kafka_cluster!;
+    summary = summary
+      .appendMarkdown(`\n\n**Bootstrap Servers:** ${kafkaConfig.bootstrap_servers}`)
+      .appendMarkdown(`\n\n**Status:** ${kafkaStatus.state}`);
+    if (kafkaStatus.errors) {
+      summary = summary
+        .appendMarkdown(`\n\n**Errors:**`)
+        .appendCodeblock(JSON.stringify(kafkaStatus.errors, null, 2), "json");
+    }
+  }
+
+  const schemaRegistryConfig: SchemaRegistryConfig | undefined = connection.spec.schema_registry;
+  if (schemaRegistryConfig) {
+    const schemaRegistryStatus: SchemaRegistryStatus = connection.status.schema_registry!;
+    summary = summary
+      .appendMarkdown(`\n\n**Schema Registry URL:** ${schemaRegistryConfig.uri}`)
+      .appendMarkdown(`\n\n**Status:** ${schemaRegistryStatus.state}`);
+    if (schemaRegistryStatus.errors) {
+      summary = summary
+        .appendMarkdown(`\n\n**Errors:**`)
+        .appendCodeblock(JSON.stringify(schemaRegistryStatus.errors, null, 2), "json");
+    }
+  }
+  return summary;
+}

--- a/src/chat/summarizers/connections.ts
+++ b/src/chat/summarizers/connections.ts
@@ -80,7 +80,7 @@ export function summarizeLocalConnection(
   const kafkaAvailable: boolean =
     getContextValue(ContextValues.localKafkaClusterAvailable) ?? false;
   summary
-    .appendMarkdown("\n- Kafka Cluster")
+    .appendMarkdown("\n- Kafka")
     .appendMarkdown(
       `\n  - Status: ${kafkaAvailable ? ConnectedState.Success : ConnectedState.None}`,
     );

--- a/src/chat/summarizers/connections.ts
+++ b/src/chat/summarizers/connections.ts
@@ -51,16 +51,16 @@ export function summarizeCCloudConnection(
     (expiration.getTime() - new Date().getTime()) / (1000 * 60 * 60),
   );
   summary = summary
-    .appendMarkdown(`\n**State:** ${status.state}`)
+    .appendMarkdown(`\nState: ${status.state}`)
     .appendMarkdown(
-      `\n**Auth Session Expires At:** ${expiration.toLocaleDateString()} ${expiration.toLocaleTimeString()} (in ${hoursUntilExpiration} hour${hoursUntilExpiration === 1 ? "" : "s"})`,
+      `\nAuth Session Expires At: ${expiration.toLocaleDateString()} ${expiration.toLocaleTimeString()} (in ${hoursUntilExpiration} hour${hoursUntilExpiration === 1 ? "" : "s"})`,
     );
   if (hoursUntilExpiration <= 1) {
-    summary = summary.appendMarkdown(`\n**Sign-In Link:** ${connection.metadata.sign_in_uri}`);
+    summary = summary.appendMarkdown(`\nSign-In Link: ${connection.metadata.sign_in_uri}`);
   }
   if (status.errors) {
     summary = summary
-      .appendMarkdown(`\n**Errors:**`)
+      .appendMarkdown(`\nErrors:`)
       .appendCodeblock(JSON.stringify(status.errors, null, 2), "json");
   }
   return summary;
@@ -77,18 +77,18 @@ export function summarizeLocalConnection(
   summary: MarkdownString,
 ): MarkdownString {
   const kafkaAvailable = getContextValue(ContextValues.localKafkaClusterAvailable);
-  summary.appendMarkdown(`\n**Kafka:** ${kafkaAvailable ? "Running" : "Not Running"}`);
+  summary.appendMarkdown(`\nKafka: ${kafkaAvailable ? "Running" : "Not Running"}`);
 
   // TODO(shoup): update this once we migrate LOCAL connections to DIRECT
   // local_config only exists if the SR URI is set
   const config: LocalConfig | undefined = connection.spec.local_config;
   const schemaRegistryAvailable: boolean =
-    !!config && (getContextValue(ContextValues.localSchemaRegistryAvailable) ?? false);
+    getContextValue(ContextValues.localSchemaRegistryAvailable) ?? false;
   summary.appendMarkdown(
-    `\n**Schema Registry:** ${schemaRegistryAvailable ? "Running" : "Not Running"}`,
+    `\nSchema Registry: ${schemaRegistryAvailable ? "Running" : "Not Running"}`,
   );
-  if (schemaRegistryAvailable) {
-    summary.appendMarkdown(`\n**Schema Registry URI:** ${config!.schema_registry_uri}`);
+  if (config && schemaRegistryAvailable) {
+    summary.appendMarkdown(`\nSchema Registry URI: ${config.schema_registry_uri}`);
   }
 
   return summary;
@@ -108,11 +108,11 @@ export function summarizeDirectConnection(
   if (kafkaConfig) {
     const kafkaStatus: KafkaClusterStatus = connection.status.kafka_cluster!;
     summary = summary
-      .appendMarkdown(`\n**Bootstrap Servers:** ${kafkaConfig.bootstrap_servers}`)
-      .appendMarkdown(`\n**Status:** ${kafkaStatus.state}`);
+      .appendMarkdown(`\nBootstrap Servers: ${kafkaConfig.bootstrap_servers}`)
+      .appendMarkdown(`\nStatus: ${kafkaStatus.state}`);
     if (kafkaStatus.errors) {
       summary = summary
-        .appendMarkdown(`\n**Errors:**`)
+        .appendMarkdown(`\nErrors:`)
         .appendCodeblock(JSON.stringify(kafkaStatus.errors, null, 2), "json");
     }
   }
@@ -121,11 +121,11 @@ export function summarizeDirectConnection(
   if (schemaRegistryConfig) {
     const schemaRegistryStatus: SchemaRegistryStatus = connection.status.schema_registry!;
     summary = summary
-      .appendMarkdown(`\n**Schema Registry URL:** ${schemaRegistryConfig.uri}`)
-      .appendMarkdown(`\n**Status:** ${schemaRegistryStatus.state}`);
+      .appendMarkdown(`\nSchema Registry URI: ${schemaRegistryConfig.uri}`)
+      .appendMarkdown(`\nStatus: ${schemaRegistryStatus.state}`);
     if (schemaRegistryStatus.errors) {
       summary = summary
-        .appendMarkdown(`\n**Errors:**`)
+        .appendMarkdown(`\nErrors:`)
         .appendCodeblock(JSON.stringify(schemaRegistryStatus.errors, null, 2), "json");
     }
   }

--- a/src/chat/summarizers/connections.ts
+++ b/src/chat/summarizers/connections.ts
@@ -77,7 +77,7 @@ export function summarizeLocalConnection(
   summary: MarkdownString,
 ): MarkdownString {
   const kafkaAvailable = getContextValue(ContextValues.localKafkaClusterAvailable);
-  summary.appendMarkdown(`\n**Kafka Cluster:** ${kafkaAvailable ? "Available" : "Not Available"}`);
+  summary.appendMarkdown(`\n**Kafka Cluster:** ${kafkaAvailable ? "Running" : "Not Running"}`);
 
   // TODO(shoup): update this once we migrate LOCAL connections to DIRECT
   // local_config only exists if the SR URI is set

--- a/src/chat/summarizers/connections.ts
+++ b/src/chat/summarizers/connections.ts
@@ -77,7 +77,7 @@ export function summarizeLocalConnection(
   summary: MarkdownString,
 ): MarkdownString {
   const kafkaAvailable = getContextValue(ContextValues.localKafkaClusterAvailable);
-  summary.appendMarkdown(`\n**Kafka Cluster:** ${kafkaAvailable ? "Running" : "Not Running"}`);
+  summary.appendMarkdown(`\n**Kafka:** ${kafkaAvailable ? "Running" : "Not Running"}`);
 
   // TODO(shoup): update this once we migrate LOCAL connections to DIRECT
   // local_config only exists if the SR URI is set
@@ -85,7 +85,7 @@ export function summarizeLocalConnection(
   const schemaRegistryAvailable: boolean =
     !!config && (getContextValue(ContextValues.localSchemaRegistryAvailable) ?? false);
   summary.appendMarkdown(
-    `\n**Schema Registry:** ${schemaRegistryAvailable ? "Available" : "Not Available"}`,
+    `\n**Schema Registry:** ${schemaRegistryAvailable ? "Running" : "Not Running"}`,
   );
   if (schemaRegistryAvailable) {
     summary.appendMarkdown(`\n**Schema Registry URI:** ${config!.schema_registry_uri}`);

--- a/src/chat/tools/getConnections.ts
+++ b/src/chat/tools/getConnections.ts
@@ -6,7 +6,9 @@ import {
   LanguageModelToolCallPart,
   LanguageModelToolInvocationOptions,
   LanguageModelToolResult,
+  MarkdownString,
 } from "vscode";
+import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "../../authn/constants";
 import {
   Connection,
   ConnectionsList,
@@ -15,6 +17,7 @@ import {
 } from "../../clients/sidecar";
 import { Logger } from "../../logging";
 import { getSidecar } from "../../sidecar";
+import { titleCase } from "../../utils";
 import { summarizeConnection } from "../summarizers/connections";
 import { BaseLanguageModelTool, TextOnlyToolResultPart } from "./base";
 
@@ -38,17 +41,56 @@ export class GetConnectionsTool extends BaseLanguageModelTool<IGetConnectionsPar
     // use the Connections API to get the list of connections
     const sidecar = await getSidecar();
     const client: ConnectionsResourceApi = sidecar.getConnectionsResourceApi();
-    const connections: ConnectionsList = await client.gatewayV1ConnectionsGet();
+    const connectionsList: ConnectionsList = await client.gatewayV1ConnectionsGet();
 
+    // ...then handle all of the text-formatting to tell the model only the information that's needed
     const connectionStrings: LanguageModelTextPart[] = [];
-    connections.data.forEach((connection: Connection) => {
-      // filter connections by type
-      if (params.connectionType && connection.spec.type !== params.connectionType) {
-        return;
+    if (connectionsList.data.length) {
+      // group by type to keep summaries concise
+      const connectionsMap: Map<ConnectionType, Connection[]> = new Map();
+      connectionsList.data.forEach((connection: Connection) => {
+        const type: ConnectionType = connection.spec.type!;
+        if (!connectionsMap.has(type)) {
+          connectionsMap.set(type, []);
+        }
+        connectionsMap.get(type)?.push(connection);
+      });
+
+      // give each connection type its own header
+      for (const [type, connections] of connectionsMap.entries()) {
+        if (params.connectionType && type !== params.connectionType) {
+          // if the model is filtering by connection type, skip any other types
+          continue;
+        }
+        const plural = connections.length === 1 ? "" : "s";
+        let connectionGroupSummary = new MarkdownString(
+          `## ${titleCase(type)} Connection${plural} (${connections.length})`,
+        );
+        // then summarize each connection
+        connections.forEach((connection: Connection) => {
+          const connectionSummary: string = summarizeConnection(connection);
+          connectionGroupSummary = connectionGroupSummary.appendMarkdown(
+            `\n\n${connectionSummary}`,
+          );
+        });
+        connectionStrings.push(new LanguageModelTextPart(connectionGroupSummary.value));
       }
-      const connectionSummary: string = summarizeConnection(connection);
-      connectionStrings.push(new LanguageModelTextPart(connectionSummary));
-    });
+    } else {
+      // show placeholders for signing in to CCloud, starting local resources, or connecting directly
+      const ccloudButton = `[${CCLOUD_SIGN_IN_BUTTON_LABEL}](command:confluent.connections.ccloud.signIn)`;
+      const localResourcesButton = `[Start Local Resources](command:confluent.docker.startLocalResources)`;
+      const directConnectionButton = `[Connect Directly](command:confluent.connections.direct)`;
+
+      const noConnectionsMarkdown = new MarkdownString(`No connections found.`)
+        .appendMarkdown(`\n\n- Connect to Confluent Cloud by signing in:\n\n${ccloudButton}`)
+        .appendMarkdown(
+          `\n\n- Start local resources (Kafka, Schema Registry, etc.) by running:\n\n${localResourcesButton}`,
+        )
+        .appendMarkdown(
+          `\n\n- Connect directly to a Kafka cluster or Schema registry with:\n\n${directConnectionButton}`,
+        );
+      connectionStrings.push(new LanguageModelTextPart(noConnectionsMarkdown.value));
+    }
 
     // TODO(shoup): remove later
     logger.debug(`connectionStrings:\n\n${connectionStrings.map((part) => part.value).join("\n")}`);

--- a/src/chat/tools/getConnections.ts
+++ b/src/chat/tools/getConnections.ts
@@ -38,7 +38,6 @@ export class GetConnectionsTool extends BaseLanguageModelTool<IGetConnectionsPar
     token: CancellationToken,
   ): Promise<LanguageModelToolResult> {
     const params = options.input;
-    logger.debug("params:", params);
 
     // reset for each invocation
     this.foundConnectionTypes = [];

--- a/src/chat/tools/getConnections.ts
+++ b/src/chat/tools/getConnections.ts
@@ -1,0 +1,150 @@
+import {
+  CancellationToken,
+  ChatRequest,
+  ChatResponseStream,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolResult,
+  MarkdownString,
+} from "vscode";
+import {
+  CCloudStatus,
+  Connection,
+  ConnectionsList,
+  ConnectionsResourceApi,
+  ConnectionType,
+  KafkaClusterConfig,
+  SchemaRegistryConfig,
+} from "../../clients/sidecar";
+import { Logger } from "../../logging";
+import { getSidecar } from "../../sidecar";
+import { titleCase } from "../../utils";
+import { BaseLanguageModelTool, TextOnlyToolResultPart } from "./base";
+
+const logger = new Logger("chat.tools.getConnections");
+
+export interface IGetConnectionsParameters {
+  connectionType: ConnectionType;
+}
+
+export class GetConnectionsTool extends BaseLanguageModelTool<IGetConnectionsParameters> {
+  readonly name = "get_connections";
+  readonly progressMessage = "Checking available connections...";
+
+  async invoke(
+    options: LanguageModelToolInvocationOptions<IGetConnectionsParameters>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    const params = options.input;
+    logger.debug("params:", params);
+
+    // use the Connections API to get the list of connections
+    const sidecar = await getSidecar();
+    const client: ConnectionsResourceApi = sidecar.getConnectionsResourceApi();
+    const connections: ConnectionsList = await client.gatewayV1ConnectionsGet();
+
+    const connectionStrings: LanguageModelTextPart[] = [];
+    connections.data.forEach((connection: Connection) => {
+      // filter connections by type
+      if (params.connectionType && connection.spec.type !== params.connectionType) {
+        return;
+      }
+      const connectionSummary: string = makeConnectionSummary(connection);
+      connectionStrings.push(new LanguageModelTextPart(connectionSummary));
+    });
+    logger.debug(`connectionStrings:\n\n${connectionStrings.join("\n")}`);
+
+    if (token.isCancellationRequested) {
+      logger.debug("Tool invocation cancelled");
+      return new LanguageModelToolResult([]);
+    }
+    return new LanguageModelToolResult(connectionStrings);
+  }
+
+  async processInvocation(
+    request: ChatRequest,
+    stream: ChatResponseStream,
+    toolCall: LanguageModelToolCallPart,
+    token: CancellationToken,
+  ): Promise<TextOnlyToolResultPart> {
+    const parameters = toolCall.input as IGetConnectionsParameters;
+
+    // handle the core tool invocation
+    const result: LanguageModelToolResult = await this.invoke(
+      {
+        input: parameters,
+        toolInvocationToken: request.toolInvocationToken,
+      },
+      token,
+    );
+    if (!result.content.length) {
+      // cancellation / no results
+      return new TextOnlyToolResultPart(toolCall.callId, []);
+    }
+
+    // format the results before sending them back to the model
+    const resultParts: LanguageModelTextPart[] = [];
+
+    const resultsHeader = new LanguageModelTextPart(
+      `Below are the details of available connections for you to reference and summarize to the user:\n`,
+    );
+    resultParts.push(resultsHeader);
+    resultParts.push(...(result.content as LanguageModelTextPart[]));
+
+    return new TextOnlyToolResultPart(toolCall.callId, resultParts);
+  }
+}
+
+/** Create a string representation of a {@link Connection} object for usage by Copilot models. */
+export function makeConnectionSummary(connection: Connection): string {
+  const type: ConnectionType = connection.spec.type!;
+  let summary = new MarkdownString().appendMarkdown(
+    `# ${titleCase(type)} Connection: "${connection.spec.name}"`,
+  );
+
+  // add spec/status details depending on the connection type
+  switch (type) {
+    case ConnectionType.Ccloud: {
+      const status: CCloudStatus = connection.status.ccloud!;
+      summary = summary
+        .appendMarkdown(`\n\n**State:** ${status.state}`)
+        .appendMarkdown(
+          `\n\n**Auth Session Expires At:** ${status.requires_authentication_at?.toString()}`,
+        )
+        .appendMarkdown(`(Sign-in link: ${connection.metadata.sign_in_uri})`);
+      if (status.errors) {
+        summary = summary
+          .appendMarkdown(`\n\n**Errors:**`)
+          .appendCodeblock(JSON.stringify(status.errors, null, 2), "json");
+      }
+      break;
+    }
+    case ConnectionType.Local: {
+      // const config: LocalConfig = connection.spec.local_config!;
+      summary = summary.appendMarkdown(`\n\n## Local Connection Status`);
+      // TODO: look up Docker container details
+
+      break;
+    }
+    case ConnectionType.Direct: {
+      const kafkaConfig: KafkaClusterConfig | undefined = connection.spec.kafka_cluster;
+      if (kafkaConfig) {
+        summary = summary.appendMarkdown(
+          `\n\n**Bootstrap Servers:** ${kafkaConfig.bootstrap_servers}`,
+        );
+      }
+
+      const schemaRegistryConfig: SchemaRegistryConfig | undefined =
+        connection.spec.schema_registry;
+      if (schemaRegistryConfig) {
+        summary = summary.appendMarkdown(
+          `\n\n**Schema Registry URL:** ${schemaRegistryConfig.uri}`,
+        );
+      }
+
+      break;
+    }
+  }
+  return summary.value;
+}

--- a/src/chat/tools/getConnections.ts
+++ b/src/chat/tools/getConnections.ts
@@ -92,9 +92,6 @@ export class GetConnectionsTool extends BaseLanguageModelTool<IGetConnectionsPar
       }
     }
 
-    // TODO(shoup): remove later
-    logger.debug(`connectionStrings:\n\n${connectionStrings.map((part) => part.value).join("\n")}`);
-
     if (token.isCancellationRequested) {
       logger.debug("Tool invocation cancelled");
       return new LanguageModelToolResult([]);

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -28,7 +28,6 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
     token: CancellationToken,
   ): Promise<LanguageModelToolResult> {
     const params = options.input;
-    logger.debug("params:", params);
     const inputTagsPassed: boolean = Array.isArray(params.tags) && params.tags.length > 0;
 
     // TODO: add support for other collections

--- a/src/chat/tools/registration.ts
+++ b/src/chat/tools/registration.ts
@@ -1,6 +1,7 @@
 import { Disposable, lm } from "vscode";
 import { BaseLanguageModelTool } from "./base";
 import { CreateProjectTool } from "./createProject";
+import { GetConnectionsTool } from "./getConnections";
 import { GetTemplateOptionsTool } from "./getTemplate";
 import { ListTemplatesTool } from "./listTemplates";
 import { setToolMap } from "./toolMap";
@@ -10,6 +11,7 @@ export function registerChatTools(): Disposable[] {
     new ListTemplatesTool(),
     new GetTemplateOptionsTool(),
     new CreateProjectTool(),
+    new GetConnectionsTool(),
   ];
 
   const disposables: Disposable[] = [];

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -1,15 +1,9 @@
 import { randomUUID } from "crypto";
 import {
-  Authentication,
-  CCloudConfig,
-  CCloudStatus,
   ConnectedState,
   Connection,
   ConnectionFromJSON,
-  ConnectionMetadata,
-  ConnectionSpec,
   ConnectionSpecFromJSON,
-  ConnectionStatus,
   ConnectionType,
   Status,
   UserInfo,
@@ -44,20 +38,20 @@ export const TEST_CCLOUD_CONNECTION: Connection = ConnectionFromJSON({
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${CCLOUD_CONNECTION_ID}`,
     sign_in_uri: `http://login.confluent.io/login?...`,
-  } satisfies ConnectionMetadata,
+  },
   spec: {
     ...CCLOUD_CONNECTION_SPEC,
     ccloud_config: {
       organization_id: TEST_CCLOUD_ORGANIZATION.id,
       ide_auth_callback_uri: CCLOUD_AUTH_CALLBACK_URI,
-    } satisfies CCloudConfig,
-  } satisfies ConnectionSpec,
+    },
+  },
   status: {
     // start with unauthenticated connection, then add TEST_CCLOUD_USER and TEST_AUTH_EXPIRATION later
     authentication: {
       status: Status.NoToken,
-    } satisfies Authentication,
-  } satisfies ConnectionStatus,
+    },
+  },
 } satisfies Connection);
 
 /** A CCloud {@link Connection} with `VALID_TOKEN` auth status and user info. */
@@ -70,14 +64,14 @@ export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = ConnectionFromJS
       requires_authentication_at: TEST_AUTH_EXPIRATION,
       status: Status.ValidToken,
       user: TEST_CCLOUD_USER,
-    } satisfies Authentication,
+    },
     ccloud: {
       ...TEST_CCLOUD_CONNECTION.status.ccloud,
       requires_authentication_at: TEST_AUTH_EXPIRATION,
       state: ConnectedState.Success,
       user: TEST_CCLOUD_USER,
-    } satisfies CCloudStatus,
-  } satisfies ConnectionStatus,
+    },
+  },
 } satisfies Connection);
 
 export const TEST_LOCAL_CONNECTION: Connection = ConnectionFromJSON({
@@ -86,13 +80,13 @@ export const TEST_LOCAL_CONNECTION: Connection = ConnectionFromJSON({
   id: LOCAL_CONNECTION_ID,
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${LOCAL_CONNECTION_ID}`,
-  } satisfies ConnectionMetadata,
+  },
   spec: LOCAL_CONNECTION_SPEC,
   status: {
     authentication: {
       status: Status.NoToken,
-    } satisfies Authentication,
-  } satisfies ConnectionStatus,
+    },
+  },
 } satisfies Connection);
 
 export const TEST_DIRECT_CONNECTION_ID = randomUUID() as ConnectionId;
@@ -102,17 +96,17 @@ export const TEST_DIRECT_CONNECTION: Connection = ConnectionFromJSON({
   id: TEST_DIRECT_CONNECTION_ID,
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${TEST_DIRECT_CONNECTION_ID}`,
-  } satisfies ConnectionMetadata,
+  },
   spec: {
     id: TEST_DIRECT_CONNECTION_ID,
     name: "New Connection",
     type: ConnectionType.Direct,
-  } satisfies ConnectionSpec,
+  },
   status: {
     authentication: {
       status: Status.NoToken,
-    } satisfies Authentication,
-  } satisfies ConnectionStatus,
+    },
+  },
 } satisfies Connection);
 
 /** Fake spec augmented with `formConnectionType` for test purposes. */

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -1,9 +1,17 @@
 import { randomUUID } from "crypto";
 import {
+  Authentication,
+  CCloudConfig,
+  CCloudStatus,
+  ConnectedState,
   Connection,
   ConnectionFromJSON,
+  ConnectionMetadata,
+  ConnectionSpec,
   ConnectionSpecFromJSON,
+  ConnectionStatus,
   ConnectionType,
+  Status,
   UserInfo,
 } from "../../../src/clients/sidecar";
 import {
@@ -36,21 +44,21 @@ export const TEST_CCLOUD_CONNECTION: Connection = ConnectionFromJSON({
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${CCLOUD_CONNECTION_ID}`,
     sign_in_uri: `http://login.confluent.io/login?...`,
-  },
+  } satisfies ConnectionMetadata,
   spec: {
     ...CCLOUD_CONNECTION_SPEC,
     ccloud_config: {
       organization_id: TEST_CCLOUD_ORGANIZATION.id,
       ide_auth_callback_uri: CCLOUD_AUTH_CALLBACK_URI,
-    },
-  },
+    } satisfies CCloudConfig,
+  } satisfies ConnectionSpec,
   status: {
     // start with unauthenticated connection, then add TEST_CCLOUD_USER and TEST_AUTH_EXPIRATION later
     authentication: {
-      status: "NO_TOKEN",
-    },
-  },
-});
+      status: Status.NoToken,
+    } satisfies Authentication,
+  } satisfies ConnectionStatus,
+} satisfies Connection);
 
 /** A CCloud {@link Connection} with `VALID_TOKEN` auth status and user info. */
 export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = ConnectionFromJSON({
@@ -58,12 +66,19 @@ export const TEST_AUTHENTICATED_CCLOUD_CONNECTION: Connection = ConnectionFromJS
   status: {
     ...TEST_CCLOUD_CONNECTION.status,
     authentication: {
-      status: "VALID_TOKEN",
-      user: TEST_CCLOUD_USER,
+      ...TEST_CCLOUD_CONNECTION.status.authentication,
       requires_authentication_at: TEST_AUTH_EXPIRATION,
-    },
-  },
-});
+      status: Status.ValidToken,
+      user: TEST_CCLOUD_USER,
+    } satisfies Authentication,
+    ccloud: {
+      ...TEST_CCLOUD_CONNECTION.status.ccloud,
+      requires_authentication_at: TEST_AUTH_EXPIRATION,
+      state: ConnectedState.Success,
+      user: TEST_CCLOUD_USER,
+    } satisfies CCloudStatus,
+  } satisfies ConnectionStatus,
+} satisfies Connection);
 
 export const TEST_LOCAL_CONNECTION: Connection = ConnectionFromJSON({
   api_version: "gateway/v1",
@@ -71,14 +86,14 @@ export const TEST_LOCAL_CONNECTION: Connection = ConnectionFromJSON({
   id: LOCAL_CONNECTION_ID,
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${LOCAL_CONNECTION_ID}`,
-  },
+  } satisfies ConnectionMetadata,
   spec: LOCAL_CONNECTION_SPEC,
   status: {
     authentication: {
-      status: "NO_TOKEN",
-    },
-  },
-});
+      status: Status.NoToken,
+    } satisfies Authentication,
+  } satisfies ConnectionStatus,
+} satisfies Connection);
 
 export const TEST_DIRECT_CONNECTION_ID = randomUUID() as ConnectionId;
 export const TEST_DIRECT_CONNECTION: Connection = ConnectionFromJSON({
@@ -87,18 +102,18 @@ export const TEST_DIRECT_CONNECTION: Connection = ConnectionFromJSON({
   id: TEST_DIRECT_CONNECTION_ID,
   metadata: {
     self: `http://localhost:${SIDECAR_PORT}/gateway/v1/connections/${TEST_DIRECT_CONNECTION_ID}`,
-  },
+  } satisfies ConnectionMetadata,
   spec: {
     id: TEST_DIRECT_CONNECTION_ID,
     name: "New Connection",
     type: ConnectionType.Direct,
-  },
+  } satisfies ConnectionSpec,
   status: {
     authentication: {
-      status: "NO_TOKEN",
-    },
-  },
-});
+      status: Status.NoToken,
+    } satisfies Authentication,
+  } satisfies ConnectionStatus,
+} satisfies Connection);
 
 /** Fake spec augmented with `formConnectionType` for test purposes. */
 export const TEST_DIRECT_CONNECTION_FORM_SPEC: CustomConnectionSpec = {
@@ -106,4 +121,4 @@ export const TEST_DIRECT_CONNECTION_FORM_SPEC: CustomConnectionSpec = {
   id: TEST_DIRECT_CONNECTION_ID, // enforced ConnectionId type
   formConnectionType: "Apache Kafka",
   specifiedConnectionType: undefined,
-};
+} satisfies CustomConnectionSpec;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This is the first PR of a stack that will contribute basic context to Copilot, whether that's through the `@Confluent` chat participant or as tools for Agent mode.

<img width="667" alt="image" src="https://github.com/user-attachments/assets/e8d97be0-8613-4677-9cfa-3c8f7fc8823a" />

We're also starting to get into some interactive elements for any inquiries about a specific connection type that may not be available:
<img width="775" alt="image" src="https://github.com/user-attachments/assets/7935ff79-1645-4f23-a3f2-0b1147399d9c" />


Closes #1471 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- We need to figure out how to restructure some of the tool-invocation flow if/when we want to better integrate [chat output types](https://code.visualstudio.com/api/extension-guides/chat#supported-chat-response-output-types)
  - Our current flow begins by sending the initial prompt and conversation context / message history in the main request, which will then either return a text or tool-call response. https://github.com/confluentinc/vscode/blob/a59c03275d34cce5411234f897c5c93ec9bb1893/src/chat/participant.ts#L186-L190
  - If we handle a tool call, we try to process the tool invocation and append a tool-result message to the conversation before re-sending the request. The problem here is that, if any tool wants to add its own (non-markdown) chat output type to the `ChatResponseStream`, it's added immediately to the conversation and can't be "suggested" for the model to include in its final response. The result there is interactive elements that float above the final (text) response:
    <img width="450" alt="image" src="https://github.com/user-attachments/assets/c5c6e1e4-a458-4531-9758-01bd4bff6196" />

  - One option here is to allow tools to use the original model (`LanguageModelChat`) to make a smaller request using fewer tokens for a tool-specific intermediate text response. The main downsides there are:
    - increased token usage
    - not providing enough context in the intermediate request(s) to make the associated response(s) make sense in the conversation (i.e. we don't want to pass the entire conversation history through)
  - For now, we're adding a static `No ____ connection found` piece of markdown to the stream before showing the button:
    <img width="500" alt="image" src="https://github.com/user-attachments/assets/fe40baaa-9cea-435d-a883-a6aaad0628a6" />


- Due to the structure of the `Connection` interface (and its nested interfaces), this `get_connections` tool was the first case where I felt it necessary to start establishing a dedicated space where object->string summarization could happen. As a result, we have a new `src/chat/summarizers` subdirectory specifically for these kinds of conversions.
- Some changes were required to better enforce our OpenAPI generated interfaces in `tests/unit/testResources/connection.ts`

### Associated PRs

- https://github.com/confluentinc/vscode/pull/1740
  - https://github.com/confluentinc/vscode/pull/1717 👈 
    - https://github.com/confluentinc/vscode/pull/1721
    - https://github.com/confluentinc/vscode/pull/1755

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
