### PR TITLE
cleanup(testing): prevent running E2E tests from VS Code terminal for same VS Code version being tested

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -734,6 +734,23 @@ export function functional(done) {
 }
 
 export function e2eRun(done) {
+  const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
+  // check for VS Code stable vs Insiders based on TERM_PROGRAM_VERSION
+  // - stable: "1.x.x"
+  // - insiders: "1.x.x-insider"
+  const runningFromVSCodeInsidersTerminal =
+    process.env.TERM_PROGRAM_VERSION?.endsWith("insider") ?? false;
+  // the only way we should allow E2E tests to run is if we're starting them from a different
+  // terminal version than the specified in the VSCODE_VERSION env var
+  const runStableFromStable = vscodeVersion !== "insiders" && !runningFromVSCodeInsidersTerminal;
+  const runInsidersFromInsiders = vscodeVersion === "insiders" && runningFromVSCodeInsidersTerminal;
+  if (runStableFromStable || runInsidersFromInsiders) {
+    console.error(
+      "If you want to run E2E tests from a VS Code terminal, you must set the VSCODE_VERSION env var to the opposite of what VS Code version you are currently using. (For example, if you are running VS Code Insiders, set VSCODE_VERSION=stable to run E2E tests.)",
+    );
+    return done(1);
+  }
+
   // Get <test-name> argument after 'npx gulp e2e -t <test-name>'
   const testFilter = process.argv.find((v, i, a) => i > 0 && a[i - 1] === "-t");
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -734,21 +734,25 @@ export function functional(done) {
 }
 
 export function e2eRun(done) {
-  const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
-  // check for VS Code stable vs Insiders based on TERM_PROGRAM_VERSION
-  // - stable: "1.x.x"
-  // - insiders: "1.x.x-insider"
-  const runningFromVSCodeInsidersTerminal =
-    process.env.TERM_PROGRAM_VERSION?.endsWith("insider") ?? false;
-  // the only way we should allow E2E tests to run is if we're starting them from a different
-  // terminal version than the specified in the VSCODE_VERSION env var
-  const runStableFromStable = vscodeVersion !== "insiders" && !runningFromVSCodeInsidersTerminal;
-  const runInsidersFromInsiders = vscodeVersion === "insiders" && runningFromVSCodeInsidersTerminal;
-  if (runStableFromStable || runInsidersFromInsiders) {
-    console.error(
-      "If you want to run E2E tests from a VS Code terminal, you must set the VSCODE_VERSION env var to the opposite of what VS Code version you are currently using. (For example, if you are running VS Code Insiders, set VSCODE_VERSION=stable to run E2E tests.)",
-    );
-    return done(1);
+  // check if the E2E tests are being run from a VS Code terminal (stable and insiders both use "vscode" here)
+  if (process.env.TERM_PROGRAM === "vscode") {
+    const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
+    // check for VS Code stable vs Insiders based on TERM_PROGRAM_VERSION
+    // - stable: "1.x.x"
+    // - insiders: "1.x.x-insider"
+    const runningFromVSCodeInsidersTerminal =
+      process.env.TERM_PROGRAM_VERSION?.endsWith("insider") ?? false;
+    // the only way we should allow E2E tests to run is if we're starting them from a different
+    // terminal version than the specified in the VSCODE_VERSION env var
+    const runStableFromStable = vscodeVersion !== "insiders" && !runningFromVSCodeInsidersTerminal;
+    const runInsidersFromInsiders =
+      vscodeVersion === "insiders" && runningFromVSCodeInsidersTerminal;
+    if (runStableFromStable || runInsidersFromInsiders) {
+      console.error(
+        "If you want to run E2E tests from a VS Code terminal, you must set the VSCODE_VERSION env var to the opposite of what VS Code version you are currently using. (For example, if you are running VS Code Insiders, set VSCODE_VERSION=stable to run E2E tests.)",
+      );
+      return done(1);
+    }
   }
 
   // Get <test-name> argument after 'npx gulp e2e -t <test-name>'

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -13,8 +13,7 @@ configDotenv({
 });
 
 const vsix: string = globSync(path.resolve(__dirname, "..", "..", "out", "*.vsix")).at(0) as string;
-const isInsiders = process.env.TERM_PROGRAM_VERSION?.endsWith("insider");
-const vscodeVersion = process.env.VSCODE_VERSION || (isInsiders ? "insiders" : "stable");
+const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
 
 export default defineConfig<VSCodeTestOptions, VSCodeWorkerOptions>({
   testDir: path.join(__dirname, "specs"),


### PR DESCRIPTION
Since most E2E tests require logging in to CCloud and handling the auth callback URI, having the same version of VS Code open (when running `gulp e2e`) can cause the URI handling to focus on the main window instead of the test window. (This causes a "do you want to install the Confluent extension" type prompt in the main window, while also causing the test window to never successfully log in and fail the tests, etc.)

This catches that behavior early on and shows an error message:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/a3688c0c-6441-4234-ab25-28b61b60eec9" />
- `gulp e2e` from stable, testing stable ❌ 
- `gulp e2e` from insiders, testing insiders ❌
- `VSCODE_VERSION=stable gulp e2e` from insiders, testing stable ✅
<img width="600" alt="image" src="https://github.com/user-attachments/assets/e5f35225-6946-42ea-ae50-d13ef517a149" />

- `VSCODE_VERSION=insiders gulp e2e` from stable, testing insiders ✅ 
<img width="590" alt="image" src="https://github.com/user-attachments/assets/69c78b3e-7b77-4ce5-ac89-61e30dbfd1a1" />