### PR TITLE
add Copilot chat participant telemetry and feedback integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -695,12 +695,12 @@
           "confluent.chat.feedback.sendErrorData": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Include **error data** from Copilot chat participant results in 👍/👎 feedback. When disabled (default), no error details will be sent with your feedback."
+            "markdownDescription": "Include **error data** from Copilot chat participant results gathered from 👍/👎 feedback. When disabled (default), no error details will be sent with your feedback."
           },
           "confluent.chat.feedback.sendToolCallData": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results in 👍/👎 feedback.\n- When disabled (default), your privacy is protected as no model-provided tool inputs or result contents will be shared.\n- When enabled, potentially sensitive information will be sent including the full inputs provided to tools and their complete outputs (which may contain names, IDs, and detailed properties of your Confluent/Kafka resources).\n\nNOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used, but not their inputs or outputs."
+            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results gathered from 👍/👎 feedback.\n- When disabled (default), your privacy is protected as no model-provided tool inputs or result contents will be shared.\n- When enabled, potentially sensitive information will be sent including the full inputs provided to tools and their complete outputs (which may contain names, IDs, and detailed properties of your Confluent/Kafka resources).\n\nNOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used, but not their inputs or outputs."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -692,15 +692,15 @@
               "experimental"
             ]
           },
-          "confluent.chat.feedback.sendErrorData": {
+          "confluent.chat.telemetry.sendErrorData": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Include **error data** from Copilot chat participant results gathered from 👍/👎 feedback. When disabled (default), no error details will be sent with your feedback."
+            "markdownDescription": "Include **error data** from Copilot chat participant results gathered from 👍/👎 feedback or from error responses. When disabled (default), no error details will be sent."
           },
-          "confluent.chat.feedback.sendToolCallData": {
+          "confluent.chat.telemetry.sendToolCallData": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results gathered from 👍/👎 feedback.\n- When disabled (default), your privacy is protected as no model-provided tool inputs or result contents will be shared.\n- When enabled, potentially sensitive information will be sent including the full inputs provided to tools and their complete outputs (which may contain names, IDs, and detailed properties of your Confluent/Kafka resources).\n\nNOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used, but not their inputs or outputs."
+            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results gathered from 👍/👎 feedback, as well as **tool call inputs** during tool call flows for general telemetry purposes.\n- When disabled (default), your privacy is protected as no model-provided tool inputs or result contents will be shared.\n- When enabled, potentially sensitive information will be sent including the full inputs provided to tools and their complete outputs (which may contain names, IDs, and detailed properties of your Confluent/Kafka resources).\n\nNOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used, but not their inputs or outputs."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -695,12 +695,12 @@
           "confluent.chat.feedback.sendErrorData": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Include **error data** from Copilot chat participant results in 👍/👎 feedback."
+            "markdownDescription": "Include **error data** from Copilot chat participant results in 👍/👎 feedback. When disabled (default), no error details will be sent with your feedback."
           },
           "confluent.chat.feedback.sendToolCallData": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results in 👍/👎 feedback. (NOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used.)"
+            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results in 👍/👎 feedback.\n- When disabled (default), your privacy is protected as no model-provided tool inputs or result contents will be shared.\n- When enabled, potentially sensitive information will be sent including the full inputs provided to tools and their complete outputs (which may contain names, IDs, and detailed properties of your Confluent/Kafka resources).\n\nNOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used, but not their inputs or outputs."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -622,14 +622,6 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Allow older schema versions to be used when producing messages to Kafka topics.\n\n- Enabling this will require selecting the schema version to use.\n\n- Disabling this will use the **latest schema version**.\n\n---\n\n⚠️ **WARNING**: Producing messages with older schema versions can be in violation of some schema compatibility settings."
-          },
-          "confluent.experimental.enableChatParticipant": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the Confluent chat participant for Copilot.",
-            "tags": [
-              "experimental"
-            ]
           }
         }
       },
@@ -685,6 +677,30 @@
               "Show a notification asking whether or not to update `#confluent.flink.database#`.",
               "**Always** update `#confluent.flink.database#` without asking."
             ]
