### PR TITLE
Integrate code from standalone getTopicsForCluster() into getChildren().

### DIFF
--- a/src/loaders/loaderUtils.ts
+++ b/src/loaders/loaderUtils.ts
@@ -61,7 +61,6 @@ export async function fetchTopics(cluster: KafkaCluster): Promise<TopicData[]> {
         });
         return [];
       }
-      // XXX todo improve this, raise a more specific error type.
       const body = await error.response.json();
 
       throw new TopicFetchError(JSON.stringify(body));

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import { TreeItemCollapsibleState } from "vscode";
+import { TreeItemCollapsibleState, window } from "vscode";
 import {
   TEST_CCLOUD_ENVIRONMENT_ID,
   TEST_CCLOUD_KAFKA_CLUSTER,
@@ -15,6 +15,7 @@ import {
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { environmentChanged, topicSearchSet } from "../emitters";
 import { CCloudResourceLoader } from "../loaders";
+import { TopicFetchError } from "../loaders/loaderUtils";
 import { SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
 import { SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -99,6 +100,15 @@ describe("TopicViewProvider search behavior", () => {
 
     assert.strictEqual(rootElements.length, 1);
     assert.deepStrictEqual(rootElements[0], TEST_CCLOUD_KAFKA_TOPIC);
+  });
+
+  it("getChildren() should showErrorMessage if loader.getTopicsForCluster() raises TopicFetchError", async () => {
+    const showErrorMessageStub = sandbox.stub(window, "showErrorMessage");
+    getTopicsForClusterStub.rejects(new TopicFetchError("Test error"));
+
+    const shouldBeEmpty = await provider.getChildren();
+    sinon.assert.calledOnce(showErrorMessageStub);
+    assert.strictEqual(shouldBeEmpty.length, 0);
   });
 
   it("getChildren() should filter schema subject containers based on search string", async () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Function src/viewProviders/topics.ts::getTopicsForCluster() used to hold a lot of code. Over time that code migrated to the loaders, leaving only a little buggy stub. The bug was that it had a try/catch block, but was forgetting to await the code which may throw what was being caught.
- Remove the function and integrate its intent into its sole callpoint, within `TopicViewProvider::getChildren()`. Write new test proving that the intended notification is raised.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #1971

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
