### PR TITLE
update `copilot-instructions.md` for broader purpose

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,19 +1,84 @@
+# Confluent VS Code Extension Development
+
+This VS Code extension makes it easy for developers to build stream processing applications using
+Confluent technology. It provides integration with Confluent Cloud products and Apache Kafka®
+compatible clusters within Visual Studio Code.
+
+## Technology Stack
+
+- TypeScript VS Code extension with strict type checking
+- Single sidecar process manages multiple workspaces concurrently
+- Integration with Confluent Cloud APIs, Apache Kafka® clusters, Schema Registry, and Flink compute
+  pools
+- Build system uses Gulp with TypeScript compilation
+- Auto-generated OpenAPI clients from specs in `src/clients/sidecar-openapi-specs/` using
+  `openapi-generator`'s `typescript-fetch` generator
+- Extension provides Kafka topic management, schema evolution, and stream processing application
+  development
+
+## Code Organization and Architecture
+
+- Use consistent directory structure for related functionality (e.g., `src/featureFlags/`,
+  `src/models/`)
+- File names should be descriptive and match their primary purpose
+- Place test files adjacent to source files with `.test.ts` suffix
+- Use ResourceLoader instances for different connection types (CCloud, Direct, Local) to load and
+  cache resources
+- Store state through ResourceManager with locking mechanisms to prevent race conditions
+- Context values control UI state and command availability through VS Code's context system
+- Auto-generated code in `src/clients/` should never be modified directly - update OpenAPI specs
+  instead
+
+## TypeScript and VS Code Extension Patterns
+
+- Use explicit types and interfaces, never use `any` type
+- Prefer `async/await` over Promise chains for better readability
+- Use `Promise.all` for concurrent operations when possible
+- Follow functional programming patterns where appropriate
+- Use classes for encapsulating related functionality and state for better organization and
+  testability
+- Variable and function names should be self-documenting to reduce the need for inline comments
+- Keep functions small and follow the single-responsibility principle
+- Follow VS Code extension API patterns for commands, tree providers, quickpicks, and webviews
+- Keep track of and handle `vscode.Disposable` resources properly to avoid memory leaks
+- Use existing ResourceLoader and ResourceManager patterns rather than creating new data fetching
+  approaches
+- Use VS Code's configuration API for user settings
+
+## Error Handling and User Experience
+
+- Use `logError()` utility for consistent error logging with stack traces and response details
+- Use `showErrorNotificationWithButtons()` for user-facing errors with "Open Logs" and "File Issue"
+  buttons
+- Error messages should be actionable with clear next steps for users
+- Wrap async operations in try/catch blocks and handle specific error types
+- Include telemetry considerations when adding new error scenarios
+- Provide graceful degradation when external services are unavailable
+- Use VS Code's progress API for long-running operations
+
+## Webview Development
+
+- Webviews use vanilla TypeScript with custom HTML templates
+- Use template literal functions for HTML generation with variable substitution
+- Follow message passing patterns between extension and webview contexts
+- Custom elements and reactive patterns using ObservableScope
+- Implement proper CSP (Content Security Policy) headers
+
 # Testing
 
-This VS Code extension uses the Mocha BDD interface and the "sinon" and "assert" packages for
-testing.
+This VS Code extension uses the Mocha BDD interface with "sinon" and "assert" packages for unit
+testing, and Playwright for functional/e2e testing.
 
-Always use a `SinonSandbox` instance when setting up stubs, spies, or fakes to ensure proper
-cleanup. Use the sinon Assert API for assertions involving the behavior of stubs, spies, or fakes.
-(For example, use `sinon.assert.called(stub)` instead of
-`assert.equal(stub.called, true, "stub should be called, but wasn't")`.) This allows for more
-concise code and provides better feedback in case of test failures.
-
-When working with a class instance where methods need to be stubbed, use the
-`sandbox.createStubInstance(ClassNameHere)` method to create a `SinonStubbedInstance` of the class.
-This will ensure that all methods are stubbed and that the instance behaves like a real instance of
-the class.
-
-Fixtures are in the `test/unit/testResources` directory and represent instances of our data models
-in `src/models` solely used for test purposes. Use these fixtures as needed, only creating new
-instances when slight variations are necessary or when a fixture is missing entirely.
+- Use descriptive test names that explain the expected behavior with the "should" prefix
+- Group related tests using `describe` blocks for better organization
+- Always use a `SinonSandbox` instance when setting up stubs, spies, or fakes to ensure proper
+  cleanup
+- Use sinon Assert API for assertions involving stubs, spies, or fakes (e.g.,
+  `sinon.assert.called(stub)` instead of `assert.equal(stub.called, true)`)
+- Use `sandbox.createStubInstance(ClassNameHere)` to create `SinonStubbedInstance` for class mocking
+- Leverage fixtures in the `test/unit/testResources/` directory for consistent test data
+  representing models from `src/models/`
+  - Create new fixture instances only when slight variations are necessary or when fixtures are
+    missing
+- Test files should be placed adjacent to source files with `.test.ts` suffix
+- Mock/stub external dependencies and API calls in unit tests to isolate the unit of work


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/vscode/pull/1611: Having just the `Testing` section made Copilot lean a little too much into suggesting tests for everything (feedback / sanity-checking implementations, rubber-ducking, Q&A, etc). This PR adds some other sections for general project purpose, architecture, suggested patterns, and other guidelines/hinting.

References:
- https://code.visualstudio.com/docs/copilot/copilot-customization
- https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot

I'd like to do some additional cleanup in follow-up branches (first around the `tests/` directory, then some of our `src/` subdirectories) since there's some additional housekeeping needed that may be causing model confusion.