### PR TITLE
Run Sonarqube scan on Linux x64 and set `main_branch: main`

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -64,7 +64,8 @@ blocks:
             - make store-test-results-to-semaphore
             # Ensures that we run the SonarQube scan only in this block, and not in the other blocks
             # where this epilogue is referenced.
-            - [[ "${RUN_SONARQUBE_SCAN}" == "true" ]] && emit-sonarqube-data --run_only_sonar_scan
+            - |
+              [[ "${RUN_SONARQUBE_SCAN}" == "true" ]] && emit-sonarqube-data --run_only_sonar_scan
 
   - name: "Build & Test (VS Code: linux arm64)"
     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,7 +65,10 @@ blocks:
             # Ensures that we run the SonarQube scan only in this block, and not in the other blocks
             # where this epilogue is referenced.
             - |
-              [[ "${RUN_SONARQUBE_SCAN}" == "true" ]] && emit-sonarqube-data --run_only_sonar_scan
+              if [[ "${RUN_SONARQUBE_SCAN}" == "true" ]]; then 
+                sem-version java 21
+                emit-sonarqube-data --run_only_sonar_scan
+              fi
 
   - name: "Build & Test (VS Code: linux arm64)"
     dependencies: []

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ blocks:
     task:
       env_vars:
         - name: RUN_SONARQUBE_SCAN
-          value: true
+          value: "true"
       agent:
         machine:
           type: s1-prod-ubuntu24-04-amd64-1

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,6 +34,9 @@ blocks:
     skip: &build-test-skip-stable
       when: "change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
+      env_vars:
+        - name: RUN_SONARQUBE_SCAN
+          value: true
       agent:
         machine:
           type: s1-prod-ubuntu24-04-amd64-1
@@ -59,6 +62,9 @@ blocks:
             - make remove-test-env
             - make ci-bin-sem-cache-store
             - make store-test-results-to-semaphore
+            # Ensures that we run the SonarQube scan only in this block, and not in the other blocks
+            # where this epilogue is referenced.
+            - [[ "${RUN_SONARQUBE_SCAN}" == "true" ]] && emit-sonarqube-data --run_only_sonar_scan
 
   - name: "Build & Test (VS Code: linux arm64)"
     dependencies: []

--- a/service.yml
+++ b/service.yml
@@ -19,6 +19,7 @@ sonarqube:
     - javascript
     - typescript
   enable: true
+  main_branch: main
   coverage_reports:
     - coverage/lcov.info
     - coverage/lcov-functional.info

--- a/service.yml
+++ b/service.yml
@@ -23,16 +23,20 @@ sonarqube:
   coverage_reports:
     - coverage/lcov.info
     - coverage/lcov-functional.info
+  coverage_sources:
+    - src/**/*.ts
   coverage_exclusions:
-    - ".vscode-test/**/*"
-    - "bin/**/*"
-    - "node_modules/**/*"
-    - "mk-files/**/*"
-    - "src/clients/**/*"
-    - "tests/**/*"
-    - "userdata/**/*"
-    - "Gulpfile.mjs"
-    - "src/testing.ts"
-    - "playwright.config.ts"
+    - .vscode-test/**/*
+    - bin/**/*
+    - node_modules/**/*
+    - mk-files/**/*
+    - src/clients/**/*
+    - tests/**/*
+    - userdata/**/*
+    - Gulpfile.mjs
+    - src/testing.ts
+    - playwright.config.ts
+    - src/**/*.test.ts
+    - src/**/*.spec.ts
 make:
   enable: false


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Set `main_branch: main` in the ServiceBot config for Sonarqube.
- Actually run the Sonarqube scan using the DevProd team provided script `emit-sonarqube-scan` -- only on Linux x64 (because that's where the epiloque YAML reference is set up and we only want to run the scan once).
- Hopefully resolves #933 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