+          }
+        }
+      },
+      {
+        "title": "Copilot Chat Participant",
+        "properties": {
+          "confluent.experimental.enableChatParticipant": {
+            "order": 0,
+            "type": "boolean",
+            "default": false,
+            "description": "Enable the Confluent chat participant for Copilot.",
+            "tags": [
+              "experimental"
+            ]
+          },
+          "confluent.chat.feedback.sendErrorData": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Include **error data** from Copilot chat participant results in 👍/👎 feedback."
+          },
+          "confluent.chat.feedback.sendToolCallData": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Include **tool call inputs and result contents** from Copilot chat participant results in 👍/👎 feedback. (NOTE: If telemetry is enabled via `#telemetry.telemetryLevel#` and `#telemetry.feedback.enabled#`, we will always send the **names** of tools used.)"
           }
         }
       }

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -51,7 +51,14 @@ export async function chatHandler(
     version: request.model?.version,
     id: request.model?.id,
   });
-  const modelInfo = JSON.parse(JSON.stringify(model));
+  const modelInfo = {
+    name: model.name,
+    id: model.id,
+    vendor: model.vendor,
+    family: model.family,
+    version: model.version,
+    maxInputTokens: model.maxInputTokens,
+  };
 
   const userPrompt = request.prompt.trim();
   // check for empty request

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -58,6 +58,9 @@ export async function chatHandler(
     family: model.family,
     version: model.version,
     maxInputTokens: model.maxInputTokens,
+    // not part of the interface, but looks something like this:
+    // { supportsImageToText: true, supportsToolCalling: true }
+    capabilities: (model as any).capabilities,
   };
 
   const userPrompt = request.prompt.trim();

--- a/src/chat/participant.ts
+++ b/src/chat/participant.ts
@@ -16,9 +16,12 @@ import {
   LanguageModelToolCallPart,
   LanguageModelToolResultPart,
   lm,
+  workspace,
 } from "vscode";
 import { logError } from "../errors";
 import { Logger } from "../logging";
+import { CHAT_SEND_TOOL_CALL_DATA } from "../preferences/constants";
+import { logUsage, UserEvent } from "../telemetry/events";
 import { INITIAL_PROMPT, PARTICIPANT_ID } from "./constants";
 import { ModelNotSupportedError } from "./errors";
 import { participantMessage, systemMessage, toolMessage, userMessage } from "./messageTypes";
@@ -51,19 +54,15 @@ export async function chatHandler(
     version: request.model?.version,
     id: request.model?.id,
   });
-  const modelInfo = {
-    name: model.name,
-    id: model.id,
-    vendor: model.vendor,
-    family: model.family,
-    version: model.version,
-    maxInputTokens: model.maxInputTokens,
-    // not part of the interface, but looks something like this:
-    // { supportsImageToText: true, supportsToolCalling: true }
-    capabilities: (model as any).capabilities,
-  };
+  const modelInfo = getModelInfo(model);
 
   const userPrompt = request.prompt.trim();
