### PR TITLE
chore: update `quickpicks/organizations.ts` and add tests

### DIFF
--- a/src/quickpicks/organizations.test.ts
+++ b/src/quickpicks/organizations.test.ts
@@ -1,0 +1,122 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import * as vscode from "vscode";
+import { TEST_CCLOUD_ORGANIZATION } from "../../tests/unit/testResources/organization";
+import { IconNames } from "../constants";
+import * as organizationsGraphQL from "../graphql/organizations";
+import { CCloudOrganization } from "../models/organization";
+import { OrganizationId } from "../models/resource";
+import { organizationQuickPick } from "./organizations";
+import { QuickPickItemWithValue } from "./types";
+
+describe("quickpicks/organizations.ts organizationQuickPick()", function () {
+  let sandbox: sinon.SinonSandbox;
+
+  let showQuickPickStub: sinon.SinonStub;
+  let showInfoStub: sinon.SinonStub;
+  let getOrganizationsStub: sinon.SinonStub;
+
+  const nonCurrentOrg = CCloudOrganization.create({
+    id: "other-org-id" as OrganizationId,
+    current: false,
+    name: "other org",
+    jit_enabled: false,
+  });
+  const testOrganizations: CCloudOrganization[] = [TEST_CCLOUD_ORGANIZATION, nonCurrentOrg];
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+
+    // vscode stubs
+    showQuickPickStub = sandbox.stub(vscode.window, "showQuickPick");
+    showInfoStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
+
+    // graphql stubs
+    getOrganizationsStub = sandbox.stub(organizationsGraphQL, "getOrganizations");
+    // return the two test organizations for most tests
+    getOrganizationsStub.resolves(testOrganizations);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should correctly set quickpick options", async function () {
+    await organizationQuickPick();
+
+    sinon.assert.calledOnce(showQuickPickStub);
+    const options = showQuickPickStub.firstCall.args[1];
+    assert.strictEqual(options.placeHolder, "Select an organization");
+    assert.strictEqual(options.ignoreFocusOut, true);
+  });
+
+  it("should show quickpick with organizations and appropriate icons", async function () {
+    await organizationQuickPick();
+
+    sinon.assert.calledOnce(getOrganizationsStub);
+    sinon.assert.calledOnce(showQuickPickStub);
+
+    const quickPickItems: QuickPickItemWithValue<CCloudOrganization>[] =
+      showQuickPickStub.firstCall.args[0];
+    assert.strictEqual(quickPickItems.length, 2);
+
+    // make sure the first item is the "current" organization and check its properties
+    const currentOrgItem = quickPickItems.find((item) => item.value!.current === true);
+    assert.ok(currentOrgItem, "Should find the current organization item");
+    assert.strictEqual(currentOrgItem.value, TEST_CCLOUD_ORGANIZATION);
+    assert.strictEqual(currentOrgItem.label, TEST_CCLOUD_ORGANIZATION.name);
+    assert.strictEqual(currentOrgItem.description, TEST_CCLOUD_ORGANIZATION.id);
+    assert.strictEqual(
+      (currentOrgItem.iconPath as vscode.ThemeIcon).id,
+      IconNames.CURRENT_RESOURCE,
+    );
+
+    // check the non-current org's properties
+    const nonCurrentOrgItem = quickPickItems.find((item) => item.value!.current === false);
+    assert.ok(nonCurrentOrgItem, "Should find the non-current organization item");
+    assert.strictEqual(nonCurrentOrgItem.value, nonCurrentOrg);
+    assert.strictEqual(nonCurrentOrgItem.label, nonCurrentOrg.name);
+    assert.strictEqual(nonCurrentOrgItem.description, nonCurrentOrg.id);
+    assert.strictEqual((nonCurrentOrgItem.iconPath as vscode.ThemeIcon).id, IconNames.ORGANIZATION);
+
+    // verify sort order
+    const alphabeticallySortedOrgs = [...testOrganizations].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+    assert.strictEqual(quickPickItems[0].value, alphabeticallySortedOrgs[0]);
+    assert.strictEqual(quickPickItems[1].value, alphabeticallySortedOrgs[1]);
+  });
+
+  it("should return the selected organization", async function () {
+    // simulate user selecting the first organization
+    showQuickPickStub.resolves({
+      label: testOrganizations[0].name,
+      value: testOrganizations[0],
+    });
+
+    const result: CCloudOrganization | undefined = await organizationQuickPick();
+
+    assert.strictEqual(result, testOrganizations[0]);
+  });
+
+  it("should return undefined if no organization is selected", async function () {
+    // user cancels the quickpick
+    showQuickPickStub.resolves(undefined);
+
+    const result: CCloudOrganization | undefined = await organizationQuickPick();
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("should skip the quickpick and show an info notification when no organizations are found", async function () {
+    // simulate getting no organizations back from GraphQL
+    getOrganizationsStub.resolves([]);
+
+    const result: CCloudOrganization | undefined = await organizationQuickPick();
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.calledOnce(showInfoStub);
+    sinon.assert.calledWithExactly(showInfoStub, "No organizations available.");
+    sinon.assert.notCalled(showQuickPickStub);
+  });
+});

