### PR TITLE
[main] Fix changelog out-of-order parsing due to lack of mutual exclusion

### DIFF
--- a/src/flinkStatementResultsManager.test.ts
+++ b/src/flinkStatementResultsManager.test.ts
@@ -275,128 +275,158 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
     assert.equal(ctx.flinkSqlStatementsApi.updateSqlv1Statement.callCount, 1);
   });
 
-  it("should abort in-flight get results when stopping statement", async () => {
-    // Clear the polling interval so we can control when fetchResults is called
-    if (ctx.manager["_pollingInterval"]) {
+  describe("with fetchResults not running in a setInterval", () => {
+    beforeEach(() => {
       clearInterval(ctx.manager["_pollingInterval"]);
       ctx.manager["_pollingInterval"] = undefined;
-    }
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.resetHistory();
 
-    // Create a promise that we can reject manually to simulate the aborted request
-    let rejectRequest: (reason: Error) => void;
-    const requestPromise = new Promise<GetSqlv1StatementResult200Response>((_resolve, reject) => {
-      rejectRequest = reject;
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.resetHistory();
     });
 
-    // Start a get results request that will be in flight
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.returns(requestPromise);
+    it("should abort in-flight get results when stopping statement", async () => {
+      // Clear the polling interval so we can control when fetchResults is called
 
-    // Start the get results request
-    const fetchPromise = ctx.manager.fetchResults();
+      // Create a promise that we can reject manually to simulate the aborted request
+      let rejectRequest: (reason: Error) => void;
+      const requestPromise = new Promise<GetSqlv1StatementResult200Response>((_resolve, reject) => {
+        rejectRequest = reject;
+      });
 
-    // Wait for the request to actually start
-    await eventually(() => {
-      assert.ok(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.calledOnce);
-    });
+      // Start a get results request that will be in flight
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.returns(requestPromise);
 
-    // While that's in flight, start stopping the statement
-    const stopPromise = vm.stopStatement();
+      // Start the get results request
+      const fetchPromise = ctx.manager.fetchResults();
 
-    // Verify the abort controller was triggered
-    assert.ok(ctx.manager["_getResultsAbortController"].signal.aborted);
+      // Wait for the request to actually start
+      await eventually(() => {
+        assert.ok(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.calledOnce);
+      });
 
-    // Verify the in-flight request was aborted
-    const callArgs = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.firstCall.args[1];
-    assert.ok(
-      callArgs && typeof callArgs === "object" && "signal" in callArgs && callArgs.signal?.aborted,
-    );
+      // While that's in flight, start stopping the statement
+      const stopPromise = vm.stopStatement();
 
-    // Now reject the request
-    const abortError = new Error("Aborted") as Error & { cause?: { name: string } };
-    abortError.cause = { name: "AbortError" };
-    rejectRequest!(abortError);
+      // Verify the abort controller was triggered
+      assert.ok(ctx.manager["_getResultsAbortController"].signal.aborted);
 
-    // Complete both operations
-    await Promise.all([fetchPromise, stopPromise]);
+      // Verify the in-flight request was aborted
+      const callArgs = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.firstCall.args[1];
+      assert.ok(
+        callArgs &&
+          typeof callArgs === "object" &&
+          "signal" in callArgs &&
+          callArgs.signal?.aborted,
+      );
 
-    // Try another fetch - should not make a new request
-    await ctx.manager["fetchResults"]();
-    assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
-  });
+      // Now reject the request
+      const abortError = new Error("Aborted") as Error & { cause?: { name: string } };
+      abortError.cause = { name: "AbortError" };
+      rejectRequest!(abortError);
 
-  it("should retry get statement results when 409", async () => {
-    if (ctx.manager["_pollingInterval"]) {
-      clearInterval(ctx.manager["_pollingInterval"]);
-      ctx.manager["_pollingInterval"] = undefined;
-    }
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.resetHistory();
+      // Complete both operations
+      await Promise.all([fetchPromise, stopPromise]);
 
-    // Mock the getSqlv1StatementResult to fail with 409 twice then succeed
-    // This happens if the statement results are not ready yet
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
-      .onFirstCall()
-      .rejects(createResponseError(409, "Conflict", "{}"));
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
-      .onSecondCall()
-      .rejects(createResponseError(409, "Conflict", "{}"));
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.onThirdCall().resolves({
-      api_version: GetSqlv1StatementResult200ResponseApiVersionEnum.SqlV1,
-      kind: GetSqlv1StatementResult200ResponseKindEnum.StatementResult,
-      metadata: {},
-      results: {
-        data: [],
-      },
-    });
-
-    // Trigger a fetch
-    await ctx.manager.fetchResults();
-
-    // Verify the request was made 3 times
-    await eventually(() => {
-      assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 3);
-    });
-  });
-
-  it("should handle fetch results with max retries exceeded", async () => {
-    if (ctx.manager["_pollingInterval"]) {
-      clearInterval(ctx.manager["_pollingInterval"]);
-      ctx.manager["_pollingInterval"] = undefined;
-    }
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.resetHistory();
-
-    // Mock the getSqlv1StatementResult to always fail with 409
-    const responseError = createResponseError(409, "Conflict", "{}");
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(responseError);
-
-    // Trigger a fetch
-    await ctx.manager.fetchResults();
-
-    await eventually(() => {
-      assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 5);
-      // Verify error state is set
-      assert.ok(ctx.manager["_latestError"]());
-    });
-  });
-
-  it("should not retry on non-409 errors during fetch", async () => {
-    if (ctx.manager["_pollingInterval"]) {
-      clearInterval(ctx.manager["_pollingInterval"]);
-      ctx.manager["_pollingInterval"] = undefined;
-    }
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.resetHistory();
-
-    // Mock the getSqlv1StatementResult to fail with 500
-    const responseError = createResponseError(500, "Internal Server Error", "{}");
-    ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(responseError);
-
-    // Trigger a fetch
-    await ctx.manager.fetchResults();
-
-    await eventually(() => {
+      // Try another fetch - should not make a new request
+      await ctx.manager["fetchResults"]();
       assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
-      // Verify error state is set
-      assert.ok(ctx.manager["_latestError"]());
+    });
+
+    it("should retry get statement results when 409", async () => {
+      // Mock the getSqlv1StatementResult to fail with 409 twice then succeed
+      // This happens if the statement results are not ready yet
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onFirstCall()
+        .rejects(createResponseError(409, "Conflict", "{}"));
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onSecondCall()
+        .rejects(createResponseError(409, "Conflict", "{}"));
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.onThirdCall().resolves({
+        api_version: GetSqlv1StatementResult200ResponseApiVersionEnum.SqlV1,
+        kind: GetSqlv1StatementResult200ResponseKindEnum.StatementResult,
+        metadata: {},
+        results: {
+          data: [],
+        },
+      });
+
+      // Trigger a fetch
+      await ctx.manager.fetchResults();
+
+      // Verify the request was made 3 times
+      await eventually(() => {
+        assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 3);
+      });
+    });
+
+    it("should handle fetch results with max retries exceeded", async () => {
+      // Mock the getSqlv1StatementResult to always fail with 409
+      const responseError = createResponseError(409, "Conflict", "{}");
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(responseError);
+
+      // Trigger a fetch
+      await ctx.manager.fetchResults();
+
+      await eventually(() => {
+        assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 5);
+        // Verify error state is set
+        assert.ok(ctx.manager["_latestError"]());
+      });
+    });
+
+    it("should not retry on non-409 errors during fetch", async () => {
+      // Mock the getSqlv1StatementResult to fail with 500
+      const responseError = createResponseError(500, "Internal Server Error", "{}");
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(responseError);
+
+      // Trigger a fetch
+      await ctx.manager.fetchResults();
+
+      await eventually(() => {
+        assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
+        // Verify error state is set
+        assert.ok(ctx.manager["_latestError"]());
+      });
+    });
+
+    it("should only allow one instance of fetchResults to run at a time", async () => {
+      // Create a promise that we can resolve manually to simulate a slow API call
+      let resolveRequest: (value: GetSqlv1StatementResult200Response) => void;
+      const requestPromise = new Promise<GetSqlv1StatementResult200Response>((resolve) => {
+        resolveRequest = resolve;
+      });
+
+      // Mock the API call to use our controllable promise
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.returns(requestPromise);
+
+      // Start multiple concurrent fetchResults calls
+      const fetchPromises = [
+        ctx.manager.fetchResults(),
+        ctx.manager.fetchResults(),
+        ctx.manager.fetchResults(),
+        ctx.manager.fetchResults(),
+        ctx.manager.fetchResults(),
+        ctx.manager.fetchResults(),
+      ];
+
+      // Wait a bit to ensure all calls have started
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Verify only one API call was made
+      assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
+
+      // Resolve the API call
+      resolveRequest!({
+        api_version: GetSqlv1StatementResult200ResponseApiVersionEnum.SqlV1,
+        kind: GetSqlv1StatementResult200ResponseKindEnum.StatementResult,
+        metadata: {},
+        results: { data: [] },
+      });
+
+      // Wait for all calls to complete
+      await Promise.all(fetchPromises);
+
+      // Verify still only one API call was made
+      assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
     });
   });
 

--- a/src/flinkStatementResultsManager.ts
+++ b/src/flinkStatementResultsManager.ts
@@ -108,6 +108,8 @@ export class FlinkStatementResultsManager {
   private _flinkStatementResultsSqlApi: StatementResultsSqlV1Api;
   private _flinkStatementsSqlApi: StatementsSqlV1Api;
 
+  private _fetchResultsLocked = false;
+
   constructor(
     private os: Scope,
     private statement: FlinkStatement,
@@ -176,117 +178,128 @@ export class FlinkStatementResultsManager {
   }
 
   async fetchResults(): Promise<void> {
-    if (
-      this._state() !== "running" ||
-      !this._moreResults() ||
-      !this.statement.areResultsViewable ||
-      this._getResultsAbortController.signal.aborted
-    ) {
-      // Self-destruct
-      clearInterval(this._pollingInterval);
-      this._pollingInterval = undefined;
+    if (this._fetchResultsLocked) {
+      logger.warn("Fetch results is locked, skipping fetch.");
       return;
     }
-
-    let reportable: { message: string } | null = null;
-    let shouldComplete = false;
-    this._fetchCount++;
-
+    this._fetchResultsLocked = true;
     try {
-      const currentResults = this._results();
-      const pageToken = this.extractPageToken(this._latestResult()?.metadata?.next);
-
-      const response = await this.retryWithBackoff(async () => {
-        return await this._flinkStatementResultsSqlApi.getSqlv1StatementResult(
-          {
-            environment_id: this.statement.environmentId,
-            organization_id: this.statement.organizationId,
-            name: this.statement.name,
-            page_token: pageToken,
-          },
-          {
-            signal: this._getResultsAbortController.signal,
-          },
-        );
-      }, "fetch statement results");
-
-      const resultsData: SqlV1StatementResultResults = response.results ?? {};
-
-      this.os.batch(() => {
-        parseResults({
-          columns: this.statement.status?.traits?.schema?.columns ?? [],
-          isAppendOnly: this.statement.status?.traits?.is_append_only ?? true,
-          upsertColumns: this.statement.status?.traits?.upsert_columns,
-          limit: this.resultLimit,
-          map: currentResults,
-          rows: resultsData.data,
-        });
-        this._filteredResults(this.filterResultsBySearch());
-        // Check if we have more results to fetch
-        if (this.extractPageToken(response?.metadata?.next) === undefined) {
-          this._moreResults(false);
-          this._state("completed");
-        }
-        this._latestError(null);
-        this._latestResult(response);
-        this.notifyUI();
-      });
-    } catch (error) {
-      if (error instanceof FetchError && error?.cause?.name === "AbortError") {
-        logger.info("Statement results fetch was aborted");
+      if (
+        this._state() !== "running" ||
+        !this._moreResults() ||
+        !this.statement.areResultsViewable ||
+        this._getResultsAbortController.signal.aborted
+      ) {
+        // Self-destruct
+        clearInterval(this._pollingInterval);
+        this._pollingInterval = undefined;
         return;
       }
+      let reportable: { message: string } | null = null;
+      let shouldComplete = false;
+      this._fetchCount++;
+      logger.debug(`Fetching statement results...: ${this._fetchCount}`);
 
-      if (isResponseError(error)) {
-        const payload = await error.response.json();
-        if (!payload?.aborted) {
-          const status = error.response.status;
-          shouldComplete = status >= 400;
-          switch (status) {
-            case 401: {
-              reportable = { message: "Authentication required." };
-              break;
-            }
-            case 403: {
-              reportable = { message: "Insufficient permissions to read statement results." };
-              break;
-            }
-            case 404: {
-              reportable = { message: "Statement not found." };
-              break;
-            }
-            case 429: {
-              reportable = { message: "Too many requests. Try again later." };
-              break;
-            }
-            default: {
-              reportable = { message: "Something went wrong." };
-              logError(error, "flink statement results", {
-                extra: { status: status.toString(), payload },
-              });
-              showErrorNotificationWithButtons("Error response while fetching statement results.");
-              break;
-            }
-          }
-          logger.error(
-            `An error occurred during statement results fetching. Status ${error.response.status}`,
+      try {
+        const currentResults = this._results();
+        const pageToken = this.extractPageToken(this._latestResult()?.metadata?.next);
+
+        const response = await this.retryWithBackoff(async () => {
+          return await this._flinkStatementResultsSqlApi.getSqlv1StatementResult(
+            {
+              environment_id: this.statement.environmentId,
+              organization_id: this.statement.organizationId,
+              name: this.statement.name,
+              page_token: pageToken,
+            },
+            {
+              signal: this._getResultsAbortController.signal,
+            },
           );
+        }, "fetch statement results");
+
+        const resultsData: SqlV1StatementResultResults = response.results ?? {};
+
+        this.os.batch(() => {
+          parseResults({
+            columns: this.statement.status?.traits?.schema?.columns ?? [],
+            isAppendOnly: this.statement.status?.traits?.is_append_only ?? true,
+            upsertColumns: this.statement.status?.traits?.upsert_columns,
+            limit: this.resultLimit,
+            map: currentResults,
+            rows: resultsData.data,
+          });
+          this._filteredResults(this.filterResultsBySearch());
+          // Check if we have more results to fetch
+          if (this.extractPageToken(response?.metadata?.next) === undefined) {
+            this._moreResults(false);
+            this._state("completed");
+          }
+          this._latestError(null);
+          this._latestResult(response);
+          this.notifyUI();
+        });
+      } catch (error) {
+        if (error instanceof FetchError && error?.cause?.name === "AbortError") {
+          logger.info("Statement results fetch was aborted");
+          return;
         }
-      } else if (error instanceof Error) {
-        logger.error(error.message);
-        reportable = { message: "An internal error occurred." };
-        shouldComplete = true;
+
+        if (isResponseError(error)) {
+          const payload = await error.response.json();
+          if (!payload?.aborted) {
+            const status = error.response.status;
+            shouldComplete = status >= 400;
+            switch (status) {
+              case 401: {
+                reportable = { message: "Authentication required." };
+                break;
+              }
+              case 403: {
+                reportable = { message: "Insufficient permissions to read statement results." };
+                break;
+              }
+              case 404: {
+                reportable = { message: "Statement not found." };
+                break;
+              }
+              case 429: {
+                reportable = { message: "Too many requests. Try again later." };
+                break;
+              }
+              default: {
+                reportable = { message: "Something went wrong." };
+                logError(error, "flink statement results", {
+                  extra: { status: status.toString(), payload },
+                });
+                showErrorNotificationWithButtons(
+                  "Error response while fetching statement results.",
+                );
+                break;
+              }
+            }
+            logger.error(
+              `An error occurred during statement results fetching. Status ${error.response.status}`,
+            );
+          }
+        } else if (error instanceof Error) {
+          logger.error(error.message);
+          reportable = { message: "An internal error occurred." };
+          shouldComplete = true;
+        }
+      } finally {
+        this.os.batch(() => {
+          if (shouldComplete) {
+            this._state("completed");
+          }
+          if (reportable != null) {
+            this._latestError(reportable);
+          }
+          this.notifyUI();
+        });
       }
     } finally {
-      this.os.batch(() => {
-        if (shouldComplete) {
-          this._state("completed");
-        }
-        if (reportable != null) {
-          this._latestError(reportable);
-        }
-        this.notifyUI();
-      });
+      this._fetchResultsLocked = false;
     }
   }
 

--- a/src/flinkStatementResultsManager.ts
+++ b/src/flinkStatementResultsManager.ts
@@ -179,7 +179,13 @@ export class FlinkStatementResultsManager {
 
   async fetchResults(): Promise<void> {
     if (this._fetchResultsLocked) {
-      logger.warn("Fetch results is locked, skipping fetch.");
+      // setInterval fires off the callbacks even if the previous one is still running
+      // (meaning we could still be awaiting a response from the GET results API)
+      // If we don't guard against only one instance of this function running at a time,
+      // we could end up with out of order application of changelogs.
+
+      // This callback being fired with another concurrently executing instance
+      // is expected and doesn't warrant a log.
       return;
     }
     this._fetchResultsLocked = true;
@@ -198,7 +204,6 @@ export class FlinkStatementResultsManager {
       let reportable: { message: string } | null = null;
       let shouldComplete = false;
       this._fetchCount++;
-      logger.debug(`Fetching statement results...: ${this._fetchCount}`);
 
       try {
         const currentResults = this._results();

--- a/tests/createResultsManager.ts
+++ b/tests/createResultsManager.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { ObservableScope } from "inertial";
+import { Scope } from "inertial";
 import sinon from "sinon";
 import { StatementResultsSqlV1Api, StatementsSqlV1Api } from "../src/clients/flinkSql";
 import { FlinkStatementResultsManager } from "../src/flinkStatementResultsManager";
@@ -41,8 +41,8 @@ export interface FlinkStatementResultsManagerTestContext {
  */
 
 export async function createTestResultsManagerContext(
-  sandbox = sinon.createSandbox(),
-  os = ObservableScope(),
+  sandbox: sinon.SinonSandbox,
+  os: Scope,
 ): Promise<FlinkStatementResultsManagerTestContext> {
   // Create sidecar and API mocks
   const mockSidecar = sandbox.createStubInstance(sidecar.SidecarHandle);
@@ -96,7 +96,7 @@ export async function createTestResultsManagerContext(
     DEFAULT_RESULTS_LIMIT,
     // Polling interval of 1ms
     1,
-     // Refresh interval
+    // Refresh interval
     100,
     resourceLoader,
   );


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- setInterval fires regardless of previous calls. This poses a problem with our awaited get results call because we could have out of order result changelog being processed. We fix it by adding a simple mutual exclusion on the fetchResults function.
- Pulls patch  #1808  to v1.3.x forward into main.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
