### PR TITLE
sanitize options: add param to getTemplatesList and test 

### DIFF
--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -31,10 +31,8 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
     logger.debug("params:", params);
     const inputTagsPassed: boolean = Array.isArray(params.tags) && params.tags.length > 0;
 
-    const templateList = await getTemplatesList();
-    logger.debug("templateList:", templateList);
-
-    const templates = Array.from(templateList.data) as ScaffoldV1Template[];
+    // TODO: add support for other collections
+    const templates: ScaffoldV1Template[] = await getTemplatesList("vscode", true);
     const templateStrings: LanguageModelTextPart[] = [];
     templates.forEach((template) => {
       const spec = template.spec!;

--- a/src/scaffold.test.ts
+++ b/src/scaffold.test.ts
@@ -1,162 +1,24 @@
 import * as assert from "assert";
-import * as sinon from "sinon";
-import * as vscode from "vscode";
-import {
-  ScaffoldV1TemplateListApiVersionEnum,
-  ScaffoldV1TemplateListDataInner,
-  ScaffoldV1TemplateListDataInnerApiVersionEnum,
-  ScaffoldV1TemplateListDataInnerKindEnum,
-  ScaffoldV1TemplateListKindEnum,
-} from "./clients/scaffoldingService";
 import * as scaffold from "./scaffold";
 
-describe("scaffoldProjectRequest", () => {
-  let sandbox: sinon.SinonSandbox;
-  let getTemplatesStub: sinon.SinonStub;
-  let quickPickStub: sinon.SinonStub;
-
-  beforeEach(async () => {
-    sandbox = sinon.createSandbox();
-
-    const templateData: ScaffoldV1TemplateListDataInner[] = [
-      {
-        api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
-        kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
-        metadata: { self: undefined },
-        spec: {
-          name: "kafka-js",
-          display_name: "Kafka Client In JavaScript",
-          description: "A simple JavaScript project",
-          tags: ["producer", "consumer", "javascript"],
-        },
-      },
-      {
-        api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
-        kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
-        metadata: { self: undefined },
-        spec: {
-          name: "flink-sql",
-          display_name: "Flink SQL Application",
-          description: "A Flink SQL application",
-          tags: ["apache flink", "table api"],
-        },
-      },
-      {
-        api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
-        kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
-        metadata: { self: undefined },
-        spec: {
-          name: "other-template",
-          display_name: "Other Template",
-          description: "Another template",
-          tags: ["other"],
-        },
-      },
-    ];
-
-    const mockTemplates = {
-      api_version: ScaffoldV1TemplateListApiVersionEnum.ScaffoldV1,
-      kind: ScaffoldV1TemplateListKindEnum.TemplateList,
-      metadata: {
-        first: true,
-        last: true,
-        total_size: 3,
-      },
-      data: new Set(templateData),
+describe("filterSensitiveKeys", () => {
+  it("filters out keys containing 'key' or 'secret'", () => {
+    const input = {
+      api_key: "sensitive",
+      secret_token: "sensitive",
+      bootstrap_server: "localhost:9092",
+      topic_name: "test-topic",
     };
 
-    getTemplatesStub = sandbox.stub(scaffold, "getTemplatesList").resolves(mockTemplates);
-    quickPickStub = sandbox.stub(vscode.window, "showQuickPick").resolves(undefined);
-  });
+    const result = scaffold.filterSensitiveKeys(input);
 
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("filters templates by kafka tags when templateType is kafka", async () => {
-    await scaffold.scaffoldProjectRequest({ templateType: "kafka" });
-    const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
-    assert.ok(quickPickItems.length > 0, "Should have at least one Kafka template");
-    assert.ok(
-      quickPickItems.every(
-        (item) => item.description?.includes("producer") || item.description?.includes("consumer"),
-      ),
-      "All items should be Kafka related",
-    );
-  });
-
-  it("filters templates by flink tags when templateType is flink", async () => {
-    await scaffold.scaffoldProjectRequest({ templateType: "flink" });
-    const quickPickItems = quickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
-    assert.ok(quickPickItems.length > 0, "Should have at least one Flink template");
-    assert.ok(
-      quickPickItems.every(
-        (item) =>
-          item.description?.includes("apache flink") || item.description?.includes("table api"),
-      ),
-      "All items should be Flink related",
-    );
-  });
-
-  it("returns undefined when no templates are available", async () => {
-    getTemplatesStub.resolves({
-      api_version: ScaffoldV1TemplateListApiVersionEnum.ScaffoldV1,
-      kind: ScaffoldV1TemplateListKindEnum.TemplateList,
-      metadata: { first: true, last: true, total_size: 0 },
-      data: new Set([]),
-    });
-
-    const result = await scaffold.scaffoldProjectRequest({ templateType: "kafka" });
-    assert.strictEqual(result, undefined);
-  });
-
-  it("finds specific template when templateName is provided", async () => {
-    await scaffold.scaffoldProjectRequest({
-      templateName: "kafka-js",
-      templateType: "kafka",
-    });
-
-    const quickPickItems = quickPickStub.firstCall?.args[0] as vscode.QuickPickItem[];
-    assert.ok(!quickPickItems, "QuickPick should not be shown when template is specified");
-  });
-
-  it("filters out sensitive options containing 'key' or 'secret'", () => {
-    const template: ScaffoldV1TemplateListDataInner = {
-      api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
-      kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
-      metadata: { self: undefined },
-      spec: {
-        name: "test-template",
-        options: {
-          api_key: { description: "API Key" },
-          secret_key: { description: "Secret Key" },
-          bootstrap_server: { description: "Bootstrap Server" },
-          topic_name: { description: "Topic Name" },
-        },
-      },
-    };
-
-    const result: ScaffoldV1TemplateListDataInner = scaffold.sanitizeTemplateOptions(template);
-
-    // Check that non-sensitive fields are preserved
-    assert.strictEqual(result.api_version, template.api_version);
-    assert.strictEqual(result.kind, template.kind);
-    assert.deepStrictEqual(result.metadata, template.metadata);
-
-    // Check that sensitive options are filtered out
-    const options = (result.spec as { options?: Record<string, unknown> })?.options || {}; // Ensure result is typed correctly
-    assert.ok(!("api_key" in options), "api_key should be filtered out");
-    assert.ok(!("secret_key" in options), "secret_key should be filtered out");
-
-    // Check that non-sensitive options are preserved
-    assert.ok("bootstrap_server" in options, "bootstrap_server should be preserved");
-    assert.ok("topic_name" in options, "topic_name should be preserved");
-
-    // Check that option objects are properly copied
     assert.deepStrictEqual(
-      options.bootstrap_server,
-      (template.spec as { options?: Record<string, unknown> })?.options?.bootstrap_server,
-      "Option object should be preserved",
+      result,
+      {
+        bootstrap_server: "localhost:9092",
+        topic_name: "test-topic",
+      },
+      "Should filter out sensitive keys while preserving others",
     );
   });
 });

--- a/src/scaffold.test.ts
+++ b/src/scaffold.test.ts
@@ -119,4 +119,44 @@ describe("scaffoldProjectRequest", () => {
     const quickPickItems = quickPickStub.firstCall?.args[0] as vscode.QuickPickItem[];
     assert.ok(!quickPickItems, "QuickPick should not be shown when template is specified");
   });
+
+  it("filters out sensitive options containing 'key' or 'secret'", () => {
+    const template: ScaffoldV1TemplateListDataInner = {
+      api_version: ScaffoldV1TemplateListDataInnerApiVersionEnum.ScaffoldV1,
+      kind: ScaffoldV1TemplateListDataInnerKindEnum.Template,
+      metadata: { self: undefined },
+      spec: {
+        name: "test-template",
+        options: {
+          api_key: { description: "API Key" },
+          secret_key: { description: "Secret Key" },
+          bootstrap_server: { description: "Bootstrap Server" },
+          topic_name: { description: "Topic Name" },
+        },
+      },
+    };
+
+    const result: ScaffoldV1TemplateListDataInner = scaffold.sanitizeTemplateOptions(template);
+
+    // Check that non-sensitive fields are preserved
+    assert.strictEqual(result.api_version, template.api_version);
+    assert.strictEqual(result.kind, template.kind);
+    assert.deepStrictEqual(result.metadata, template.metadata);
+
+    // Check that sensitive options are filtered out
+    const options = (result.spec as { options?: Record<string, unknown> })?.options || {}; // Ensure result is typed correctly
+    assert.ok(!("api_key" in options), "api_key should be filtered out");
+    assert.ok(!("secret_key" in options), "secret_key should be filtered out");
+
+    // Check that non-sensitive options are preserved
+    assert.ok("bootstrap_server" in options, "bootstrap_server should be preserved");
+    assert.ok("topic_name" in options, "topic_name should be preserved");
+
+    // Check that option objects are properly copied
+    assert.deepStrictEqual(
+      options.bootstrap_server,
+      (template.spec as { options?: Record<string, unknown> })?.options?.bootstrap_server,
+      "Option object should be preserved",
+    );
+  });
 });

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -98,10 +98,9 @@ export const scaffoldProjectRequest = async (templateRequestOptions?: PrefilledT
   try {
     // should only be using a templateCollection if this came from a URI; by default all other uses
     // will default to the "vscode" collection
-    const templateListResponse: ScaffoldV1Template[] = await getTemplatesList(
+    let templateList: ScaffoldV1Template[] = await getTemplatesList(
       templateRequestOptions?.templateCollection,
     );
-    let templateList = Array.from(templateListResponse) as ScaffoldV1Template[];
     if (templateRequestOptions && !templateRequestOptions.templateName) {
       // When we're triggering the scaffolding from the cluster or topic context menu, we want to show only
       // templates that are tagged as producer or consumer but with a quickpick


### PR DESCRIPTION
## Summary of Changes

Adds sanitizeOptions to getTemplatesList so that we can return options without secret or key. 

Needed to help the `list_projectTemplates` tool so Copilot is completely unaware of any kind of `*secret*` or `*key*` input options. For now this is just handled by iterating through the options and string matching, but can be cleaned up when the templates provide an explicit property/flag like `is_sensitive` for easier filtering.

## Any additional details or context that should be provided?

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
