### PR TITLE
fix: register support commands earlier in extension activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@ All notable changes to this extension will be documented in this file.
 
 - Added functionality to the Results Viewer to allow users to toggle between table and changelog
   view modes:
-  - **Table view** shows the current state of the data by collapsing the changelog stream - records are
-    updated in place rather than showing the full history of changes
-  - **Changelog view** shows the raw results from the Flink API, where each record includes an opcode
-    indicating how it should be interpreted in the context of the overall result:
+  - **Table view** shows the current state of the data by collapsing the changelog stream - records
+    are updated in place rather than showing the full history of changes
+  - **Changelog view** shows the raw results from the Flink API, where each record includes an
+    opcode indicating how it should be interpreted in the context of the overall result:
     - `+I`: Insert operation (new row added)
     - `-U`: UpdateBefore operation (previous version of updated row)
     - `+U`: UpdateAfter operation (new version of updated row)
     - `-D`: Delete operation (row removed)
+
+### Fixed
+
+- Fixed an issue where the "File Issue" button would not work if the extension failed to activate
+  properly. [#1823](https://github.com/confluentinc/vscode/issues/1823)
 
 ## 1.3.0
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,9 +148,14 @@ async function _activateExtension(
   // (e.g. for globalState/workspaceState/secrets storage, webviews for extension root path, etc)
   setExtensionContext(context);
 
-  // register the log output channels and debugging commands before anything else, in case we need
-  // to reset global/workspace state or there's a problem further down with extension activation
-  context.subscriptions.push(OUTPUT_CHANNEL, SIDECAR_OUTPUT_CHANNEL, ...registerDebugCommands());
+  // register the log output channels, debugging commands, and support commands to ensure we have
+  // visibility into the extension and sidecar logs and can download support .zip and/or file issues
+  context.subscriptions.push(
+    OUTPUT_CHANNEL,
+    SIDECAR_OUTPUT_CHANNEL,
+    ...registerDebugCommands(),
+    ...registerSupportCommands(),
+  );
   // automatically display and focus the Confluent extension output channel in development mode
   // to avoid needing to keep the main window & Debug Console tab open alongside the extension dev
   // host window during debugging
@@ -220,7 +225,6 @@ async function _activateExtension(
     ...registerEnvironmentCommands(),
     ...registerSchemaRegistryCommands(),
     ...registerSchemaCommands(),
-    ...registerSupportCommands(),
     ...registerTopicCommands(),
     ...registerDiffCommands(),
     ...registerExtraCommands(),


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We got some Sentry reports that users were trying to use the "File Issue" button from notifications when the extension would fail to activate, which would then break since we hadn't yet registered those support commands (including downloading logs and the support .zip), so this PR ensures we register those commands much earlier in the process.


https://github.com/user-attachments/assets/2894c69e-b4ac-452d-ad95-a593bba5cc2e


Closes #1823.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
