### PR TITLE
Fix: Use statement name in FlinkStatement.ccloudUrl

### DIFF
--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -31,6 +31,18 @@ describe("FlinkStatement", () => {
     assert.strictEqual(statement.id, "statement0@env0", "Expected id to be made of name@env");
   });
 
+  it("should construct the right CCloud URL", () => {
+    const statement = createFlinkStatement({
+      name: "statement0",
+      environmentId: "env0" as EnvironmentId,
+      computePoolId: "pool0",
+    });
+
+    const expectedUrl =
+      "https://confluent.cloud/environments/env0/flink/statements/statement0/activity?utm_source=vscode-ext";
+    assert.strictEqual(statement.ccloudUrl, expectedUrl, "Expected ccloudUrl to be correct");
+  });
+
   it("isTerminal returns true for terminal phases", () => {
     for (const phase of TERMINAL_PHASES) {
       const statement = createFlinkStatement({ phase });

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -130,7 +130,7 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable, IEnvP
   }
 
   get ccloudUrl(): string {
-    return `https://confluent.cloud/environments/${this.environmentId}/flink/statements/${this.id}/activity?utm_source=${UTM_SOURCE_VSCODE}`;
+    return `https://confluent.cloud/environments/${this.environmentId}/flink/statements/${this.name}/activity?utm_source=${UTM_SOURCE_VSCODE}`;
   }
 
   get isTerminal(): boolean {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- We recently changed `FlinkStatement.id` to return `name@env` instead of `name`. The "View in Confluent Cloud" URL constructed for statements then led to 404. 
- Fix was to swap with `name`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
