### PR TITLE
refactor Copilot tool calling flow to enforce `LanguageModelToolResultPart` usage

### DIFF
--- a/src/chat/messageTypes.ts
+++ b/src/chat/messageTypes.ts
@@ -1,4 +1,8 @@
-import { LanguageModelChatMessage } from "vscode";
+import {
+  LanguageModelChatMessage,
+  LanguageModelToolCallPart,
+  LanguageModelToolResultPart,
+} from "vscode";
 import { PARTICIPANT_ID } from "./constants";
 
 /**
@@ -15,7 +19,7 @@ export function userMessage(message: string) {
  * Returns an {@link LanguageModelChatMessage.Assistant Assistant message} with a participant tag as
  * the {@linkcode PARTICIPANT_ID} to clearly separate it from other `Assistant` message implementations.
  */
-export function participantMessage(message: string) {
+export function participantMessage(message: string | LanguageModelToolCallPart[]) {
   return LanguageModelChatMessage.Assistant(message, PARTICIPANT_ID);
 }
 
@@ -28,6 +32,20 @@ export function systemMessage(message: string) {
   return LanguageModelChatMessage.User(`SYSTEM: ${message}`, "system");
 }
 
-// NOTE: "tool" messages should be handled via the `.toolMessage()` method from the
-// `BaseLanguageModelTool` class, but we may want to migrate it here for easier access and
-// consistency in the future
+/**
+ * Returns a {@link LanguageModelChatMessage.User User message} with a "tool" tag to clearly
+ * distinguish it from other `User` message implementations.
+ *
+ * This should be used to wrap the {@link LanguageModelToolResultPart}s of a tool invocation.
+ */
+export function toolMessage(
+  toolName: string,
+  results: LanguageModelToolResultPart[],
+  status?: string,
+): LanguageModelChatMessage {
+  let roleName = `tool:${toolName}`;
+  if (status !== undefined) {
+    roleName = `${roleName}:${status}`;
+  }
+  return LanguageModelChatMessage.User(results, roleName);
+}

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -166,6 +166,11 @@ export async function handleChatMessage(
   const chatTools: LanguageModelChatTool[] = registeredTools.map(
     (tool: BaseLanguageModelTool<any>) => tool.toChatTool(),
   );
+  // keep this around for debugging new tools to make sure they are registered correctly
+  logger.debug(
+    "registered tools:",
+    chatTools.map((tool) => tool.name),
+  );
   const requestOptions: LanguageModelChatRequestOptions = {
     tools: chatTools,
     toolMode: LanguageModelChatToolMode.Auto,

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -11,6 +11,7 @@ import {
   LanguageModelChatRequestOptions,
   LanguageModelChatResponse,
   LanguageModelChatSelector,
+  LanguageModelChatTool,
   LanguageModelChatToolMode,
   LanguageModelTextPart,
   LanguageModelToolCallPart,
@@ -25,7 +26,6 @@ import { participantMessage, systemMessage, toolMessage, userMessage } from "./m
 import { parseReferences } from "./references";
 import { summarizeChatHistory } from "./summarizers/chatHistory";
 import { BaseLanguageModelTool, TextOnlyToolResultPart } from "./tools/base";
-import { ListTemplatesTool } from "./tools/listTemplates";
 import { getToolMap } from "./tools/toolMap";
 import { ToolCallMetadata } from "./tools/types";
 
@@ -162,8 +162,12 @@ export async function handleChatMessage(
   const maxIterations = 10; // TODO: make this user-configurable?
 
   // inform the model that tools can be invoked as part of the response stream
+  const registeredTools: BaseLanguageModelTool<any>[] = Array.from(getToolMap().values());
+  const chatTools: LanguageModelChatTool[] = registeredTools.map(
+    (tool: BaseLanguageModelTool<any>) => tool.toChatTool(),
+  );
   const requestOptions: LanguageModelChatRequestOptions = {
-    tools: [new ListTemplatesTool().toChatTool()],
+    tools: chatTools,
     toolMode: LanguageModelChatToolMode.Auto,
   };
   // determine whether or not to continue sending chat requests to the model as a result of any tool

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -268,7 +268,6 @@ export async function handleChatMessage(
 function filterContextHistory(
   history: readonly (ChatRequestTurn | ChatResponseTurn)[],
 ): LanguageModelChatMessage[] {
-  // remove the last message from the history since it is the current request
   logger.debug("context history:\n", JSON.stringify(history, null, 2));
 
   // only use messages where the participant was tagged, or messages where the participant responded

--- a/src/chat/summarizers/chatHistory.ts
+++ b/src/chat/summarizers/chatHistory.ts
@@ -27,12 +27,6 @@ export function summarizeChatHistory(
 
     // responses from the assistant:
     if (turn instanceof ChatResponseTurn) {
-      // unlike requests, responses can have multiple parts, so we need to iterate through them
-      for (const part of turn.response) {
-        if (part instanceof ChatResponseMarkdownPart) {
-          summary.appendMarkdown(`\n\nASSISTANT: "${part.value.value}"`);
-        }
-      }
       // also check if there was any tool call data in the result.metadata.toolsCalled object
       const toolCallResults: ToolCallMetadata[] = turn.result.metadata?.toolsCalled;
       if (toolCallResults && toolCallResults.length) {
@@ -47,6 +41,12 @@ export function summarizeChatHistory(
           summary.appendMarkdown(
             `\n\nUSER tool call result${plural}: "${toolCall.request.name}": "${textResults.map((part) => part.value).join("\n")}"`,
           );
+        }
+      }
+      // unlike requests, responses can have multiple parts, so we need to iterate through them
+      for (const part of turn.response) {
+        if (part instanceof ChatResponseMarkdownPart) {
+          summary.appendMarkdown(`\n\nASSISTANT: "${part.value.value}"`);
         }
       }
     }

--- a/src/chat/summarizers/chatHistory.ts
+++ b/src/chat/summarizers/chatHistory.ts
@@ -1,0 +1,38 @@
+import {
+  ChatRequestTurn,
+  ChatResponseMarkdownPart,
+  ChatResponseTurn,
+  MarkdownString,
+} from "vscode";
+import { PARTICIPANT_ID } from "../constants";
+
+export function summarizeChatHistory(
+  history: readonly (ChatRequestTurn | ChatResponseTurn)[],
+): string {
+  let summary = new MarkdownString("These are the previous messages in the conversation:");
+
+  for (const turn of history) {
+    if (turn.participant !== PARTICIPANT_ID) {
+      // skip messages for/from other participants
+      continue;
+    }
+
+    // requests from the user:
+    if (turn instanceof ChatRequestTurn) {
+      summary.appendMarkdown(`\n\nUSER: "${turn.prompt}"`);
+      continue;
+    }
+
+    // responses from the assistant:
+    if (turn instanceof ChatResponseTurn) {
+      // unlike requests, responses can have multiple parts, so we need to iterate through them
+      for (const part of turn.response) {
+        if (part instanceof ChatResponseMarkdownPart) {
+          summary.appendMarkdown(`\n\nASSISTANT: "${part.value.value}"`);
+        }
+      }
+    }
+  }
+
+  return summary.value;
+}

--- a/src/chat/summarizers/projectTemplate.ts
+++ b/src/chat/summarizers/projectTemplate.ts
@@ -1,0 +1,12 @@
+import { MarkdownString } from "vscode";
+import { ScaffoldV1Template, ScaffoldV1TemplateSpec } from "../../clients/scaffoldingService";
+
+export function summarizeProjectTemplate(template: ScaffoldV1Template): string {
+  const spec: ScaffoldV1TemplateSpec = template.spec!;
+  let summary = new MarkdownString()
+    .appendMarkdown(`"${spec.display_name}":`)
+    .appendMarkdown(`\n\t- ID: "${spec.name}"`)
+    .appendMarkdown(`\n\t- Description: "${spec.description}"`);
+
+  return summary.value;
+}

--- a/src/chat/tools/README.md
+++ b/src/chat/tools/README.md
@@ -2,8 +2,3 @@ This subdirectory houses the registration and handling of "tools" that can be in
 (if registered in `package.json`'s `languageModelTools` section with
 `canBeReferencedInPrompt: true`) and/or by the language model (if sent as part of `tools` in the
 `LanguageModelChatRequestOptions`).
-
-Tools that provide additional context to conversations should return messages via the
-`.toolMessage()` method, which will tag an `Assistant` message with the tool name and a `tool` role.
-(This is different than the `systemMessage()` function, which wraps a `User` message to provide
-non-tool context to the language model.)

--- a/src/chat/tools/base.ts
+++ b/src/chat/tools/base.ts
@@ -2,12 +2,13 @@ import {
   CancellationToken,
   ChatRequest,
   ChatResponseStream,
-  LanguageModelChatMessage,
   LanguageModelChatTool,
+  LanguageModelTextPart,
   LanguageModelTool,
   LanguageModelToolCallPart,
   LanguageModelToolInvocationOptions,
   LanguageModelToolResult,
+  LanguageModelToolResultPart,
 } from "vscode";
 import { getExtensionContext } from "../../context/extension";
 import { LanguageModelToolContribution } from "./types";
@@ -27,24 +28,20 @@ export abstract class BaseLanguageModelTool<T> implements LanguageModelTool<T> {
   ): Promise<LanguageModelToolResult>;
 
   /**
-   * Invokes the tool and processes the result through the {@link ChatResponseStream}.
-   * This should be called when the model selects this tool in a {@link LanguageModelToolCallPart}.
+   * This is a wrapper around {@linkcode invoke} that provides a {@link LanguageModelTool} access to
+   * the original request, tool call, and response stream to be used for progress updates and/or
+   * interactive outputs.
+   * (see https://code.visualstudio.com/api/extension-guides/chat#supported-chat-response-output-types)
+   *
+   * This is called when the model selects this tool in a {@link LanguageModelToolCallPart}
+   * (tool call request).
    */
   abstract processInvocation(
     request: ChatRequest,
     stream: ChatResponseStream,
     toolCall: LanguageModelToolCallPart,
     token: CancellationToken,
-  ): Promise<LanguageModelChatMessage[]>;
-
-  /** Return an `Assistant` message with tool-call related information. */
-  toolMessage(message: string, status?: string): LanguageModelChatMessage {
-    let roleName = `tool:${this.name}`;
-    if (status !== undefined) {
-      roleName = `${roleName}:${status}`;
-    }
-    return LanguageModelChatMessage.Assistant(message, roleName);
-  }
+  ): Promise<TextOnlyToolResultPart>;
 
   /** Converts this tool to a {@link LanguageModelChatTool} for use in chat requests. */
   toChatTool(): LanguageModelChatTool {
@@ -61,5 +58,27 @@ export abstract class BaseLanguageModelTool<T> implements LanguageModelTool<T> {
       description: registeredTool.modelDescription,
       inputSchema: registeredTool.inputSchema,
     } as LanguageModelChatTool;
+  }
+}
+
+/**
+ * A result from a tool invocation that is intended to be sent back to the model. This is a
+ * {@link LanguageModelToolResultPart} where the `content` property is restricted to be an array of
+ * {@link LanguageModelTextPart} objects.
+ *
+ * Since we aren't using `LanguageModelPromptTsxPart`, a tool's `.invoke()` is only ever returning
+ * {@link LanguageModelTextPart} instances in its {@link LanguageModelToolResult}, which are then
+ * passed directly to the {@link LanguageModelToolResultPart} constructor. That
+ * {@link LanguageModelToolResultPart} will then be wrapped as a `User` message before being added
+ * to the message history.
+ */
+export class TextOnlyToolResultPart extends LanguageModelToolResultPart {
+  // explicitly restricted to be an array of LanguageModelTextPart, removing
+  // `LanguageModelPromptTsxPart` and `unknown` from the type
+  override content: LanguageModelTextPart[];
+
+  constructor(callId: string, content: LanguageModelTextPart[]) {
+    super(callId, content);
+    this.content = content;
   }
 }

--- a/src/chat/tools/registration.ts
+++ b/src/chat/tools/registration.ts
@@ -4,16 +4,14 @@ import { ListTemplatesTool } from "./listTemplates";
 import { setToolMap } from "./toolMap";
 
 export function registerChatTools(): Disposable[] {
+  const tools: BaseLanguageModelTool<any>[] = [new ListTemplatesTool()];
+
   const disposables: Disposable[] = [];
-
-  const tools = new Map<string, BaseLanguageModelTool<any>>([
-    ["list_projectTemplates", new ListTemplatesTool()],
-  ]);
-
-  for (const [toolId, tool] of tools.entries()) {
-    disposables.push(lm.registerTool(toolId, tool));
-    setToolMap(toolId, tool);
+  for (const tool of tools) {
+    const toolDisposable: Disposable = lm.registerTool(tool.name, tool);
+    disposables.push(toolDisposable);
+    // also update the registry map for easier lookup later
+    setToolMap(tool.name, tool);
   }
-
   return disposables;
 }

--- a/src/chat/tools/types.ts
+++ b/src/chat/tools/types.ts
@@ -1,7 +1,22 @@
-// NOTE: property descriptions below taken from package.json help text, not currently available at
-// https://code.visualstudio.com/api/references/contribution-points
+import { LanguageModelToolCallPart } from "vscode";
+import { TextOnlyToolResultPart } from "./base";
 
-/** An object in the package.json `languageModelTools`. */
+/**
+ * Object representing the request/response of a single tool call, stored in the `ChatResult`
+ * metadata after a single `ChatRequest` is sent so that the tool call can be referenced in future
+ * requests without the model needing to repeat the tool call(s).
+ */
+export type ToolCallMetadata = {
+  request: LanguageModelToolCallPart;
+  response: TextOnlyToolResultPart;
+};
+
+/**
+ * An object in the package.json `languageModelTools`.
+ *
+ * NOTE: property descriptions below taken from package.json help text, not currently available at
+ * https://code.visualstudio.com/api/references/contribution-points
+ */
 export interface LanguageModelToolContribution {
   /**
    * A unique name for this tool. This name must be a globally unique identifier, and is also used


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

While working on https://github.com/confluentinc/vscode/pull/1717 and its child branches, I noticed some concerning behavior with the tool calling flow where Copilot would be missing tool call results/references and having to repeat a lot of the same tool calls at each request. This was not ideal since it can drive up the token usage for some very simple tool chaining flows.

While debugging this behavior and poring over https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/vscode/index.d.ts, I realized we were mixing a lot of the core types/interfaces while trying to convert tools' `LanguageModelTextPart`s into `User` messages.

This PR aims to address all of the above by:
- explicitly adding [tool call metadata](https://github.com/confluentinc/vscode/blob/b5c761d241359af8be9bc1a7cd8c364713161990/src/chat/tools/types.ts#L4-L12) to the `ChatResult` returned by our main `chatHandler` function : https://github.com/confluentinc/vscode/blob/b5c761d241359af8be9bc1a7cd8c364713161990/src/chat/participant.ts#L83-L90
  - ...so it's able to be included in the "chat history": https://github.com/confluentinc/vscode/blob/b5c761d241359af8be9bc1a7cd8c364713161990/src/chat/summarizers/chatHistory.ts#L30-L45
- streamlining the tools' `processInvocation()` and `invoke()` behavior to enforce only using `LanguageModelTextPart`s, **not `LanguageModelPromptTsxPart` or `unknown`**, and wrapping them in a subclass of `LanguageModelToolResultPart`
  - this is done so we can directly add the tool results to [`User` messages](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/21cd76b39432bd90c646981208f58bc090681616/types/vscode/index.d.ts#L19956), which requires adding the tool call as an Assistant message: https://github.com/confluentinc/vscode/blob/b5c761d241359af8be9bc1a7cd8c364713161990/src/chat/participant.ts#L247-L253

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Local debugging of tool call results and messages sent is pretty painful due to the nested interfaces not serializing well, so I added a `debugLogChatMessages` helper function (not enabled by default).
- Some of the conversation/project summarizing from child branches has been brought up into this branch to help keep those branches smaller while addressing necessary changes.

### Associated PRs

- https://github.com/confluentinc/vscode/pull/1740 👈
  - "Project scaffolding" stack:
    - https://github.com/confluentinc/vscode/pull/1735
      - https://github.com/confluentinc/vscode/pull/1736
  - "Sidebar context" stack:
    - https://github.com/confluentinc/vscode/pull/1717 
      - https://github.com/confluentinc/vscode/pull/1721
      - placeholder for `get_kafkaClusters` tool
        - placeholder for `get_kafkaTopics` tool
      - placeholder for `get_schemaRegistries` tool
        - placeholder for `get_schemas` tool

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
