### PR TITLE
feat: add preview setting for enabling Flink SQL CCloud language server integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -795,7 +795,7 @@
         "properties": {
           "confluent.flink.enableConfluentCloudLanguageServer": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "markdownDescription": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents. (Requires [signing in to Confluent Cloud](command:confluent.connections.ccloud.signIn).)",
             "tags": [
               "preview"

--- a/package.json
+++ b/package.json
@@ -796,7 +796,7 @@
           "confluent.flink.enableConfluentCloudLanguageServer": {
             "type": "boolean",
             "default": true,
-            "description": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents.",
+            "markdownDescription": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents. (Requires [signing in to Confluent Cloud](command:confluent.connections.ccloud.signIn).)",
             "tags": [
               "preview"
             ]

--- a/package.json
+++ b/package.json
@@ -793,6 +793,14 @@
       {
         "title": "Flink SQL Defaults",
         "properties": {
+          "confluent.flink.enableConfluentCloudLanguageServer": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents.",
+            "tags": [
+              "preview"
+            ]
+          },
           "confluent.flink.computePoolId": {
             "type": "string",
             "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,11 @@ import { FlinkStatementDocumentProvider } from "./documentProviders/flinkStateme
 import { MESSAGE_URI_SCHEME, MessageDocumentProvider } from "./documentProviders/message";
 import { SCHEMA_URI_SCHEME, SchemaDocumentProvider } from "./documentProviders/schema";
 import { logError } from "./errors";
-import { ENABLE_CHAT_PARTICIPANT } from "./extensionSettings/constants";
+import {
+  ENABLE_CHAT_PARTICIPANT,
+  ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
+  ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT,
+} from "./extensionSettings/constants";
 import { createConfigChangeListener } from "./extensionSettings/listener";
 import { updatePreferences } from "./extensionSettings/sidecarSync";
 import {
@@ -243,12 +247,20 @@ async function _activateExtension(
     uriHandler,
     WebsocketManager.getInstance(),
     FlinkStatementManager.getInstance(),
-    initializeFlinkLanguageClientManager(),
     ...authProviderDisposables,
     ...viewProviderDisposables,
     ...registeredCommands,
     ...documentProviders,
   );
+
+  const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+  // if the Flink CCloud language server setting is enabled, get the client manager ready for use
+  if (
+    config.get(ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER, ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT)
+  ) {
+    const flinkLanguageClientManager = initializeFlinkLanguageClientManager();
+    context.subscriptions.push(flinkLanguageClientManager);
+  }
 
   // these are also just handling command registration and setting disposables
   activateMessageViewer(context);

--- a/src/extensionSettings/constants.ts
+++ b/src/extensionSettings/constants.ts
@@ -42,8 +42,6 @@ export const USE_TOPIC_NAME_STRATEGY =
 export const ALLOW_OLDER_SCHEMA_VERSIONS =
   prefix + "topic.produceMessages.schemas.allowOlderVersions";
 
-export const ENABLE_CHAT_PARTICIPANT = prefix + "experimental.enableChatParticipant";
-
 /** Default Flink compute pool ID. */
 export const FLINK_CONFIG_COMPUTE_POOL = prefix + "flink.computePoolId";
 /** Default Flink database (Kafka cluster) ID. */
@@ -92,3 +90,13 @@ export const CHAT_SEND_ERROR_DATA = prefix + "chat.telemetry.sendErrorData";
  * Also affects whether we include tool call inputs in general tool-handling telemetry events.
  */
 export const CHAT_SEND_TOOL_CALL_DATA = prefix + "chat.telemetry.sendToolCallData";
+
+// --- EXPERIMENTAL / PREVIEW SETTINGS ---
+
+/** Whether or not to enable the Confluent Cloud language client+server integration for Flink SQL documents. */
+export const ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER =
+  prefix + "flink.enableConfluentCloudLanguageServer";
+export const ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT = true;
+
+/** Whether or not to enable the `@Confluent` chat participant and associated tools. */
+export const ENABLE_CHAT_PARTICIPANT = prefix + "experimental.enableChatParticipant";

--- a/src/extensionSettings/constants.ts
+++ b/src/extensionSettings/constants.ts
@@ -96,7 +96,7 @@ export const CHAT_SEND_TOOL_CALL_DATA = prefix + "chat.telemetry.sendToolCallDat
 /** Whether or not to enable the Confluent Cloud language client+server integration for Flink SQL documents. */
 export const ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER =
   prefix + "flink.enableConfluentCloudLanguageServer";
-export const ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT = true;
+export const ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT = false;
 
 /** Whether or not to enable the `@Confluent` chat participant and associated tools. */
 export const ENABLE_CHAT_PARTICIPANT = prefix + "experimental.enableChatParticipant";

--- a/src/extensionSettings/listener.test.ts
+++ b/src/extensionSettings/listener.test.ts
@@ -14,7 +14,7 @@ import {
 import { createConfigChangeListener } from "./listener";
 import * as updates from "./sidecarSync";
 
-describe("preferences/listener", function () {
+describe("extensionSettings/listener.ts", function () {
   let sandbox: sinon.SinonSandbox;
   let getConfigurationStub: sinon.SinonStub;
   let onDidChangeConfigurationStub: sinon.SinonStub;

--- a/src/extensionSettings/listener.test.ts
+++ b/src/extensionSettings/listener.test.ts
@@ -151,9 +151,6 @@ describe("extensionSettings/listener.ts", function () {
     const stubbedFlinkLanguageClientManager = sandbox.createStubInstance(
       FlinkLanguageClientManager,
     );
-    // need to explicitly stub the private method since createStubInstance doesn't
-    const maybeStartLanguageClientStub = sandbox.stub().resolves();
-    stubbedFlinkLanguageClientManager["maybeStartLanguageClient"] = maybeStartLanguageClientStub;
     sandbox
       .stub(FlinkLanguageClientManager, "getInstance")
       .returns(stubbedFlinkLanguageClientManager);
@@ -166,7 +163,7 @@ describe("extensionSettings/listener.ts", function () {
     createConfigChangeListener();
     await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
 
-    sinon.assert.called(maybeStartLanguageClientStub);
+    sinon.assert.called(stubbedFlinkLanguageClientManager.maybeStartLanguageClient);
     sinon.assert.calledWith(logUsageStub, telemetryEvents.UserEvent.ExtensionSettingsChange, {
       settingId: ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
       enabled: true,

--- a/src/extensionSettings/listener.ts
+++ b/src/extensionSettings/listener.ts
@@ -84,7 +84,7 @@ export function createConfigChangeListener(): Disposable {
           // start the Flink Language Client Manager up if it isn't already running
           // (this is typically done internally based on various events, but we want to ensure
           // it starts up when the user opts in to the feature)
-          manager["maybeStartLanguageClient"]();
+          manager.maybeStartLanguageClient();
         } else {
           // stop the Flink Language Client Manager if it's running
           manager.dispose();

--- a/src/extensionSettings/listener.ts
+++ b/src/extensionSettings/listener.ts
@@ -72,10 +72,11 @@ export function createConfigChangeListener(): Disposable {
 
       if (event.affectsConfiguration(ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER)) {
         // user toggled the "Enable Flink CCloud Language Server" preview setting
-        const enabled: boolean = configs.get(
-          ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
-          ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT,
-        );
+        const enabled: boolean =
+          configs.get(
+            ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
+            ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT,
+          ) ?? false;
         logger.debug(`"${ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER}" config changed`, { enabled });
 
         const manager = FlinkLanguageClientManager.getInstance();

--- a/src/extensionSettings/listener.ts
+++ b/src/extensionSettings/listener.ts
@@ -77,13 +77,18 @@ export function createConfigChangeListener(): Disposable {
           ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT,
         );
         logger.debug(`"${ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER}" config changed`, { enabled });
+
+        const manager = FlinkLanguageClientManager.getInstance();
         if (enabled) {
           // start the Flink Language Client Manager up if it isn't already running
-          FlinkLanguageClientManager.getInstance();
+          // (this is typically done internally based on various events, but we want to ensure
+          // it starts up when the user opts in to the feature)
+          manager["maybeStartLanguageClient"]();
         } else {
           // stop the Flink Language Client Manager if it's running
-          FlinkLanguageClientManager.getInstance().dispose();
+          manager.dispose();
         }
+
         // telemetry for how often users opt in or out of the Flink CCloud Language Server feature
         logUsage(UserEvent.ExtensionSettingsChange, {
           settingId: ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,

--- a/src/extensionSettings/listener.ts
+++ b/src/extensionSettings/listener.ts
@@ -6,6 +6,7 @@ import { logUsage, UserEvent } from "../telemetry/events";
 import {
   ENABLE_CHAT_PARTICIPANT,
   ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
+  ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT,
   KRB5_CONFIG_PATH,
   LOCAL_DOCKER_SOCKET_PATH,
   SSL_PEM_PATHS,
@@ -71,7 +72,10 @@ export function createConfigChangeListener(): Disposable {
 
       if (event.affectsConfiguration(ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER)) {
         // user toggled the "Enable Flink CCloud Language Server" preview setting
-        const enabled = configs.get(ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER, false);
+        const enabled: boolean = configs.get(
+          ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
+          ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER_DEFAULT,
+        );
         logger.debug(`"${ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER}" config changed`, { enabled });
         if (enabled) {
           // start the Flink Language Client Manager up if it isn't already running

--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -21,7 +21,7 @@ import {
 import * as updates from "./sidecarSync";
 import { loadPreferencesFromWorkspaceConfig } from "./sidecarSync";
 
-describe("preferences/updates", function () {
+describe("extensionSettings/sidecarSync.ts", function () {
   let sandbox: sinon.SinonSandbox;
   let mockClient: sinon.SinonStubbedInstance<PreferencesResourceApi>;
   let getConfigurationStub: sinon.SinonStub;

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -90,7 +90,7 @@ export class FlinkLanguageClientManager implements Disposable {
       workspace.onDidChangeConfiguration(async (e) => {
         if (e.affectsConfiguration(ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER)) {
           // guard against any toggling of this setting, since its behavior is handled
-          // at the `src/preferences/listener.ts` level
+          // at the `src/extensionSettings/listener.ts` level
           return;
         }
         // real default settings changes

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -1,8 +1,19 @@
-import { Disposable, WorkspaceConfiguration, commands, window, workspace } from "vscode";
+import {
+  Disposable,
+  LogOutputChannel,
+  WorkspaceConfiguration,
+  commands,
+  window,
+  workspace,
+} from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudConnected } from "../emitters";
-import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../extensionSettings/constants";
+import {
+  ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
+  FLINK_CONFIG_COMPUTE_POOL,
+  FLINK_CONFIG_DATABASE,
+} from "../extensionSettings/constants";
 import { getEnvironments } from "../graphql/environments";
 import { getCurrentOrganization } from "../graphql/organizations";
 import { Logger } from "../logging";
@@ -10,6 +21,7 @@ import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { SIDECAR_PORT } from "../sidecar/constants";
 import { initializeLanguageClient } from "./languageClient";
+import { getFlinkSQLLanguageServerOutputChannel } from "./logging";
 
 const logger = new Logger("flinkLanguageClientManager");
 
@@ -42,6 +54,9 @@ export class FlinkLanguageClientManager implements Disposable {
   }
 
   private constructor() {
+    // make sure we dispose the output channel when the manager is disposed
+    const outputChannel: LogOutputChannel = getFlinkSQLLanguageServerOutputChannel();
+    this.disposables.push(outputChannel);
     this.registerListeners();
   }
 
@@ -70,6 +85,12 @@ export class FlinkLanguageClientManager implements Disposable {
     // Monitor Flink settings changes
     this.disposables.push(
       workspace.onDidChangeConfiguration(async (e) => {
+        if (e.affectsConfiguration(ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER)) {
+          // guard against any toggling of this setting, since its behavior is handled
+          // at the `src/preferences/listener.ts` level
+          return;
+        }
+        // real default settings changes
         if (e.affectsConfiguration("confluent.flink")) {
           if (this.languageClient) {
             await this.notifyConfigChanged();
@@ -380,6 +401,7 @@ export class FlinkLanguageClientManager implements Disposable {
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];
     FlinkLanguageClientManager.instance = null; // reset singleton instance to clear state
+    logger.debug("FlinkLanguageClientManager disposed");
   }
 }
 

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -379,6 +379,7 @@ export class FlinkLanguageClientManager implements Disposable {
     await this.cleanupLanguageClient();
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];
+    FlinkLanguageClientManager.instance = null; // reset singleton instance to clear state
   }
 }
 

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -21,7 +21,10 @@ import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { SIDECAR_PORT } from "../sidecar/constants";
 import { initializeLanguageClient } from "./languageClient";
-import { getFlinkSQLLanguageServerOutputChannel } from "./logging";
+import {
+  clearFlinkSQLLanguageServerOutputChannel,
+  getFlinkSQLLanguageServerOutputChannel,
+} from "./logging";
 
 const logger = new Logger("flinkLanguageClientManager");
 
@@ -401,6 +404,7 @@ export class FlinkLanguageClientManager implements Disposable {
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];
     FlinkLanguageClientManager.instance = null; // reset singleton instance to clear state
+    clearFlinkSQLLanguageServerOutputChannel();
     logger.debug("FlinkLanguageClientManager disposed");
   }
 }

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -235,7 +235,7 @@ export class FlinkLanguageClientManager implements Disposable {
    * - User has opened a Flink SQL file
    * - User has not disabled Flink in settings
    */
-  private async maybeStartLanguageClient(): Promise<void> {
+  public async maybeStartLanguageClient(): Promise<void> {
     if (this.languageClient) {
       if (this.isLanguageClientConnected()) {
         // If we already have a client and it's healthy we're cool

--- a/src/flinkSql/logging.ts
+++ b/src/flinkSql/logging.ts
@@ -14,3 +14,12 @@ export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
   }
   return languageServerOutputChannel;
 }
+
+/**
+ * Reset the Flink SQL language server output channel.
+ * This is done whenever `FlinkLanguageClientManager` is disposed to ensure a new output channel is
+ * created when the language client is restarted.
+ */
+export function clearFlinkSQLLanguageServerOutputChannel(): void {
+  languageServerOutputChannel = undefined;
+}

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -22,6 +22,13 @@ export enum UserEvent {
   FlinkStatementAction = "Flink Statement Action",
   FlinkStatementViewStatistics = "Flink Statement View Statistics",
   CopilotInteraction = "Copilot Interaction",
+  /**
+   * Used for basic settings changes like enabling/disabling a feature or changing enum/numeric
+   * values.
+   *
+   * This SHOULD NEVER be used for potentially sensitive string values like file paths, usernames, passwords, etc.
+   */
+  ExtensionSettingsChange = "Extension Settings Change",
 }
 
 /** Log a {@link UserEvent} with optional extra data. */


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Add a new setting to control whether or not the Flink SQL language client/server integration is enabled:


https://github.com/user-attachments/assets/2b40e968-8adf-4537-8529-9246ef3ffc56



## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This PR also lets the `FlinkLanguageClientManager` be in control of the "Confluent Flink SQL Language Server" output channel's lifecycle, so whenever it's disposed -- (which should only be on extension deactivation after this setting is removed) -- the output channel is disposed (and cleared in `src/flinkSql/logging.ts`)
- Special attention to the new user event enum value + comment for telemetry purposes: https://github.com/confluentinc/vscode/blob/e5fe565110e1fb52a74243d9f445bcced81f5ac9/src/telemetry/events.ts#L25-L31

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
