### PR TITLE
Add statement status and stop functionality to results viewer

### DIFF
--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -9,7 +9,7 @@ import { FLINK_SQL_FILE_EXTENSIONS, FLINK_SQL_LANGUAGE_ID } from "../flinkSql/co
 import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
-import { FAILED_PHASE, FlinkStatement, restFlinkStatementToModel } from "../models/flinkStatement";
+import { FlinkStatement, Phase, restFlinkStatementToModel } from "../models/flinkStatement";
 import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
 import { showErrorNotificationWithButtons } from "../notifications";
 import { flinkComputePoolQuickPick } from "../quickpicks/flinkComputePools";
@@ -208,7 +208,7 @@ export async function submitFlinkStatementCommand(
     const restResponse = await submitFlinkStatement(submission);
     const newStatement = restFlinkStatementToModel(restResponse, computePool);
 
-    if (newStatement.status.phase === FAILED_PHASE) {
+    if (newStatement.status.phase === Phase.FAILED) {
       // Immediate failure of the statement. User gave us something
       // bad, like perhaps a bad table / column name, etc..
 

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -32,20 +32,6 @@
               </vscode-dropdown>
             </div>
 
-            <div class="dropdown-container">
-              <!-- Empty label for aligned layout with the rest of controls -->
-              <label for="stream-toggle"><span>&nbsp;</span></label>
-              <vscode-button
-                appearance="primary"
-                id="stream-toggle"
-                data-on-click="this.handleStreamToggle(this.streamState())"
-                data-text="this.streamStateLabel()"
-                data-attr-title="this.streamStateTooltip()"
-                data-attr-disabled="this.streamState() === 'completed'"
-              >
-              </vscode-button>
-            </div>
-
             <template data-if="this.streamError() != null">
               <div class="dropdown-container">
                 <!-- Empty label for aligned layout with the rest of controls -->
@@ -64,18 +50,6 @@
                     <p data-text="this.streamError().message"></p>
                   </div>
                 </div>
-              </div>
-            </template>
-
-            <template data-if="this.timer() != null">
-              <div class="dropdown-container">
-                <label>Time elapsed</label>
-                <flink-timer
-                  class="timer"
-                  data-attr-class="'timer ' + this.streamState()"
-                  data-prop-time="this.timer()"
-                  data-prop-state="this.streamState()"
-                ></flink-timer>
               </div>
             </template>
           </div>
@@ -106,15 +80,6 @@
           <div class="grid-banner">
             <vscode-progress-ring></vscode-progress-ring>
             <label>Waiting for results…</label>
-          </div>
-        </template>
-
-        <template
-          data-if="this.waitingForResults() && this.streamState() === 'paused' && this.streamError() == null"
-        >
-          <div class="grid-banner">
-            <span class="codicon codicon-debug-pause banner-pending"></span>
-            <label>Paused</label>
           </div>
         </template>
 

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -15,6 +15,26 @@
       <header class="statement-details-header">
         <section class="statement-details-section">
           <h4>Statement details</h4>
+          <div class="statement-info">
+            <div class="flex-row">
+              <div class="info-item">
+                <label>Start Time:</label>
+                <span data-text="this.statementMeta().startTime"></span>
+              </div>
+              <div class="info-item">
+                <label>Status:</label>
+                <span data-text="this.statementMeta().status"></span>
+              </div>
+              <vscode-button
+                appearance="primary"
+                data-on-click="this.stopStatement()"
+                data-attr-disabled="!this.statementMeta().stoppable || this.stopButtonClicked()"
+              >
+                <span class="codicon codicon-stop"></span>
+                <label>&nbsp;Stop</label>
+              </vscode-button>
+            </div>
+          </div>
           <div class="flex-row">
             <template data-if="this.streamError() != null">
               <div class="dropdown-container">
@@ -37,27 +57,30 @@
               </div>
             </template>
           </div>
-
-          <div class="statement-info">
-            <div class="flex-row">
-              <div class="info-item">
-                <label>Start Time:</label>
-                <span data-text="this.statementMeta().startTime"></span>
+          <template data-if="this.statementMeta().failed && this.statementMeta().detail">
+            <div class="reportable-box red">
+              <div class="error-heading">
+                <span class="codicon codicon-error"></span>
+                Something went wrong.
               </div>
-              <div class="info-item">
-                <label>Status:</label>
-                <span data-text="this.statementMeta().status"></span>
-              </div>
-              <vscode-button
-                appearance="primary"
-                data-on-click="this.stopStatement()"
-                data-attr-disabled="!this.statementMeta().stoppable"
-              >
-                <span class="codicon codicon-stop"></span>
-                <label>&nbsp;Stop</label>
-              </vscode-button>
+              <div
+                class="reportable-message"
+                data-html="this.statementMeta().detail && this.statementMeta().detail.replace(/\n/g, '<br>')"
+              ></div>
             </div>
-          </div>
+          </template>
+          <template data-if="!this.statementMeta().failed && this.statementMeta().detail">
+            <div class="reportable-box blue">
+              <div class="error-heading">
+                <span class="codicon codicon-info"></span>
+                Info
+              </div>
+              <div
+                class="reportable-message"
+                data-html="this.statementMeta().detail && this.statementMeta().detail.replace(/\n/g, '<br>')"
+              ></div>
+            </div>
+          </template>
         </section>
 
         <section>
@@ -492,6 +515,38 @@
       .info-item label {
         font-weight: 500;
         color: var(--vscode-descriptionForeground);
+      }
+
+      .reportable-box {
+        padding: 12px;
+        border-radius: 6px;
+        margin-top: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .reportable-box.red {
+        background: #ffeaea;
+        border: 1px solid #e53935;
+        color: #b71c1c;
+      }
+
+      .reportable-box.blue {
+        background: #e3f2fd;
+        border: 1px solid #1976d2;
+        color: #0d47a1;
+      }
+
+      .reportable-message {
+        margin-top: 4px;
+        font-size: 95%;
+      }
+
+      .error-heading {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+        font-weight: bold;
+        margin-bottom: 4px;
       }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -12,26 +12,10 @@
 
   <body>
     <main class="wrapper">
-      <header class="results-viewer-settings">
-        <section class="flink-settings">
-          <h4>Statement Results Settings</h4>
-
+      <header class="statement-details-header">
+        <section class="statement-details-section">
+          <h4>Statement details</h4>
           <div class="flex-row">
-            <div class="dropdown-container">
-              <label for="results-limit">Max results</label>
-              <vscode-dropdown
-                id="results-limit"
-                data-prop-value="this.resultLimit()"
-                data-on-change="this.handleResultLimitChange(event.target.value)"
-              >
-                <vscode-option value="100">100</vscode-option>
-                <vscode-option value="1k">1,000</vscode-option>
-                <vscode-option value="10k">10,000</vscode-option>
-                <vscode-option value="100k">100,000</vscode-option>
-                <vscode-option value="1m">1,000,000</vscode-option>
-              </vscode-dropdown>
-            </div>
-
             <template data-if="this.streamError() != null">
               <div class="dropdown-container">
                 <!-- Empty label for aligned layout with the rest of controls -->
@@ -53,10 +37,30 @@
               </div>
             </template>
           </div>
+
+          <div class="statement-info">
+            <div class="flex-row">
+              <div class="info-item">
+                <label>Start Time:</label>
+                <span data-text="this.statementMeta().startTime"></span>
+              </div>
+              <div class="info-item">
+                <label>Status:</label>
+                <span data-text="this.statementMeta().status"></span>
+              </div>
+              <vscode-button
+                appearance="primary"
+                data-on-click="this.stopStatement()"
+                data-attr-disabled="!this.statementMeta().stoppable"
+              >
+                <span class="codicon codicon-stop"></span>
+                <label>&nbsp;Stop</label>
+              </vscode-button>
+            </div>
+          </div>
         </section>
 
         <section>
-          <h4>Results Quick Search</h4>
           <div class="flex-row">
             <vscode-text-field
               id="results-search"
@@ -88,6 +92,15 @@
             <span class="codicon codicon-error banner-error"></span>
             <label>Failed to load results.</label>
             <label data-text="this.streamError().message"></label>
+          </div>
+        </template>
+
+        <template
+          data-if="!this.waitingForResults() && !this.hasResults() && !this.emptyFilterResult()"
+        >
+          <div class="grid-banner">
+            <span class="codicon codicon-info"></span>
+            <label>No results available</label>
           </div>
         </template>
 
@@ -254,12 +267,12 @@
         margin: 0;
       }
 
-      .results-viewer-settings {
+      .statement-details-header {
         display: flex;
         flex-direction: column;
       }
 
-      .results-viewer-settings > * {
+      .statement-details-header > * {
         padding: 12px;
       }
 
@@ -281,7 +294,7 @@
         color: var(--vscode-list-activeSelectionForeground, #ffffff);
       }
 
-      .flink-settings {
+      .statement-details-section {
         background: var(--vscode-sideBarTitle-background);
         border-bottom: 1px solid var(--vscode-sideBar-border);
       }
@@ -465,19 +478,20 @@
         font-size: 14px;
       }
 
-      .timer {
-        font-size: 1rem;
-        font-weight: 600;
-        padding: 2px 0;
-        line-height: 1;
-        flex: 1;
-        align-items: center;
-        display: flex;
-        color: var(--vscode-editor-foreground);
+      .statement-info {
+        margin-top: 0.5rem;
       }
 
-      .timer.paused {
-        opacity: 0.5;
+      .info-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-right: 1rem;
+      }
+
+      .info-item label {
+        font-weight: 500;
+        color: var(--vscode-descriptionForeground);
       }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -363,6 +363,10 @@ class FlinkStatementResultsViewModel extends ViewModel {
   async stopStatement() {
     this.stopButtonClicked(true);
     await post("StopStatement", { timestamp: this.timestamp() });
+
+    // Reset the button state after a short delay
+    // in case the stop failed for some reason
+    setTimeout(() => this.stopButtonClicked(false), 2000);
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Show statement created time and status (similar to CCloud UI)
- Allow stopping statement
- Handles various edge cases

Here's a demo:

https://github.com/user-attachments/assets/40526c77-7bfb-4890-8a5f-1f49918091da


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
