### PR TITLE
1842: Update container tool summarizer to include port info

### DIFF
--- a/src/chat/summarizers/dockerContainers.ts
+++ b/src/chat/summarizers/dockerContainers.ts
@@ -3,14 +3,40 @@ import { ContainerInspectResponse } from "../../clients/docker";
 import { DEFAULT_KAFKA_IMAGE_REPO, DEFAULT_SCHEMA_REGISTRY_REPO } from "../../docker/constants";
 import { LOCAL_KAFKA_IMAGE, LOCAL_SCHEMA_REGISTRY_IMAGE } from "../../preferences/constants";
 
-/**
- * Create a string representation of a {@link ContainerInspectResponse} object, limiting the
- * output to only the relevant Kafka/SR container information:
- * - Container name
- * - Image name (repo:tag)
- * - Environment variables that start with `KAFKA_`
- * - Status (running, exited, etc.)
- */
+function summarizeContainer(
+  summary: MarkdownString,
+  container: ContainerInspectResponse,
+  image: string,
+): string {
+  summary.appendMarkdown(`\n- Image: ${image}`);
+
+  const ports = container.NetworkSettings?.Ports ?? {};
+  const portMappings = Object.entries(ports).map(([containerPort, hostBindings]) => {
+    const hostPort = hostBindings?.[0]?.HostPort;
+    return { containerPort, hostPort: hostPort ?? containerPort };
+  });
+
+  const env: string[] = container.Config?.Env ?? [];
+  if (env.length || portMappings.length) {
+    summary.appendMarkdown(`\n- Environment Variables:`);
+    // Add port mappings as environment variables
+    portMappings.forEach(({ containerPort, hostPort }) => {
+      summary.appendMarkdown(`\n  - PORT_${containerPort.split("/")[0]}: ${hostPort}`);
+    });
+    env.forEach((envVar) => {
+      if (envVar.startsWith("KAFKA_") || envVar.startsWith("SCHEMA_REGISTRY_")) {
+        const [key, value] = envVar.split("=");
+        if (value !== "") {
+          summary.appendMarkdown(`\n  - ${key}: ${value}`);
+        }
+      }
+    });
+  }
+
+  summary.appendMarkdown(`\n- Status: ${container.State?.Status}`);
+  return summary.value;
+}
+
 export function summarizeLocalDockerContainer(container: ContainerInspectResponse): string {
   const containerName = container.Name?.replace("/", "") ?? "";
   const summary = new MarkdownString().appendMarkdown(`### "${containerName}"`);
@@ -20,75 +46,17 @@ export function summarizeLocalDockerContainer(container: ContainerInspectRespons
   const schemaRegistryImageRepo: string =
     config.get(LOCAL_SCHEMA_REGISTRY_IMAGE) ?? DEFAULT_SCHEMA_REGISTRY_REPO;
 
-  // Get the full image string from container config
   const image: string | undefined = container.Config?.Image;
 
-  // Check if image contains the repo name rather than container name
-  if (image?.includes(kafkaImageRepo)) {
-    if (image) {
-      summary.appendMarkdown(`\n- Image: ${image}`);
-    }
-
-    const ports = container.NetworkSettings?.Ports ?? {};
-    const portMappings = Object.entries(ports).map(([containerPort, hostBindings]) => {
-      const hostPort = hostBindings?.[0]?.HostPort;
-      return { containerPort, hostPort: hostPort ?? containerPort };
-    });
-
-    const env: string[] = container.Config?.Env ?? [];
-    if (env.length || portMappings.length) {
-      summary.appendMarkdown(`\n- Environment Variables:`);
-      // Add port mappings as environment variables
-      portMappings.forEach(({ containerPort, hostPort }) => {
-        summary.appendMarkdown(`\n  - PORT_${containerPort.split("/")[0]}: ${hostPort}`);
-      });
-      env.forEach((envVar) => {
-        if (envVar.startsWith("KAFKA_") || envVar.startsWith("SCHEMA_REGISTRY_")) {
-          const [key, value] = envVar.split("=");
-          if (value !== "") {
-            summary.appendMarkdown(`\n  - ${key}: ${value}`);
-          }
-        }
-      });
-    }
-
-    summary.appendMarkdown(`\n- Status: ${container.State?.Status}`);
-
-    return summary.value;
-  } else if (image?.includes(schemaRegistryImageRepo)) {
-    const image: string | undefined = container.Config?.Image;
-    if (image) {
-      summary.appendMarkdown(`\n- Image: ${container.Config?.Image}`);
-    }
-
-    const ports = container.NetworkSettings?.Ports ?? {};
-    const portMappings = Object.entries(ports).map(([containerPort, hostBindings]) => {
-      const hostPort = hostBindings?.[0]?.HostPort;
-      return { containerPort, hostPort: hostPort ?? containerPort };
-    });
-
-    const env: string[] = container.Config?.Env ?? [];
-    if (env.length || portMappings.length) {
-      summary.appendMarkdown(`\n- Environment Variables:`);
-      // Add port mappings as environment variables
-      portMappings.forEach(({ containerPort, hostPort }) => {
-        summary.appendMarkdown(`\n  - PORT_${containerPort.split("/")[0]}: ${hostPort}`);
-      });
-      env.forEach((envVar) => {
-        if (envVar.startsWith("KAFKA_") || envVar.startsWith("SCHEMA_REGISTRY_")) {
-          const [key, value] = envVar.split("=");
-          if (value !== "") {
-            summary.appendMarkdown(`\n  - ${key}: ${value}`);
-          }
-        }
-      });
-    }
-
-    summary.appendMarkdown(`\n- Status: ${container.State?.Status}`);
-
-    return summary.value;
-  } else {
-    summary.appendMarkdown(`\n- Error: Unrecognized container type`);
+  if (!image) {
+    summary.appendMarkdown(`\n- Error: No image configuration found`);
     return summary.value;
   }
+
+  if (image.includes(kafkaImageRepo) || image.includes(schemaRegistryImageRepo)) {
+    return summarizeContainer(summary, container, image);
+  }
+
+  summary.appendMarkdown(`\n- Error: Unrecognized container type`);
+  return summary.value;
 }

--- a/src/chat/summarizers/dockerContainers.ts
+++ b/src/chat/summarizers/dockerContainers.ts
@@ -48,7 +48,7 @@ function appendEnvironmentVars(summary: MarkdownString, container: ContainerInsp
  */
 export function summarizeLocalDockerContainer(container: ContainerInspectResponse): string {
   const containerName = container.Name?.replace("/", "") ?? "";
-  const summary = new MarkdownString().appendMarkdown(`# "${containerName}"`);
+  const summary = new MarkdownString().appendMarkdown(`## "${containerName}"`);
 
   const config = workspace.getConfiguration();
   const kafkaImageRepo: string = config.get(LOCAL_KAFKA_IMAGE) ?? DEFAULT_KAFKA_IMAGE_REPO;

--- a/src/chat/summarizers/dockerContainers.ts
+++ b/src/chat/summarizers/dockerContainers.ts
@@ -3,43 +3,52 @@ import { ContainerInspectResponse } from "../../clients/docker";
 import { DEFAULT_KAFKA_IMAGE_REPO, DEFAULT_SCHEMA_REGISTRY_REPO } from "../../docker/constants";
 import { LOCAL_KAFKA_IMAGE, LOCAL_SCHEMA_REGISTRY_IMAGE } from "../../preferences/constants";
 
-function summarizeContainer(
-  summary: MarkdownString,
-  container: ContainerInspectResponse,
-  image: string,
-): string {
-  summary.appendMarkdown(`\n- Image: ${image}`);
-
+function appendPortMappings(summary: MarkdownString, container: ContainerInspectResponse): void {
   const ports = container.NetworkSettings?.Ports ?? {};
   const portMappings = Object.entries(ports).map(([containerPort, hostBindings]) => {
     const hostPort = hostBindings?.[0]?.HostPort;
     return { containerPort, hostPort: hostPort ?? containerPort };
   });
 
-  const env: string[] = container.Config?.Env ?? [];
-  if (env.length || portMappings.length) {
-    summary.appendMarkdown(`\n- Environment Variables:`);
-    // Add port mappings as environment variables
+  if (portMappings.length) {
+    summary.appendMarkdown("\n\n### Ports");
     portMappings.forEach(({ containerPort, hostPort }) => {
-      summary.appendMarkdown(`\n  - PORT_${containerPort.split("/")[0]}: ${hostPort}`);
+      summary.appendMarkdown(`\n- ${containerPort} → ${hostPort}`);
     });
-    env.forEach((envVar) => {
-      if (envVar.startsWith("KAFKA_") || envVar.startsWith("SCHEMA_REGISTRY_")) {
-        const [key, value] = envVar.split("=");
-        if (value !== "") {
-          summary.appendMarkdown(`\n  - ${key}: ${value}`);
-        }
+  }
+}
+
+function appendEnvironmentVars(summary: MarkdownString, container: ContainerInspectResponse): void {
+  const env: string[] = container.Config?.Env ?? [];
+  const relevantEnvVars = env.filter(
+    (envVar) =>
+      (envVar.startsWith("KAFKA_") || envVar.startsWith("SCHEMA_REGISTRY_")) &&
+      envVar.includes("="),
+  );
+
+  if (relevantEnvVars.length) {
+    summary.appendMarkdown("\n\n### Environment Variables");
+    relevantEnvVars.forEach((envVar) => {
+      const [key, value] = envVar.split("=");
+      if (value) {
+        summary.appendMarkdown(`\n- ${key}: ${value}`);
       }
     });
   }
-
-  summary.appendMarkdown(`\n- Status: ${container.State?.Status}`);
-  return summary.value;
 }
 
+/**
+ * Create a string representation of a {@link ContainerInspectResponse} object, limiting the
+ * output to only the relevant Kafka/SR container information:
+ * - Container name
+ * - Port mappings
+ * - Image name (repo:tag)
+ * - Environment variables that start with `KAFKA_`
+ * - Status (running, exited, etc.)
+ */
 export function summarizeLocalDockerContainer(container: ContainerInspectResponse): string {
   const containerName = container.Name?.replace("/", "") ?? "";
-  const summary = new MarkdownString().appendMarkdown(`### "${containerName}"`);
+  const summary = new MarkdownString().appendMarkdown(`# "${containerName}"`);
 
   const config = workspace.getConfiguration();
   const kafkaImageRepo: string = config.get(LOCAL_KAFKA_IMAGE) ?? DEFAULT_KAFKA_IMAGE_REPO;
@@ -49,14 +58,20 @@ export function summarizeLocalDockerContainer(container: ContainerInspectRespons
   const image: string | undefined = container.Config?.Image;
 
   if (!image) {
-    summary.appendMarkdown(`\n- Error: No image configuration found`);
+    summary.appendMarkdown(`\n\n### Error\nNo image configuration found`);
     return summary.value;
   }
 
-  if (image.includes(kafkaImageRepo) || image.includes(schemaRegistryImageRepo)) {
-    return summarizeContainer(summary, container, image);
+  if (!image.includes(kafkaImageRepo) && !image.includes(schemaRegistryImageRepo)) {
+    summary.appendMarkdown(`\n\n### Error\nUnrecognized container type`);
+    return summary.value;
   }
 
-  summary.appendMarkdown(`\n- Error: Unrecognized container type`);
+  summary.appendMarkdown(`\n\n### Image\n${image}`);
+  summary.appendMarkdown(`\n\n### Status\n${container.State?.Status ?? "unknown"}`);
+
+  appendPortMappings(summary, container);
+  appendEnvironmentVars(summary, container);
+
   return summary.value;
 }


### PR DESCRIPTION
## Summary of Changes

Includes port information in summarizing logic. Ideally, this is what happens: 


<img width="1626" alt="Screenshot 2025-05-20 at 2 25 28 PM" src="https://github.com/user-attachments/assets/700db540-8c85-4284-9c65-9ab042e6ea44" />


But there are cases (when you ask it to generate a template without asking it to tell you about local docker first) that you may end up with it filling the template with the default local port first, then "realizing" its mistake, but there's no way to re-render a form so: 
<img width="1224" alt="Screenshot 2025-05-20 at 2 20 16 PM" src="https://github.com/user-attachments/assets/94a69206-386e-4fd8-b5e4-c531841a4ec6" />


addresses: #1842 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
