### PR TITLE
[WIP] Language Client Refactor

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -231,7 +231,7 @@ export class FlinkLanguageClientManager implements Disposable {
   }
 
   /**
-   * Ensures the language client is initialized if prerequisites are met
+   * Ensures the default language client is initialized if prerequisites are met
    * Prerequisites:
    * - User is authenticated with CCloud
    * - User has selected a compute pool to use for websocket connection (language server route is region/provider specific)

--- a/src/flinkSql/flinkServerProvider.ts
+++ b/src/flinkSql/flinkServerProvider.ts
@@ -1,0 +1,401 @@
+import * as vscode from "vscode";
+import {
+  Message,
+  MessageReader,
+  MessageTransports,
+  MessageWriter,
+} from "vscode-languageclient/node";
+import { Logger } from "../logging";
+import { MultiServerManager } from "./multiSocketManager";
+
+const logger = new Logger("flinkSql.serverOptionsProvider");
+
+/**
+ * Custom MessageReader that forwards to the appropriate WebSocket based on document context
+ */
+class FlinkSqlMessageReader implements MessageReader {
+  private onErrorEmitter = new vscode.EventEmitter<Error>();
+  private onCloseEmitter = new vscode.EventEmitter<void>();
+  private onPartialMessageEmitter = new vscode.EventEmitter<any>();
+  private listeners: Map<string, vscode.Disposable> = new Map();
+  private onMessageEmitter = new vscode.EventEmitter<Message>();
+
+  constructor() {}
+
+  public get onError() {
+    return this.onErrorEmitter.event;
+  }
+
+  public get onClose() {
+    return this.onCloseEmitter.event;
+  }
+
+  public get onPartialMessage() {
+    return this.onPartialMessageEmitter.event;
+  }
+
+  /**
+   * Method called by the language client to register a callback for incoming messages
+   */
+  public listen(callback: (message: Message) => void): vscode.Disposable {
+    // Setup subscription to our message emitter
+    logger.debug("Language client registered to listen for incoming messages");
+    const subscription = this.onMessageEmitter.event((message) => {
+      try {
+        // Log information about the response
+        if (typeof message === "object" && message !== null) {
+          if ("id" in message && "result" in message) {
+            const responseId = message.id;
+            let resultInfo = "";
+
+            // For completion responses, add more detailed logging
+            if (
+              typeof message.result === "object" &&
+              message.result !== null &&
+              "items" in message.result
+            ) {
+              const items = message.result.items;
+              const itemCount = Array.isArray(items) ? items.length : "?";
+              resultInfo = ` with ${itemCount} completion items`;
+            }
+
+            logger.debug(`Processing response for request id ${responseId}${resultInfo}`);
+          } else if ("method" in message) {
+            logger.debug(`Processing notification: ${message.method}`);
+          }
+        }
+
+        // Forward the message to the language client
+        callback(message);
+      } catch (error) {
+        logger.error(`Error in message listener callback: ${error}`);
+      }
+    });
+
+    return {
+      dispose: () => {
+        logger.debug("Language client message listener disposed");
+        subscription.dispose();
+      },
+    };
+  }
+
+  /**
+   * Pass a message received from a websocket to our message emitter
+   */
+  public forwardMessage(message: Message): void {
+    try {
+      // Log message ID and type for debugging
+      if (typeof message === "object" && message !== null) {
+        if ("id" in message && "result" in message) {
+          logger.debug(`Forwarding response for request id ${message.id} to language client`);
+        } else if ("method" in message) {
+          logger.debug(`Forwarding notification with method ${message.method} to language client`);
+        } else {
+          logger.debug(
+            `Forwarding message to language client: ${JSON.stringify(message).substring(0, 100)}...`,
+          );
+        }
+      } else {
+        logger.debug("Forwarding non-object message to language client");
+      }
+
+      this.onMessageEmitter.fire(message);
+    } catch (error) {
+      logger.error(`Error forwarding message: ${error}`);
+    }
+  }
+
+  /**
+   * Dispose all resources
+   */
+  public dispose(): void {
+    this.listeners.forEach((listener) => listener.dispose());
+    this.listeners.clear();
+    this.onErrorEmitter.dispose();
+    this.onCloseEmitter.dispose();
+    this.onPartialMessageEmitter.dispose();
+    this.onMessageEmitter.dispose();
+  }
+}
+
+/**
+ * Custom MessageWriter that forwards messages to the appropriate WebSocket
+ * based on document context
+ */
+class FlinkSqlMessageWriter implements MessageWriter {
+  private onErrorEmitter = new vscode.EventEmitter<
+    [Error, Message | undefined, number | undefined]
+  >();
+  private onCloseEmitter = new vscode.EventEmitter<void>();
+  private serverManager: MultiServerManager;
+  private openDocuments: Map<string, vscode.TextDocument> = new Map();
+  private documentSelector: vscode.DocumentSelector;
+  private pendingRequests: Map<number | string, string> = new Map(); // Maps request IDs to document URIs
+
+  constructor(serverManager: MultiServerManager, documentSelector: vscode.DocumentSelector) {
+    this.serverManager = serverManager;
+    this.documentSelector = documentSelector;
+
+    // Track open documents to know which server to route messages to
+    vscode.workspace.textDocuments.forEach((doc) => {
+      if (vscode.languages.match(this.documentSelector, doc)) {
+        this.openDocuments.set(doc.uri.toString(), doc);
+      }
+    });
+
+    // Listen for document open/close events
+    vscode.workspace.onDidOpenTextDocument((doc) => {
+      if (vscode.languages.match(this.documentSelector, doc)) {
+        logger.debug(`Tracking document: ${doc.uri.toString()}`);
+        this.openDocuments.set(doc.uri.toString(), doc);
+      }
+    });
+
+    vscode.workspace.onDidCloseTextDocument((doc) => {
+      logger.debug(`Removing tracked document: ${doc.uri.toString()}`);
+      this.openDocuments.delete(doc.uri.toString());
+    });
+  }
+
+  public get onError() {
+    return this.onErrorEmitter.event;
+  }
+
+  public get onClose() {
+    return this.onCloseEmitter.event;
+  }
+
+  /**
+   * Find the active document to use for routing
+   * This is a heuristic - we try to use the most recently active document
+   * that matches our document selector
+   */
+  private getActiveDocument(): vscode.TextDocument | undefined {
+    // Try the active editor first
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor && vscode.languages.match(this.documentSelector, activeEditor.document)) {
+      return activeEditor.document;
+    }
+
+    // Fall back to any visible editor
+    for (const editor of vscode.window.visibleTextEditors) {
+      if (vscode.languages.match(this.documentSelector, editor.document)) {
+        return editor.document;
+      }
+    }
+
+    // Last resort: use any open document
+    if (this.openDocuments.size > 0) {
+      return Array.from(this.openDocuments.values())[0];
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Write a message to the appropriate WebSocket
+   */
+  public async write(message: Message): Promise<void> {
+    // Check if this looks like an initialization message by examining the method property
+    const isInitializationMessage =
+      message &&
+      typeof message === "object" &&
+      "method" in message &&
+      typeof message.method === "string" &&
+      (message.method === "initialize" || message.method.startsWith("$/"));
+
+    // Check if this is a request message (has ID and method)
+    const isRequest =
+      message && typeof message === "object" && "id" in message && "method" in message;
+
+    // Get additional information about the request for logging
+    let requestMethod =
+      isRequest && typeof (message as any).method === "string"
+        ? (message as any).method
+        : "unknown";
+    let requestId = isRequest ? (message as any).id : null;
+
+    // If this is a completion or other document-specific request, try to extract document URI
+    let documentUri: string | undefined;
+    if (
+      isRequest &&
+      (message as any).method === "textDocument/completion" &&
+      typeof (message as any).params === "object" &&
+      (message as any).params &&
+      "textDocument" in (message as any).params &&
+      (message as any).params.textDocument &&
+      "uri" in (message as any).params.textDocument
+    ) {
+      documentUri = (message as any).params.textDocument.uri;
+
+      // Store the document URI associated with this request ID for later
+      if (requestId !== null && documentUri) {
+        logger.debug(`Associating request ${requestId} with document ${documentUri}`);
+        this.pendingRequests.set(requestId as string | number, documentUri);
+      }
+    }
+
+    if (isInitializationMessage) {
+      logger.debug(`Handling initialization or protocol message: ${message.method}`);
+      // For initialization and protocol messages, always route to the default server
+      try {
+        await this.serverManager.sendToDefaultServer(message);
+        return Promise.resolve();
+      } catch (error) {
+        logger.error(`Error sending initialization message: ${error}`);
+        this.onErrorEmitter.fire([error as Error, message, undefined]);
+        return Promise.reject(error);
+      }
+    }
+
+    // If we have a document URI from the request, try to use that document
+    let activeDocument: vscode.TextDocument | undefined;
+    if (documentUri) {
+      activeDocument = this.openDocuments.get(documentUri);
+      if (activeDocument) {
+        logger.debug(`Using document from request params: ${documentUri}`);
+      } else {
+        logger.debug(`Document from request params not found in open documents: ${documentUri}`);
+      }
+    }
+
+    // If we don't have a document from the request, try to find an active document
+    if (!activeDocument) {
+      activeDocument = this.getActiveDocument();
+    }
+
+    if (!activeDocument) {
+      logger.debug(
+        `No active document found for ${isRequest ? "request" : "message"} ${requestMethod}${requestId ? ` (id: ${requestId})` : ""}, using default server`,
+      );
+
+      // No document context available, try to find a connected server
+      if (!this.serverManager.hasConnectedServers()) {
+        logger.error("No connected servers available to send message");
+        return Promise.reject(new Error("No connected servers available"));
+      }
+
+      // Send to the default server since we don't have a document context
+      try {
+        await this.serverManager.sendToDefaultServer(message);
+        return Promise.resolve();
+      } catch (error) {
+        logger.error(`Error sending message to default server: ${error}`);
+        this.onErrorEmitter.fire([error as Error, message, undefined]);
+        return Promise.reject(error);
+      }
+    }
+
+    try {
+      logger.debug(
+        `Sending ${isRequest ? "request" : "message"} ${requestMethod}${requestId ? ` (id: ${requestId})` : ""} for document ${activeDocument.uri.toString()}`,
+      );
+      await this.serverManager.sendMessage(message, activeDocument);
+      return Promise.resolve();
+    } catch (error) {
+      logger.error(`Error sending message: ${error}`);
+      this.onErrorEmitter.fire([error as Error, message, undefined]);
+      return Promise.reject(error);
+    }
+  }
+
+  /**
+   * End the writer - we don't do anything here as the connections
+   * are managed by the MultiWebSocketServerManager
+   */
+  public end(): void {
+    // No-op, connections are managed by the MultiWebSocketServerManager
+  }
+
+  /**
+   * Dispose resources
+   */
+  public dispose(): void {
+    this.onErrorEmitter.dispose();
+    this.onCloseEmitter.dispose();
+  }
+}
+
+/**
+ * A custom MessageTransports implementation that uses our MultiWebSocketServerManager
+ * to route messages to the appropriate server
+ */
+class FlinkSqlMessageTransports implements MessageTransports {
+  public reader: MessageReader;
+  public writer: MessageWriter;
+  private serverManager: MultiServerManager;
+
+  constructor(serverManager: MultiServerManager, documentSelector: vscode.DocumentSelector) {
+    this.serverManager = serverManager;
+    this.reader = new FlinkSqlMessageReader();
+    this.writer = new FlinkSqlMessageWriter(serverManager, documentSelector);
+
+    // Connect the message handler so incoming WebSocket messages get forwarded to the reader
+    serverManager.setMessageHandler((message: Message) => {
+      this.forwardIncomingMessage(message);
+    });
+  }
+
+  /**
+   * Pass a message received from a websocket to our reader
+   */
+  public forwardIncomingMessage(message: Message): void {
+    logger.debug("Forwarding message to LSP client");
+    (this.reader as FlinkSqlMessageReader).forwardMessage(message);
+  }
+}
+
+/**
+ * Provides server options for the language client using our websocket manager
+ */
+export class FlinkServerProvider {
+  private serverManager: MultiServerManager;
+  private messageTransports: FlinkSqlMessageTransports | null = null;
+  private documentSelector: vscode.DocumentSelector;
+
+  constructor(serverManager: MultiServerManager, documentSelector: vscode.DocumentSelector) {
+    this.serverManager = serverManager;
+    this.documentSelector = documentSelector;
+  }
+
+  /**
+   * Get server options for the language client
+   * This returns a factory function that will be called by the client
+   */
+  public getServerOptions() {
+    return async () => {
+      try {
+        // Connect to all servers
+        await this.serverManager.connectAll();
+
+        this.messageTransports = new FlinkSqlMessageTransports(
+          this.serverManager,
+          this.documentSelector,
+        );
+
+        // Verify that at least one server is connected
+        if (!this.serverManager.hasConnectedServers()) {
+          throw new Error("No WebSocket servers connected");
+        }
+
+        logger.debug("Server options created successfully");
+        return this.messageTransports;
+      } catch (error) {
+        logger.error(`Failed to create server options: ${error}`);
+        throw error;
+      }
+    };
+  }
+
+  /**
+   * Dispose resources
+   */
+  public dispose(): void {
+    if (this.messageTransports) {
+      this.messageTransports.reader.dispose();
+      this.messageTransports.writer.dispose();
+      this.messageTransports = null;
+    }
+  }
+}

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -8,15 +8,13 @@ import {
   Message,
   Trace,
 } from "vscode-languageclient/node";
-import { WebSocket } from "ws";
 import { Logger } from "../logging";
-import { getStorageManager } from "../storage";
-import { SecretStorageKeys } from "../storage/constants";
-import { WebsocketTransport } from "./websocketTransport";
+import { FlinkServerProvider } from "./flinkServerProvider";
+import { MultiServerManager } from "./multiSocketManager";
 
 const logger = new Logger("flinkSql.languageClient");
 
-/** Initialize the FlinkSQL language client and connect to the language server websocket
+/** Initialize the "default" FlinkSQL language client and connect to the language server websocket
  * @returns A promise that resolves to the language client, or null if initialization failed
  * Prerequisites:
  * - User is authenticated with CCloud
@@ -26,139 +24,109 @@ export async function initializeLanguageClient(
   url: string,
   onWebSocketDisconnect: () => void,
 ): Promise<LanguageClient | null> {
-  let accessToken: string | undefined = await getStorageManager().getSecret(
-    SecretStorageKeys.SIDECAR_AUTH_TOKEN,
-  );
-  if (!accessToken) {
-    logger.error(
-      "Failed to initialize Flink SQL language client: No access token found for language client",
+  try {
+    const documentSelector = [
+      { language: "flinksql" },
+      { scheme: "untitled", language: "flinksql" },
+      { pattern: "**/*.flink.sql" },
+    ];
+    const serverManager = new MultiServerManager();
+    logger.debug("Registering default server");
+    serverManager.registerServer(
+      "default",
+      url,
+      (document) =>
+        document.languageId === "flinksql" ||
+        !!vscode.languages.match({ pattern: "**/*.flink.sql" }, document),
+      true, // Set as default server
     );
