### PR TITLE
Add `confluent.krb5ConfigPath` extension setting and show warning message in direct connection form

### DIFF
--- a/package.json
+++ b/package.json
@@ -704,6 +704,11 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Allow older schema versions to be used when producing messages to Kafka topics.\n\n- Enabling this will require selecting the schema version to use.\n\n- Disabling this will use the **latest schema version**.\n\n---\n\n⚠️ **WARNING**: Producing messages with older schema versions can be in violation of some schema compatibility settings."
+          },
+          "confluent.krb5ConfigPath": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "Path to the `krb5.conf` file to use for Kerberos authentication in direct connections. This setting is used when connecting to Kafka clusters that require Kerberos authentication."
           }
         }
       },

--- a/src/preferences/constants.ts
+++ b/src/preferences/constants.ts
@@ -13,6 +13,11 @@ export const SSL_PEM_PATHS = prefix + "ssl.pemPaths";
 /** Default value for the {@link SSL_PEM_PATHS} setting. */
 export const DEFAULT_SSL_PEM_PATHS: string[] = [];
 
+/** Path to the krb5.conf file for Kerberos authentication in direct connections. */
+export const KRB5_CONFIG_PATH = prefix + "krb5ConfigPath";
+/** Default value for the {@link KRB5_CONFIG_PATH} setting. */
+export const DEFAULT_KRB5_CONFIG_PATH = "";
+
 /**
  * Disable SSL/TLS server certificate verification when making requests to Confluent/Kafka
  * connections or resources.

--- a/src/preferences/listener.ts
+++ b/src/preferences/listener.ts
@@ -11,6 +11,7 @@ import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import {
   ENABLE_CHAT_PARTICIPANT,
   ENABLE_FLINK,
+  KRB5_CONFIG_PATH,
   LOCAL_DOCKER_SOCKET_PATH,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
@@ -47,6 +48,13 @@ export function createConfigChangeListener(): Disposable {
           `"${LOCAL_DOCKER_SOCKET_PATH}" changed:`,
           configs.get(LOCAL_DOCKER_SOCKET_PATH),
         );
+        return;
+      }
+
+      if (event.affectsConfiguration(KRB5_CONFIG_PATH)) {
+        // inform the sidecar that the krb5 config path has changed
+        logger.debug(`"${KRB5_CONFIG_PATH}" config changed`);
+        await updatePreferences();
         return;
       }
 

--- a/src/preferences/sidecarSync.ts
+++ b/src/preferences/sidecarSync.ts
@@ -13,8 +13,10 @@ import {
 } from "../notifications";
 import { getSidecar } from "../sidecar";
 import {
+  DEFAULT_KRB5_CONFIG_PATH,
   DEFAULT_SSL_PEM_PATHS,
   DEFAULT_TRUST_ALL_CERTIFICATES,
+  KRB5_CONFIG_PATH,
   SSL_PEM_PATHS,
   SSL_VERIFY_SERVER_CERT_DISABLED,
 } from "./constants";
@@ -33,10 +35,12 @@ export function loadPreferencesFromWorkspaceConfig(): PreferencesSpec {
     SSL_VERIFY_SERVER_CERT_DISABLED,
     DEFAULT_TRUST_ALL_CERTIFICATES,
   );
+  const krb5ConfigPath: string = configs.get(KRB5_CONFIG_PATH, DEFAULT_KRB5_CONFIG_PATH);
 
   return {
     tls_pem_paths: pemPaths,
     trust_all_certificates: trustAllCerts,
+    kerberos_config_file_path: krb5ConfigPath,
   };
 }
 

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -130,6 +130,14 @@
             </select>
           </div>
           <div class="content-wrapper">
+            <template data-if="this.showMacOSKerberosMessage()">
+              <div class="msg-banner error">
+                <span>
+                  To use Kerberos authentication on MacOS, set the <code>krb5.conf</code> file path in the extension
+                  settings under <a data-attr-href="this.krb5ConfigPathExtensionSettingUrl()"><code>confluent.krb5ConfigPath</code></a>.
+                </span>
+              </div>
+            </template>
             <auth-credentials
               data-prop-namespace="'kafka_cluster'"
               data-on-change="this.updateValue(event.detail)"

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -133,8 +133,12 @@
             <template data-if="this.showMacOSKerberosMessage()">
               <div class="msg-banner error">
                 <span>
-                  To use Kerberos authentication on MacOS, set the <code>krb5.conf</code> file path in the extension
-                  settings under <a data-attr-href="this.krb5ConfigPathExtensionSettingUrl()"><code>confluent.krb5ConfigPath</code></a>.
+                  On MacOS, you must set the <code>krb5.conf</code> file path in the extension
+                  settings under
+                  <a data-attr-href="this.krb5ConfigPathExtensionSettingUrl()"
+                    ><code>confluent.krb5ConfigPath</code></a
+                  >
+                  for Kerberos authentication to work.
                 </span>
               </div>
             </template>


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Shows a message (open to suggestions on improving it) to MacOS users who choose Kerberos authentication asking them to set the krb5.conf in the extension settings.
- I decided against disabling/hiding the Kerberos options, I think the message is sufficient.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Demo:

https://github.com/user-attachments/assets/3edc60bb-000f-478d-af86-373cb101b05c

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
