### PR TITLE
MINOR: create single log output channel for Flink SQL language server

### DIFF
--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -12,6 +12,7 @@ import { WebSocket } from "ws";
 import { Logger } from "../logging";
 import { SecretStorageKeys } from "../storage/constants";
 import { getSecretStorage } from "../storage/utils";
+import { getFlinkSQLLanguageServerOutputChannel } from "./logging";
 import { WebsocketTransport } from "./websocketTransport";
 
 const logger = new Logger("flinkSql.languageClient");
@@ -56,6 +57,7 @@ export async function initializeLanguageClient(
             { scheme: "untitled", language: "flinksql" },
             { pattern: "**/*.flink.sql" },
           ],
+          outputChannel: getFlinkSQLLanguageServerOutputChannel(),
           middleware: {
             didOpen: (document, next) => {
               return next(document);

--- a/src/flinkSql/logging.ts
+++ b/src/flinkSql/logging.ts
@@ -5,9 +5,12 @@ let languageServerOutputChannel: LogOutputChannel | undefined;
 /** Get the {@link LogOutputChannel} for the Flink SQL language server, creating it if it doesn't already exist. */
 export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
   if (!languageServerOutputChannel) {
-    languageServerOutputChannel = window.createOutputChannel("Confluent Flink SQL", {
-      log: true,
-    });
+    languageServerOutputChannel = window.createOutputChannel(
+      "Confluent Flink SQL Language Server",
+      {
+        log: true,
+      },
+    );
   }
   return languageServerOutputChannel;
 }

--- a/src/flinkSql/logging.ts
+++ b/src/flinkSql/logging.ts
@@ -1,0 +1,13 @@
+import { LogOutputChannel, window } from "vscode";
+
+let languageServerOutputChannel: LogOutputChannel | undefined;
+
+/** Get the {@link LogOutputChannel} for the Flink SQL language server, creating it if it doesn't already exist. */
+export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
+  if (!languageServerOutputChannel) {
+    languageServerOutputChannel = window.createOutputChannel("Confluent Flink SQL", {
+      log: true,
+    });
+  }
+  return languageServerOutputChannel;
+}


### PR DESCRIPTION
## Before
Dynamically created (possibly multiple, based on disconnects) regular `OutputChannel`s
<img width=600 src="https://github.com/user-attachments/assets/ed14fd88-7306-469a-883f-c5e109059678" />

## After
Single output channel reused even between disconnects, uses the `LogOutputChannel` format for some syntax highlighting and support for compound-log creation.
<img width=1000 src="https://github.com/user-attachments/assets/87c52969-da57-4ab9-a83e-c57b024b12a9" />
