### PR TITLE
MINOR: fix `commands/documents.ts resetCCloudMetadataForUriCommand()` test suite setup

### DIFF
--- a/src/commands/documents.test.ts
+++ b/src/commands/documents.test.ts
@@ -375,6 +375,7 @@ describe("commands/documents.ts resetCCloudMetadataForUriCommand()", () => {
 
   let stubResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
   let uriMetadataSetFireStub: sinon.SinonStub;
+  let hasCCloudAuthSessionStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -383,6 +384,11 @@ describe("commands/documents.ts resetCCloudMetadataForUriCommand()", () => {
     sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
 
     uriMetadataSetFireStub = sandbox.stub(uriMetadataSet, "fire");
+
+    // assume the user is signed in to CCloud for most tests
+    hasCCloudAuthSessionStub = sandbox
+      .stub(ccloudConnections, "hasCCloudAuthSession")
+      .returns(true);
   });
 
   afterEach(() => {
@@ -394,6 +400,16 @@ describe("commands/documents.ts resetCCloudMetadataForUriCommand()", () => {
     await resetCCloudMetadataForUriCommand();
 
     sinon.assert.notCalled(stubResourceManager.setUriMetadata);
+    sinon.assert.notCalled(uriMetadataSetFireStub);
+  });
+
+  it("should do nothing when no CCloud auth session is available", async () => {
+    // simulate user not being signed in to CCloud
+    hasCCloudAuthSessionStub.returns(false);
+
+    await resetCCloudMetadataForUriCommand(testUri);
+
+    sinon.assert.notCalled(stubResourceManager.setUriMetadataValue);
     sinon.assert.notCalled(uriMetadataSetFireStub);
   });
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes the test suite where one of the tests was failing in isolation since `hasCCloudAuthSession` wasn't stubbed:
<img width="787" alt="image" src="https://github.com/user-attachments/assets/fbf7407e-35c0-4658-8f76-0b9371dad8d7" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
