### PR TITLE
Remove Pause/Resume and timer functionality from results viewer

### DIFF
--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -32,20 +32,6 @@
               </vscode-dropdown>
             </div>
 
-            <div class="dropdown-container">
-              <!-- Empty label for aligned layout with the rest of controls -->
-              <label for="stream-toggle"><span>&nbsp;</span></label>
-              <vscode-button
-                appearance="primary"
-                id="stream-toggle"
-                data-on-click="this.handleStreamToggle(this.streamState())"
-                data-text="this.streamStateLabel()"
-                data-attr-title="this.streamStateTooltip()"
-                data-attr-disabled="this.streamState() === 'completed'"
-              >
-              </vscode-button>
-            </div>
-
             <template data-if="this.streamError() != null">
               <div class="dropdown-container">
                 <!-- Empty label for aligned layout with the rest of controls -->
@@ -64,18 +50,6 @@
                     <p data-text="this.streamError().message"></p>
                   </div>
                 </div>
-              </div>
-            </template>
-
-            <template data-if="this.timer() != null">
-              <div class="dropdown-container">
-                <label>Time elapsed</label>
-                <flink-timer
-                  class="timer"
-                  data-attr-class="'timer ' + this.streamState()"
-                  data-prop-time="this.timer()"
-                  data-prop-state="this.streamState()"
-                ></flink-timer>
               </div>
             </template>
           </div>
@@ -106,15 +80,6 @@
           <div class="grid-banner">
             <vscode-progress-ring></vscode-progress-ring>
             <label>Waiting for results…</label>
-          </div>
-        </template>
-
-        <template
-          data-if="this.waitingForResults() && this.streamState() === 'paused' && this.streamError() == null"
-        >
-          <div class="grid-banner">
-            <span class="codicon codicon-debug-pause banner-pending"></span>
-            <label>Paused</label>
           </div>
         </template>
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Keeping pause/resume in the results viewer would do nothing but confuse the user into thinking they're able to pause the statement execution. This PR removes it.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
