### PR TITLE
Fixed Sentry Rollup Plugin link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Confluent can make it even more useful.
 The extension uses [Sentry](https://sentry.io) to capture and analyze errors, which enables more
 robust and friendly error debugging. It is the first item initialized in `extension.ts`, so that it
 can send any uncaught exceptions globally, and it's invoked in certain catch blocks to send specific
-errors. The [@sentry/rollup-plugin](#) is used to upload source maps.
+errors. The [@sentry/rollup-plugin](https://www.npmjs.com/package/@sentry/rollup-plugin) is used to upload source maps.
 
 ## Additional References
 


### PR DESCRIPTION
## Summary of Changes
<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
- Updated the broken Sentry Rollup Plugin link in the README to point to the correct resource. Verified that the change aligns with the intended documentation structure and improves accessibility for contributors. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
- Before: The README contained an outdated Sentry Rollup Plugin link, leading to a broken reference.  [@sentry/rollup-plugin] (https://github.com/confluentinc/vscode#)

- After: The updated link correctly points to the plugin documentation, ensuring contributors can access the relevant details without issue.  [@sentry/rollup-plugin] (https://www.npmjs.com/package/@sentry/rollup-plugin)

- Validation: The extension was successfully built and installed using gulp clicktest, confirming that no unexpected issues were introduced

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

  [X ] No new tests required (documentation update).

##### Other
<!-- prettier-ignore -->
  [X ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
  **Yes, this update affects documentation.**

  [X ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
   **Yes, validated using gulp clicktest.**

  ```shell
  gulp clicktest
  ```