+  const promptTokensUsed: number = await model.countTokens(userPrompt);
+  logUsage(UserEvent.CopilotInteraction, {
+    status: "user prompt received",
+    promptTokensUsed,
+    modelInfo,
+  });
   // check for empty request
   if (userPrompt === "" && request.references.length === 0 && request.command === undefined) {
     stream.markdown("Hmm... I don't know how to respond to that.");
@@ -85,6 +84,12 @@ export async function chatHandler(
   }
 
   if (request.command) {
+    logUsage(UserEvent.CopilotInteraction, {
+      status: "slash command used",
+      command: request.command,
+      promptTokensUsed,
+      modelInfo,
+    });
     // TODO: implement command handling and update CustomChatResult interface
     return { metadata: { modelInfo } };
   }
@@ -98,9 +103,22 @@ export async function chatHandler(
       stream,
       token,
     );
+    logUsage(UserEvent.CopilotInteraction, {
+      status: "message handling succeeded",
+      promptTokensUsed,
+      modelInfo,
+      toolsCalled: toolsCalled.map((metadata: ToolCallMetadata) => {
+        return metadata.request.name;
+      }),
+    });
     return { metadata: { toolsCalled, modelInfo } };
   } catch (error) {
     if (error instanceof Error) {
+      logUsage(UserEvent.CopilotInteraction, {
+        status: "message handling failed",
+        promptTokensUsed,
+        modelInfo,
+      });
       if (error.message.includes("model_not_supported")) {
         // NOTE: some models returned from `selectChatModels()` may return an error 400 response
         // while streaming the response. This is out of our control, and attempting to find a fallback
@@ -119,7 +137,7 @@ export async function chatHandler(
         };
       }
       // some other kind of error when sending the request or streaming the response
-      logError(error, "chatHandler", { extra: { model: model?.name ?? "unknown" } });
+      logError(error, "chatHandler", { extra: { model: JSON.stringify(modelInfo) } });
       return {
         errorDetails: { message: error.message },
         metadata: { modelInfo },
@@ -153,6 +171,21 @@ async function getModel(selector: LanguageModelChatSelector): Promise<LanguageMo
   return selectedModel;
 }
 
+function getModelInfo(model: LanguageModelChat): Record<string, any> {
+  const modelInfo: Record<string, any> = {
+    name: model.name,
+    id: model.id,
+    vendor: model.vendor,
+    family: model.family,
+    version: model.version,
+    maxInputTokens: model.maxInputTokens,
+    // not part of the interface, but looks something like this:
+    // { supportsImageToText: true, supportsToolCalling: true }
+    capabilities: (model as any).capabilities,
+  };
+  return modelInfo;
+}
+
 /** Send message(s) and stream the response in markdown format. */
 export async function handleChatMessage(
   request: ChatRequest,
@@ -167,6 +200,10 @@ export async function handleChatMessage(
   // keep track of which calls the model has made to prevent repeats by stringifying any
   // `LanguageModelToolCallPart` results
   const toolCallsMade = new Set<string>();
+
+  // top-level telemetry data that won't change as a result of tool call iterations for this request
+  const modelInfo = getModelInfo(model);
+  const promptTokensUsed: number = await model.countTokens(request.prompt);
 
   // limit number of iterations to prevent infinite loops
   let iterations = 0;
@@ -202,9 +239,27 @@ export async function handleChatMessage(
     );
     iterations++;
 
+    // dynamic telemetry data that may change as a result of tool call iterations
+    const toolsCalled: string[] = toolCallMetadata.map((metadata: ToolCallMetadata) => {
+      return metadata.request.name;
+    });
+    const previousMessageCount: number = messages.length;
+    // also check user/workspace settings to see if we can send tool call data with telemetry
+    const shouldSendToolCallData: boolean = workspace
+      .getConfiguration()
+      .get(CHAT_SEND_TOOL_CALL_DATA, false);
+
     for await (const fragment of response.stream) {
       if (token.isCancellationRequested) {
         logger.debug("chat request canceled");
+        logUsage(UserEvent.CopilotInteraction, {
+          status: "message handling canceled by user",
+          promptTokensUsed,
+          modelInfo,
+          previousMessageCount,
+          toolsCalled,
+          toolCallIteration: iterations,
+        });
         return toolCallMetadata;
       }
 
@@ -215,6 +270,16 @@ export async function handleChatMessage(
         // tool call: look up the tool from the map, process its invocation result(s), and continue on
         const toolCall: LanguageModelToolCallPart = fragment as LanguageModelToolCallPart;
         const tool: BaseLanguageModelTool<any> | undefined = getToolMap().get(toolCall.name);
+        logUsage(UserEvent.CopilotInteraction, {
+          status: "tool call received from model",
+          promptTokensUsed,
+          modelInfo,
+          previousMessageCount,
+          toolsCalled,
+          toolCallIteration: iterations,
+          toolName: toolCall.name,
+          toolCallInput: shouldSendToolCallData ? JSON.stringify(toolCall.input) : undefined,
+        });
         if (!tool) {
           const errorMsg = `Tool "${toolCall.name}" not found.`;
           logger.error(errorMsg);
@@ -263,6 +328,17 @@ export async function handleChatMessage(
           status = "error";
         }
         toolCallsMade.add(JSON.stringify(toolCall));
+
+        logUsage(UserEvent.CopilotInteraction, {
+          status: `tool invocation ${status}`,
+          promptTokensUsed,
+          modelInfo,
+          previousMessageCount,
+          toolsCalled,
+          toolCallIteration: iterations,
+          toolName: toolCall.name,
+          toolCallInput: shouldSendToolCallData ? JSON.stringify(toolCall.input) : undefined,
+        });
 
         // add the Assistant message for the LanguageModelToolCallPart,
         // then a User message for the LanguageModelToolResultPart

--- a/src/chat/telemetry.test.ts
+++ b/src/chat/telemetry.test.ts
@@ -1,0 +1,185 @@
+import * as assert from "assert";
+import { randomUUID } from "crypto";
+import * as sinon from "sinon";
+import {
+  ChatErrorDetails,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  workspace,
+  WorkspaceConfiguration,
+} from "vscode";
+import { CHAT_SEND_ERROR_DATA, CHAT_SEND_TOOL_CALL_DATA } from "../preferences/constants";
+import { sanitizeFeedbackResult } from "./telemetry";
+import { TextOnlyToolResultPart } from "./tools/base";
+import { ToolCallMetadata } from "./tools/types";
+import { CustomChatResult } from "./types";
+
+const fakeModelInfo = {
+  name: "gpt-4",
+  version: "1.0",
+  vendor: "OpenAI",
+  family: "gpt",
+};
+const fakeErrorDetails: ChatErrorDetails = { message: "Uh oh" };
+
+describe("chat/telemetry.ts sanitizeFeedbackResult", () => {
+  let sandbox: sinon.SinonSandbox;
+  let getConfigStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    getConfigStub = sandbox.stub();
+    sandbox.stub(workspace, "getConfiguration").returns({
+      get: getConfigStub,
+      update: sandbox.stub(),
+      has: sandbox.stub(),
+      inspect: sandbox.stub(),
+    } as unknown as WorkspaceConfiguration);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return an empty result when no configuration options are enabled", () => {
+    // not sending any error details or tool call inputs/contents
+    getConfigStub.withArgs(CHAT_SEND_ERROR_DATA).returns(false);
+    getConfigStub.withArgs(CHAT_SEND_TOOL_CALL_DATA).returns(false);
+
+    const toolNames = ["tool1", "tool2"];
+    const toolMetadatas: ToolCallMetadata[] = toolNames.map((toolName) =>
+      createFakeToolCallMetadata(toolName),
+    );
+    const result: CustomChatResult = {
+      errorDetails: fakeErrorDetails,
+      metadata: {
+        modelInfo: fakeModelInfo,
+        toolsCalled: toolMetadatas,
+      },
+    };
+    const sanitizedResult = sanitizeFeedbackResult(result);
+
+    assert.deepStrictEqual(sanitizedResult, {
+      modelInfo: fakeModelInfo,
+      toolCallNames: toolNames,
+      // no errorDetails
+      // no toolsCalled
+    });
+  });
+
+  it(`should include error details when "${CHAT_SEND_ERROR_DATA}" is enabled`, () => {
+    // sending error details but not tool call inputs/contents
+    getConfigStub.withArgs(CHAT_SEND_ERROR_DATA).returns(true);
+    getConfigStub.withArgs(CHAT_SEND_TOOL_CALL_DATA).returns(false);
+
+    const toolNames = ["tool1", "tool2"];
+    const toolMetadatas: ToolCallMetadata[] = toolNames.map((toolName) =>
+      createFakeToolCallMetadata(toolName),
+    );
+    const result: CustomChatResult = {
+      errorDetails: fakeErrorDetails,
+      metadata: {
+        modelInfo: fakeModelInfo,
+        toolsCalled: toolMetadatas,
+      },
+    };
+    const sanitizedResult = sanitizeFeedbackResult(result);
+
+    assert.deepStrictEqual(sanitizedResult, {
+      modelInfo: fakeModelInfo,
+      toolCallNames: toolNames,
+      errorDetails: fakeErrorDetails,
+      // no toolsCalled
+    });
+  });
+
+  it(`should include 'toolsCalled' content when "${CHAT_SEND_TOOL_CALL_DATA}" is enabled`, () => {
+    getConfigStub.withArgs(CHAT_SEND_ERROR_DATA).returns(false);
+    getConfigStub.withArgs(CHAT_SEND_TOOL_CALL_DATA).returns(true);
+
+    const toolNames = ["tool1", "tool2"];
+    const toolMetadatas: ToolCallMetadata[] = toolNames.map((toolName) =>
+      createFakeToolCallMetadata(toolName),
+    );
+    const result: CustomChatResult = {
+      errorDetails: fakeErrorDetails,
+      metadata: {
+        modelInfo: fakeModelInfo,
+        toolsCalled: toolMetadatas,
+      },
+    };
+
+    const sanitizedResult = sanitizeFeedbackResult(result);
+
+    assert.deepStrictEqual(sanitizedResult, {
+      modelInfo: fakeModelInfo,
+      toolCallNames: toolNames,
+      // no errorDetails
+      toolsCalled: toolMetadatas,
+    });
+  });
+
+  it("should not include tool call fields when 'toolsCalled' is undefined", () => {
+    // not sending any error details or tool call inputs/contents
+    getConfigStub.withArgs(CHAT_SEND_ERROR_DATA).returns(false);
+    getConfigStub.withArgs(CHAT_SEND_TOOL_CALL_DATA).returns(false);
+
+    const result: CustomChatResult = {
+      errorDetails: fakeErrorDetails,
+      metadata: {
+        modelInfo: fakeModelInfo,
+      },
+    };
+    const sanitizedResult = sanitizeFeedbackResult(result);
+
+    assert.deepStrictEqual(sanitizedResult, {
+      modelInfo: fakeModelInfo,
+      // no toolCallNames
+      // no errorDetails
+      // no toolsCalled (since it was undefined)
+    });
+  });
+
+  it(`should include all fields when both "${CHAT_SEND_ERROR_DATA}" and "${CHAT_SEND_TOOL_CALL_DATA}" are enabled`, () => {
+    // sending error details and tool call inputs/contents
+    getConfigStub.withArgs(CHAT_SEND_ERROR_DATA).returns(true);
+    getConfigStub.withArgs(CHAT_SEND_TOOL_CALL_DATA).returns(true);
+
+    const toolNames = ["tool1", "tool2"];
+    const toolMetadatas: ToolCallMetadata[] = toolNames.map((toolName) =>
+      createFakeToolCallMetadata(toolName),
+    );
+    const result: CustomChatResult = {
+      errorDetails: fakeErrorDetails,
+      metadata: {
+        modelInfo: fakeModelInfo,
+        toolsCalled: toolMetadatas,
+      },
+    };
+    const sanitizedResult = sanitizeFeedbackResult(result);
+
+    assert.deepStrictEqual(sanitizedResult, {
+      modelInfo: fakeModelInfo,
+      toolCallNames: toolNames,
+      errorDetails: fakeErrorDetails,
+      toolsCalled: toolMetadatas,
+    });
+  });
+});
+
+/** Create a fake {@link ToolCallMetadata} object for testing. */
+function createFakeToolCallMetadata(toolName: string): ToolCallMetadata {
+  const toolCallId = "test-call-" + randomUUID();
+
+  const fakeToolCall = new LanguageModelToolCallPart(toolCallId, toolName, { key: "value" });
+  const fakeToolResult = new TextOnlyToolResultPart(toolCallId, [
+    new LanguageModelTextPart("Here are results from the tool call."),
+  ]);
+
+  const metadata: ToolCallMetadata = {
+    request: fakeToolCall,
+    response: fakeToolResult,
+  };
+  return metadata;
+}

--- a/src/chat/telemetry.ts
+++ b/src/chat/telemetry.ts
@@ -1,0 +1,54 @@
+import {
+  ChatResultFeedback,
+  ChatResultFeedbackKind,
+  workspace,
+  WorkspaceConfiguration,
+} from "vscode";
+import { CHAT_SEND_ERROR_DATA, CHAT_SEND_TOOL_CALL_DATA } from "../preferences/constants";
+import { logUsage, UserEvent } from "../telemetry/events";
+import { ToolCallMetadata } from "./tools/types";
+import { CustomChatResult } from "./types";
+
+export function handleFeedback(feedback: ChatResultFeedback): void {
+  logUsage(UserEvent.CopilotInteraction, {
+    // only includes error info and tool call metadata, not the prompt or response text
+    result: sanitizeFeedbackResult(feedback.result as CustomChatResult),
+    isHelpful: feedback.kind === ChatResultFeedbackKind.Helpful,
+  });
+}
+
+/**
+ * Check user/workspace configurations to determine what parts of {@link CustomChatResult} the user
+ * has opted in to sending.
+ */
+export function sanitizeFeedbackResult(result: CustomChatResult): Record<string, any> {
+  const newResult: Record<string, any> = {};
+
+  // always send the model info if we have it
+  const modelInfo = result.metadata?.modelInfo;
+  if (modelInfo) {
+    newResult.modelInfo = modelInfo;
+  }
+
+  const config: WorkspaceConfiguration = workspace.getConfiguration();
+  // check if the user is opting in to sending error data
+  const shouldSendErrorData: boolean = config.get(CHAT_SEND_ERROR_DATA, false);
+  if (shouldSendErrorData) {
+    newResult.errorDetails = result.errorDetails;
+  }
+
+  // check if the user is opting in to sending tool call inputs and tool result contents
+  const shouldSendToolCallData: boolean = config.get(CHAT_SEND_TOOL_CALL_DATA, false);
+  if (shouldSendToolCallData) {
+    newResult.toolsCalled = result.metadata?.toolsCalled;
+  }
+  // always send the tool call names if tools were called
+  const toolCalls: ToolCallMetadata[] | undefined = result.metadata?.toolsCalled;
+  if (toolCalls !== undefined && toolCalls.length) {
+    newResult.toolCallNames = toolCalls.map((metadata: ToolCallMetadata) => {
+      return metadata.request.name;
+    });
+  }
+
+  return newResult;
+}

--- a/src/chat/telemetry.ts
+++ b/src/chat/telemetry.ts
@@ -11,8 +11,9 @@ import { CustomChatResult } from "./types";
 
 export function handleFeedback(feedback: ChatResultFeedback): void {
   logUsage(UserEvent.CopilotInteraction, {
-    // only includes error info and tool call metadata, not the prompt or response text
-    result: sanitizeFeedbackResult(feedback.result as CustomChatResult),
+    status: "feedback provided",
+    // only includes error info and tool call metadata, not the prompt or final response text
+    chatResult: sanitizeFeedbackResult(feedback.result as CustomChatResult),
     isHelpful: feedback.kind === ChatResultFeedbackKind.Helpful,
   });
 }

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -1,0 +1,10 @@
+import { ChatResult } from "vscode";
+import { ToolCallMetadata } from "./tools/types";
+
+/** Extension of {@link ChatResult} to set specific keys and types for `metadata`. */
+export interface CustomChatResult extends ChatResult {
+  metadata?: {
+    modelInfo: Record<string, any>;
+    toolsCalled?: ToolCallMetadata[];
+  };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { getCCloudAuthSession } from "./authn/utils";
 import { disableCCloudStatusPolling, enableCCloudStatusPolling } from "./ccloudStatus/polling";
 import { PARTICIPANT_ID } from "./chat/constants";
 import { chatHandler } from "./chat/participant";
+import { handleFeedback } from "./chat/telemetry";
 import { registerChatTools } from "./chat/tools/registration";
 import { FlinkSqlCodelensProvider } from "./codelens/flinkSqlProvider";
 import { registerCommandWithLogging } from "./commands";
@@ -282,8 +283,9 @@ async function _activateExtension(
 
   // register the Copilot chat participant
   const chatParticipant = vscode.chat.createChatParticipant(PARTICIPANT_ID, chatHandler);
+  const feedbackListener: vscode.Disposable = chatParticipant.onDidReceiveFeedback(handleFeedback);
   chatParticipant.iconPath = new vscode.ThemeIcon(IconNames.CONFLUENT_LOGO);
-  context.subscriptions.push(chatParticipant, ...registerChatTools());
+  context.subscriptions.push(chatParticipant, feedbackListener, ...registerChatTools());
 
   // track the status bar for CCloud notices (fetched from the Statuspage Status API)
   enableCCloudStatusPolling();

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -55,3 +55,9 @@ export const UPDATE_DEFAULT_POOL_ID_FROM_LENS = prefix + "flink.updateComputePoo
  * "Set Catalog & Database" codelens. Possible values are `never`, `ask`, or `always`.
  */
 export const UPDATE_DEFAULT_DATABASE_FROM_LENS = prefix + "flink.updateDatabaseFromCodelens";
+
+/** Whether or not to include `errorDetails` from the `ChatResult` while handling `ChatResultFeedback`. */
+export const CHAT_SEND_ERROR_DATA = prefix + "chat.feedback.sendErrorData";
+
+/** Whether or not to include tool call inputs and tool result contents while handling `ChatResultFeedback`. */
+export const CHAT_SEND_TOOL_CALL_DATA = prefix + "chat.feedback.sendToolCallData";

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -60,10 +60,10 @@ export const UPDATE_DEFAULT_DATABASE_FROM_LENS = prefix + "flink.updateDatabaseF
  * Whether or not to include `errorDetails` from the `ChatResult` while handling `ChatResultFeedback`.
  * Also affects whether we send `error` data for "message handling failed" telemetry events.
  */
-export const CHAT_SEND_ERROR_DATA = prefix + "chat.feedback.sendErrorData";
+export const CHAT_SEND_ERROR_DATA = prefix + "chat.telemetry.sendErrorData";
 
 /**
  * Whether or not to include tool call inputs and tool result contents while handling `ChatResultFeedback`.
  * Also affects whether we include tool call inputs in general tool-handling telemetry events.
  */
-export const CHAT_SEND_TOOL_CALL_DATA = prefix + "chat.feedback.sendToolCallData";
+export const CHAT_SEND_TOOL_CALL_DATA = prefix + "chat.telemetry.sendToolCallData";

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -56,8 +56,14 @@ export const UPDATE_DEFAULT_POOL_ID_FROM_LENS = prefix + "flink.updateComputePoo
  */
 export const UPDATE_DEFAULT_DATABASE_FROM_LENS = prefix + "flink.updateDatabaseFromCodelens";
 
-/** Whether or not to include `errorDetails` from the `ChatResult` while handling `ChatResultFeedback`. */
+/**
+ * Whether or not to include `errorDetails` from the `ChatResult` while handling `ChatResultFeedback`.
+ * Also affects whether we send `error` data for "message handling failed" telemetry events.
+ */
 export const CHAT_SEND_ERROR_DATA = prefix + "chat.feedback.sendErrorData";
 
-/** Whether or not to include tool call inputs and tool result contents while handling `ChatResultFeedback`. */
+/**
+ * Whether or not to include tool call inputs and tool result contents while handling `ChatResultFeedback`.
+ * Also affects whether we include tool call inputs in general tool-handling telemetry events.
+ */
 export const CHAT_SEND_TOOL_CALL_DATA = prefix + "chat.feedback.sendToolCallData";

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -20,6 +20,7 @@ export enum UserEvent {
   ViewSearchAction = "View Search Action",
   SchemaAction = "Schema Action",
   FlinkStatementAction = "Flink Statement Action",
+  CopilotInteraction = "Copilot Interaction",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR addresses two main telemetry asks under a new `Copilot Interaction` event:
- Handling user feedback via the 👍 / 👎 ([docs](https://code.visualstudio.com/api/extension-guides/chat#measuring-success)), which includes two new settings (in a dedicated section) to control how much data is being sent (error details, and tool calls/results)
  <img width="915" alt="image" src="https://github.com/user-attachments/assets/16ca0129-7565-49f4-b72c-c8dfca29d173" />

- General usage events for requests, tool chaining iterations, and responses

<img width="1589" alt="image" src="https://github.com/user-attachments/assets/2dc4067c-3f6f-4fb1-aac8-00105c6df453" />

Closes #1475

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Since the `ChatResult.metadata` [accepts arbitrary key/value pairs](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d2e940c81701bda35414024afa8751fa8deb1477/types/vscode/index.d.ts#L19496-L19509), I wanted to enforce expected fields by setting up a `CustomChatResult` interface so we didn't accidentally start passing arbitrary key/value pairs through: https://github.com/confluentinc/vscode/blob/4494cb4e8490385b9725daadc28d6a659370f6fc/src/chat/types.ts#L4-L10

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
