### PR TITLE
feat(Copilot): add tool for applying project template and showing form

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
             },
             "templateOptions": {
               "type": "object",
-              "description": "The input options for the selected project template. This should match the result returned by 'get_templateOptions'."
+              "description": "The input options for the selected project template. Use the result of the 'get_templateOptions' and any user-provided values to fill out this object."
             }
           },
           "required": [

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
           "projects"
         ],
         "displayName": "Create Project",
-        "modelDescription": "Create a new project using the selected template and input options. Use this after 'get_templateOptions' when the provided values for the selected template have been provided.",
+        "modelDescription": "Create a new project using the selected template and input options. If the user provides values for these options, ALWAYS pass them to this tool as input for the templateOptions.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "createProject",
         "icon": "$(checklist)",
@@ -135,7 +135,7 @@
             },
             "templateOptions": {
               "type": "object",
-              "description": "The input options for the selected project template. Use the result of the 'get_templateOptions' and any user-provided values to fill out this object."
+              "description": "The input options for the selected project template. The keys for this object must match the input options defined in the template."
             }
           },
           "required": [

--- a/package.json
+++ b/package.json
@@ -114,6 +114,35 @@
             "templateId"
           ]
         }
+      },
+      {
+        "name": "create_project",
+        "when": "confluent.chatParticipantEnabled",
+        "tags": [
+          "projects"
+        ],
+        "displayName": "Create Project",
+        "modelDescription": "Create a new project using the selected template and input options. Use this after 'get_templateOptions' when the provided values for the selected template have been provided.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "createProject",
+        "icon": "$(checklist)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "templateId": {
+              "type": "string",
+              "description": "The ID of the project template to use."
+            },
+            "templateOptions": {
+              "type": "object",
+              "description": "The input options for the selected project template. This should match the result returned by 'get_templateOptions'."
+            }
+          },
+          "required": [
+            "templateId",
+            "templateOptions"
+          ]
+        }
       }
     ],
     "commands": [

--- a/src/chat/tools/createProject.ts
+++ b/src/chat/tools/createProject.ts
@@ -1,0 +1,103 @@
+import {
+  CancellationToken,
+  ChatRequest,
+  ChatResponseStream,
+  LanguageModelChatMessage,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolResult,
+} from "vscode";
+import { ScaffoldV1Template } from "../../clients/scaffoldingService";
+import { Logger } from "../../logging";
+import { getTemplatesList, scaffoldProjectRequest } from "../../scaffold";
+import { PostResponse } from "../../webview/scaffold-form";
+import { BaseLanguageModelTool } from "./base";
+
+const logger = new Logger("chat.tools.getTemplateOptions");
+
+export interface ICreateProjectParameters {
+  templateId: string;
+  templateOptions: { [key: string]: string | boolean };
+}
+
+export class CreateProjectTool extends BaseLanguageModelTool<ICreateProjectParameters> {
+  readonly name = "create_project";
+  readonly progressMessage = "Setting up project...";
+
+  async invoke(
+    options: LanguageModelToolInvocationOptions<ICreateProjectParameters>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    const params = options.input;
+
+    if (!params.templateId || !params.templateOptions) {
+      logger.error("No template ID provided");
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(`Provide a template ID to create a project with it.`),
+      ]);
+    }
+
+    // TODO: add support for other collections
+    const templates: ScaffoldV1Template[] = await getTemplatesList("vscode", true);
+    const matchingTemplate: ScaffoldV1Template | undefined = templates.find(
+      (template) => template.spec?.name === params.templateId,
+    );
+    if (!matchingTemplate) {
+      logger.error(`No template found with ID: ${params.templateId}`);
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(
+          `No template found with ID "${params.templateId}". Run the "list_projectTemplates" tool to get available templates.`,
+        ),
+      ]);
+    }
+
+    // just try to open the form for now
+    const resp: PostResponse = await scaffoldProjectRequest({
+      templateName: params.templateId,
+      ...params.templateOptions,
+    });
+    if (!resp.success) {
+      logger.error(`Error creating project: ${resp.message}`);
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(`Error creating project: ${resp.message}`),
+      ]);
+    }
+
+    if (token.isCancellationRequested) {
+      logger.info("Tool invocation cancelled");
+      return new LanguageModelToolResult([]);
+    }
+    return new LanguageModelToolResult([
+      new LanguageModelTextPart(
+        `Project created successfully. The user can refer to the form to make any necessary adjustments.`,
+      ),
+    ]);
+  }
+
+  async processInvocation(
+    request: ChatRequest,
+    stream: ChatResponseStream,
+    toolCall: LanguageModelToolCallPart,
+    token: CancellationToken,
+  ): Promise<LanguageModelChatMessage[]> {
+    const parameters = toolCall.input as ICreateProjectParameters;
+
+    const result: LanguageModelToolResult = await this.invoke(
+      {
+        input: parameters,
+        toolInvocationToken: request.toolInvocationToken,
+      },
+      token,
+    );
+
+    const messages: LanguageModelChatMessage[] = [];
+    if (result.content && Array.isArray(result.content)) {
+      // no header/footer messages needed here
+      for (const part of result.content as LanguageModelTextPart[]) {
+        messages.push(this.toolMessage(part.value, "result"));
+      }
+    }
+    return messages;
+  }
+}

--- a/src/chat/tools/createProject.ts
+++ b/src/chat/tools/createProject.ts
@@ -64,10 +64,13 @@ export class CreateProjectTool extends BaseLanguageModelTool<ICreateProjectParam
     }
 
     // just try to open the form for now
