### PR TITLE
Tests over src/graphql/environments.ts

### DIFF
--- a/src/graphql/direct.test.ts
+++ b/src/graphql/direct.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
+import { getSidecarStub } from "../../tests/stubs/sidecar";
 import {
   TEST_DIRECT_KAFKA_CLUSTER,
   TEST_DIRECT_SCHEMA_REGISTRY,
@@ -15,7 +16,7 @@ import { DirectEnvironment } from "../models/environment";
 import { DirectKafkaCluster } from "../models/kafkaCluster";
 import { DirectSchemaRegistry } from "../models/schemaRegistry";
 import * as notifications from "../notifications";
-import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import { CustomConnectionSpec, ResourceManager } from "../storage/resourceManager";
 import { getDirectResources } from "./direct";
 
@@ -45,7 +46,7 @@ const fakeDirectConnectionByIdResult = {
 describe("graphql/direct.ts getDirectResources()", () => {
   let sandbox: sinon.SinonSandbox;
 
-  let sidecarStub: sinon.SinonStubbedInstance<sidecar.SidecarHandle>;
+  let sidecarStub: sinon.SinonStubbedInstance<SidecarHandle>;
   let logErrorStub: sinon.SinonStub;
   let showErrorNotificationStub: sinon.SinonStub;
   let stubbedResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
@@ -54,8 +55,7 @@ describe("graphql/direct.ts getDirectResources()", () => {
     sandbox = sinon.createSandbox();
 
     // create the stub for the sidecar (which will automatically stub the .query method)
-    sidecarStub = sandbox.createStubInstance(sidecar.SidecarHandle);
-    sandbox.stub(sidecar, "getSidecar").resolves(sidecarStub);
+    sidecarStub = getSidecarStub(sandbox);
 
     // for stubbing the stored (test) direct connection spec
     stubbedResourceManager = sandbox.createStubInstance(ResourceManager);

--- a/src/graphql/environments.test.ts
+++ b/src/graphql/environments.test.ts
@@ -1,21 +1,20 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 
+import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
 import { getSidecarStub } from "../../tests/stubs/sidecar";
 
 import { SidecarHandle } from "../sidecar";
-
-import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
 import { getEnvironments } from "./environments";
 
 describe("environments.ts getEnvironments()", () => {
   let sandbox: sinon.SinonSandbox;
-  let sidecar: sinon.SinonStubbedInstance<SidecarHandle>;
+  let sidecarStub: sinon.SinonStubbedInstance<SidecarHandle>;
   let showErrorNotificationStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    sidecar = getSidecarStub(sandbox);
+    sidecarStub = getSidecarStub(sandbox);
     showErrorNotificationStub = getShowErrorNotificationWithButtonsStub(sandbox);
   });
 
@@ -24,7 +23,7 @@ describe("environments.ts getEnvironments()", () => {
   });
 
   it("Returns empty array and shows notification if query raises an error", async () => {
-    sidecar.query.rejects(new Error("Query failed"));
+    sidecarStub.query.rejects(new Error("Query failed"));
 
     const result = await getEnvironments();
 
@@ -33,14 +32,16 @@ describe("environments.ts getEnvironments()", () => {
   });
 
   it("Returns empty array if no environments are returned", async () => {
-    sidecar.query.resolves({ ccloudConnectionById: { environments: null } });
+    sidecarStub.query.resolves({ ccloudConnectionById: { environments: null } });
+
     const result = await getEnvironments();
+
     assert.deepStrictEqual(result, []);
     sinon.assert.notCalled(showErrorNotificationStub);
   });
 
   it("Returns empty array if no environments are found", async () => {
-    sidecar.query.resolves({ ccloudConnectionById: { environments: [] } });
+    sidecarStub.query.resolves({ ccloudConnectionById: { environments: [] } });
 
     const result = await getEnvironments();
 
@@ -49,7 +50,7 @@ describe("environments.ts getEnvironments()", () => {
   });
 
   it("Handles degenerate environments from graphql", async () => {
-    sidecar.query.resolves({ ccloudConnectionById: { environments: [null, null] } });
+    sidecarStub.query.resolves({ ccloudConnectionById: { environments: [null, null] } });
 
     const result = await getEnvironments();
 
@@ -88,8 +89,7 @@ describe("environments.ts getEnvironments()", () => {
         ],
       },
     };
-
-    sidecar.query.resolves(mockEnvironments);
+    sidecarStub.query.resolves(mockEnvironments);
 
     const result = await getEnvironments();
 
@@ -101,7 +101,6 @@ describe("environments.ts getEnvironments()", () => {
     assert.strictEqual(result[0].kafkaClusters[0].environmentId, "env1");
     assert.strictEqual(result[0].kafkaClusters[1].name, "Kafka Cluster 2");
     assert.strictEqual(result[0].kafkaClusters[0].environmentId, "env1");
-
     assert.strictEqual(result[0].schemaRegistry, undefined);
 
     sinon.assert.notCalled(showErrorNotificationStub);
@@ -135,9 +134,10 @@ describe("environments.ts getEnvironments()", () => {
         ],
       },
     };
+    sidecarStub.query.resolves(mockEnvironments);
 
-    sidecar.query.resolves(mockEnvironments);
     const result = await getEnvironments();
+
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].kafkaClusters.length, 1);
     assert.strictEqual(result[0].schemaRegistry!.environmentId, "env1");
@@ -168,9 +168,10 @@ describe("environments.ts getEnvironments()", () => {
         ],
       },
     };
+    sidecarStub.query.resolves(mockEnvironments);
 
-    sidecar.query.resolves(mockEnvironments);
     const result = await getEnvironments();
+
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].flinkComputePools.length, 1);
     assert.strictEqual(result[0].flinkComputePools[0].id, "flink1");
@@ -201,12 +202,14 @@ describe("environments.ts getEnvironments()", () => {
         ],
       },
     };
+    sidecarStub.query.resolves(mockEnvironments);
 
-    sidecar.query.resolves(mockEnvironments);
     const result = await getEnvironments();
+
     assert.strictEqual(result.length, 2);
     assert.strictEqual(result[0].name, "Environment 1");
     assert.strictEqual(result[1].name, "Environment 2");
+
     sinon.assert.notCalled(showErrorNotificationStub);
   });
 });

--- a/src/graphql/environments.test.ts
+++ b/src/graphql/environments.test.ts
@@ -1,0 +1,212 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+
+import { getSidecarStub } from "../../tests/stubs/sidecar";
+
+import { SidecarHandle } from "../sidecar";
+
+import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
+import { getEnvironments } from "./environments";
+
+describe("environments.ts getEnvironments()", () => {
+  let sandbox: sinon.SinonSandbox;
+  let sidecar: sinon.SinonStubbedInstance<SidecarHandle>;
+  let showErrorNotificationStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sidecar = getSidecarStub(sandbox);
+    showErrorNotificationStub = getShowErrorNotificationWithButtonsStub(sandbox);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Returns empty array and shows notification if query raises an error", async () => {
+    sidecar.query.rejects(new Error("Query failed"));
+
+    const result = await getEnvironments();
+
+    assert.deepStrictEqual(result, []);
+    sinon.assert.calledOnce(showErrorNotificationStub);
+  });
+
+  it("Returns empty array if no environments are returned", async () => {
+    sidecar.query.resolves({ ccloudConnectionById: { environments: null } });
+    const result = await getEnvironments();
+    assert.deepStrictEqual(result, []);
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+
+  it("Returns empty array if no environments are found", async () => {
+    sidecar.query.resolves({ ccloudConnectionById: { environments: [] } });
+
+    const result = await getEnvironments();
+
+    assert.deepStrictEqual(result, []);
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+
+  it("Handles degenerate environments from graphql", async () => {
+    sidecar.query.resolves({ ccloudConnectionById: { environments: [null, null] } });
+
+    const result = await getEnvironments();
+
+    assert.deepStrictEqual(result, []);
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+
+  it("Returns environments with sorted Kafka clusters", async () => {
+    const mockEnvironments = {
+      ccloudConnectionById: {
+        environments: [
+          {
+            id: "env1",
+            name: "Environment 1",
+            governancePackage: "package1",
+            kafkaClusters: [
+              // Note: The order of these clusters is reversed to test sorting
+              {
+                id: "kafka2",
+                name: "Kafka Cluster 2",
+                provider: "aws",
+                region: "us-west-2",
+                bootstrapServers: "kafka2.example.com",
+                uri: "kafka2-uri",
+              },
+              {
+                id: "kafka1",
+                name: "Kafka Cluster 1",
+                provider: "aws",
+                region: "us-east-1",
+                bootstrapServers: "kafka1.example.com",
+                uri: "kafka1-uri",
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    sidecar.query.resolves(mockEnvironments);
+
+    const result = await getEnvironments();
+
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].id, "env1");
+    assert.strictEqual(result[0].name, "Environment 1");
+    assert.strictEqual(result[0].kafkaClusters.length, 2);
+    assert.strictEqual(result[0].kafkaClusters[0].name, "Kafka Cluster 1");
+    assert.strictEqual(result[0].kafkaClusters[0].environmentId, "env1");
+    assert.strictEqual(result[0].kafkaClusters[1].name, "Kafka Cluster 2");
+    assert.strictEqual(result[0].kafkaClusters[0].environmentId, "env1");
+
+    assert.strictEqual(result[0].schemaRegistry, undefined);
+
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+
+  it("Returns environments with schema registries", async () => {
+    const mockEnvironments = {
+      ccloudConnectionById: {
+        environments: [
+          {
+            id: "env1",
+            name: "Environment 1",
+            governancePackage: "package1",
+            kafkaClusters: [
+              {
+                id: "kafka1",
+                name: "Kafka Cluster 1",
+                provider: "aws",
+                region: "us-east-1",
+                bootstrapServers: "kafka1.example.com",
+                uri: "kafka1-uri",
+              },
+            ],
+            schemaRegistry: {
+              id: "schema1",
+              provider: "aws",
+              region: "us-east-1",
+              uri: "schema1-uri",
+            },
+          },
+        ],
+      },
+    };
+
+    sidecar.query.resolves(mockEnvironments);
+    const result = await getEnvironments();
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].kafkaClusters.length, 1);
+    assert.strictEqual(result[0].schemaRegistry!.environmentId, "env1");
+
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+
+  it("Returns environments with Flink compute pools", async () => {
+    const mockEnvironments = {
+      ccloudConnectionById: {
+        environments: [
+          {
+            id: "env1",
+            name: "Environment 1",
+            governancePackage: "package1",
+            kafkaClusters: null,
+            schemaRegistry: null,
+            flinkComputePools: [
+              {
+                id: "flink1",
+                display_name: "Flink Pool 1",
+                provider: "aws",
+                region: "us-east-1",
+                max_cfu: 1000,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    sidecar.query.resolves(mockEnvironments);
+    const result = await getEnvironments();
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].flinkComputePools.length, 1);
+    assert.strictEqual(result[0].flinkComputePools[0].id, "flink1");
+    assert.strictEqual(result[0].flinkComputePools[0].environmentId, "env1");
+
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+
+  it("Returns environments sorted by name", async () => {
+    const mockEnvironments = {
+      ccloudConnectionById: {
+        environments: [
+          // Note: The order of these environments is reversed to test sorting
+          {
+            id: "env2",
+            name: "Environment 2",
+            governancePackage: "package",
+            kafkaClusters: [],
+            schemaRegistry: null,
+          },
+          {
+            id: "env1",
+            name: "Environment 1",
+            governancePackage: "package",
+            kafkaClusters: [],
+            schemaRegistry: null,
+          },
+        ],
+      },
+    };
+
+    sidecar.query.resolves(mockEnvironments);
+    const result = await getEnvironments();
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, "Environment 1");
+    assert.strictEqual(result[1].name, "Environment 2");
+    sinon.assert.notCalled(showErrorNotificationStub);
+  });
+});

--- a/tests/stubs/notifications.ts
+++ b/tests/stubs/notifications.ts
@@ -1,0 +1,9 @@
+import { SinonSandbox } from "sinon";
+import * as notifications from "../../src/notifications";
+
+/**
+ * Stub for the `showErrorNotificationWithButtons` function.
+ */
+export function getShowErrorNotificationWithButtonsStub(sandbox: SinonSandbox) {
+  return sandbox.stub(notifications, "showErrorNotificationWithButtons");
+}

--- a/tests/stubs/sidecar.ts
+++ b/tests/stubs/sidecar.ts
@@ -1,0 +1,14 @@
+import { SinonSandbox, SinonStubbedInstance } from "sinon";
+
+import * as sidecar from "../../src/sidecar";
+
+/**
+ * Wire up getSidecar() to return a stubbed instance of SidecarHandle, the one returned here for the
+ * caller to further configure as needed.
+ **/
+export function getSidecarStub(sandbox: SinonSandbox): SinonStubbedInstance<sidecar.SidecarHandle> {
+  const sidecarStub = sandbox.createStubInstance(sidecar.SidecarHandle);
+  sandbox.stub(sidecar, "getSidecar").resolves(sidecarStub);
+
+  return sidecarStub;
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Get test coverage over the CCloud graphql query handler, `src/graphql/environments.ts::getEnvironments()`.
- While here, write new sinon stub generators for sidecar handle and notifications.showErrorNotificationWithButtons().

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1934 

![image](https://github.com/user-attachments/assets/ed02593e-624b-4443-9ae9-f8287dd576ea)


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
