### PR TITLE
Check for glibc not found errors

### DIFF
--- a/src/sidecar/logging.ts
+++ b/src/sidecar/logging.ts
@@ -198,7 +198,8 @@ export async function gatherSidecarOutputs(
   };
 }
 
-export function divineSidecarStartupFailureReason(
+/** Try to guess as to reason why Sidecar died very quickly after starting up through heuristics against logged lines or stderr. */
+export function determineSidecarStartupFailureReason(
   outputs: SidecarOutputs,
 ): SidecarStartupFailureReason {
   // Check for the presence of specific error messages in the logs
@@ -206,6 +207,10 @@ export function divineSidecarStartupFailureReason(
     outputs.parsedLogLines.some((log) => /seems to be in use by another process/.test(log.message))
   ) {
     return SidecarStartupFailureReason.PORT_IN_USE;
+  }
+
+  if (outputs.stderrLines.some((line) => /GLIBC.*not found/.test(line))) {
+    return SidecarStartupFailureReason.LINUX_GLIBC_NOT_FOUND;
   }
 
   // If no specific error messages are found, return UNKNOWN

--- a/src/sidecar/sidecarManager.test.ts
+++ b/src/sidecar/sidecarManager.test.ts
@@ -238,7 +238,7 @@ describe("sidecarManager.ts", () => {
         } as SidecarOutputs);
 
         sandbox
-          .stub(sidecarLogging, "divineSidecarStartupFailureReason")
+          .stub(sidecarLogging, "determineSidecarStartupFailureReason")
           .returns(SidecarStartupFailureReason.PORT_IN_USE);
 
         try {

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -555,7 +555,7 @@ export class SidecarManager {
 
   /**
    * Check the sidecar process status to ensure it has started up, logging any stderr output and the
-   * last few lines of the sidecar log file.
+   * last few lines of the sidecar log file. Called a short time after the sidecar process is spawned.
    *
    * @throws SidecarFatalError if the sidecar process is not running, annotated with
    * our best guess as to why it failed to start (attribute `reason`). Will have already
@@ -574,33 +574,32 @@ export class SidecarManager {
     logger.info(`${logPrefix}: Sidecar process status check - running: ${isRunning}`);
 
     if (isRunning) {
+      // All done here.
       return;
     }
 
-    if (!isRunning) {
-      // for some reason the sidecar process died immediately after startup, so log the error and
-      // report to Sentry so we can investigate.
+    // For some reason the sidecar process died immediately after startup, so log the error and
+    // report to Sentry so we can investigate.
+    const outputs = await gatherSidecarOutputs(getSidecarLogfilePath(), stderrPath);
 
-      const outputs = await gatherSidecarOutputs(getSidecarLogfilePath(), stderrPath);
+    let failureReason: SidecarStartupFailureReason = determineSidecarStartupFailureReason(outputs);
 
-      let failureReason: SidecarStartupFailureReason =
-        determineSidecarStartupFailureReason(outputs);
+    const failureMsg = `${logPrefix}: Sidecar process ${pid} died immediately after startup`;
 
-      const failureMsg = `${logPrefix}: Sidecar process ${pid} died immediately after startup`;
+    const error = new SidecarFatalError(failureReason, failureMsg);
 
-      const error = new SidecarFatalError(failureReason, failureMsg);
+    // Send to sentry and error logger.
+    logError(error, `sidecar process failed to start`, {
+      extra: {
+        stderr: outputs.stderrLines.join("\n"),
+        logs: outputs.logLines.join("\n"),
+        reason: failureReason,
+      },
+    });
 
-      // Send to sentry and error logger.
-      logError(error, `sidecar process failed to start`, {
-        extra: {
-          stderr: outputs.stderrLines.join("\n"),
-          logs: outputs.logLines.join("\n"),
-          reason: failureReason,
-        },
-      });
-
-      // prettyprint the last few lines of the sidecar log file to logs, 'cause user will probably
-      // open the logs.
+    // Prettyprint the last few lines of the sidecar logs and/or stderr to our logs, 'cause user will probably
+    // open our logs.
+    if (outputs.parsedLogLines.length > 0) {
       logger.error(
         `${logPrefix}: Latest sidecar log lines:\n${outputs.parsedLogLines
           .slice(-5)
@@ -609,9 +608,19 @@ export class SidecarManager {
           })
           .join("\n")}`,
       );
-
-      throw error;
     }
+
+    // Likewise for stderr. Will usually be either one or the other between this and the sidecar logs.
+    if (outputs.stderrLines.length > 0) {
+      logger.error(
+        `${logPrefix}: Latest sidecar stderr lines:\n${outputs.stderrLines
+          .slice(-5)
+          .map((line) => `\t> ${line}`)
+          .join("\n")}`,
+      );
+    }
+
+    throw error;
   }
 
   dispose() {

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -23,7 +23,7 @@ import { SecretStorageKeys } from "../storage/constants";
 import { getSecretStorage } from "../storage/utils";
 import { NoSidecarRunningError, SidecarFatalError, WrongAuthSecretError } from "./errors";
 import {
-  divineSidecarStartupFailureReason,
+  determineSidecarStartupFailureReason,
   gatherSidecarOutputs,
   getSidecarLogfilePath,
   startTailingSidecarLogs,
@@ -583,7 +583,8 @@ export class SidecarManager {
 
       const outputs = await gatherSidecarOutputs(getSidecarLogfilePath(), stderrPath);
 
-      let failureReason: SidecarStartupFailureReason = divineSidecarStartupFailureReason(outputs);
+      let failureReason: SidecarStartupFailureReason =
+        determineSidecarStartupFailureReason(outputs);
 
       const failureMsg = `${logPrefix}: Sidecar process ${pid} died immediately after startup`;
 

--- a/src/sidecar/types.ts
+++ b/src/sidecar/types.ts
@@ -34,6 +34,9 @@ export enum SidecarStartupFailureReason {
   /** Quarkus startup logs indicated some other process camped out on {@see SIDECAR_PORT}. */
   PORT_IN_USE = "PORT_IN_USE",
 
+  /** Running on an older linux that doesn't have the minimum version GLIBC required */
+  LINUX_GLIBC_NOT_FOUND = "LINUX_GLIBC_NOT_FOUND",
+
   /** Error when trying to kill() uncooperative or wrong-version running sidecar. */
   CANNOT_KILL_OLD_PROCESS = "CANNOT_KILL_OLD_PROCESS",
 

--- a/src/sidecar/utils.test.ts
+++ b/src/sidecar/utils.test.ts
@@ -324,12 +324,14 @@ describe("sidecar/utils.ts", () => {
         reason: SidecarStartupFailureReason.PORT_IN_USE,
         expectedRegex: /is in use by another process/,
       },
-
       {
         reason: SidecarStartupFailureReason.NON_SIDECAR_HTTP_SERVER,
         expectedRegex: /which seems to be a web server/,
       },
-
+      {
+        reason: SidecarStartupFailureReason.LINUX_GLIBC_NOT_FOUND,
+        expectedRegex: /Linux.*required GLIBC version/,
+      },
       {
         reason: SidecarStartupFailureReason.CANNOT_KILL_OLD_PROCESS,
         expectedRegex: /Failed to kill old sidecar process/,
@@ -346,7 +348,6 @@ describe("sidecar/utils.ts", () => {
         reason: SidecarStartupFailureReason.SPAWN_RESULT_UNDEFINED_PID,
         expectedRegex: /resulting PID was undefined/,
       },
-
       {
         reason: SidecarStartupFailureReason.HANDSHAKE_FAILED,
         expectedRegex: /Handshake failed/,
@@ -357,11 +358,11 @@ describe("sidecar/utils.ts", () => {
       },
       {
         reason: SidecarStartupFailureReason.UNKNOWN,
-        expectedRegex: /Please check the logs for more details/,
+        expectedRegex: /Sidecar failed to start/,
       },
     ] as TestCase[]) {
       it(`should show expected error message for ${testCase.reason}`, async () => {
-        const error = new SidecarFatalError(testCase.reason, "Test error");
+        const error = new SidecarFatalError(testCase.reason, `Test error: ${testCase.reason}`);
         await showSidecarStartupErrorMessage(error);
 
         sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
@@ -437,9 +438,8 @@ describe("sidecar/utils.ts", () => {
       await showSidecarStartupErrorMessage(error);
       sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
       const message = showErrorNotificationWithButtonsStub.getCall(0).args[0];
-      // assert that the message contains the expected regex
       assert.strictEqual(
-        message.match(/Please check the logs for more details/) !== null,
+        message.match(/Sidecar failed to start/) !== null,
         true,
         `Message: ${message}`,
       );

--- a/src/sidecar/utils.ts
+++ b/src/sidecar/utils.ts
@@ -211,8 +211,6 @@ export function checkSidecarFile(executablePath: string) {
  * carrying a SidecarStartupFailureReason.
  */
 export async function showSidecarStartupErrorMessage(e: unknown): Promise<void> {
-  const checkLogsBoilerplate = `Please check the logs for more details`;
-
   if (e instanceof SidecarFatalError) {
     logger.error(`showSidecarStartupErrorMessage(): ${e.message} (${e.reason})`);
     const portBoilerplate = `Sidecar could not start, port ${SIDECAR_PORT} is in use by another process`;
@@ -227,8 +225,12 @@ export async function showSidecarStartupErrorMessage(e: unknown): Promise<void> 
         message = `${portBoilerplate}, which seems to be a web server but is not our sidecar. Please check for other applications using this port.`;
         break;
 
+      case SidecarStartupFailureReason.LINUX_GLIBC_NOT_FOUND:
+        message = `It appears your Linux installation is too old and does not have the required GLIBC version. We build on Ubuntu 22.04 and need at least GLIBC_2.32. Please upgrade your distribution to a more recent version.`;
+        break;
+
       case SidecarStartupFailureReason.CANNOT_KILL_OLD_PROCESS:
-        message = `Sidecar failed to start: Failed to kill old sidecar process. ${checkLogsBoilerplate}.`;
+        message = `Sidecar failed to start: Failed to kill old sidecar process.`;
         break;
 
       case SidecarStartupFailureReason.SPAWN_RESULT_UNKNOWN:
@@ -236,30 +238,26 @@ export async function showSidecarStartupErrorMessage(e: unknown): Promise<void> 
         break;
 
       case SidecarStartupFailureReason.SPAWN_ERROR:
-        message = `Sidecar executable was not able to be spawned. ${checkLogsBoilerplate}.`;
+        message = `Sidecar executable was not able to be spawned.`;
         break;
 
       case SidecarStartupFailureReason.SPAWN_RESULT_UNDEFINED_PID:
-        message = `Sidecar executable was not able to be spawned -- resulting PID was undefined. ${checkLogsBoilerplate}.`;
-        break;
-
-      case SidecarStartupFailureReason.MISSING_EXECUTABLE:
-        // "Component {executablePath} does not exist or is not executable"
-        message = `${e.message}. ${checkLogsBoilerplate}.`;
+        message = `Sidecar executable was not able to be spawned -- resulting PID was undefined.`;
         break;
 
       case SidecarStartupFailureReason.HANDSHAKE_FAILED:
-        message = `Sidecar failed to start: Handshake failed. ${checkLogsBoilerplate}.`;
+        message = `Sidecar failed to start: Handshake failed.`;
         break;
 
       case SidecarStartupFailureReason.MAX_ATTEMPTS_EXCEEDED:
-        message = `Sidecar failed to start: Handshake failed after repeated attempts. ${checkLogsBoilerplate}.`;
+        message = `Sidecar failed to start: Handshake failed after repeated attempts.`;
         break;
 
+      case SidecarStartupFailureReason.MISSING_EXECUTABLE:
       case SidecarStartupFailureReason.WRONG_ARCHITECTURE:
       case SidecarStartupFailureReason.CANNOT_GET_SIDECAR_PID:
-        // These two use the error message embedded in the exception,
-        // in that the raising point
+        // These use the error message embedded in the exception,
+        // in that the raising point.
         message = e.message;
 
         // But we can add a button to open the marketplace in case of WRONG_ARCHITECTURE.
@@ -274,16 +272,14 @@ export async function showSidecarStartupErrorMessage(e: unknown): Promise<void> 
         break;
 
       default:
-        message = `Sidecar failed to start: ${e.message}. ${checkLogsBoilerplate}.`;
+        message = `Sidecar failed to start: ${e.message}`;
         break;
     }
 
     void showErrorNotificationWithButtons(message, buttons);
   } else {
     // Was some truly unexpected exception!
-    void showErrorNotificationWithButtons(
-      `Sidecar failed to start: ${e}. ${checkLogsBoilerplate}.`,
-    );
+    void showErrorNotificationWithButtons(`Sidecar failed to start: ${e}`);
   }
 }
 

--- a/tests/fixtures/sidecarLogs/sidecar-glibc-death/vscode-confluent-sidecar.log.stderr
+++ b/tests/fixtures/sidecarLogs/sidecar-glibc-death/vscode-confluent-sidecar.log.stderr
@@ -1,1 +1,3 @@
-/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found
+/lib64/libc.so.6: version `GLIBC_2.33' not found (required by /home/user/.vscode-server/extensions/confluentinc.vscode-confluent-1.2.1/ide-sidecar-0.196.0-runner)
+/lib64/libc.so.6: version `GLIBC_2.32' not found (required by /home/user/.vscode-server/extensions/confluentinc.vscode-confluent-1.2.1/ide-sidecar-0.196.0-runner)
+/lib64/libc.so.6: version `GLIBC_2.34' not found (required by /home/user/.vscode-server/extensions/confluentinc.vscode-confluent-1.2.1/ide-sidecar-0.196.0-runner)


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Detect quick sidecar death due to missing GLIBC. Show a specific diagnostic to the user at startup.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

<img width="509" alt="image" src="https://github.com/user-attachments/assets/5b19d3d4-0547-43fe-9ccb-c797f461e4cd" />

- Closes #1698 
- Do some followup nits from the prior PR, namely:
  -  Stop telling user to 'check logs for more details' when we're showing them an 'open logs' button already.
  - Rename `divineSidecarStartupFailureReason()` (as in reading the tea leaves) to `determineSidecarStartupFailureReason()`.
  - No need for second condition in `confirmSidecarProcessIsRunning()` if first one short-circuit returned.   



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