-    const resp: PostResponse = await scaffoldProjectRequest({
-      templateName: templateId,
-      ...templateOptions,
-    });
+    const resp: PostResponse = await scaffoldProjectRequest(
+      {
+        templateName: templateId,
+        ...templateOptions,
+      },
+      `copilot:${this.name}`,
+    );
     if (!resp.success) {
       logger.error(`Error creating project: ${resp.message}`);
       return new LanguageModelToolResult([

--- a/src/chat/tools/createProject.ts
+++ b/src/chat/tools/createProject.ts
@@ -81,7 +81,7 @@ export class CreateProjectTool extends BaseLanguageModelTool<ICreateProjectParam
     }
     return new LanguageModelToolResult([
       new LanguageModelTextPart(
-        `Project created successfully. The user can refer to the form to make any necessary adjustments.`,
+        `The project template form was successfully opened, and is now ready for the user to verify and/or make any necessary adjustments before the project can be created.`,
       ),
     ]);
   }

--- a/src/chat/tools/getTemplate.ts
+++ b/src/chat/tools/getTemplate.ts
@@ -88,8 +88,10 @@ export class GetTemplateOptionsTool extends BaseLanguageModelTool<IGetTemplateOp
     );
     resultParts.push(resultsHeader);
     resultParts.push(...(result.content as LanguageModelTextPart[]));
-    // TODO: add hint for the model to create a project based on user inputs
-
+    const resultsFooter = new LanguageModelTextPart(
+      `If the user wants to continue with this template, run the "create_project" tool with the template ID and the provided input values.`,
+    );
+    resultParts.push(resultsFooter);
     return new TextOnlyToolResultPart(toolCall.callId, resultParts);
   }
 }

--- a/src/chat/tools/getTemplate.ts
+++ b/src/chat/tools/getTemplate.ts
@@ -89,7 +89,12 @@ export class GetTemplateOptionsTool extends BaseLanguageModelTool<IGetTemplateOp
     resultParts.push(resultsHeader);
     resultParts.push(...(result.content as LanguageModelTextPart[]));
     const resultsFooter = new LanguageModelTextPart(
-      `If the user wants to continue with this template, run the "create_project" tool with the template ID and the provided input values.`,
+      `If the user wants to continue with this template:
+      1. Ask the user to provide values for ALL required inputs listed above
+      2. After collecting all user inputs, call the "create_project" tool with:
+        - the 'templateId': "${parameters.templateId}"
+        - 'templateOptions': an object containing ALL user-provided values
+      IMPORTANT: Always include the complete templateOptions object with ALL user input values when calling create_project.`,
     );
     resultParts.push(resultsFooter);
     return new TextOnlyToolResultPart(toolCall.callId, resultParts);

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -43,6 +43,14 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
       const templateSummary = summarizeProjectTemplate(template);
       templateStrings.push(new LanguageModelTextPart(templateSummary));
     });
+    if (inputTagsPassed && !templateStrings.length) {
+      // invalid tags, no results
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(
+          `No templates matched the provided tags: ${JSON.stringify(params.tags)}`,
+        ),
+      ]);
+    }
 
     if (token.isCancellationRequested) {
       logger.debug("Tool invocation cancelled");

--- a/src/chat/tools/listTemplates.ts
+++ b/src/chat/tools/listTemplates.ts
@@ -78,7 +78,11 @@ export class ListTemplatesTool extends BaseLanguageModelTool<IListTemplatesParam
     resultParts.push(...(result.content as LanguageModelTextPart[]));
     // add a footer to the results
     const resultsFooter = new LanguageModelTextPart(
-      `Summarize all of the above project templates for the user. If the user is interested in a specific project template, provide the template's 'ID' with the "get_templateOptions" tool to determine what inputs they need to provide.`,
+      `Summarize all of the above project templates for the user. If the user is interested in a specific project template:
+      1. Use the "get_templateOptions" tool with the template's 'ID' to determine what inputs they need to provide
+      2. Ask the user to provide values for any/all **required** fields
+      3. AFTER collecting user inputs, call the "create_project" tool with BOTH the 'templateId' AND all user-provided values in the 'templateOptions' object
+      IMPORTANT: Never call "create_project" without including ALL user input values in 'templateOptions'.`,
     );
     resultParts.push(resultsFooter);
     return new TextOnlyToolResultPart(toolCall.callId, resultParts);

--- a/src/chat/tools/registration.ts
+++ b/src/chat/tools/registration.ts
@@ -1,5 +1,6 @@
 import { Disposable, lm } from "vscode";
 import { BaseLanguageModelTool } from "./base";
+import { CreateProjectTool } from "./createProject";
 import { GetTemplateOptionsTool } from "./getTemplate";
 import { ListTemplatesTool } from "./listTemplates";
 import { setToolMap } from "./toolMap";
@@ -8,6 +9,7 @@ export function registerChatTools(): Disposable[] {
   const tools: BaseLanguageModelTool<any>[] = [
     new ListTemplatesTool(),
     new GetTemplateOptionsTool(),
+    new CreateProjectTool(),
   ];
 
   const disposables: Disposable[] = [];


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to https://github.com/confluentinc/vscode/pull/1735 to take user-provided inputs (based on project template `options`) and pass them to `scaffoldProjectRequest()` to show the project generation form.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Some additional changes were needed in `scaffold.ts` to clean up the telemetry source attribution as well as return the same kind of `{ success: boolean, message: string }` structure to help the tool result handling
- Similar to https://github.com/confluentinc/vscode/pull/1735, this also required adding a hint to the "parent" tool (`get_templateOptions`) to continue on and pass values into this `create_project` tool

Closes #1470 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
