### PR TITLE
View sql statement from Flink statement results viewer

### DIFF
--- a/src/flinkStatementResults.ts
+++ b/src/flinkStatementResults.ts
@@ -72,6 +72,8 @@ async function handleFlinkStatementResults(
   // Handle messages from the webview and delegate to the results manager
   const handler = handleWebviewMessage(panel.webview, (...args) => {
     let result;
+    // handleMessage() may end up reassigning many signals, so do
+    // so in a batch.
     os.batch(() => (result = resultsManager.handleMessage(...args)));
     return result;
   });

--- a/src/flinkStatementResultsManager.test.ts
+++ b/src/flinkStatementResultsManager.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
+import * as flinkStatementsCommands from "../src/commands/flinkStatements";
 import * as messageUtils from "../src/documentProviders/message";
 import {
   FlinkStatementResultsManagerTestContext,
@@ -62,6 +63,17 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
     assert.deepStrictEqual(results, { results: expectedParsedResults });
   });
 
+  it("should handle viewing the statement source", async () => {
+    const viewStatementSqlCommandStub = sandbox
+      .stub(flinkStatementsCommands, "viewStatementSqlCommand")
+      .resolves();
+
+    // Simulate hitting the button to view the statement source
+    await vm.viewStatementSource();
+    sinon.assert.calledOnce(viewStatementSqlCommandStub);
+    sinon.assert.calledWith(viewStatementSqlCommandStub, ctx.statement);
+  });
+
   it("should handle PreviewResult and PreviewAllResults", async () => {
     const showJsonPreviewMock = sandbox.stub(messageUtils, "showJsonPreview").resolves();
 
@@ -85,8 +97,6 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
     assert.ok(response.filename.startsWith("flink-statement-results-"), response.filename);
     assert.ok(response.filename.endsWith(".json"));
     assert.deepStrictEqual(response.result, expectedParsedResults);
-
-    showJsonPreviewMock.restore();
   });
 
   it("should filter results based on search query", async () => {

--- a/src/flinkStatementResultsManager.ts
+++ b/src/flinkStatementResultsManager.ts
@@ -415,6 +415,7 @@ export class FlinkStatementResultsManager {
     }
   }
 
+  /** Open up a read-only view over the statement's sources SQL. */
   private async viewStatementSource(): Promise<void> {
     await viewStatementSqlCommand(this.statement);
   }

--- a/src/flinkStatementResultsManager.ts
+++ b/src/flinkStatementResultsManager.ts
@@ -7,6 +7,7 @@ import {
   StatementResultsSqlV1Api,
   StatementsSqlV1Api,
 } from "./clients/flinkSql";
+import { viewStatementSqlCommand } from "./commands/flinkStatements";
 import { showJsonPreview } from "./documentProviders/message";
 import { isResponseError, isResponseErrorWithStatus, logError } from "./errors";
 import { CCloudResourceLoader } from "./loaders/ccloudResourceLoader";
@@ -35,6 +36,7 @@ export type MessageType =
   | "SetVisibleColumns"
   | "GetStatementMeta"
   | "StopStatement"
+  | "ViewStatementSource"
   | "SetViewMode"
   | "GetViewMode";
 
@@ -81,6 +83,7 @@ export type PostFunction = {
     isForeground: boolean;
   }>;
   (type: "StopStatement", body: { timestamp?: number }): Promise<null>;
+  (type: "ViewStatementSource", body: { timestamp?: number }): Promise<null>;
   (type: "SetViewMode", body: { viewMode: ViewMode; timestamp?: number }): Promise<null>;
   (type: "GetViewMode", body: { timestamp?: number }): Promise<ViewMode>;
 };
@@ -412,6 +415,10 @@ export class FlinkStatementResultsManager {
     }
   }
 
+  private async viewStatementSource(): Promise<void> {
+    await viewStatementSqlCommand(this.statement);
+  }
+
   private async _stopStatement() {
     await this._flinkStatementsSqlApi.updateSqlv1Statement({
       organization_id: this.statement.organizationId,
@@ -504,6 +511,9 @@ export class FlinkStatementResultsManager {
       }
       case "StopStatement": {
         return this.stopStatement();
+      }
+      case "ViewStatementSource": {
+        return this.viewStatementSource();
       }
       case "SetViewMode": {
         this._viewMode(body.viewMode! as ViewMode);

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -26,6 +26,12 @@
                 <span data-testid="statement-status" data-text="this.statementMeta().status"></span>
               </div>
               <vscode-button
+                data-testid="view-statement-source-button"
+                data-on-click="this.viewStatementSource()"
+              >
+                <label>View Statement Source</label>
+              </vscode-button>
+              <vscode-button
                 appearance="primary"
                 data-testid="stop-statement-button"
                 data-on-click="this.stopStatement()"

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -443,6 +443,10 @@ export class FlinkStatementResultsViewModel extends ViewModel {
     return this.post("PreviewAllResults", { timestamp: this.timestamp() });
   }
 
+  viewStatementSource() {
+    return this.post("ViewStatementSource", { timestamp: this.timestamp() });
+  }
+
   async stopStatement() {
     this.stopButtonClicked(true);
     await this.post("StopStatement", { timestamp: this.timestamp() });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Add a 'View Statement Source' button to the Flink results view. Drives the preëxising command to open the statement in a read-only buffer. If the statement sources was already being shown in a read-only buffer, will bring focus to it. The user is free to tear either the statement results or the statement source tab into a new window to view both side-side.
- Totally copied the HTML of the 'Stop' (statement execution) button. Am indifferent as to if this UI element should become a link, or its position in the 'page', or its styling. This here is FE-by-backend, and would be delighted to pass the last mile over to opinion and skill.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1610 , more or less.

![view-statement](https://github.com/user-attachments/assets/880c2b4d-5607-4547-9ab3-59863a4e3104)




## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
