### PR TITLE
security: tighten credential store handling for local Docker engine API requests

### DIFF
--- a/src/docker/credentials.test.ts
+++ b/src/docker/credentials.test.ts
@@ -1,0 +1,190 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as fsWrappers from "../utils/fsWrappers";
+import {
+  DockerAuthHeaders,
+  getDockerCredsStore,
+  isValidCredsStoreName,
+  validateDockerCredentials,
+} from "./credentials";
+
+describe("docker/credentials.ts isValidCredsStoreName()", function () {
+  it("should return true for valid credential store names", function () {
+    const validNames = [
+      "desktop",
+      "osxkeychain",
+      "test_store",
+      "store-with-hyphens",
+      "store123",
+      "a",
+    ];
+
+    validNames.forEach((name) => {
+      assert.strictEqual(isValidCredsStoreName(name), true, `Expected "${name}" to be valid`);
+    });
+  });
+
+  it("should return false for invalid credential store names", function () {
+    const invalidNames = [
+      "store;rm -rf /", // command injection attempt
+      "store && echo 'pwned'", // command chaining
+      "store$(whoami)", // command substitution
+      "store`id`", // backtick command substitution
+      "store|cat /etc/passwd", // pipe injection
+      "store > /tmp/file", // redirection
+      "store < /etc/passwd", // input redirection
+      "store & background", // background process
+      "store'DROP TABLE users", // SQL injection style
+      'store"DROP TABLE users', // SQL injection with double quotes
+      "store/../../etc/passwd", // path traversal
+      "store\\..\\..\\windows\\system32", // Windows path traversal
+      "store%PATH%", // environment variable expansion
+      "store$PATH", // Unix environment variable
+      // other invalid character use:
+      "store with spaces", // spaces not allowed
+      "store\ttab", // tab character
+      "store\nnewline", // newline character
+      "store\rcarriage", // carriage return
+      "store\0null", // null byte
+      "store@hostname",
+      "store#comment",
+      "store*wildcard",
+      "store?question",
+      "store[bracket]",
+      "store{brace}",
+      "store(paren)",
+      "store~tilde",
+      "store!exclamation",
+      "store+plus",
+      "store=equals",
+    ];
+
+    invalidNames.forEach((name) => {
+      assert.strictEqual(isValidCredsStoreName(name), false, `Expected "${name}" to be invalid`);
+    });
+  });
+
+  it("should return false for empty strings", function () {
+    assert.strictEqual(isValidCredsStoreName(""), false);
+  });
+
+  it("should return false for credential store names that are too long", function () {
+    const longName = "a".repeat(100); // exactly 100 characters
+    const tooLongName = "a".repeat(101); // 101 characters
+
+    assert.strictEqual(isValidCredsStoreName(longName), false);
+    assert.strictEqual(isValidCredsStoreName(tooLongName), false);
+  });
+
+  it("should return true for credential store names at the maximum allowed length", function () {
+    const maxLengthName = "a".repeat(99); // 99 characters (just under limit)
+
+    assert.strictEqual(isValidCredsStoreName(maxLengthName), true);
+  });
+
+  it("should not allow special unicode characters", function () {
+    const unicodeNames = [
+      "storeᄀ", // Korean character
+      "store漢", // Chinese character
+      "store🐳", // emoji
+      "storeĠ", // accented character
+    ];
+
+    unicodeNames.forEach((name) => {
+      assert.strictEqual(isValidCredsStoreName(name), false);
+    });
+  });
+});
+
+describe("docker/credentials.ts getDockerCredsStore()", function () {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(async function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should return undefined when the ~/.docker/config.json does not exist", function () {
+    sandbox.stub(fsWrappers, "readFileSync").throws(new Error("ENOENT"));
+
+    const result: string | undefined = getDockerCredsStore();
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("should return undefined when the ~/.docker/config.json contains invalid JSON", function () {
+    sandbox.stub(fsWrappers, "readFileSync").returns("invalid json{");
+
+    const result: string | undefined = getDockerCredsStore();
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("should return undefined when credsStore contains invalid characters", function () {
+    sandbox.stub(fsWrappers, "readFileSync").returns(
+      JSON.stringify({
+        credsStore: "malicious;rm -rf /",
+      }),
+    );
+
+    const result: string | undefined = getDockerCredsStore();
+
+    assert.strictEqual(result, undefined);
+  });
+
+  it("should return valid credsStore when properly configured", function () {
+    sandbox.stub(fsWrappers, "readFileSync").returns(
+      JSON.stringify({
+        credsStore: "desktop",
+      }),
+    );
+
+    const result: string | undefined = getDockerCredsStore();
+
+    assert.strictEqual(result, "desktop");
+  });
+});
+
+describe("docker/credentials.ts validateDockerCredentials()", function () {
+  it("should return undefined for null or undefined input", function () {
+    assert.strictEqual(validateDockerCredentials(null), undefined);
+    assert.strictEqual(validateDockerCredentials(undefined), undefined);
+  });
+
+  it("should return undefined for invalid credential formats", function () {
+    assert.strictEqual(validateDockerCredentials({}), undefined);
+    assert.strictEqual(validateDockerCredentials({ Username: "user" }), undefined);
+    assert.strictEqual(validateDockerCredentials({ Password: "pass" }), undefined);
+    assert.strictEqual(validateDockerCredentials({ Username: 123, Password: "pass" }), undefined);
+  });
+
+  it("should return proper auth headers for valid credentials", function () {
+    const result: DockerAuthHeaders | undefined = validateDockerCredentials({
+      Username: "testuser",
+      Password: "testpass",
+      ServerURL: "https://registry.example.com",
+    });
+
+    assert.deepStrictEqual(result, {
+      username: "testuser",
+      password: "testpass",
+      serveraddress: "https://registry.example.com",
+    });
+  });
+
+  it("should use default Docker Hub URL when ServerURL is missing", function () {
+    const result: DockerAuthHeaders | undefined = validateDockerCredentials({
+      Username: "testuser",
+      Password: "testpass",
+    });
+
+    assert.deepStrictEqual(result, {
+      username: "testuser",
+      password: "testpass",
+      serveraddress: "https://index.docker.io/v1/",
+    });
+  });
+});

--- a/src/docker/credentials.ts
+++ b/src/docker/credentials.ts
@@ -1,0 +1,128 @@
+import { execSync } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import { SecretStorage } from "vscode";
+import { Logger } from "../logging";
+import { SecretStorageKeys } from "../storage/constants";
+import { getSecretStorage } from "../storage/utils";
+import { readFileSync } from "../utils/fsWrappers";
+
+const logger = new Logger("docker.credentials");
+
+/**
+ * Look up the name of the `credsStore` from the local Docker config, if it's set.
+ * @see https://docs.docker.com/reference/cli/docker/login/#credential-stores
+ */
+export function getDockerCredsStore(): string | undefined {
+  let credsStore: string | undefined;
+  try {
+    const dockerConfigPath = join(homedir(), ".docker", "config.json");
+    const dockerConfig = JSON.parse(readFileSync(dockerConfigPath, "utf-8"));
+    credsStore = dockerConfig.credsStore;
+  } catch (error) {
+    logger.debug("failed to read Docker config:", error);
+    return;
+  }
+  if (credsStore === undefined) {
+    logger.debug("no Docker creds store configured in config.json");
+    return;
+  }
+  if (!isValidCredsStoreName(credsStore)) {
+    logger.debug("invalid Docker creds store name:", credsStore);
+    return;
+  }
+  return credsStore;
+}
+
+/**
+ * Validate that the credential store name is safe for command execution.
+ * Only allow alphanumeric characters, hyphens, and underscores.
+ */
+export function isValidCredsStoreName(credsStore: string): boolean {
+  // only allow only alphanumeric characters, hyphens, and underscores, like:
+  // - desktop
+  // - osxkeychain
+  // - wincred
+  // ...etc
+  // and require at least one character, but no more than 100 characters (not hard limit, but seems reasonable)
+  return /^[a-zA-Z0-9_-]+$/.test(credsStore) && credsStore.length > 0 && credsStore.length < 100;
+}
+
+/**
+ * Get the Docker credentials for the current user, provided a `credsStore` is set.
+ * This function will cache the credentials in SecretStorage for future use.
+ * @returns A base64-encoded string of the Docker credentials, or `undefined` if the credentials
+ * could not be retrieved.
+ * @see https://docs.docker.com/reference/cli/docker/login/#credential-stores
+ */
+export async function getDockerCredentials(): Promise<string | undefined> {
+  const secretStorage: SecretStorage = getSecretStorage();
+  const cachedDockerCreds: string | undefined = await secretStorage.get(
+    SecretStorageKeys.DOCKER_CREDS_SECRET_KEY,
+  );
+  if (cachedDockerCreds) {
+    return cachedDockerCreds;
+  }
+
+  const credsStore: string | undefined = getDockerCredsStore();
+  if (!credsStore) {
+    return;
+  }
+
+  let credsString: string | undefined;
+  try {
+    // unfortunately, there isn't a way to get the credentials directly from the store, so we have
+    // to try calling the `docker-credential-<store> get` command and parse the output
+    const command: string = credsStore.startsWith("docker-credential-")
+      ? credsStore
+      : `docker-credential-${credsStore}`;
+    credsString = execSync(`${command} get`, {
+      input: "https://index.docker.io/v1/",
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+  } catch (error) {
+    logger.debug("failed to load Docker credentials:", error);
+    return;
+  }
+
+  const credentialHeaders: DockerAuthHeaders | undefined = validateDockerCredentials(
+    JSON.parse(credsString),
+  );
+  if (!credentialHeaders) {
+    logger.debug("invalid Docker credentials:", credsString);
+    return;
+  }
+  const encodedCreds: string = Buffer.from(JSON.stringify(credentialHeaders)).toString("base64");
+  await secretStorage.store(SecretStorageKeys.DOCKER_CREDS_SECRET_KEY, encodedCreds);
+  return encodedCreds;
+}
+
+/**
+ * Interface for Docker engine API authentication headers.
+ * @see https://docs.docker.com/reference/api/engine/version/v1.41/#section/Authentication
+ */
+export interface DockerAuthHeaders {
+  username: string;
+  password: string;
+  serveraddress: string;
+}
+
+/**
+ * Validate the Docker credentials object and convert it to a {@link DockerAuthHeaders} object.
+ * @param creds The JSON-parsed credentials object to validate.
+ * @returns A {@link DockerAuthHeaders} object if valid, or `undefined` if invalid.
+ * @see https://docs.docker.com/reference/cli/docker/login/#credential-helper-protocol
+ */
+export function validateDockerCredentials(creds: any): DockerAuthHeaders | undefined {
+  if (!creds) {
+    return;
+  }
+  if (typeof creds.Username === "string" && typeof creds.Password === "string") {
+    return {
+      username: creds.Username,
+      password: creds.Password,
+      serveraddress: creds.ServerURL ?? "https://index.docker.io/v1/",
+    };
+  }
+}

--- a/src/utils/fsWrappers.ts
+++ b/src/utils/fsWrappers.ts
@@ -44,6 +44,14 @@ export function tmpdir(): string {
   return os.tmpdir();
 }
 
+/** Wrapper for fs.readFileSync() */
+export function readFileSync(
+  path: fs.PathOrFileDescriptor,
+  options?: { encoding?: BufferEncoding; flag?: string } | BufferEncoding,
+): string {
+  return fs.readFileSync(path, options || "utf-8") as string;
+}
+
 /** Wrapper for fs.writeFileSync() */
 export function writeFileSync(
   path: fs.PathOrFileDescriptor,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Originally flagged from sonarqube as an area that needed better handling:
https://github.com/confluentinc/vscode/blob/a6c2cc3e49c20ae31aeda348e96efdf75f84542b/src/docker/configs.ts#L116

This PR adds validation steps to the [credential store](https://docs.docker.com/reference/cli/docker/login/#credential-stores) (from `~/.docker/config.json`) and returned credentials structure used for providing [auth headers](https://docs.docker.com/reference/api/engine/version/v1.41/#section/Authentication) don't contain unsupported characters (possibly preventing some attack vectors).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
