### PR TITLE
Direct resource loader cache

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -91,7 +91,7 @@ export class DirectConnectionManager {
           // purge the cache of existing loaders to ensure they re-fetch the latest resources next time
           // (may have been reconfigured, e.g. new kafka cluster or schema registry, or improved)
           for (const id of connections.keys()) {
-            if (!existingLoaderIds.has(id)) {
+            if (!existingDirectLoadersById.has(id)) {
               this.initResourceLoader(id);
             } else {
               // Get this preexisting loader to purge its cache, so it can re-fetch the latest resources. The

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -91,7 +91,7 @@ export class DirectConnectionManager {
           // purge the cache of existing loaders to ensure they re-fetch the latest resources next time
           // (may have been reconfigured, e.g. new kafka cluster or schema registry, or improved)
           for (const id of connections.keys()) {
-            if (!existingLoaderIds.includes(id)) {
+            if (!existingLoaderIds.has(id)) {
               this.initResourceLoader(id);
             } else {
               // Get this preexisting loader to purge its cache, so it can re-fetch the latest resources. The
@@ -100,9 +100,10 @@ export class DirectConnectionManager {
               // we get the change event, so we have to be conservative and purge the caches of any
               // existing direct loaders.
               const existingLoader = existingDirectLoadersById.get(id)!;
-              await existingLoader.purgeCache();
+              existingLoader.purgeCache();
             }
           }
+
           // part 2: remove any direct connections not in the secret storage to prevent
           // requests to orphaned resources/connections
           for (const id of existingLoaderIds) {

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -74,16 +74,33 @@ export class DirectConnectionManager {
         if (key === SecretStorageKeys.DIRECT_CONNECTIONS) {
           const connections: DirectConnectionsById =
             await getResourceManager().getDirectConnections();
-          // ensure all DirectResourceLoader instances are up to date
+          // ensure all DirectResourceLoader instances are up to date.
+
           // part 1: ensure any new connections have registered loaders; if this isn't done, hopping
           // workspaces and attempting to focus on a direct connection-based resource will fail with
-          // the `Unknown connection ID` error
-          const existingLoaderIds: ConnectionId[] = ResourceLoader.loaders()
-            .filter((loader) => loader.connectionType === "DIRECT")
-            .map((loader) => loader.connectionId);
+          // the `Unknown connection ID` error. And purge the cache of any existing loaders
+          // so they can re-fetch the latest resources, which may have just been reconfigured.
+
+          const existingDirectLoadersById: Map<ConnectionId, DirectResourceLoader> = new Map(
+            ResourceLoader.directLoaders().map((loader) => [loader.connectionId, loader]),
+          );
+
+          const existingLoaderIds: ConnectionId[] = Array.from(existingDirectLoadersById.keys());
+
+          // Either make new loaders for any connections that don't have one, or
+          // purge the cache of existing loaders to ensure they re-fetch the latest resources next time
+          // (may have been reconfigured, e.g. new kafka cluster or schema registry, or improved)
           for (const id of connections.keys()) {
             if (!existingLoaderIds.includes(id)) {
               this.initResourceLoader(id);
+            } else {
+              // Get this preexisting loader to purge its cache, so it can re-fetch the latest resources. The
+              // connection may have gained or lost kafka cluster or schema registry, or improved
+              // the spelling of which. Alas we don't know if this connection was changed at all when
+              // we get the change event, so we have to be conservative and purge the caches of any
+              // existing direct loaders.
+              const existingLoader = existingDirectLoadersById.get(id)!;
+              await existingLoader.purgeCache();
             }
           }
           // part 2: remove any direct connections not in the secret storage to prevent

--- a/src/loaders/directResourceLoader.test.ts
+++ b/src/loaders/directResourceLoader.test.ts
@@ -101,6 +101,16 @@ describe("DirectResourceLoader", () => {
     });
   });
 
+  describe("purgeCache()", () => {
+    it("Clears the cached environments", async () => {
+      await loader.getEnvironments(); // Load and cache first.
+      sinon.assert.calledOnce(getDirectResourcesStub);
+      await loader.purgeCache(); // Clear the cache.
+      await loader.getEnvironments(); // Should call the stub again.
+      sinon.assert.calledTwice(getDirectResourcesStub); // Should have called the stub again.
+    });
+  });
+
   describe("getKafkaClustersForEnvironmentId()", () => {
     it("Returns Kafka clusters for the specified environment ID", async () => {
       const kafkaClusters = await loader.getKafkaClustersForEnvironmentId(

--- a/src/loaders/directResourceLoader.test.ts
+++ b/src/loaders/directResourceLoader.test.ts
@@ -105,7 +105,7 @@ describe("DirectResourceLoader", () => {
     it("Clears the cached environments", async () => {
       await loader.getEnvironments(); // Load and cache first.
       sinon.assert.calledOnce(getDirectResourcesStub);
-      await loader.purgeCache(); // Clear the cache.
+      loader.purgeCache(); // Clear the cache.
       await loader.getEnvironments(); // Should call the stub again.
       sinon.assert.calledTwice(getDirectResourcesStub); // Should have called the stub again.
     });

--- a/src/loaders/directResourceLoader.test.ts
+++ b/src/loaders/directResourceLoader.test.ts
@@ -1,0 +1,149 @@
+import assert from "assert";
+import * as sinon from "sinon";
+
+import { ConnectionType } from "../clients/sidecar";
+import * as directGraphQl from "../graphql/direct";
+import { DirectEnvironment } from "../models/environment";
+import { DirectKafkaCluster } from "../models/kafkaCluster";
+import { ConnectionId, EnvironmentId } from "../models/resource";
+import { DirectSchemaRegistry } from "../models/schemaRegistry";
+import { DirectResourceLoader } from "./directResourceLoader";
+
+describe("DirectResourceLoader", () => {
+  const connectionId = "test-connection-id";
+
+  // As if from GraphQL, describing multiple direct environments.
+  let totalEnvironments: DirectEnvironment[];
+  let myEnvironment: DirectEnvironment;
+
+  let sandbox: sinon.SinonSandbox;
+  let loader: DirectResourceLoader;
+  let getDirectResourcesStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    loader = new DirectResourceLoader(connectionId as ConnectionId);
+
+    sandbox = sinon.createSandbox();
+
+    // The DirectEnvironment for the connectionId we're testing, initially configured
+    // with a Kafka cluster and no Schema Registry.
+    myEnvironment = new DirectEnvironment({
+      id: connectionId as EnvironmentId,
+      connectionId: connectionId as ConnectionId,
+      name: "Environment 1",
+      kafkaConfigured: true,
+      kafkaClusters: [
+        DirectKafkaCluster.create({
+          id: "kafka-cluster-1",
+          name: "Kafka Cluster 1",
+          bootstrapServers: "kafka1.example.com:9092",
+          uri: "kafka://kafka1.example.com:9092",
+          connectionId: connectionId as ConnectionId,
+          connectionType: ConnectionType.Direct,
+        }),
+      ],
+      schemaRegistryConfigured: false,
+      schemaRegistry: DirectSchemaRegistry.create({
+        connectionId: connectionId as ConnectionId,
+        connectionType: ConnectionType.Direct,
+        id: "schema-registry-1",
+        uri: "http://schema-registry1.example.com:8081",
+        environmentId: connectionId as EnvironmentId,
+      }),
+    });
+
+    // All environments returned by the GraphQL query.
+    totalEnvironments = [
+      myEnvironment,
+      // Another environment that is not the one we're testing.
+      new DirectEnvironment({
+        id: "another-environment-id" as EnvironmentId,
+        connectionId: "another-connection-id" as ConnectionId,
+        name: "Environment 2",
+        kafkaConfigured: true,
+        kafkaClusters: [
+          DirectKafkaCluster.create({
+            id: "kafka-cluster-2",
+            name: "Kafka Cluster 2",
+            bootstrapServers: "kafka2.example.com:9092",
+            uri: "kafka://kafka2.example.com:9092",
+            connectionId: "another-connection-id" as ConnectionId,
+            connectionType: ConnectionType.Direct,
+          }),
+        ],
+        schemaRegistryConfigured: false,
+        schemaRegistry: undefined,
+      }),
+    ];
+
+    getDirectResourcesStub = sandbox
+      .stub(directGraphQl, "getDirectResources")
+      .resolves(totalEnvironments);
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe("getEnvironments()", () => {
+    it("Deep fetches once and caches the result", async () => {
+      const environments = await loader.getEnvironments();
+      sinon.assert.calledOnce(getDirectResourcesStub);
+      assert.deepStrictEqual(environments, [myEnvironment]);
+
+      // Call again, should not call the stub again.
+      const cachedEnvironments = await loader.getEnvironments();
+      sinon.assert.calledOnce(getDirectResourcesStub);
+      assert.deepStrictEqual(cachedEnvironments, [myEnvironment]);
+
+      // Call with forceDeepRefresh, should call the stub again.
+      const refreshedEnvironments = await loader.getEnvironments(true);
+      sinon.assert.calledTwice(getDirectResourcesStub);
+      assert.deepStrictEqual(refreshedEnvironments, [myEnvironment]);
+    });
+  });
+
+  describe("getKafkaClustersForEnvironmentId()", () => {
+    it("Returns Kafka clusters for the specified environment ID", async () => {
+      const kafkaClusters = await loader.getKafkaClustersForEnvironmentId(
+        connectionId as EnvironmentId,
+      );
+      assert.deepStrictEqual(kafkaClusters, myEnvironment.kafkaClusters);
+    });
+
+    it("Throws an error for unknown environment ID", async () => {
+      await assert.rejects(
+        loader.getKafkaClustersForEnvironmentId("unknown-environment-id"),
+        /Unknown environmentId unknown-environment-id/,
+      );
+    });
+  });
+
+  describe("getSchemaRegistries()", () => {
+    it("Returns the expected schema registry", async () => {
+      const schemaRegistries = await loader.getSchemaRegistries();
+      assert.deepStrictEqual(schemaRegistries, [myEnvironment.schemaRegistry]);
+    });
+
+    it("Returns an empty array if no schema registries are configured", async () => {
+      // Modify the environment to not have a schema registry.
+      myEnvironment.schemaRegistry = undefined;
+      const schemaRegistries = await loader.getSchemaRegistries();
+      assert.deepStrictEqual(schemaRegistries, []);
+    });
+  });
+
+  describe("getSchemaRegistryForEnvironmentId()", () => {
+    it("Returns the schema registry for the specified environment ID", async () => {
+      const schemaRegistry = await loader.getSchemaRegistryForEnvironmentId(
+        connectionId as EnvironmentId,
+      );
+      assert.deepStrictEqual(schemaRegistry, myEnvironment.schemaRegistry);
+    });
+
+    it("Returns undefined for an environment without a schema registry", async () => {
+      const schemaRegistry = await loader.getSchemaRegistryForEnvironmentId(
+        "another-environment-id" as EnvironmentId,
+      );
+      assert.strictEqual(schemaRegistry, undefined);
+    });
+  });
+});

--- a/src/loaders/directResourceLoader.ts
+++ b/src/loaders/directResourceLoader.ts
@@ -51,7 +51,7 @@ export class DirectResourceLoader extends ResourceLoader {
   /**
    * Clear all cached data for this connection.
    */
-  async purgeCache(): Promise<void> {
+  purgeCache(): void {
     this.logger.debug("purgeCache()");
     this.cachedEnvironments = undefined;
   }

--- a/src/loaders/directResourceLoader.ts
+++ b/src/loaders/directResourceLoader.ts
@@ -28,7 +28,7 @@ export class DirectResourceLoader extends ResourceLoader {
     if (!this.cachedEnvironments || forceDeepRefresh) {
       // Fetch all of them, across all direct connections, sigh.
       const envs: DirectEnvironment[] = await getDirectResources();
-      // Filter down to just "mine."" Should only be an array of one DirectEnvironment
+      // Filter down to just "mine." Should be an array of one single DirectEnvironment.
       this.cachedEnvironments = envs.filter((env) => env.connectionId === this.connectionId);
     }
     return this.cachedEnvironments;

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -13,6 +13,7 @@ import { KafkaTopic } from "../models/topic";
 import { showWarningNotificationWithButtons } from "../notifications";
 import { getSidecar } from "../sidecar";
 import { getResourceManager } from "../storage/resourceManager";
+import { DirectResourceLoader } from "./directResourceLoader";
 import {
   correlateTopicsWithSchemaSubjects,
   fetchSchemasForSubject,
@@ -57,8 +58,16 @@ export abstract class ResourceLoader implements IResourceBase {
     ResourceLoader.registry.delete(connectionId);
   }
 
+  /** Get all registered resource loaders */
   static loaders(): ResourceLoader[] {
     return Array.from(ResourceLoader.registry.values());
+  }
+
+  /** Get all registered DirectResourceLoader instances */
+  static directLoaders(): DirectResourceLoader[] {
+    return ResourceLoader.loaders().filter(
+      (loader) => loader.connectionType === ConnectionType.Direct,
+    ) as DirectResourceLoader[];
   }
 
   /** Get the ResourceLoader subclass instance corresponding to the given connectionId */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Get each `DirectConnectionLoader` to cache its subset of the graphql results, so as to reduce the number of times we make the deep graphql fetch.
- When direct connections are updated (or, sigh, added or deleted), we pessimistically clear any cached data for existing direct connection loaders.
- Will improve performance / reduce deep graphql calls, both before and after migrating `DirectConnectionLoader` over to using single-connection-graphql query from https://github.com/confluentinc/ide-sidecar/issues/434.
- While here, new method to get at all of the `DirectConnectionLoader` instances registered in the `ResourceLoader` registry, `static ResourceLoader.directLoaders()`. There are probably a few places that want to call it, but now starting within `DirectConnectionManager`'s `getSecretStorage().onDidChange()` event listener.
- New test suite over `DirectConnectionLoader`, 100% line and branch coverage.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1911

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
