### PR TITLE
Saner client instance management (Follow-up #1 for FlinkSQL language client)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ import {
   checkForExtensionDisabledReason,
   showExtensionDisabledNotification,
 } from "./featureFlags/evaluation";
-import { initializeFlinkConfigManager } from "./flinkSql/flinkConfigManager";
+import { initializeFlinkLanguageClientManager } from "./flinkSql/flinkLanguageClientManager";
 import { activateFlinkStatementResultsViewer } from "./flinkStatementResults";
 import { constructResourceLoaderSingletons } from "./loaders";
 import { cleanupOldLogFiles, getLogFileStream, Logger, OUTPUT_CHANNEL } from "./logging";
@@ -242,7 +242,7 @@ async function _activateExtension(
   context.subscriptions.push(
     uriHandler,
     WebsocketManager.getInstance(),
-    initializeFlinkConfigManager(),
+    initializeFlinkLanguageClientManager(),
     ...authProviderDisposables,
     ...viewProviderDisposables,
     ...registeredCommands,

--- a/src/flinkSql/flinkConfigManager.test.ts
+++ b/src/flinkSql/flinkConfigManager.test.ts
@@ -8,7 +8,7 @@ import * as environmentsModule from "../graphql/environments";
 import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
-import { FLINK_CONFIG_COMPUTE_POOL } from "../preferences/constants";
+import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../preferences/constants";
 import * as ccloud from "../sidecar/connections/ccloud";
 import { FlinkConfigurationManager } from "./flinkConfigManager";
 
@@ -64,8 +64,8 @@ describe("FlinkConfigurationManager", () => {
       const configMock = {
         get: sandbox.stub(),
       };
-      configMock.get.withArgs("computePoolId").returns("");
-      configMock.get.withArgs("database").returns("");
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("");
+      configMock.get.withArgs(FLINK_CONFIG_DATABASE).returns("");
       configStub.returns(configMock);
 
       const result = await flinkManager.validateFlinkSettings();

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -10,20 +10,20 @@ import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../preferences/constants";
 import * as ccloud from "../sidecar/connections/ccloud";
-import { FlinkConfigurationManager } from "./flinkConfigManager";
+import { FlinkLanguageClientManager } from "./flinkLanguageClientManager";
 
-describe("FlinkConfigurationManager", () => {
+describe("FlinkLanguageClientManager", () => {
   let sandbox: sinon.SinonSandbox;
   let configStub: sinon.SinonStub;
   let contextValueStub: sinon.SinonStub;
   let hasCCloudAuthSessionStub: sinon.SinonStub;
-  let flinkManager: FlinkConfigurationManager;
+  let flinkManager: FlinkLanguageClientManager;
   let ccloudLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
   let getEnvironmentsStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    FlinkConfigurationManager["instance"] = null;
+    FlinkLanguageClientManager["instance"] = null;
     configStub = sandbox.stub(vscode.workspace, "getConfiguration");
     const configMock = {
       get: sandbox.stub(),
@@ -38,13 +38,14 @@ describe("FlinkConfigurationManager", () => {
 
     getEnvironmentsStub = sandbox.stub(environmentsModule, "getEnvironments");
 
-    flinkManager = FlinkConfigurationManager.getInstance();
+    flinkManager = FlinkLanguageClientManager.getInstance();
     sandbox.stub(flinkManager, "promptChooseDefaultComputePool" as any).resolves();
     sandbox.stub(flinkManager, "checkFlinkResourcesAvailability" as any).resolves();
   });
+
   afterEach(() => {
     sandbox.restore();
-    FlinkConfigurationManager["instance"] = null;
+    FlinkLanguageClientManager["instance"] = null;
   });
 
   describe("validateFlinkSettings", () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes https://github.com/confluentinc/vscode/issues/1729 
- Refactors what was the "FlinkConfigManager" so that it is only responsible for the language client and handles the entire client lifecycle, so we can avoid hard-to-debug disconnect logic spread across the codebase 😁 
- Language Client file is simpler - it just initiates the client and handles logic specific to LSP messages, and server websocket  interactions.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This is based on the prev branch `ncothren/flink-language-client`, PR open [here.](https://github.com/confluentinc/vscode/pull/1630)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
