### PR TITLE
remove status bar item coloring

### DIFF
--- a/src/statusBar/ccloudItem.test.ts
+++ b/src/statusBar/ccloudItem.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { MarkdownString, StatusBarItem, ThemeColor, window } from "vscode";
+import { MarkdownString, StatusBarItem, window } from "vscode";
 import {
   TEST_CCLOUD_INCIDENT,
   TEST_CCLOUD_SCHEDULED_MAINTENANCE,
@@ -13,7 +13,6 @@ import {
   getCCloudStatusBarItem,
   updateCCloudStatus,
 } from "./ccloudItem";
-import { ERROR_BACKGROUND_COLOR_ID, WARNING_BACKGROUND_COLOR_ID } from "./constants";
 import {
   ACTIVE_INCIDENT_STATUS_ORDER,
   ACTIVE_MAINTENANCE_STATUS_ORDER,
@@ -62,7 +61,6 @@ describe("statusBar/ccloudItem.ts", () => {
     updateCCloudStatus(TEST_CCLOUD_STATUS_SUMMARY);
 
     assert.strictEqual(statusBarItem.text, `$(${IconNames.CONFLUENT_LOGO})`);
-    assert.strictEqual(statusBarItem.backgroundColor, undefined);
     const tooltip = statusBarItem.tooltip as MarkdownString;
     assert.ok(tooltip.value.includes(`**$(${IconNames.CONFLUENT_LOGO}) Confluent Cloud Status**`));
     assert.ok(tooltip.value.includes("No notices for Confluent Cloud at this time"));
@@ -80,8 +78,6 @@ describe("statusBar/ccloudItem.ts", () => {
       updateCCloudStatus(activeIncidentSummary);
 
       assert.strictEqual(statusBarItem.text, `$(${IconNames.CONFLUENT_LOGO}) ${incidents.length}`);
-      assert.ok(statusBarItem.backgroundColor instanceof ThemeColor);
-      assert.strictEqual(statusBarItem.backgroundColor.id, ERROR_BACKGROUND_COLOR_ID);
     });
   }
 
@@ -100,8 +96,6 @@ describe("statusBar/ccloudItem.ts", () => {
         statusBarItem.text,
         `$(${IconNames.CONFLUENT_LOGO}) ${maintenances.length}`,
       );
-      assert.ok(statusBarItem.backgroundColor instanceof ThemeColor);
-      assert.strictEqual(statusBarItem.backgroundColor.id, WARNING_BACKGROUND_COLOR_ID);
     });
   }
 
@@ -116,9 +110,6 @@ describe("statusBar/ccloudItem.ts", () => {
     updateCCloudStatus(multipleSummary);
 
     assert.strictEqual(statusBarItem.text, "$(confluent-logo) 2");
-    assert.ok(statusBarItem.backgroundColor instanceof ThemeColor);
-    // incident color takes priority
-    assert.strictEqual(statusBarItem.backgroundColor.id, ERROR_BACKGROUND_COLOR_ID);
   });
 
   for (const status of COMPLETED_INCIDENT_STATUSES) {
@@ -132,7 +123,6 @@ describe("statusBar/ccloudItem.ts", () => {
       updateCCloudStatus(activeIncidentSummary);
 
       assert.strictEqual(statusBarItem.text, `$(${IconNames.CONFLUENT_LOGO})`);
-      assert.strictEqual(statusBarItem.backgroundColor, undefined);
     });
   }
 
@@ -147,7 +137,6 @@ describe("statusBar/ccloudItem.ts", () => {
       updateCCloudStatus(activeMaintenanceSummary);
 
       assert.strictEqual(statusBarItem.text, `$(${IconNames.CONFLUENT_LOGO})`);
-      assert.strictEqual(statusBarItem.backgroundColor, undefined);
     });
   }
 });

--- a/src/statusBar/ccloudItem.ts
+++ b/src/statusBar/ccloudItem.ts
@@ -1,7 +1,6 @@
-import { StatusBarAlignment, StatusBarItem, ThemeColor, window } from "vscode";
+import { StatusBarAlignment, StatusBarItem, window } from "vscode";
 import { CCloudStatusSummary, Incident, ScheduledMaintenance } from "../ccloudStatus/types";
 import { IconNames } from "../constants";
-import { ERROR_BACKGROUND_COLOR_ID, WARNING_BACKGROUND_COLOR_ID } from "./constants";
 import {
   ACTIVE_INCIDENT_STATUS_ORDER,
   ACTIVE_MAINTENANCE_STATUS_ORDER,
@@ -52,14 +51,6 @@ export function updateCCloudStatus(status: CCloudStatusSummary) {
   // only show the number of active incidents and maintenances if there are any
   item.text =
     `$(${IconNames.CONFLUENT_LOGO}) ${activeIncidents.length + activeMaintenances.length || ""}`.trim();
-
-  // active incidents will use the error color; active maintenances will use the warning color
-  // if both are present, the error color will take precedence
-  item.backgroundColor = activeIncidents.length
-    ? new ThemeColor(ERROR_BACKGROUND_COLOR_ID)
-    : activeMaintenances.length
-      ? new ThemeColor(WARNING_BACKGROUND_COLOR_ID)
-      : undefined;
 
   item.tooltip = createStatusSummaryMarkdown(status);
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Need to revisit how to best color these updates so they're immediately relevant to users, since they were previously very distracting.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
