### PR TITLE
fix: quickpick followup

### DIFF
--- a/src/quickpicks/utils/quickPickUtils.ts
+++ b/src/quickpicks/utils/quickPickUtils.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import { Disposable, QuickInputButton, QuickPick, QuickPickOptions, window } from "vscode";
 import { QuickPickItemWithValue } from "../types";
 
 /**
@@ -10,9 +10,9 @@ import { QuickPickItemWithValue } from "../types";
  *   title: "Select an item",
  *   placeHolder: "Search items...",
  *   canSelectMany: true,
- *   buttons: [vscode.QuickInputButtons.Back],
+ *   buttons: [QuickInputButtons.Back],
  *   onButtonClicked: async (button, quickPick) => {
- *     if (button === vscode.QuickInputButtons.Back) {
+ *     if (button === QuickInputButtons.Back) {
  *       quickPick.hide();
  *     }
  *   },
@@ -23,7 +23,7 @@ import { QuickPickItemWithValue } from "../types";
  * ```
  */
 export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
-  extends vscode.QuickPickOptions {
+  extends QuickPickOptions {
   /**
    * Callback triggered when a button on a specific QuickPick item is clicked.
    * Useful for implementing actions specific to individual items.
@@ -39,9 +39,9 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
    * ```
    */
   onItemButtonClicked?: (event: {
-    button: vscode.QuickInputButton;
+    button: QuickInputButton;
     item: T;
-    quickPick: vscode.QuickPick<T>;
+    quickPick: QuickPick<T>;
   }) => Promise<void> | void;
 
   /**
@@ -55,7 +55,7 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
    * }
    * ```
    */
-  onSelectionChange?: (items: readonly T[], quickPick: vscode.QuickPick<T>) => void;
+  onSelectionChange?: (items: readonly T[], quickPick: QuickPick<T>) => void;
 
   /**
    * Callback triggered when the active (highlighted) item changes.
@@ -70,7 +70,7 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
    * }
    * ```
    */
-  onActiveItemChange?: (item: T | undefined, quickPick: vscode.QuickPick<T>) => void;
+  onActiveItemChange?: (item: T | undefined, quickPick: QuickPick<T>) => void;
 
   /**
    * Navigation buttons displayed at the top of the QuickPick.
@@ -79,12 +79,12 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
    * @example
    * ```typescript
    * buttons: [
-   *   vscode.QuickInputButtons.Back,
-   *   { iconPath: new vscode.ThemeIcon('refresh') }
+   *   QuickInputButtons.Back,
+   *   { iconPath: new ThemeIcon('refresh') }
    * ]
    * ```
    */
-  buttons?: readonly vscode.QuickInputButton[];
+  buttons?: readonly QuickInputButton[];
 
   /**
    * Callback triggered when a navigation button is clicked.
@@ -101,10 +101,7 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
    * }
    * ```
    */
-  onButtonClicked?: (
-    button: vscode.QuickInputButton,
-    quickPick: vscode.QuickPick<T>,
-  ) => Promise<void> | void;
+  onButtonClicked?: (button: QuickInputButton, quickPick: QuickPick<T>) => Promise<void> | void;
 
   /**
    * Enables multi-select mode in the QuickPick.
@@ -144,7 +141,7 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
    * }
    * ```
    */
-  onDidAccept?: (quickPick: vscode.QuickPick<T>) => Promise<void> | void;
+  onDidAccept?: (quickPick: QuickPick<T>) => Promise<void> | void;
 }
 
 /**
@@ -158,8 +155,8 @@ export interface EnhancedQuickPickOptions<T extends QuickPickItemWithValue<any>>
 export function createEnhancedQuickPick<T extends QuickPickItemWithValue<any>>(
   items: T[] | Promise<T[]>,
   options?: EnhancedQuickPickOptions<T>,
-): Promise<{ quickPick: vscode.QuickPick<T>; selectedItems: T[] }> {
-  const quickPick = vscode.window.createQuickPick<T>();
+): Promise<{ quickPick: QuickPick<T>; selectedItems: T[] }> {
+  const quickPick = window.createQuickPick<T>();
   let selectedItems: T[] = [];
 
   // Set standard options
@@ -196,13 +193,13 @@ export function createEnhancedQuickPick<T extends QuickPickItemWithValue<any>>(
   }
 
   const disposables: Disposable[] = [];
-  
+
   // Set up event handlers
   if (options?.onSelectionChange) {
     disposables.push(
       quickPick.onDidChangeSelection((items: readonly T[]) => {
         options.onSelectionChange?.(items, quickPick);
-      })
+      }),
     );
   }
 
@@ -210,8 +207,8 @@ export function createEnhancedQuickPick<T extends QuickPickItemWithValue<any>>(
     disposables.push(
       quickPick.onDidChangeActive((items: readonly T[]) => {
         options.onActiveItemChange?.(items[0], quickPick);
-      });
-    )
+      }),
+    );
   }
 
   if (options?.onItemButtonClicked) {
@@ -246,12 +243,7 @@ export function createEnhancedQuickPick<T extends QuickPickItemWithValue<any>>(
   quickPick.show();
   return new Promise((resolve) => {
     quickPick.onDidHide(() => {
-      // If we have pre-selected items and haven't captured any selections yet,
-      // use the pre-selected items
-      if (selectedItems.length === 0 && options?.selectedItems) {
-        selectedItems = [...options.selectedItems];
-      }
-      disposables.forEach(d => d.dispose());
+      disposables.forEach((d) => d.dispose());
       resolve({ quickPick, selectedItems });
     });
   });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up from https://github.com/confluentinc/vscode/pull/1272 to address https://github.com/confluentinc/vscode/pull/1272#discussion_r2047376234 and fix a syntax error. Also includes a new test and some additional test adjustments.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
