### PR TITLE
Harden results viewer: Increase num of retries to 60 with constant backoff of 500ms

### DIFF
--- a/src/flinkStatementResultsManager.ts
+++ b/src/flinkStatementResultsManager.ts
@@ -209,7 +209,7 @@ export class FlinkStatementResultsManager {
         const currentResults = this._results();
         const pageToken = this.extractPageToken(this._latestResult()?.metadata?.next);
 
-        const response = await this.retryWithBackoff(async () => {
+        const response = await this.retry(async () => {
           return await this._flinkStatementResultsSqlApi.getSqlv1StatementResult(
             {
               environment_id: this.statement.environmentId,
@@ -334,12 +334,15 @@ export class FlinkStatementResultsManager {
     );
   }
 
-  private async retryWithBackoff<T>(
+  /**
+   * Retries {@link maxRetries} times with a constant backoff delay of
+   * {@link backoffMs}. Nothing fancy.
+   */
+  private async retry<T>(
     operation: () => Promise<T>,
     operationName: string,
-    maxRetries: number = 5,
-    initialBackoffMs: number = 100,
-    maxBackoffMs: number = 10_000,
+    maxRetries: number = 60,
+    backoffMs: number = 500,
   ): Promise<T> {
     let lastErr: Error | undefined;
     for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -349,8 +352,7 @@ export class FlinkStatementResultsManager {
         lastErr = err as Error;
         if (isResponseErrorWithStatus(err, 409)) {
           if (attempt < maxRetries - 1) {
-            const backoffMs = Math.min(initialBackoffMs * Math.pow(2, attempt), maxBackoffMs);
-            logger.debug(
+            logger.info(
               `Retrying ${operationName} after 409 conflict. Attempt ${attempt + 1}/${maxRetries}. Waiting ${backoffMs}ms`,
             );
             await new Promise((resolve) => setTimeout(resolve, backoffMs));
@@ -369,7 +371,7 @@ export class FlinkStatementResultsManager {
     this._getResultsAbortController.abort();
 
     try {
-      await this.retryWithBackoff(async () => {
+      await this.retry(async () => {
         await this.refreshStatement();
         await this._stopStatement();
       }, "stop statement");

--- a/src/flinkStatementResultsManager.ts
+++ b/src/flinkStatementResultsManager.ts
@@ -352,7 +352,7 @@ export class FlinkStatementResultsManager {
         lastErr = err as Error;
         if (isResponseErrorWithStatus(err, 409)) {
           if (attempt < maxRetries - 1) {
-            logger.info(
+            logger.debug(
               `Retrying ${operationName} after 409 conflict. Attempt ${attempt + 1}/${maxRetries}. Waiting ${backoffMs}ms`,
             );
             await new Promise((resolve) => setTimeout(resolve, backoffMs));


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- As title

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1820

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
