### PR TITLE
MINOR: revert `contextualTitle`s change

### DIFF
--- a/package.json
+++ b/package.json
@@ -949,37 +949,32 @@
         {
           "id": "confluent-resources",
           "name": "Resources",
-          "icon": "$(confluent-logo)",
-          "contextualTitle": "Confluent: Resources"
+          "icon": "$(confluent-logo)"
         },
         {
           "id": "confluent-topics",
           "name": "Topics",
           "visibility": "collapsed",
-          "icon": "$(confluent-logo)",
-          "contextualTitle": "Confluent: Topics"
+          "icon": "$(confluent-logo)"
         },
         {
           "id": "confluent-schemas",
           "name": "Schemas",
           "visibility": "collapsed",
-          "icon": "$(confluent-logo)",
-          "contextualTitle": "Confluent: Schemas"
+          "icon": "$(confluent-logo)"
         },
         {
           "id": "confluent-flink-statements",
           "name": "Flink Statements",
           "visibility": "collapsed",
-          "icon": "$(confluent-logo)",
-          "contextualTitle": "Confluent: Flink Statements"
+          "icon": "$(confluent-logo)"
         },
         {
           "id": "confluent-flink-artifacts",
           "name": "Flink Artifacts",
           "visibility": "collapsed",
           "icon": "$(confluent-logo)",
-          "when": "false",
-          "contextualTitle": "Confluent: Flink Artifacts"
+          "when": "false"
         },
         {
           "id": "confluent-support",


### PR DESCRIPTION
Reverts the change from https://github.com/confluentinc/vscode/pull/1395 to add `contextualTitle`s to our views. These are really only used if we want to customize how views are displayed when inside **another** view container. By default, VS Code will prepend any view names with the extension name if we don't have `contextualTitle` set up, so this PR dedupes that behavior by letting VS Code handle the prefixing.

### Output (panel) view container
| Before | After |
|--------|--------|
| <img width="634" alt="image" src="https://github.com/user-attachments/assets/a0454e9c-5b11-4622-a7ab-319bc3a34533" /> | <img width="603" alt="image" src="https://github.com/user-attachments/assets/7d95b349-107d-4c54-90ad-dae46814ac1a" /> | 

### Custom view container based on user layout
There was previously some weird mixing of prefixes happening here, where the first view's `contextualTitle` would be used as the view container label, and any additional views added would include the `contextualTitle`+name:
| Before | After |
|--------|--------|
| <img width="629" alt="image" src="https://github.com/user-attachments/assets/242b857c-8399-4263-be13-518d74295798" /> |  <img width="597" alt="image" src="https://github.com/user-attachments/assets/f14a7c52-5837-4ba3-a093-71d84d1ab836" /> | 

Closes #1714 