### PR TITLE
Include cloud provider/region in ccloud kafka clusterrs and flink compute pools searchable text

### DIFF
--- a/src/models/flinkComputePool.test.ts
+++ b/src/models/flinkComputePool.test.ts
@@ -21,7 +21,10 @@ describe("models/flinkComputePool.ts CCloudFlinkComputePool", () => {
   it("should generate correct searchableText", () => {
     const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
 
-    assert.strictEqual(pool.searchableText(), `${pool.name} ${pool.id}`);
+    assert.strictEqual(
+      pool.searchableText(),
+      `${pool.name} ${pool.id} ${pool.provider}/${pool.region}`,
+    );
   });
 });
 

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -52,6 +52,10 @@ export class CCloudFlinkComputePool extends FlinkComputePool implements IEnvProv
   get ccloudUrl(): string {
     return `https://confluent.cloud/environments/${this.environmentId}/flink/pools/${this.id}/overview`;
   }
+
+  searchableText(): string {
+    return `${this.name} ${this.id} ${this.provider}/${this.region}`;
+  }
 }
 
 export class FlinkComputePoolTreeItem extends TreeItem {

--- a/src/models/kafkaCluster.test.ts
+++ b/src/models/kafkaCluster.test.ts
@@ -3,8 +3,8 @@ import {
   TEST_CCLOUD_KAFKA_CLUSTER,
   TEST_LOCAL_KAFKA_CLUSTER,
 } from "../../tests/unit/testResources/kafkaCluster";
-import { createKafkaClusterTooltip, LocalKafkaCluster } from "./kafkaCluster";
 import { UTM_SOURCE_VSCODE } from "../constants";
+import { createKafkaClusterTooltip, LocalKafkaCluster } from "./kafkaCluster";
 describe("createKafkaClusterTooltip()", () => {
   it("should return the correct tooltip for a Confluent Cloud Kafka cluster", () => {
     const tooltipString = createKafkaClusterTooltip(TEST_CCLOUD_KAFKA_CLUSTER).value;
@@ -47,6 +47,13 @@ describe("Test CCloudKafkaCluster properties", () => {
     assert.strictEqual(
       `https://confluent.cloud/environments/${TEST_CCLOUD_KAFKA_CLUSTER.environmentId}/clusters/${TEST_CCLOUD_KAFKA_CLUSTER.id}/api-keys?utm_source=${UTM_SOURCE_VSCODE}`,
       TEST_CCLOUD_KAFKA_CLUSTER.ccloudApiKeysUrl,
+    );
+  });
+
+  it("searchableText should return the correct string for ccloud kafka cluster", () => {
+    assert.strictEqual(
+      `${TEST_CCLOUD_KAFKA_CLUSTER.name} ${TEST_CCLOUD_KAFKA_CLUSTER.id} ${TEST_CCLOUD_KAFKA_CLUSTER.provider}/${TEST_CCLOUD_KAFKA_CLUSTER.region}`,
+      TEST_CCLOUD_KAFKA_CLUSTER.searchableText(),
     );
   });
 });

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -47,6 +47,10 @@ export class CCloudKafkaCluster extends KafkaCluster {
   get ccloudApiKeysUrl(): string {
     return `https://confluent.cloud/environments/${this.environmentId}/clusters/${this.id}/api-keys?utm_source=${UTM_SOURCE_VSCODE}`;
   }
+
+  searchableText(): string {
+    return `${this.name} ${this.id} ${this.provider}/${this.region}`;
+  }
 }
 
 /** A "direct" {@link KafkaCluster} that is configured via webview form. */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Include the cloud provider/region in CCloud  Kafka clusters and Flink compute pools `searchableText` so can be searched.

<img width="462" alt="Screenshot 2025-05-14 at 5 56 55 PM" src="https://github.com/user-attachments/assets/3d6ffb6c-4afe-4594-a928-43e1b90036e5" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1773

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
