### PR TITLE
CoPilot: enable tool access in Agent mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
         ],
         "displayName": "List Project Templates",
         "modelDescription": "List all available templates for creating a streaming data project or application. Use this when the user asks about available templates or you want to show them a list of templates.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "listProjectTemplates",
+        "userDescription": "Get a list of available templates for creating a streaming data project or application.",
         "icon": "$(list-selection)",
         "inputSchema": {
           "type": "object",
@@ -100,7 +102,9 @@
         ],
         "displayName": "Get Project Template Options",
         "modelDescription": "Get the input options for filling out a project template. Use this after 'list_projectTemplates' when the user selects a template to create a new project. This will return the input options for the selected template.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getTemplateOptions",
+        "userDescription": "Get the input options for a specific project template.",
         "icon": "$(checklist)",
         "inputSchema": {
           "type": "object",
@@ -125,6 +129,7 @@
         "modelDescription": "Create a new project using the selected template and input options. If the user provides values for these options, ALWAYS pass them to this tool as input for the templateOptions.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "createProject",
+        "userDescription": "Create a new project using a specific template and input options.",
         "icon": "$(checklist)",
         "inputSchema": {
           "type": "object",
@@ -152,7 +157,9 @@
         ],
         "displayName": "Get Connections",
         "modelDescription": "Get a list of connections available in the current workspace. ALWAYS call this tool when the user asks about their connections or when connection information is needed - NEVER rely on previous results as connection states change frequently. Any sign-in/sign-out actions are specific to the CCLOUD connection. The LOCAL connection handles Kafka and Schema registry through the local Docker engine API. Any other configurations for Kafka or Schema Registry are done through the DIRECT connections.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getConnections",
+        "userDescription": "Get a list of Kafka connections available in the current workspace.",
         "icon": "$(list-selection)",
         "inputSchema": {
           "type": "object",
@@ -178,7 +185,9 @@
         ],
         "displayName": "Get Docker Containers",
         "modelDescription": "Get information about Docker containers for Kafka or Schema Registry running on the local machine. Use this when the user asks about their local connection/resources or any direct connections using 'localhost'.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getDockerContainers",
+        "userDescription": "Get information about Docker containers for Kafka or Schema Registry running on the local machine.",
         "icon": "$(docker)",
         "inputSchema": {
           "type": "object",
@@ -205,7 +214,9 @@
         ],
         "displayName": "Get Environments",
         "modelDescription": "Get a list of environments available for a specific connection. Environments are logical groupings of resources that may contain Kafka clusters, Schema Registry, and Flink compute pools. Use this when the user asks about their environments or needs to locate resource IDs for other operations.",
-        "canBeReferencedInPrompt": false,
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "getEnvironments",
+        "userDescription": "Get a list of environments available for a specific connection.",
         "icon": "$(list-selection)",
         "inputSchema": {
           "type": "object",


### PR DESCRIPTION
## Summary of Changes

Claud 3.7, GPT-4o, and Gemini 2.0 Flash all work smoothly when Confluent chat participant tools are invoked in agent mode. This PR enables agent mode discovery of these tools [via the needed config](https://code.visualstudio.com/api/extension-guides/tools#static-configuration-in-package.json): 
- icon 
- toolReferenceName
- userDescription
- canBeReferencedInPrompt (true) 



<img width="997" alt="Screenshot 2025-05-23 at 8 00 59 AM" src="https://github.com/user-attachments/assets/682fbd80-db34-4830-9da5-dcd96477390d" />
<img width="524" alt="Screenshot 2025-05-23 at 8 00 25 AM" src="https://github.com/user-attachments/assets/70d8f22a-a53f-4fd5-9bbc-44c0ab943180" />

Dev note: Agent mode lists the input and output automatically when invoking a tool, which should be a nice debugging help in addition to adding transparency in our interactions with the user. 
## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