--- a/src/quickpicks/organizations.test.ts
+++ b/src/quickpicks/organizations.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import * as vscode from "vscode";
+import { ThemeIcon, window } from "vscode";
 import { TEST_CCLOUD_ORGANIZATION } from "../../tests/unit/testResources/organization";
 import { IconNames } from "../constants";
 import * as organizationsGraphQL from "../graphql/organizations";
@@ -28,8 +28,8 @@ describe("quickpicks/organizations.ts organizationQuickPick()", function () {
     sandbox = sinon.createSandbox();
 
     // vscode stubs
-    showQuickPickStub = sandbox.stub(vscode.window, "showQuickPick");
-    showInfoStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
+    showQuickPickStub = sandbox.stub(window, "showQuickPick");
+    showInfoStub = sandbox.stub(window, "showInformationMessage").resolves();
 
     // graphql stubs
     getOrganizationsStub = sandbox.stub(organizationsGraphQL, "getOrganizations");
@@ -66,10 +66,7 @@ describe("quickpicks/organizations.ts organizationQuickPick()", function () {
     assert.strictEqual(currentOrgItem.value, TEST_CCLOUD_ORGANIZATION);
     assert.strictEqual(currentOrgItem.label, TEST_CCLOUD_ORGANIZATION.name);
     assert.strictEqual(currentOrgItem.description, TEST_CCLOUD_ORGANIZATION.id);
-    assert.strictEqual(
-      (currentOrgItem.iconPath as vscode.ThemeIcon).id,
-      IconNames.CURRENT_RESOURCE,
-    );
+    assert.strictEqual((currentOrgItem.iconPath as ThemeIcon).id, IconNames.CURRENT_RESOURCE);
 
     // check the non-current org's properties
     const nonCurrentOrgItem = quickPickItems.find((item) => item.value!.current === false);
@@ -77,7 +74,7 @@ describe("quickpicks/organizations.ts organizationQuickPick()", function () {
     assert.strictEqual(nonCurrentOrgItem.value, nonCurrentOrg);
     assert.strictEqual(nonCurrentOrgItem.label, nonCurrentOrg.name);
     assert.strictEqual(nonCurrentOrgItem.description, nonCurrentOrg.id);
-    assert.strictEqual((nonCurrentOrgItem.iconPath as vscode.ThemeIcon).id, IconNames.ORGANIZATION);
+    assert.strictEqual((nonCurrentOrgItem.iconPath as ThemeIcon).id, IconNames.ORGANIZATION);
 
     // verify sort order
     const alphabeticallySortedOrgs = [...testOrganizations].sort((a, b) =>

--- a/src/quickpicks/organizations.ts
+++ b/src/quickpicks/organizations.ts
@@ -1,34 +1,39 @@
-import * as vscode from "vscode";
+import { ThemeIcon, window } from "vscode";
 import { IconNames } from "../constants";
 import { getOrganizations } from "../graphql/organizations";
 import { CCloudOrganization } from "../models/organization";
+import { QuickPickItemWithValue } from "./types";
 
+/**
+ * Displays a quickpick for selecting a CCloud organization.
+ *
+ * @returns The selected {@link CCloudOrganization} or `undefined` if no selection was made.
+ */
 export async function organizationQuickPick(): Promise<CCloudOrganization | undefined> {
   const ccloudOrganizations: CCloudOrganization[] = await getOrganizations();
   if (ccloudOrganizations.length === 0) {
-    vscode.window.showInformationMessage("No organizations available.");
-    return undefined;
+    window.showInformationMessage("No organizations available.");
+    return;
   }
 
-  let organizationItems: vscode.QuickPickItem[] = [];
+  let organizationItems: QuickPickItemWithValue<CCloudOrganization>[] = [];
   ccloudOrganizations.sort((a, b) => a.name.localeCompare(b.name));
   ccloudOrganizations.forEach((organization: CCloudOrganization) => {
     organizationItems.push({
       label: organization.name,
       description: organization.id,
-      iconPath: new vscode.ThemeIcon(
+      iconPath: new ThemeIcon(
         organization.current ? IconNames.CURRENT_RESOURCE : IconNames.ORGANIZATION,
       ),
+      value: organization,
     });
   });
 
-  const chosenOrganizationItem: vscode.QuickPickItem | undefined =
-    await vscode.window.showQuickPick(organizationItems, {
+  const chosenOrganizationItem: QuickPickItemWithValue<CCloudOrganization> | undefined =
+    await window.showQuickPick(organizationItems, {
       placeHolder: "Select an organization",
       ignoreFocusOut: true,
     });
 
-  return chosenOrganizationItem
-    ? ccloudOrganizations.find((org) => org.id === chosenOrganizationItem.description)
-    : undefined;
+  return chosenOrganizationItem?.value;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Mainly to use `QuickPickItemWithValue<CCloudOrganization>` objects instead of the base `QuickPickItem`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