+    const serverOptionsProvider = new FlinkServerProvider(serverManager, documentSelector);
+    const serverOptions = await serverOptionsProvider.getServerOptions();
+    const clientOptions: LanguageClientOptions = {
+      documentSelector,
+      middleware: {
+        didOpen: (document, next) => next(document),
+        didChange: (event, next) => {
+          const diagnostics = vscode.languages.getDiagnostics(event.document.uri);
+          if (diagnostics.length > 0) {
+            const diagnosticCollection = vscode.languages.createDiagnosticCollection("flinksql");
+            diagnosticCollection.delete(event.document.uri);
+          }
+          return next(event);
+        },
+        provideCompletionItem: async (document, position, context, token, next) => {
+          const result: any = await next(document, position, context, token);
+          if (result) {
+            const items: any = result.items;
+            items.forEach((element: vscode.CompletionItem) => {
+              if (
+                element.filterText &&
+                element.filterText.startsWith("`") &&
+                element.filterText.endsWith("`")
+              ) {
+                element.filterText = element.filterText.substring(1, element.filterText.length - 1);
+              }
+            });
+            return result;
+          }
+          return [];
+        },
+        sendRequest: (type, params, token, next) => {
+          if (
+            typeof type === "object" &&
+            type.method &&
+            type.method === "textDocument/completion"
+          ) {
+            if (params && (params as any).position && (params as any).textDocument?.uri) {
+              const uri = (params as any).textDocument.uri;
+              const document = vscode.workspace.textDocuments.find(
+                (doc) => doc.uri.toString() === uri,
+              );
+              if (document) {
+                const originalPosition = (params as any).position;
+                (params as any).position = convertToSingleLinePosition(
+                  document,
+                  new vscode.Position(originalPosition.line, originalPosition.character),
+                );
+              }
+            }
+          }
+          return next(type, params, token);
+        },
+      },
+      errorHandler: {
+        error: (error: Error, message: Message): ErrorHandlerResult => {
+          logger.error(`Language server error: ${message}`);
+          return {
+            action: ErrorAction.Continue,
+            message: `${message ?? error.message}`,
+            handled: true,
+          };
+        },
+        closed: () => {
+          logger.warn("Language server connection closed by the client's error handler");
+          onWebSocketDisconnect();
+          return {
+            action: CloseAction.Restart,
+            handled: true,
+          };
+        },
+      },
+    };
+    const languageClient = new LanguageClient(
+      "confluent.flinksqlLanguageServer",
+      "ConfluentFlinkSQL",
+      serverOptions,
+      clientOptions,
+    );
+    await languageClient.start();
+    logger.debug("FlinkSQL Language Server started");
+    languageClient.setTrace(Trace.Compact);
+    return languageClient;
+  } catch (e) {
+    logger.error(`Error starting FlinkSQL language server: ${e}`);
     return null;
   }
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(url, {
-      headers: { authorization: `Bearer ${accessToken}` },
-    });
-    ws.onerror = (error) => {
-      logger.error(`WebSocket connection error: ${error}`);
-      reject(new Error("Failed to connect to Flink SQL language server")); //FIXME here's one error that surfaces to users
-    };
-    ws.onopen = async () => {
-      logger.debug("WebSocket connection opened");
-      try {
-        const transport = new WebsocketTransport(ws);
-        const serverOptions = () => {
-          return Promise.resolve(transport);
-        };
-        const clientOptions: LanguageClientOptions = {
-          documentSelector: [
-            { language: "flinksql" },
-            { scheme: "untitled", language: "flinksql" },
-            { pattern: "**/*.flink.sql" },
-          ],
-          middleware: {
-            didOpen: (document, next) => {
-              return next(document);
-            },
-            didChange: (event, next) => {
-              // Clear diagnostics when document changes, so user sees only latest issues
-              const diagnostics = vscode.languages.getDiagnostics(event.document.uri);
-              if (diagnostics.length > 0) {
-                const diagnosticCollection =
-                  vscode.languages.createDiagnosticCollection("flinksql");
-                diagnosticCollection.delete(event.document.uri);
-              }
-              return next(event);
-            },
-            provideCompletionItem: async (document, position, context, token, next) => {
-              const result: any = await next(document, position, context, token);
-              if (result) {
-                const items: any = result.items;
-                items.forEach((element: vscode.CompletionItem) => {
-                  // The server sends backticks in the filterText for all Resource completions, but vscode languageclient
-                  // will filter out these items if the completion range doesn't start with a backtick, so we remove them
-                  if (
-                    element.filterText &&
-                    element.filterText.startsWith("`") &&
-                    element.filterText.endsWith("`")
-                  ) {
-                    element.filterText = element.filterText.substring(
-                      1,
-                      element.filterText.length - 1,
-                    );
-                  }
-                });
-                return result;
-              }
-              return [];
-            },
-            sendRequest: (type, params, token, next) => {
-              // Server does not accept line positions > 0 for completions, so we need to convert them to single-line
-              if (
-                typeof type === "object" &&
-                type.method &&
-                type.method === "textDocument/completion"
-              ) {
-                if (params && (params as any).position && (params as any).textDocument?.uri) {
-                  const uri = (params as any).textDocument.uri;
-                  const document = vscode.workspace.textDocuments.find(
-                    (doc) => doc.uri.toString() === uri,
-                  );
-                  if (document) {
-                    const originalPosition = (params as any).position;
-                    (params as any).position = convertToSingleLinePosition(
-                      document,
-                      new vscode.Position(originalPosition.line, originalPosition.character),
-                    );
-                  }
-                }
-              }
-
-              return next(type, params, token);
-            },
-          },
-          errorHandler: {
-            error: (error: Error, message: Message): ErrorHandlerResult => {
-              logger.error(`Language server error: ${message}`);
-              return {
-                action: ErrorAction.Continue,
-                message: `${message ?? error.message}`,
-                handled: true,
-              };
-            },
-            closed: () => {
-              logger.warn("Language server connection closed by the client's error handler");
-              onWebSocketDisconnect();
-              return {
-                action: CloseAction.Restart,
-                handled: true,
-              };
-            },
-          },
-        };
-
-        const languageClient = new LanguageClient(
-          "confluent.flinksqlLanguageServer",
-          "ConfluentFlinkSQL",
-          serverOptions,
-          clientOptions,
-        );
-
-        await languageClient.start();
-        logger.debug("FlinkSQL Language Server started");
-        languageClient.setTrace(Trace.Compact);
-        resolve(languageClient);
-      } catch (e) {
-        logger.error(`Error starting FlinkSQL language server: ${e}`);
-        reject(e);
-      }
-    };
-    ws.onclose = async (event) => {
-      const reason = event.reason || "Unknown reason";
-      const code = event.code;
-      logger.warn(`WebSocket connection closed: Code ${code}, Reason: ${reason}`);
-    };
-  });
 }
 
 /** Helper to convert vscode.Position to always have {line: 0...},

--- a/src/flinkSql/multiSocketManager.ts
+++ b/src/flinkSql/multiSocketManager.ts
@@ -1,0 +1,198 @@
+import { TextDocument } from "vscode";
+import { Message } from "vscode-languageclient/node";
+import { Logger } from "../logging";
+import { ConnectionStatus, LanguageServerConnection } from "./socketConnectionManager";
+
+const logger = new Logger("flinkSql.multiServerManager");
+
+interface ServerInfo {
+  url: string;
+  manager: LanguageServerConnection;
+  documentFilter: (document: TextDocument) => boolean;
+}
+
+/**
+ *  Manages multiple websocket server connections, routes messages based on document filters
+ */
+export class MultiServerManager {
+  private servers: Map<string, ServerInfo> = new Map();
+  private defaultServerId: string | null = null;
+  private _messageHandler: ((message: Message) => void) | null = null;
+
+  /**
+   * Set a message handler for all servers
+   * @param handler The handler function to call with received messages
+   */
+  public setMessageHandler(handler: (message: Message) => void): void {
+    this._messageHandler = handler;
+
+    // Set handler for all existing servers
+    for (const [_, serverInfo] of this.servers.entries()) {
+      serverInfo.manager.setMessageHandler(handler);
+    }
+  }
+
+  /**
+   * Register a new server with a unique ID and connection info
+   * @param id Unique identifier for this server
+   * @param url WebSocket URL
+   * @param documentFilter Function to determine if a document should use this server
+   * @param isDefault Whether this should be the default server when no match is found
+   */
+  public registerServer(
+    id: string,
+    url: string,
+    documentFilter: (document: TextDocument) => boolean,
+    isDefault: boolean = false,
+  ): void {
+    if (this.servers.has(id)) {
+      logger.warn(`Server with ID '${id}' already registered, replacing`);
+      this.servers.get(id)?.manager.dispose();
+    }
+
+    const manager = new LanguageServerConnection(url);
+    this.servers.set(id, { url, manager, documentFilter });
+
+    // Set message handler if we already have one
+    if (this._messageHandler) {
+      manager.setMessageHandler(this._messageHandler);
+    }
+
+    // Monitor connection status for logging
+    manager.onConnectionStatusChange((status) => {
+      logger.debug(`Server '${id}' connection status: ${status}`);
+    });
+
+    if (isDefault) {
+      this.defaultServerId = id;
+    }
+  }
+
+  /**
+   * Get the appropriate server for a given document
+   * @param document The document to route
+   * @returns The server info or null if no match
+   */
+  public getServerForDocument(document: TextDocument): ServerInfo | null {
+    // Try to find a server that matches the document filter
+    for (const [id, serverInfo] of this.servers.entries()) {
+      if (serverInfo.documentFilter(document)) {
+        logger.debug(`Routing document ${document.uri.toString()} to server '${id}'`);
+        return serverInfo;
+      }
+    }
+
+    // Fall back to default server if available
+    if (this.defaultServerId && this.servers.has(this.defaultServerId)) {
+      logger.debug(
+        `No specific server found for ${document.uri.toString()}, using default server '${this.defaultServerId}'`,
+      );
+      return this.servers.get(this.defaultServerId) || null;
+    }
+
+    logger.warn(`No server found for document ${document.uri.toString()}`);
+    return null;
+  }
+
+  /**
+   * Connect to a specific server by ID
+   * @param id The server ID to connect to
+   */
+  public async connectToServer(id: string): Promise<void> {
+    const server = this.servers.get(id);
+    if (!server) {
+      throw new Error(`Server with ID '${id}' not found`);
+    }
+
+    try {
+      await server.manager.connect();
+    } catch (error) {
+      logger.error(`Failed to connect to server '${id}': ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Connect to all registered servers
+   */
+  public async connectAll(): Promise<void> {
+    const connectionPromises = Array.from(this.servers.entries()).map(async ([id, server]) => {
+      try {
+        await server.manager.connect();
+        logger.debug(`Connected to server '${id}'`);
+      } catch (error) {
+        logger.error(`Failed to connect to server '${id}': ${error}`);
+      }
+    });
+
+    await Promise.all(connectionPromises);
+  }
+
+  /**
+   * Send a message to the default server
+   * @param message The message to send
+   */
+  public async sendToDefaultServer(message: Message): Promise<void> {
+    if (!this.defaultServerId || !this.servers.has(this.defaultServerId)) {
+      throw new Error("No default server configured");
+    }
+
+    const serverInfo = this.servers.get(this.defaultServerId);
+    if (!serverInfo) {
+      throw new Error(`Default server '${this.defaultServerId}' not found`);
+    }
+
+    logger.debug(`Sending message to default server '${this.defaultServerId}'`);
+    return serverInfo.manager.queueMessage(message);
+  }
+
+  /**
+   * Send a message to the appropriate server based on document info
+   * @param message The message to send
+   * @param document The document context for routing
+   */
+  public async sendMessage(message: Message, document: TextDocument): Promise<void> {
+    const server = this.getServerForDocument(document);
+    if (!server) {
+      throw new Error(`No server available for document ${document.uri.toString()}`);
+    }
+
+    return server.manager.queueMessage(message);
+  }
+
+  /**
+   * Get the connection status for a specific server
+   * @param id The server ID
+   */
+  public getServerStatus(id: string): ConnectionStatus | null {
+    const server = this.servers.get(id);
+    if (!server) {
+      return null;
+    }
+    return server.manager.connectionStatus;
+  }
+
+  /**
+   * Check if any servers are currently connected
+   */
+  public hasConnectedServers(): boolean {
+    for (const [_, server] of this.servers.entries()) {
+      if (server.manager.connectionStatus === ConnectionStatus.CONNECTED) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Dispose all server connections
+   */
+  public dispose(): void {
+    for (const [id, server] of this.servers.entries()) {
+      logger.debug(`Disposing server '${id}'`);
+      server.manager.dispose();
+    }
+    this.servers.clear();
+    this.defaultServerId = null;
+  }
+}

--- a/src/flinkSql/socketConnectionManager.ts
+++ b/src/flinkSql/socketConnectionManager.ts
@@ -1,0 +1,331 @@
+import { EventEmitter } from "vscode";
+import { Message, MessageTransports } from "vscode-languageclient/node";
+import { WebSocket } from "ws";
+import { Logger } from "../logging";
+import { getStorageManager } from "../storage";
+import { SecretStorageKeys } from "../storage/constants";
+import { WebsocketTransport } from "./websocketTransport";
+
+const logger = new Logger("flinkSql.websocketServerManager");
+
+// Connection statuses
+export enum ConnectionStatus {
+  DISCONNECTED = "disconnected",
+  CONNECTING = "connecting",
+  CONNECTED = "connected",
+  RECONNECTING = "reconnecting",
+}
+
+interface QueuedMessage {
+  message: Message;
+  timestamp: number;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export class LanguageServerConnection {
+  private _url: string;
+  private _socket: WebSocket | null = null;
+  private _transport: WebsocketTransport | null = null;
+  private _isReconnecting = false;
+  private _reconnectAttempts = 0;
+  private _maxReconnectAttempts = 5;
+  private _reconnectBackoff = 1000; // Start with 1 second
+  private _reconnectTimer: NodeJS.Timeout | null = null;
+  private _messageQueue: QueuedMessage[] = [];
+  private _connectionStatusEmitter = new EventEmitter<ConnectionStatus>();
+  private _connectionStatus: ConnectionStatus = ConnectionStatus.DISCONNECTED;
+  private _connectionToken: string | null = null;
+  private _messageHandler: ((message: Message) => void) | null = null;
+
+  constructor(url: string) {
+    this._url = url;
+  }
+
+  get connectionStatus(): ConnectionStatus {
+    return this._connectionStatus;
+  }
+
+  get onConnectionStatusChange() {
+    return this._connectionStatusEmitter.event;
+  }
+
+  /**
+   * Set a callback to be called when a message is received from the server
+   * @param handler Function to call with received messages
+   */
+  public setMessageHandler(handler: (message: Message) => void): void {
+    this._messageHandler = handler;
+  }
+
+  private setConnectionStatus(status: ConnectionStatus) {
+    this._connectionStatus = status;
+    this._connectionStatusEmitter.fire(status);
+  }
+
+  /**
+   * Initialize the connection to the WebSocket server
+   */
+  public async connect(): Promise<MessageTransports> {
+    if (this._transport && this._socket?.readyState === WebSocket.OPEN) {
+      logger.debug("Using existing WebSocket connection");
+      return this._transport;
+    }
+
+    logger.info(`Connecting to WebSocket server: ${this._url}`);
+    this.setConnectionStatus(ConnectionStatus.CONNECTING);
+
+    try {
+      logger.debug("Retrieving access token");
+      const accessToken = await getStorageManager().getSecret(SecretStorageKeys.SIDECAR_AUTH_TOKEN);
+
+      if (!accessToken) {
+        const error = new Error("No access token found for WebSocket connection");
+        logger.error(error.message);
+        this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+        throw error;
+      }
+
+      this._connectionToken = accessToken;
+      logger.debug("Access token retrieved, creating WebSocket connection");
+      return await this.createWebSocketConnection(accessToken);
+    } catch (error) {
+      this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+      logger.error(`Failed to connect to WebSocket server: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Create a WebSocket connection and set up event handlers
+   */
+  private async createWebSocketConnection(accessToken: string): Promise<MessageTransports> {
+    return new Promise((resolve, reject) => {
+      logger.debug(`Creating WebSocket connection to ${this._url}`);
+
+      try {
+        const socket = new WebSocket(this._url, {
+          headers: { authorization: `Bearer ${accessToken}` },
+        });
+
+        const errorHandler = (error: any) => {
+          const errorMsg = error?.message || String(error);
+          logger.error(`WebSocket connection error: ${errorMsg}`);
+          if (this._connectionStatus === ConnectionStatus.CONNECTING) {
+            reject(new Error(`Failed to connect to WebSocket server: ${errorMsg}`));
+          } else {
+            this.handleDisconnect();
+          }
+        };
+
+        socket.onerror = errorHandler;
+
+        // Set a timeout for the connection
+        const connectionTimeout = setTimeout(() => {
+          if (this._connectionStatus === ConnectionStatus.CONNECTING) {
+            logger.error("WebSocket connection timeout");
+            socket.close();
+            reject(new Error("Connection timeout"));
+          }
+        }, 10000); // 10 second timeout
+
+        // Clear the timeout once connected
+        socket.onopen = () => {
+          clearTimeout(connectionTimeout);
+
+          logger.info("WebSocket connection established successfully");
+          this._socket = socket;
+          this._reconnectAttempts = 0;
+          this._transport = new WebsocketTransport(socket);
+
+          // Set up the message handler to forward received messages
+          socket.onmessage = (event) => {
+            try {
+              const data =
+                typeof event.data === "string" ? event.data : event.data.toString("utf8");
+              const message = JSON.parse(data);
+
+              // Log more information about the message for debugging
+              if (typeof message === "object" && message !== null) {
+                if ("id" in message && "result" in message) {
+                  // This is a response to a previous request
+                  logger.debug(`Received response for request id ${message.id}`);
+
+                  // For completion results, log more details
+                  if (
+                    typeof message.result === "object" &&
+                    message.result !== null &&
+                    "items" in message.result
+                  ) {
+                    const items = message.result.items;
+                    const itemCount = Array.isArray(items) ? items.length : "?";
+                    logger.debug(`Response contains ${itemCount} completion items`);
+                  }
+                } else if ("method" in message) {
+                  // This is a notification or request from the server
+                  logger.debug(`Received message with method: ${message.method}`);
+                } else {
+                  // Other type of message
+                  logger.debug(`Received message: ${JSON.stringify(message).substring(0, 100)}...`);
+                }
+              } else {
+                logger.debug("Received non-object message");
+              }
+
+              if (this._messageHandler) {
+                logger.debug("Forwarding received message to language client");
+                this._messageHandler(message);
+              } else {
+                logger.warn("Message received but no handler is registered");
+              }
+            } catch (error) {
+              logger.error(`Error processing incoming message: ${error}`);
+            }
+          };
+
+          this.setConnectionStatus(ConnectionStatus.CONNECTED);
+          this.processQueuedMessages();
+
+          resolve(this._transport);
+        };
+
+        socket.onclose = (event) => {
+          clearTimeout(connectionTimeout);
+          const reason = event.reason || "Unknown reason";
+          const code = event.code;
+          logger.warn(`WebSocket connection closed: Code ${code}, Reason: ${reason}`);
+          this.handleDisconnect();
+        };
+      } catch (error) {
+        logger.error(`Error creating WebSocket: ${error}`);
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Handle WebSocket disconnection with automatic reconnection
+   */
+  private handleDisconnect() {
+    if (this._isReconnecting) {
+      return;
+    }
+
+    this._isReconnecting = true;
+    this.setConnectionStatus(ConnectionStatus.RECONNECTING);
+
+    if (this._reconnectAttempts < this._maxReconnectAttempts) {
+      const backoffTime = this._reconnectBackoff * Math.pow(2, this._reconnectAttempts);
+      logger.info(
+        `Reconnecting to WebSocket server in ${backoffTime}ms (attempt ${this._reconnectAttempts + 1}/${this._maxReconnectAttempts})`,
+      );
+
+      this._reconnectTimer = setTimeout(async () => {
+        this._reconnectAttempts++;
+
+        try {
+          if (this._connectionToken) {
+            await this.createWebSocketConnection(this._connectionToken);
+            this._isReconnecting = false;
+          } else {
+            // Need to get a new token
+            this._isReconnecting = false;
+            await this.connect();
+          }
+        } catch (error) {
+          logger.error(`Reconnection attempt failed: ${error}`);
+          this._isReconnecting = false;
+          this.handleDisconnect();
+        }
+      }, backoffTime);
+    } else {
+      logger.error(
+        `Maximum reconnection attempts (${this._maxReconnectAttempts}) reached. Giving up.`,
+      );
+      this._isReconnecting = false;
+      this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+    }
+  }
+
+  /**
+   * Queue a message to be sent when the connection is available
+   */
+  public queueMessage(message: Message): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      // If we have an active connection, try to send immediately
+      if (this._socket?.readyState === WebSocket.OPEN && this._transport) {
+        this._transport.writer.write(message).then(resolve).catch(reject);
+        return;
+      }
+
+      // Otherwise queue the message
+      this._messageQueue.push({
+        message,
+        timestamp: Date.now(),
+        resolve,
+        reject,
+      });
+
+      // If we're not already reconnecting, try to connect
+      if (this._connectionStatus === ConnectionStatus.DISCONNECTED && !this._isReconnecting) {
+        this.connect().catch((error) => {
+          logger.error(`Failed to reconnect: ${error}`);
+        });
+      }
+    });
+  }
+
+  /**
+   * Process any queued messages
+   */
+  private processQueuedMessages() {
+    if (!this._transport || this._socket?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    const messagesToProcess = [...this._messageQueue];
+    this._messageQueue = [];
+
+    for (const queuedMessage of messagesToProcess) {
+      this._transport.writer
+        .write(queuedMessage.message)
+        .then(queuedMessage.resolve)
+        .catch((error) => {
+          logger.error(`Failed to send queued message: ${error}`);
+          queuedMessage.reject(error);
+        });
+    }
+  }
+
+  /**
+   * Dispose the WebSocket connection and cleanup resources
+   */
+  public dispose() {
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+
+    if (this._transport) {
+      this._transport.dispose();
+      this._transport = null;
+    }
+
+    if (
+      this._socket &&
+      (this._socket.readyState === WebSocket.OPEN ||
+        this._socket.readyState === WebSocket.CONNECTING)
+    ) {
+      try {
+        this._socket.close(1000, "Manager disposed");
+      } catch (err) {
+        logger.error(`Error closing WebSocket: ${err}`);
+      }
+    }
+
+    this._socket = null;
+    this._messageQueue = [];
+    this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+    this._connectionStatusEmitter.dispose();
+  }
+}


### PR DESCRIPTION
# Still a rough WIP 🏗️ _not working as expected yet_ 🚧 
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Due to lots of reconnections (needed/expected from server side) and the related errors they surface, as well as our desire for the language client to support multiple files with different compute pool ids, we will try to abstract the Server into a class that will manage multiple connections under the hood while maintaining a single Client connection. 
- LanguageClient will connect to a ServerProvider, which will connect to the multiSocketManager and route messages to multiple websocket transports depending on compute. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Yes, a ton. I will type up a doc with other options considered, risks, etc. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
