### PR TITLE
Remove wildcard from coverage sources

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -24,7 +24,7 @@ sonarqube:
     - coverage/lcov.info
     - coverage/lcov-functional.info
   coverage_sources:
-    - src/**/*.ts
+    - src
   coverage_exclusions:
     - .vscode-test/**/*
     - bin/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,5 @@ sonar.exclusions=.vscode-test/**/*,Gulpfile.mjs,bin/**/*,mk-files/**/*,node_modu
 sonar.javascript.lcov.reportPaths=coverage/lcov-functional.info,coverage/lcov.info
 sonar.language=javascript,typescript
 sonar.projectKey=vscode
-sonar.sources=src/**/*.ts
+sonar.sources=src
 sonar.typescript.coverage.reportPaths=coverage/lcov-functional.info,coverage/lcov.info


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes this error:
```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'ProjectReactor' defined in org.sonar.scanner.scan.MutableProjectReactorProvider: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.sonar.api.batch.bootstrap.ProjectReactor]: Factory method 'provide' threw exception; nested exception is Wildcards ** and * are not supported in "sonar.sources" and "sonar.tests" properties. "sonar.sources" and "sonar.tests" properties support only comma separated list of directories. Use "sonar.exclusions/sonar.inclusions" and "sonar.test.exclusions/sonar.test.inclusions" to further filter files in "sonar.sources" and "sonar.tests" respectively. Please refer to SonarQube documentation for more details.
```

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
