### PR TITLE
chore: add `ResourceLoader` stubbed instance helper functions

### DIFF
--- a/src/quickpicks/topics.ts
+++ b/src/quickpicks/topics.ts
@@ -1,4 +1,4 @@
-import { commands, ProgressOptions, ThemeIcon, window } from "vscode";
+import { commands, ThemeIcon, window } from "vscode";
 import { IconNames } from "../constants";
 import { ResourceLoader } from "../loaders";
 import { KafkaCluster } from "../models/kafkaCluster";
@@ -6,57 +6,47 @@ import { KafkaTopic } from "../models/topic";
 import { QuickPickItemWithValue } from "./types";
 
 /**
- * Displays a quickpick for selecting a Kafka topic from the given {@link KafkaCluster}. While the
- * quickpick is visible, the Topics view will show a loading indicator.
+ * Displays a quickpick for selecting a Kafka topic from the given {@link KafkaCluster}.
  *
  * @param cluster - The Kafka cluster to load topics from.
  * @param forceRefresh - Whether to force refresh the topics list.
  * @returns The selected Kafka topic or undefined if no selection was made.
  */
-export async function topicQuickPick(
-  cluster: KafkaCluster,
-  forceRefresh: boolean = false,
-): Promise<KafkaTopic | undefined> {
-  const options: ProgressOptions = {
-    location: { viewId: "confluent-topics" },
-    title: "Loading topics...",
-  };
-  return window.withProgress(options, async () => {
-    const loader = ResourceLoader.getInstance(cluster.connectionId);
+export async function topicQuickPick(cluster: KafkaCluster, forceRefresh: boolean = false) {
+  const loader = ResourceLoader.getInstance(cluster.connectionId);
 
-    const topics: KafkaTopic[] = await loader.getTopicsForCluster(cluster, forceRefresh);
-    if (!topics.length) {
-      window
-        .showInformationMessage(
-          `No topics found for Kafka cluster "${cluster.name}".`,
-          "Create Topic",
-        )
-        .then((selection) => {
-          if (selection === "Create Topic") {
-            commands.executeCommand("confluent.topics.create", cluster);
-          }
-        });
-      return;
-    }
+  const topics: KafkaTopic[] = await loader.getTopicsForCluster(cluster, forceRefresh);
+  if (!topics.length) {
+    window
+      .showInformationMessage(
+        `No topics found for Kafka cluster "${cluster.name}".`,
+        "Create Topic",
+      )
+      .then((selection) => {
+        if (selection === "Create Topic") {
+          commands.executeCommand("confluent.topics.create", cluster);
+        }
+      });
+    return;
+  }
 
-    const choices: QuickPickItemWithValue<KafkaTopic>[] = topics.map((topic) => {
-      return {
-        label: topic.name,
-        value: topic,
-        iconPath: topic.hasSchema
-          ? new ThemeIcon(IconNames.TOPIC)
-          : new ThemeIcon(IconNames.TOPIC_WITHOUT_SCHEMA),
-      };
-    });
-
-    const choice: QuickPickItemWithValue<KafkaTopic> | undefined = await window.showQuickPick(
-      choices,
-      {
-        placeHolder: "Select a topic",
-        ignoreFocusOut: true,
-      },
-    );
-
-    return choice?.value;
+  const choices: QuickPickItemWithValue<KafkaTopic>[] = topics.map((topic) => {
+    return {
+      label: topic.name,
+      value: topic,
+      iconPath: topic.hasSchema
+        ? new ThemeIcon(IconNames.TOPIC)
+        : new ThemeIcon(IconNames.TOPIC_WITHOUT_SCHEMA),
+    };
   });
+
+  const choice: QuickPickItemWithValue<KafkaTopic> | undefined = await window.showQuickPick(
+    choices,
+    {
+      placeHolder: "Select a topic",
+      ignoreFocusOut: true,
+    },
+  );
+
+  return choice?.value;
 }

--- a/src/quickpicks/utils/schemas.test.ts
+++ b/src/quickpicks/utils/schemas.test.ts
@@ -1,13 +1,14 @@
 import * as assert from "assert";
 import sinon from "sinon";
 import { workspace } from "vscode";
+import { getStubbedLocalResourceLoader } from "../../../tests/stubs/resourceLoaders";
 import {
   TEST_LOCAL_SCHEMA,
   TEST_LOCAL_SCHEMA_REVISED,
 } from "../../../tests/unit/testResources/schema";
 import { TEST_LOCAL_SCHEMA_REGISTRY } from "../../../tests/unit/testResources/schemaRegistry";
 import { TEST_LOCAL_KAFKA_TOPIC } from "../../../tests/unit/testResources/topic";
-import { LocalResourceLoader, ResourceLoader } from "../../loaders";
+import { LocalResourceLoader } from "../../loaders";
 import * as notifications from "../../notifications";
 import { ALLOW_OLDER_SCHEMA_VERSIONS } from "../../preferences/constants";
 import { SubjectNameStrategy } from "../../schemas/produceMessageSchema";
@@ -20,15 +21,13 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
 
   let showErrorNotificationStub: sinon.SinonStub;
 
-  let getSchemaRegistriesStub: sinon.SinonStub;
   let getSubjectNameForStrategyStub: sinon.SinonStub;
   let schemaVersionQuickPickStub: sinon.SinonStub;
-  let getSchemasForSubjectStub: sinon.SinonStub;
+
   let getConfigurationStub: sinon.SinonStub;
 
-  let resourceLoaderStub: sinon.SinonStub;
   // use local loaders for these tests; no functional difference between local/CCloud/direct here
-  let resourceLoader: sinon.SinonStubbedInstance<LocalResourceLoader>;
+  let stubbedLoader: sinon.SinonStubbedInstance<LocalResourceLoader>;
 
   const testSchemas = [
     TEST_LOCAL_SCHEMA_REVISED, // version 2
@@ -42,13 +41,9 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
     showErrorNotificationStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
 
     // ResourceLoader stubs
-    resourceLoaderStub = sandbox.stub(ResourceLoader, "getInstance");
-    resourceLoader = sandbox.createStubInstance(LocalResourceLoader);
-    resourceLoaderStub.returns(resourceLoader);
-    getSchemaRegistriesStub = resourceLoader.getSchemaRegistries.resolves([
-      TEST_LOCAL_SCHEMA_REGISTRY,
-    ]);
-    getSchemasForSubjectStub = resourceLoader.getSchemasForSubject.resolves(testSchemas);
+    stubbedLoader = getStubbedLocalResourceLoader(sandbox);
+    stubbedLoader.getSchemaRegistries.resolves([TEST_LOCAL_SCHEMA_REGISTRY]);
+    stubbedLoader.getSchemasForSubject.resolves(testSchemas);
 
     // quickpick+util stubs
     schemaVersionQuickPickStub = sandbox.stub(schemaQuickPicks, "schemaVersionQuickPick");
@@ -69,7 +64,7 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
 
   it("should throw an error when no Schema Registry is found", async () => {
     // no SR instances loaded
-    getSchemaRegistriesStub.resolves([]);
+    stubbedLoader.getSchemaRegistries.resolves([]);
 
     await assert.rejects(
       async () => promptForSchema(TEST_LOCAL_KAFKA_TOPIC, "key", SubjectNameStrategy.TOPIC_NAME),
@@ -77,7 +72,7 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
     );
     sinon.assert.calledOnce(showErrorNotificationStub);
     sinon.assert.notCalled(schemaVersionQuickPickStub);
-    sinon.assert.notCalled(getSchemasForSubjectStub);
+    sinon.assert.notCalled(stubbedLoader.getSchemasForSubject);
     sinon.assert.notCalled(getSubjectNameForStrategyStub);
   });
 
@@ -92,7 +87,7 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
     // don't check for error notification here since it depends on the settings and quickpick path
     // and will only be shown for TopicNameStrategy
     sinon.assert.notCalled(schemaVersionQuickPickStub);
-    sinon.assert.notCalled(getSchemasForSubjectStub);
+    sinon.assert.notCalled(stubbedLoader.getSchemasForSubject);
   });
 
   it("should use schemaVersionQuickPick when `allowOlderVersions` is true", async () => {
@@ -130,12 +125,12 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
       { message: "Schema version not chosen." },
     );
     sinon.assert.calledOnce(schemaVersionQuickPickStub);
-    sinon.assert.notCalled(getSchemasForSubjectStub);
+    sinon.assert.notCalled(stubbedLoader.getSchemasForSubject);
     sinon.assert.notCalled(showErrorNotificationStub);
   });
 
   it("should return the latest schema version when `allowOlderVersions` is false", async () => {
-    getSchemasForSubjectStub.resolves(testSchemas);
+    stubbedLoader.getSchemasForSubject.resolves(testSchemas);
 
     const result = await promptForSchema(
       TEST_LOCAL_KAFKA_TOPIC,
@@ -148,7 +143,7 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
   });
 
   it("should throw an error when no schema versions are found for the subject", async () => {
-    getSchemasForSubjectStub.resolves([]);
+    stubbedLoader.getSchemasForSubject.resolves([]);
 
     await assert.rejects(
       async () => promptForSchema(TEST_LOCAL_KAFKA_TOPIC, "value", SubjectNameStrategy.TOPIC_NAME),

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import { Disposable, EventEmitter, TreeItem, window } from "vscode";
+import { getStubbedResourceLoader } from "../../tests/stubs/resourceLoaders";
 import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources/environments";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import {
@@ -13,7 +14,7 @@ import { ConnectionType } from "../clients/sidecar";
 import * as contextValues from "../context/values";
 import { ContextValues } from "../context/values";
 import { ccloudConnected } from "../emitters";
-import { CCloudResourceLoader, ResourceLoader } from "../loaders";
+import { ResourceLoader } from "../loaders";
 import { CCloudFlinkComputePool, FlinkComputePool } from "../models/flinkComputePool";
 import { FlinkStatement, FlinkStatementTreeItem, Phase } from "../models/flinkStatement";
 import { BaseViewProvider } from "./base";
@@ -199,9 +200,9 @@ describe("viewProviders/base.ts BaseViewProvider updateTreeViewDescription()", (
   it("should set the description and set .environment when a resource is focused", async () => {
     // specifically stub the CCloudResourceLoader since the ResourceLoader's `getEnvironments`
     // (abstract) method is considered undefined here
-    const loaderStub = sandbox.createStubInstance(CCloudResourceLoader);
-    sandbox.stub(ResourceLoader, "getInstance").returns(loaderStub);
-    loaderStub.getEnvironments.resolves([TEST_CCLOUD_ENVIRONMENT]);
+    const stubbedLoader: sinon.SinonStubbedInstance<ResourceLoader> =
+      getStubbedResourceLoader(sandbox);
+    stubbedLoader.getEnvironments.resolves([TEST_CCLOUD_ENVIRONMENT]);
 
     const provider = TestViewProvider.getInstance();
     provider.environment = TEST_CCLOUD_ENVIRONMENT;

--- a/tests/stubs/resourceLoaders.ts
+++ b/tests/stubs/resourceLoaders.ts
@@ -1,0 +1,109 @@
+import { SinonSandbox, SinonStubbedInstance } from "sinon";
+import { CCLOUD_CONNECTION_ID, LOCAL_CONNECTION_ID } from "../../src/constants";
+import {
+  CCloudResourceLoader,
+  DirectResourceLoader,
+  LocalResourceLoader,
+  ResourceLoader,
+} from "../../src/loaders";
+
+/**
+ * Creates a stubbed instance of the abstract {@link ResourceLoader} class.
+ *
+ * NOTE: This function stubs the static `getInstance()` method as well as the abstract methods of
+ * the {@link ResourceLoader} class.
+ *
+ * @param sandbox The {@link SinonSandbox} to use for creating stubs.
+ * @returns A {@link SinonStubbedInstance} of the {@link ResourceLoader} class.
+ */
+export function getStubbedResourceLoader(
+  sandbox: SinonSandbox,
+): SinonStubbedInstance<ResourceLoader> {
+  const stubbedLoader: SinonStubbedInstance<ResourceLoader> =
+    sandbox.createStubInstance(ResourceLoader);
+  // add stubs for abstract methods
+  stubbedLoader.getEnvironments = sandbox.stub();
+  stubbedLoader.getKafkaClustersForEnvironmentId = sandbox.stub();
+  stubbedLoader.getSchemaRegistries = sandbox.stub();
+  stubbedLoader.getSchemaRegistryForEnvironmentId = sandbox.stub();
+  stubbedLoader.getTopicSubjectGroups = sandbox.stub();
+  // stub the static method to return the stubbed instance
+  sandbox.stub(ResourceLoader, "getInstance").returns(stubbedLoader);
+  return stubbedLoader;
+}
+
+/**
+ * Creates a stubbed instance of the {@link CCloudResourceLoader} class.
+ *
+ * This function stubs the static `getInstance()` methods of both {@link CCloudResourceLoader}
+ * and {@link ResourceLoader} (when called with {@linkcode CCLOUD_CONNECTION_ID}) to return
+ * the created stub.
+ *
+ * @param sandbox The {@link SinonSandbox} to use for creating stubs.
+ * @returns A {@link SinonStubbedInstance} of the {@link CCloudResourceLoader} class.
+ */
+export function getStubbedCCloudResourceLoader(
+  sandbox: SinonSandbox,
+): SinonStubbedInstance<CCloudResourceLoader> {
+  const stubbedLoader: SinonStubbedInstance<CCloudResourceLoader> =
+    sandbox.createStubInstance(CCloudResourceLoader);
+  // stub the static methods to return the stubbed instance
+  sandbox.stub(CCloudResourceLoader, "getInstance").returns(stubbedLoader);
+  sandbox.stub(ResourceLoader, "getInstance").withArgs(CCLOUD_CONNECTION_ID).returns(stubbedLoader);
+  return stubbedLoader;
+}
+
+/**
+ * Creates a stubbed instance of the {@link LocalResourceLoader} class.
+ *
+ * This function stubs the static `getInstance()` methods of both {@link LocalResourceLoader}
+ * and {@link ResourceLoader} (when called with {@linkcode LOCAL_CONNECTION_ID}) to return
+ * the created stub.
+ *
+ * @param sandbox The {@link SinonSandbox} to use for creating stubs.
+ * @returns A {@link SinonStubbedInstance} of the {@link LocalResourceLoader} class.
+ */
+export function getStubbedLocalResourceLoader(
+  sandbox: SinonSandbox,
+): SinonStubbedInstance<LocalResourceLoader> {
+  const stubbedLoader: SinonStubbedInstance<LocalResourceLoader> =
+    sandbox.createStubInstance(LocalResourceLoader);
+  // stub the static methods to return the stubbed instance
+  sandbox.stub(LocalResourceLoader, "getInstance").returns(stubbedLoader);
+  sandbox.stub(ResourceLoader, "getInstance").withArgs(LOCAL_CONNECTION_ID).returns(stubbedLoader);
+  return stubbedLoader;
+}
+
+/**
+ * Creates a stubbed instance of the {@link DirectResourceLoader} class.
+ *
+ * This function stubs the static `getInstance()` method of {@link DirectResourceLoader}
+ * and conditionally stubs the {@link ResourceLoader.getInstance} method for connection IDs
+ * that are not {@linkcode CCLOUD_CONNECTION_ID} or {@linkcode LOCAL_CONNECTION_ID}.
+ *
+ * Unlike the other stub functions, this preserves any existing stubs for the `CCLOUD` and `LOCAL`
+ * connections.
+ *
+ * @param sandbox The {@link SinonSandbox} to use for creating stubs.
+ * @returns A {@link SinonStubbedInstance} of the {@link DirectResourceLoader} class.
+ */
+export function getStubbedDirectResourceLoader(
+  sandbox: SinonSandbox,
+): SinonStubbedInstance<DirectResourceLoader> {
+  const stubbedLoader: SinonStubbedInstance<DirectResourceLoader> =
+    sandbox.createStubInstance(DirectResourceLoader);
+  // stub the static methods to return the stubbed instance
+  sandbox.stub(DirectResourceLoader, "getInstance").returns(stubbedLoader);
+  const originalGetInstance = ResourceLoader.getInstance;
+  sandbox.stub(ResourceLoader, "getInstance").callsFake((connectionId) => {
+    // only stub the getInstance method for non-local and non-ccloud connections. otherwise, return
+    // the original instance (and if those are stubbed as well from the above functions, return
+    // those stubbed instances)
+    if (connectionId === CCLOUD_CONNECTION_ID || connectionId === LOCAL_CONNECTION_ID) {
+      return originalGetInstance.call(ResourceLoader, connectionId);
+    }
+    return stubbedLoader;
+  });
+
+  return stubbedLoader;
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Similar addition to `tests/stubs/` as https://github.com/confluentinc/vscode/pull/1858, but this time just for the various `ResourceLoader` instances. Tests should just have to call `getStubbed*ResourceLoader()` instead of having to set up the stubbed instances and also stub the `ResourceLoader.getInstance` call:
<img width="534" alt="image" src="https://github.com/user-attachments/assets/92623db4-ff95-4808-bacc-b5e0e5b80213" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Most test suites using ResourceLoader stubs were straightforward to update, but the `quickpicks/topics.test.ts` was somewhat hairy since it included a test that asserted the right loader was used based on the connection ID. That test was removed in favor of a standalone suite that used dedicated stubbed loader instances for each Kafka cluster type (CCloud, local, direct).
  - While I was in there, I realized we didn't actually need to show any progress indicator on the Topics view like we do for the "Select Kafka cluster / Schema Registry" quickpicks, so I removed that (and its test and stubs) entirely. 🪓 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
