### PR TITLE
telemetry: add `failedReason` to start aggregating common direct-connection failures

### DIFF
--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -558,6 +558,7 @@ describe("sidecar/connections/watcher.ts getConnectionSummaries()", () => {
     assert.strictEqual(summaries[0].connectionType, ConnectionType.Direct);
     assert.strictEqual(summaries[0].configType, "Kafka");
     assert.strictEqual(summaries[0].connectedState, ConnectedState.Success);
+    assert.strictEqual(summaries[0].failedReason, undefined);
   });
 
   it("should return a Schema Registry config summary when state matches for a DIRECT connection", async () => {
@@ -579,6 +580,7 @@ describe("sidecar/connections/watcher.ts getConnectionSummaries()", () => {
     assert.strictEqual(summaries[0].connectionType, ConnectionType.Direct);
     assert.strictEqual(summaries[0].configType, "Schema Registry");
     assert.strictEqual(summaries[0].connectedState, ConnectedState.Success);
+    assert.strictEqual(summaries[0].failedReason, undefined);
   });
 
   it("should return Kafka+SR summaries when both states match for a DIRECT connection", async () => {

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -6,7 +6,9 @@ import {
   ConnectionSpec,
   ConnectionType,
   KafkaClusterConfig,
+  KafkaClusterStatus,
   SchemaRegistryConfig,
+  SchemaRegistryStatus,
 } from "../../clients/sidecar";
 import { getCredentialsType } from "../../directConnections/credentials";
 import { FormConnectionType, SupportedAuthTypes } from "../../directConnections/types";
@@ -120,34 +122,36 @@ export async function reportUsableState(connection: Connection) {
   // send an event for direct connections to help understand how often SUCCESS/FAILED happens,
   // for which configs, etc.
   if (connection.spec.type === ConnectionType.Direct) {
-    failedConnectionSummaries.forEach((state) => {
-      const configPrefix = state.configType === "Kafka" ? "kafka" : "schemaRegistry";
+    failedConnectionSummaries.forEach((summary) => {
+      const configPrefix = summary.configType === "Kafka" ? "kafka" : "schemaRegistry";
       logUsage(UserEvent.DirectConnectionAction, {
         action: "failed to connect",
-        type: state.type, // formConnectionType
-        specifiedConnectionType: state.specifiedConnectionType,
+        type: summary.type, // formConnectionType
+        specifiedConnectionType: summary.specifiedConnectionType,
         // withKafka or withSchemaRegistry
-        [`with${state.configType.replace(" ", "")}`]: true,
-        configType: state.configType,
+        [`with${summary.configType.replace(" ", "")}`]: true,
+        configType: summary.configType,
         // kafkaAuthType or schemaRegistryAuthType
-        [`${configPrefix}AuthType`]: state.authType,
+        [`${configPrefix}AuthType`]: summary.authType,
         // kafkaConfigSslEnabled or schemaRegistryConfigSslEnabled
-        [`${configPrefix}SslEnabled`]: state.sslEnabled,
+        [`${configPrefix}SslEnabled`]: summary.sslEnabled,
+        failedReason: summary.failedReason,
       });
     });
-    successfulConnectionSummaries.forEach((state) => {
-      const configPrefix = state.configType === "Kafka" ? "kafka" : "schemaRegistry";
+    successfulConnectionSummaries.forEach((summary) => {
+      const configPrefix = summary.configType === "Kafka" ? "kafka" : "schemaRegistry";
       logUsage(UserEvent.DirectConnectionAction, {
         action: "successfully connected",
-        type: state.type,
-        specifiedConnectionType: state.specifiedConnectionType,
+        type: summary.type,
+        specifiedConnectionType: summary.specifiedConnectionType,
         // withKafka or withSchemaRegistry
-        [`with${state.configType.replace(" ", "")}`]: true,
-        configType: state.configType,
+        [`with${summary.configType.replace(" ", "")}`]: true,
+        configType: summary.configType,
         // kafkaAuthType or schemaRegistryAuthType
-        [`${configPrefix}AuthType`]: state.authType,
+        [`${configPrefix}AuthType`]: summary.authType,
         // kafkaConfigSslEnabled or schemaRegistryConfigSslEnabled
-        [`${configPrefix}SslEnabled`]: state.sslEnabled,
+        [`${configPrefix}SslEnabled`]: summary.sslEnabled,
+        failedReason: summary.failedReason,
       });
     });
   }
@@ -171,6 +175,7 @@ export interface ConnectionSummary {
   specifiedConnectionType?: string; // "Other" form connection type's user-entered string
   authType?: SupportedAuthTypes | "Browser";
   sslEnabled?: boolean;
+  failedReason?: string; // only for `FAILED` states
 }
 
 /**
@@ -192,9 +197,8 @@ export async function getConnectionSummaries(
         const formSpec: CustomConnectionSpec | null =
           await getResourceManager().getDirectConnection(connection.id as ConnectionId);
 
-        const kafkaClusterState: ConnectedState | undefined =
-          connection.status.kafka_cluster?.state;
-        if (kafkaClusterState === state) {
+        const kafkaClusterStatus: KafkaClusterStatus | undefined = connection.status.kafka_cluster;
+        if (kafkaClusterStatus && kafkaClusterStatus?.state === state) {
           const kafkaConfig: KafkaClusterConfig | undefined = connection.spec.kafka_cluster;
           states.push({
             connectionType: ConnectionType.Direct,
@@ -204,12 +208,13 @@ export async function getConnectionSummaries(
             authType: getCredentialsType(kafkaConfig?.credentials),
             sslEnabled: kafkaConfig?.ssl?.enabled ?? false,
             connectedState: state,
+            failedReason: kafkaClusterStatus.errors?.sign_in?.message,
           });
         }
 
-        const schemaRegistryState: ConnectedState | undefined =
-          connection.status.schema_registry?.state;
-        if (schemaRegistryState === state) {
+        const schemaRegistryState: SchemaRegistryStatus | undefined =
+          connection.status.schema_registry;
+        if (schemaRegistryState && schemaRegistryState.state === state) {
           const schemaRegistryConfig: SchemaRegistryConfig | undefined =
             connection.spec.schema_registry;
           states.push({
@@ -220,6 +225,7 @@ export async function getConnectionSummaries(
             authType: getCredentialsType(schemaRegistryConfig?.credentials),
             sslEnabled: schemaRegistryConfig?.ssl?.enabled ?? false,
             connectedState: state,
+            failedReason: schemaRegistryState.errors?.sign_in?.message,
           });
         }
       }

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -198,7 +198,7 @@ export async function getConnectionSummaries(
           await getResourceManager().getDirectConnection(connection.id as ConnectionId);
 
         const kafkaClusterStatus: KafkaClusterStatus | undefined = connection.status.kafka_cluster;
-        if (kafkaClusterStatus && kafkaClusterStatus?.state === state) {
+        if (kafkaClusterStatus && kafkaClusterStatus.state === state) {
           const kafkaConfig: KafkaClusterConfig | undefined = connection.spec.kafka_cluster;
           states.push({
             connectionType: ConnectionType.Direct,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We want to get a better feel for how often users are encountering `FAILED` connection states with direct connections - in order to do that, this PR is pulling out any `sign_in` errors (see sidecar [Kafka](https://github.com/confluentinc/ide-sidecar/blob/2d770d3574b632f0c5367cb75df8d3b6fec31e20/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java#L203-L208) and [SR](https://github.com/confluentinc/ide-sidecar/blob/2d770d3574b632f0c5367cb75df8d3b6fec31e20/src/main/java/io/confluent/idesidecar/restapi/connections/DirectConnectionState.java#L244-L249) handling) and including them in the `ConnectionSummary` interface to then forward on to Segment.

Samples:
<img width="1317" alt="image" src="https://github.com/user-attachments/assets/394ac7dd-4504-46cf-ab2e-1ebdeeef8a50" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
