### PR TITLE
MINOR fix: truncate the error content sent to the notification on statement submission

### DIFF
--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -218,8 +218,9 @@ export async function submitFlinkStatementCommand(
         failure_reason: newStatement.status.detail,
       });
 
+      // limit the error message content so the notification isn't hidden automatically
       await showErrorNotificationWithButtons(
-        `Error submitting statement: ${newStatement.status.detail}`,
+        `Error submitting statement: ${newStatement.status.detail?.slice(0, 500)}`,
       );
       return;
     }


### PR DESCRIPTION
If the content of a notification is too long, VS Code won't show it but will have a small badge/indicator in the notification section of the status bar. This PR limits the error details to 500 characters so longer errors aren't hidden.

### Before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e35e7434-a70e-4a85-9507-2b017265c3c2" />

### After
<img width="800" alt="image" src="https://github.com/user-attachments/assets/8c07a94b-e77e-4d12-98f6-bf5cbedfe990" />
