### PR TITLE
[v1.3.x] temporarily disable Flink SQL language client

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,6 @@ import {
   checkForExtensionDisabledReason,
   showExtensionDisabledNotification,
 } from "./featureFlags/evaluation";
-import { initializeFlinkLanguageClientManager } from "./flinkSql/flinkLanguageClientManager";
 import { FlinkStatementManager } from "./flinkSql/flinkStatementManager";
 import { activateFlinkStatementResultsViewer } from "./flinkStatementResults";
 import { constructResourceLoaderSingletons } from "./loaders";
@@ -245,7 +244,7 @@ async function _activateExtension(
     uriHandler,
     WebsocketManager.getInstance(),
     FlinkStatementManager.getInstance(),
-    initializeFlinkLanguageClientManager(),
+    // initializeFlinkLanguageClientManager(),
     ...authProviderDisposables,
     ...viewProviderDisposables,
     ...registeredCommands,


### PR DESCRIPTION
Just until we can dig into the error notifications VS Code is showing (all but the top notification in the screenshot below):
![image](https://github.com/user-attachments/assets/338f253c-ec97-428f-b5db-26387ff0b346)
