### PR TITLE
Show table with columns while waiting for results

### DIFF
--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -103,12 +103,87 @@
       </header>
 
       <section class="content">
-        <template
-          data-if="this.waitingForResults() && this.streamState() === 'running' && this.streamError() == null"
-        >
+        <div class="grid-container">
+          <!-- Settings control positioned outside the grid -->
+          <div
+            class="grid-cell grid-column-header cell-text-overflow grid-settings-control"
+            popovertarget="columnSettings"
+            data-on-click="window.columnSettings.togglePopover()"
+            data-position="bottom-end"
+            tabindex="-1"
+          >
+            <span class="codicon codicon-gear"></span>
+          </div>
+
+          <table
+            class="grid"
+            cellpadding="0"
+            cellspacing="0"
+            data-prop-style="this.gridTemplateColumns()"
+          >
+            <thead class="sticky-table-header">
+              <tr class="grid-row">
+                <template data-for="column of this.visibleColumns() by column">
+                  <th class="grid-cell grid-column-header cell-text-overflow" tabindex="-1">
+                    <span data-text="this.columns()[this.column()].title()"></span>
+                    <div
+                      class="resize-handler"
+                      data-on-pointerdown="this.handleStartResize(event, this.columns()[this.column()].index)"
+                      data-on-pointermove="this.handleMoveResize(event, this.columns()[this.column()].index)"
+                      data-on-pointerup="this.handleStopResize(event)"
+                    ></div>
+                  </th>
+                </template>
+              </tr>
+            </thead>
+
+            <section popover id="columnSettings" class="column-control">
+              <div class="flex-column" style="--gap: 0">
+                <label>Columns</label>
+                <template data-for="column of this.allColumns() by column">
+                  <label class="checkbox">
+                    <input
+                      type="checkbox"
+                      data-prop-checked="this.isColumnVisible(this.columns()[this.column()].index)"
+                      data-prop-disabled="this.isColumnVisible(this.columns()[this.column()].index) && this.columnVisibilityFlags().filter(f => f).length <= 1"
+                      data-on-change="event.preventDefault(); this.toggleColumnVisibility(this.columns()[this.column()].index)"
+                    />
+                    <span data-text="this.columns()[this.column()].title()"></span>
+                  </label>
+                </template>
+              </div>
+            </section>
+
+            <template data-if="this.hasResults() || this.emptyFilterResult()">
+              <tbody>
+                <template data-for="result of this.snapshot().results">
+                  <tr class="grid-row" data-on-dblclick="this.previewResult(this.result())" data-testid="column-row">
+                    <template data-for="column of this.visibleColumns() by column">
+                      <td
+                        class="grid-cell cell-text-overflow"
+                        tabindex="-1"
+                        data-children="((this.columns())[this.column()]).children(this.result())"
+                        data-prop-title="((this.columns())[this.column()]).title()"
+                      ></td>
+                    </template>
+                  </tr>
+                </template>
+              </tbody>
+            </template>
+          </table>
+          <template
+            data-if="this.waitingForResults() && this.streamState() === 'running' && this.streamError() == null"
+          >
+            <div class="grid-banner" data-testid="waiting-for-results">
+              <vscode-progress-ring></vscode-progress-ring>
+              <label>Waiting for results…</label>
+            </div>
+          </template>
+        </div>
+
+        <template data-if="this.emptyFilterResult()">
           <div class="grid-banner">
-            <vscode-progress-ring></vscode-progress-ring>
-            <label>Waiting for results…</label>
+            <p>Unable to find results for current search</p>
           </div>
         </template>
 
@@ -126,82 +201,6 @@
           <div class="grid-banner">
             <span class="codicon codicon-info"></span>
             <label>No results available</label>
