### PR TITLE
feat(Copilot): add tool for listing environments and Kafka, Schema Registry, and Flink compute pool names & IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,29 @@
             "resourceKind"
           ]
         }
+      },
+      {
+        "name": "get_environments",
+        "when": "confluent.chatParticipantEnabled",
+        "tags": [
+          "environments"
+        ],
+        "displayName": "Get Environments",
+        "modelDescription": "Get a list of environments available for a specific connection. Environments are logical groupings of resources that may contain Kafka clusters, Schema Registry, and Flink compute pools. Use this when the user asks about their environments or needs to locate resource IDs for other operations.",
+        "canBeReferencedInPrompt": false,
+        "icon": "$(list-selection)",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "connectionId": {
+              "type": "string",
+              "description": "The ID of the connection to get environments for."
+            }
+          },
+          "required": [
+            "connectionId"
+          ]
+        }
       }
     ],
     "commands": [

--- a/src/chat/constants.ts
+++ b/src/chat/constants.ts
@@ -3,4 +3,6 @@ export const PARTICIPANT_ID = "confluent.chat-participant";
 /** The first message sent to the language model in the chat request. */
 export const INITIAL_PROMPT = `You are an assistant who helps developers working with Confluent and Apache Kafka® ecosystems, including Kafka clusters, topics, Schema Registry, Flink, and streaming applications. You provide guidance on configuration, development best practices, and troubleshooting for all Confluent-related technologies.
 
-You may use tools to help you answer questions. Do not refer to them by name/ID, but describe what you are trying to do when invoking them.`;
+You may use tools to help you answer questions. Do not refer to them by name/ID, but describe what you are trying to do when invoking them.
+
+If a tool requires a connection that was previously unavailable, call "get_connections" again to see if the connection state has been updated since the last user message.`;

--- a/src/chat/summarizers/connections.ts
+++ b/src/chat/summarizers/connections.ts
@@ -15,7 +15,9 @@ import { ContextValues, getContextValue } from "../../context/values";
 /** Create a string representation of a {@link Connection} object. */
 export function summarizeConnection(connection: Connection): string {
   const type: ConnectionType = connection.spec.type!;
-  let summary = new MarkdownString().appendMarkdown(`### "${connection.spec.name}"`);
+  let summary = new MarkdownString().appendMarkdown(
+    `### "${connection.spec.name}" (ID: ${connection.id})`,
+  );
 
   // add spec/status details depending on the connection type
   switch (type) {

--- a/src/chat/summarizers/environments.ts
+++ b/src/chat/summarizers/environments.ts
@@ -1,26 +1,50 @@
 import { MarkdownString } from "vscode";
 import { Environment } from "../../models/environment";
+import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
+import { CCloudKafkaCluster } from "../../models/kafkaCluster";
+import { isCCloud } from "../../models/resource";
+import { CCloudSchemaRegistry } from "../../models/schemaRegistry";
 
 export function summarizeEnvironment(env: Environment): string {
   const summary = new MarkdownString()
     .appendMarkdown(`### "${env.name}"`)
     .appendMarkdown(`\n- ID: ${env.id}`);
 
+  const isCCloudEnv: boolean = isCCloud(env);
+
   // only include names and IDs of child resources, for easier follow-up tool calls
   if (env.kafkaClusters.length) {
     summary.appendMarkdown(`\n- Kafka Clusters:`);
     env.kafkaClusters.forEach((cluster) => {
       summary.appendMarkdown(`\n  - "${cluster.name}" (ID: ${cluster.id})`);
+      if (isCCloudEnv) {
+        const ccloudCluster = cluster as CCloudKafkaCluster;
+        summary.appendMarkdown(
+          `\n    - Cloud Provider & Region: ${ccloudCluster.provider} ${ccloudCluster.region}`,
+        );
+      }
     });
   }
   if (env.schemaRegistry) {
     summary.appendMarkdown(`\n- Schema Registry:`);
     summary.appendMarkdown(`\n  - "${env.schemaRegistry.name}" (ID: ${env.schemaRegistry.id})`);
+    if (isCCloudEnv) {
+      const ccloudSR = env.schemaRegistry as CCloudSchemaRegistry;
+      summary.appendMarkdown(
+        `\n    - Cloud Provider & Region: ${ccloudSR.provider} ${ccloudSR.region}`,
+      );
+    }
   }
   if (env.flinkComputePools.length) {
     summary.appendMarkdown(`\n- Flink Compute Pools:`);
     env.flinkComputePools.forEach((pool) => {
       summary.appendMarkdown(`\n  - "${pool.name}" (ID: ${pool.id})`);
+      if (isCCloudEnv) {
+        const ccloudPool = pool as CCloudFlinkComputePool;
+        summary.appendMarkdown(
+          `\n    - Cloud Provider & Region: ${ccloudPool.provider} ${ccloudPool.region}`,
+        );
+      }
     });
   }
 

--- a/src/chat/summarizers/environments.ts
+++ b/src/chat/summarizers/environments.ts
@@ -1,0 +1,28 @@
+import { MarkdownString } from "vscode";
+import { Environment } from "../../models/environment";
+
+export function summarizeEnvironment(env: Environment): string {
+  const summary = new MarkdownString()
+    .appendMarkdown(`### "${env.name}"`)
+    .appendMarkdown(`\n- ID: ${env.id}`);
+
+  // only include names and IDs of child resources, for easier follow-up tool calls
+  if (env.kafkaClusters.length) {
+    summary.appendMarkdown(`\n- Kafka Clusters:`);
+    env.kafkaClusters.forEach((cluster) => {
+      summary.appendMarkdown(`\n  - "${cluster.name}" (ID: ${cluster.id})`);
+    });
+  }
+  if (env.schemaRegistry) {
+    summary.appendMarkdown(`\n- Schema Registry:`);
+    summary.appendMarkdown(`\n  - "${env.schemaRegistry.name}" (ID: ${env.schemaRegistry.id})`);
+  }
+  if (env.flinkComputePools.length) {
+    summary.appendMarkdown(`\n- Flink Compute Pools:`);
+    env.flinkComputePools.forEach((pool) => {
+      summary.appendMarkdown(`\n  - "${pool.name}" (ID: ${pool.id})`);
+    });
+  }
+
+  return summary.value;
+}

--- a/src/chat/tools/getEnvironments.ts
+++ b/src/chat/tools/getEnvironments.ts
@@ -1,0 +1,102 @@
+import {
+  CancellationToken,
+  ChatRequest,
+  ChatResponseStream,
+  LanguageModelTextPart,
+  LanguageModelToolCallPart,
+  LanguageModelToolInvocationOptions,
+  LanguageModelToolResult,
+} from "vscode";
+import { ResourceLoader } from "../../loaders";
+import { Logger } from "../../logging";
+import { Environment } from "../../models/environment";
+import { ConnectionId } from "../../models/resource";
+import { summarizeEnvironment } from "../summarizers/environments";
+import { BaseLanguageModelTool, TextOnlyToolResultPart } from "./base";
+
+const logger = new Logger("chat.tools.getEnvironments");
+
+export const NO_RESULTS: string = "No environments found.";
+
+export interface IGetEnvironmentsParameters {
+  connectionId: ConnectionId;
+}
+
+export class GetEnvironmentsTool extends BaseLanguageModelTool<IGetEnvironmentsParameters> {
+  readonly name = "get_environments";
+  readonly progressMessage = "Looking up environments...";
+
+  async invoke(
+    options: LanguageModelToolInvocationOptions<IGetEnvironmentsParameters>,
+    token: CancellationToken,
+  ): Promise<LanguageModelToolResult> {
+    const params = options.input;
+
+    if (!params.connectionId) {
+      logger.debug("No connection ID provided");
+      return new LanguageModelToolResult([
+        new LanguageModelTextPart(
+          "No connection ID provided. Provide a valid connection ID from the 'get_connections' tool and try again.",
+        ),
+      ]);
+    }
+
+    const loader = ResourceLoader.getInstance(params.connectionId);
+    const environments: Environment[] = await loader.getEnvironments();
+    if (!environments.length) {
+      logger.debug("No environments found");
+      // TODO: add hinting? the user shouldn't get here if they have at least one connection
+      return new LanguageModelToolResult([new LanguageModelTextPart(NO_RESULTS)]);
+    }
+
+    const environmentStrings: LanguageModelTextPart[] = [];
+    for (const env of environments) {
+      const envString: string = summarizeEnvironment(env);
+      environmentStrings.push(new LanguageModelTextPart(`\n${envString}`));
+    }
+
+    if (token.isCancellationRequested) {
+      logger.debug("Tool invocation cancelled");
+      return new LanguageModelToolResult([]);
+    }
+    return new LanguageModelToolResult(environmentStrings);
+  }
+
+  async processInvocation(
+    request: ChatRequest,
+    stream: ChatResponseStream,
+    toolCall: LanguageModelToolCallPart,
+    token: CancellationToken,
+  ): Promise<TextOnlyToolResultPart> {
+    const parameters = toolCall.input as IGetEnvironmentsParameters;
+
+    // handle the core tool invocation
+    const result: LanguageModelToolResult = await this.invoke(
+      {
+        input: parameters,
+        toolInvocationToken: request.toolInvocationToken,
+      },
+      token,
+    );
+    if (!result.content.length) {
+      // cancellation / no results
+      return new TextOnlyToolResultPart(toolCall.callId, []);
+    }
+
+    // format the results before sending them back to the model
+    const resultParts: LanguageModelTextPart[] = [];
+
+    const contents = result.content as LanguageModelTextPart[];
+    if (contents.length === 1 && contents[0].value === NO_RESULTS) {
+      const resultsHeader = new LanguageModelTextPart("No environments found.");
+      resultParts.push(resultsHeader);
+    } else {
+      const resultsHeader = new LanguageModelTextPart("Here are your available environments:");
+      resultParts.push(resultsHeader);
+      resultParts.push(...contents);
+      // TODO: add footer hint for providing env child resource IDs for follow-up tool calls
+    }
+
+    return new TextOnlyToolResultPart(toolCall.callId, resultParts);
+  }
+}

--- a/src/chat/tools/registration.ts
+++ b/src/chat/tools/registration.ts
@@ -3,6 +3,7 @@ import { BaseLanguageModelTool } from "./base";
 import { CreateProjectTool } from "./createProject";
 import { GetConnectionsTool } from "./getConnections";
 import { GetDockerContainersTool } from "./getDockerContainers";
+import { GetEnvironmentsTool } from "./getEnvironments";
 import { GetTemplateOptionsTool } from "./getTemplate";
 import { ListTemplatesTool } from "./listTemplates";
 import { setToolMap } from "./toolMap";
@@ -14,6 +15,7 @@ export function registerChatTools(): Disposable[] {
     new CreateProjectTool(),
     new GetConnectionsTool(),
     new GetDockerContainersTool(),
+    new GetEnvironmentsTool(),
   ];
 
   const disposables: Disposable[] = [];


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Now that #1717 allows Copilot to look up CCloud/local/direct connections, the next layer down in our resource hierarchy is **environments**. Also, since we load Kafka/SR/Flink compute pool details at the time we construct environments ([CCloud](https://github.com/confluentinc/vscode/blob/473a85421c03ecd3cafc64f2243c5fbc1c3f2f25/src/graphql/environments.ts#L73-L126), [local](https://github.com/confluentinc/vscode/blob/473a85421c03ecd3cafc64f2243c5fbc1c3f2f25/src/graphql/local.ts#L71-L99), [direct](https://github.com/confluentinc/vscode/blob/473a85421c03ecd3cafc64f2243c5fbc1c3f2f25/src/graphql/direct.ts#L67-L104)), we shouldn't need explicit tooling to get names/IDs of those resources. (We may still want tools later that can look up _other_ properties for those "cluster"-likes, though.)

<img width="829" alt="image" src="https://github.com/user-attachments/assets/f672d20c-ea4d-489c-9c0c-a4641b7939c1" />


### Associated PRs

- https://github.com/confluentinc/vscode/pull/1717
  - https://github.com/confluentinc/vscode/pull/1755  👈

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
