### PR TITLE
Respell message viewer "Timestamp" message to "Refresh"

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -285,7 +285,7 @@ function messageViewerStartPollingCommand(
   /** Notify an active webview only after flushing the rest of updates. */
   const notifyUI = () => {
     queueMicrotask(() => {
-      if (panelActive()) panel.webview.postMessage(["Timestamp", "Success", Date.now()]);
+      if (panelActive()) panel.webview.postMessage(["Refresh", "Success", null]);
     });
   };
 

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -566,7 +566,7 @@ class MessageViewerViewModel extends ViewModel {
         if (!signal.aborted) result(value);
       }
       function handle(event: MessageEvent<any[]>) {
-        if (event.data[0] === "Timestamp") update();
+        if (event.data[0] === "Refresh") update();
       }
       addEventListener("message", handle, { signal });
       update();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Respell message viewer "Timestamp" vscode -> webview message to "Refresh" to better indicate that it is a message to get the UI to repaint, and that nothing timestamp-y is really needed here.
- Per discussion with @alexeyraspopov
- Clicked, continues to work and repaint fine.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