-          </div>
-        </template>
-
-        <template data-if="this.hasResults() || this.emptyFilterResult()">
-          <div class="grid-container">
-            <!-- Settings control positioned outside the grid -->
-            <div
-              class="grid-cell grid-column-header cell-text-overflow grid-settings-control"
-              popovertarget="columnSettings"
-              data-on-click="window.columnSettings.togglePopover()"
-              data-position="bottom-end"
-              tabindex="-1"
-            >
-              <span class="codicon codicon-gear"></span>
-            </div>
-
-            <table
-              class="grid"
-              cellpadding="0"
-              cellspacing="0"
-              data-prop-style="this.gridTemplateColumns()"
-            >
-              <thead class="sticky-table-header">
-                <tr class="grid-row">
-                  <template data-for="column of this.visibleColumns() by column">
-                    <th class="grid-cell grid-column-header cell-text-overflow" tabindex="-1">
-                      <span data-text="this.columns()[this.column()].title()"></span>
-                      <div
-                        class="resize-handler"
-                        data-on-pointerdown="this.handleStartResize(event, this.columns()[this.column()].index)"
-                        data-on-pointermove="this.handleMoveResize(event, this.columns()[this.column()].index)"
-                        data-on-pointerup="this.handleStopResize(event)"
-                      ></div>
-                    </th>
-                  </template>
-                </tr>
-              </thead>
-
-              <section popover id="columnSettings" class="column-control">
-                <div class="flex-column" style="--gap: 0">
-                  <label>Columns</label>
-                  <template data-for="column of this.allColumns() by column">
-                    <label class="checkbox">
-                      <input
-                        type="checkbox"
-                        data-prop-checked="this.isColumnVisible(this.columns()[this.column()].index)"
-                        data-prop-disabled="this.isColumnVisible(this.columns()[this.column()].index) && this.columnVisibilityFlags().filter(f => f).length <= 1"
-                        data-on-change="event.preventDefault(); this.toggleColumnVisibility(this.columns()[this.column()].index)"
-                      />
-                      <span data-text="this.columns()[this.column()].title()"></span>
-                    </label>
-                  </template>
-                </div>
-              </section>
-
-              <tbody>
-                <template data-for="result of this.snapshot().results">
-                  <tr class="grid-row" data-on-dblclick="this.previewResult(this.result())">
-                    <template data-for="column of this.visibleColumns() by column">
-                      <td
-                        class="grid-cell cell-text-overflow"
-                        tabindex="-1"
-                        data-children="((this.columns())[this.column()]).children(this.result())"
-                        data-prop-title="((this.columns())[this.column()]).title()"
-                      ></td>
-                    </template>
-                  </tr>
-                </template>
-              </tbody>
-
-              <template data-if="this.emptyFilterResult()">
-                <div class="grid-banner">
-                  <p>Unable to find results for current search</p>
-                </div>
-              </template>
-            </table>
           </div>
         </template>
       </section>

--- a/tests/e2e/specs/utils/flinkStatement.ts
+++ b/tests/e2e/specs/utils/flinkStatement.ts
@@ -41,6 +41,9 @@ export async function submitFlinkStatement(page: Page, fileName: string) {
   // Assert that a new Results Viewer tab with "Statement : ..." opens up
   await page.waitForSelector("text=Statement:");
 
+  // Assert that we can see the columns immediately.
+  await expect(page.getByTestId(FlinkStatementTestIds.columnRow)).toBeVisible();
+
   // We don't make assumptions about whether the statement will go into RUNNING state or not.
   // That's up to the caller to decide.
 }

--- a/tests/e2e/specs/utils/flinkStatement.ts
+++ b/tests/e2e/specs/utils/flinkStatement.ts
@@ -41,9 +41,6 @@ export async function submitFlinkStatement(page: Page, fileName: string) {
   // Assert that a new Results Viewer tab with "Statement : ..." opens up
   await page.waitForSelector("text=Statement:");
 
-  // Assert that we can see the columns immediately.
-  await expect(page.getByTestId(FlinkStatementTestIds.columnRow)).toBeVisible();
-
   // We don't make assumptions about whether the statement will go into RUNNING state or not.
   // That's up to the caller to decide.
 }
@@ -119,6 +116,9 @@ export async function testFlinkStatement(page: Page, params: FlinkStatementTestP
   await submitFlinkStatement(page, params.fileName);
 
   const webview = page.locator("iframe").contentFrame().locator("iframe").contentFrame();
+
+  // Assert that we can see the columns immediately.
+  await expect(webview.getByTestId(FlinkStatementTestIds.columnRow)).toBeVisible();
 
   // Wait for statement to run and verify status
   await verifyStatementStatus(webview, params.eventualExpectedStatus);

--- a/tests/e2e/specs/utils/testIds.ts
+++ b/tests/e2e/specs/utils/testIds.ts
@@ -13,4 +13,6 @@ export enum FlinkStatementTestIds {
 
   // Results related
   resultsStats = "results-stats",
+  waitingForResults = "waiting-for-results",
+  columnRow = "column-row",
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Moves around some HTML to always show table columns.

<img width="1210" alt="Screenshot 2025-05-22 at 2 02 04 PM" src="https://github.com/user-attachments/assets/386de11f-9afe-459e-b379-685e213b7d78" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
