### PR TITLE
MINOR testing(Mocha): set `forbidOnly` in CI

### DIFF
--- a/src/documentMetadataManager.test.ts
+++ b/src/documentMetadataManager.test.ts
@@ -22,7 +22,7 @@ describe("documentMetadataManager.ts", () => {
     sandbox.restore();
   });
 
-  it.only("should create only one instance of DocumentMetadataManager", () => {
+  it("should create only one instance of DocumentMetadataManager", () => {
     const instance1 = DocumentMetadataManager.getInstance();
     const instance2 = DocumentMetadataManager.getInstance();
     assert.strictEqual(instance1, instance2);


### PR DESCRIPTION
Sets [`forbidOnly`](https://mochajs.org/api/mocha#forbidOnly) so any Mocha tests (or suites) accidentally left with `.only` will fail.
Same kind of behavior in the E2E playwright [config](https://github.com/confluentinc/vscode/blob/d981b1c6c8bcef0538a46465d4608d4d3a2e9d29/tests/e2e/playwright.config.ts#L21).

Sample failure from https://github.com/confluentinc/vscode/pull/1929/commits/334c418bd2cea1fb495718fbf158eec04781f81c:
<img width="891" alt="image" src="https://github.com/user-attachments/assets/95e8381d-8749-4640-a7c6-87c084b41beb" />
