### PR TITLE
MINOR: don't let `gulp format` affect `graphql/sidecarGraphQL.d.ts`

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -862,6 +862,7 @@ export async function format() {
     src([
       "src/**/*.ts",
       "!src/clients/**/*.ts", // don't reformat apigen generated code
+      "!src/graphql/sidecarGraphQL.d.ts", // don't reformat gql.tada generated code
       "src/**/*.css",
       "src/**/*.html",
       "src/**/*.json",

--- a/src/graphql/sidecarGraphQL.d.ts
+++ b/src/graphql/sidecarGraphQL.d.ts
@@ -34,16 +34,16 @@ export type introspection_types = {
  */
 export type introspection = {
   name: never;
-  query: "Query";
+  query: 'Query';
   mutation: never;
   subscription: never;
   types: introspection_types;
 };
 
-import * as gqlTada from "gql.tada";
+import * as gqlTada from 'gql.tada';
 
-declare module "gql.tada" {
+declare module 'gql.tada' {
   interface setupSchema {
-    introspection: introspection;
+    introspection: introspection
   }
 }


### PR DESCRIPTION
This file is automatically generated/updated by gql.tada based on: https://github.com/confluentinc/vscode/blob/8dafd000411968a8fb25dd097bfd74955579cf04/tsconfig.json#L13-L17

Formatting it will only cause gql.tada to undo the formatting and show (revert) changes whenever it decides to update that file, which causes unnecessary changes to show up in work branches.