### PR TITLE
feat: enable search in the Flink Satements view

### DIFF
--- a/package.json
+++ b/package.json
@@ -721,6 +721,17 @@
         "command": "confluent.connections.setKrb5ConfigPath",
         "title": "Set Kerberos krb5.conf Path",
         "category": "Confluent: Connections"
+      },
+      {
+        "command": "confluent.flink.statements.search",
+        "icon": "$(search)",
+        "title": "Search",
+        "category": "Confluent: Flink Statements View"
+      },
+      {
+        "command": "confluent.flink.statements.search.clear",
+        "title": "Clear Search",
+        "category": "Confluent: Flink Statements View"
       }
     ],
     "configuration": [
@@ -933,6 +944,12 @@
         "key": "ctrl+f",
         "mac": "cmd+f",
         "when": "focusedView == confluent-schemas"
+      },
+      {
+        "command": "confluent.flink.statements.search",
+        "key": "ctrl+f",
+        "mac": "cmd+f",
+        "when": "focusedView == confluent-flink-statements"
       }
     ],
     "viewsContainers": {
@@ -1047,7 +1064,12 @@
       {
         "view": "confluent-flink-statements",
         "contents": "No Flink statements found.",
-        "when": "confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected"
+        "when": "confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected && !confluent.flinkStatementsSearchApplied"
+      },
+      {
+        "view": "confluent-flink-statements",
+        "contents": "No Flink statements match search string. [Clear search](command:confluent.flink.statements.search.clear) or [try a new search](command:confluent.flink.statements.search).",
+        "when": "confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected && confluent.flinkStatementsSearchApplied"
       },
       {
         "view": "confluent-flink-artifacts",
@@ -1226,6 +1248,10 @@
         {
           "command": "confluent.resources.scaffold",
           "when": "false"
+        },
+        {
+          "command": "confluent.flink.statements.search.clear",
+          "when": "confluent.flinkStatementsSearchApplied"
         }
       ],
       "editor/title": [
@@ -1292,12 +1318,12 @@
         },
         {
           "command": "confluent.schemas.search",
-          "when": "view == confluent-schemas && !confluent.schemaSearchApplied",
+          "when": "view == confluent-schemas && confluent.schemaRegistrySelected && !confluent.schemaSearchApplied",
           "group": "navigation@1"
         },
         {
           "command": "confluent.schemas.search.clear",
-          "when": "view == confluent-schemas && confluent.schemaSearchApplied",
+          "when": "view == confluent-schemas && confluent.schemaRegistrySelected && confluent.schemaSearchApplied",
           "group": "navigation@1"
         },
         {
@@ -1317,7 +1343,7 @@
         },
         {
           "command": "confluent.schemas.refresh",
-          "when": "view == confluent-schemas",
+          "when": "view == confluent-schemas && confluent.schemaRegistrySelected",
           "group": "navigation@5"
         },
         {
@@ -1327,12 +1353,12 @@
         },
         {
           "command": "confluent.topics.search",
-          "when": "view == confluent-topics && !confluent.topicSearchApplied",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected && !confluent.topicSearchApplied",
           "group": "navigation@1"
         },
         {
           "command": "confluent.topics.search.clear",
-          "when": "view == confluent-topics && confluent.topicSearchApplied",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected && confluent.topicSearchApplied",
           "group": "navigation@1"
         },
         {
@@ -1347,7 +1373,7 @@
         },
         {
           "command": "confluent.topics.refresh",
-          "when": "view == confluent-topics",
+          "when": "view == confluent-topics && confluent.kafkaClusterSelected",
           "group": "navigation@4"
         },
         {
@@ -1366,24 +1392,34 @@
           "group": "2_copy@3"
         },
         {
+          "command": "confluent.flink.statements.search",
+          "when": "view == confluent-flink-statements && confluent.flinkStatementsPoolSelected && !confluent.flinkStatementsSearchApplied",
+          "group": "navigation@1"
+        },
+        {
+          "command": "confluent.flink.statements.search.clear",
+          "when": "view == confluent-flink-statements && confluent.flinkStatementsPoolSelected && confluent.flinkStatementsSearchApplied",
+          "group": "navigation@1"
+        },
+        {
           "command": "confluent.statements.create",
           "when": "view == confluent-flink-statements && confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "confluent.resources.ccloudenvironment.viewflinkstatements",
           "when": "view == confluent-flink-statements && confluent.ccloudConnectionAvailable",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "confluent.statements.flink-compute-pool.select",
           "when": "view == confluent-flink-statements && confluent.ccloudConnectionAvailable",
-          "group": "navigation@3"
+          "group": "navigation@4"
         },
         {
           "command": "confluent.statements.refresh",
           "when": "view == confluent-flink-statements && confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected",
-          "group": "navigation@4"
+          "group": "navigation@5"
         },
         {
           "command": "confluent.artifacts.flink-compute-pool.select",

--- a/src/commands/extra.ts
+++ b/src/commands/extra.ts
@@ -8,7 +8,6 @@ import {
   topicSearchSet,
 } from "../emitters";
 import { Logger } from "../logging";
-import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 
 const logger = new Logger("commands.extra");
 
@@ -87,14 +86,14 @@ async function searchTopics() {
   if (!searchString) {
     return;
   }
-  FlinkStatementsViewProvider.getInstance().setSearch(searchString);
+  await setContextValue(ContextValues.topicSearchApplied, true);
   logger.debug("Searching topics");
   topicSearchSet.fire(searchString);
 }
 
 async function clearTopicSearch() {
   logger.debug("Clearing topic search");
-  FlinkStatementsViewProvider.getInstance().setSearch(null);
+  await setContextValue(ContextValues.topicSearchApplied, false);
   topicSearchSet.fire(null);
 }
 

--- a/src/commands/extra.ts
+++ b/src/commands/extra.ts
@@ -1,8 +1,14 @@
 import { Disposable, env, Uri, window } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
-import { resourceSearchSet, schemaSearchSet, topicSearchSet } from "../emitters";
+import {
+  flinkStatementSearchSet,
+  resourceSearchSet,
+  schemaSearchSet,
+  topicSearchSet,
+} from "../emitters";
 import { Logger } from "../logging";
+import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 
 const logger = new Logger("commands.extra");
 
@@ -81,14 +87,14 @@ async function searchTopics() {
   if (!searchString) {
     return;
   }
-  await setContextValue(ContextValues.topicSearchApplied, true);
+  FlinkStatementsViewProvider.getInstance().setSearch(searchString);
   logger.debug("Searching topics");
   topicSearchSet.fire(searchString);
 }
 
 async function clearTopicSearch() {
   logger.debug("Clearing topic search");
-  await setContextValue(ContextValues.topicSearchApplied, false);
+  FlinkStatementsViewProvider.getInstance().setSearch(null);
   topicSearchSet.fire(null);
 }
 
@@ -111,6 +117,25 @@ async function clearSchemaSearch() {
   schemaSearchSet.fire(null);
 }
 
+async function searchFlinkStatements() {
+  const searchString = await window.showInputBox({
+    title: "Search items in the Flink Statements view",
+    ignoreFocusOut: true,
+  });
+  if (!searchString) {
+    return;
+  }
+  logger.debug("Searching Flink statements");
+  // not setting ContextValues.flinkStatementsSearchApplied here because the view provider will handle it
+  flinkStatementSearchSet.fire(searchString);
+}
+
+async function clearFlinkStatementsSearch() {
+  logger.debug("Clearing Flink statements search");
+  // not setting ContextValues.flinkStatementsSearchApplied here because the view provider will handle it
+  flinkStatementSearchSet.fire(null);
+}
+
 export function registerExtraCommands(): Disposable[] {
   return [
     registerCommandWithLogging("confluent.openCCloudLink", openCCloudLink),
@@ -124,5 +149,10 @@ export function registerExtraCommands(): Disposable[] {
     registerCommandWithLogging("confluent.topics.search.clear", clearTopicSearch),
     registerCommandWithLogging("confluent.schemas.search", searchSchemas),
     registerCommandWithLogging("confluent.schemas.search.clear", clearSchemaSearch),
+    registerCommandWithLogging("confluent.flink.statements.search", searchFlinkStatements),
+    registerCommandWithLogging(
+      "confluent.flink.statements.search.clear",
+      clearFlinkStatementsSearch,
+    ),
   ];
 }

--- a/src/commands/extra.ts
+++ b/src/commands/extra.ts
@@ -1,12 +1,5 @@
 import { Disposable, env, Uri, window } from "vscode";
 import { registerCommandWithLogging } from ".";
-import { ContextValues, setContextValue } from "../context/values";
-import {
-  flinkStatementSearchSet,
-  resourceSearchSet,
-  schemaSearchSet,
-  topicSearchSet,
-} from "../emitters";
 import { Logger } from "../logging";
 
 const logger = new Logger("commands.extra");
@@ -59,82 +52,6 @@ async function copyResourceUri(item: any) {
   window.showInformationMessage(`Copied "${item.uri}" to clipboard.`);
 }
 
-async function searchResources() {
-  const searchString = await window.showInputBox({
-    title: "Search items in the Resources view",
-    ignoreFocusOut: true,
-  });
-  if (!searchString) {
-    return;
-  }
-  await setContextValue(ContextValues.resourceSearchApplied, true);
-  logger.debug("Searching resources");
-  resourceSearchSet.fire(searchString);
-}
-
-async function clearResourceSearch() {
-  logger.debug("Clearing resource search");
-  await setContextValue(ContextValues.resourceSearchApplied, false);
-  resourceSearchSet.fire(null);
-}
-
-async function searchTopics() {
-  const searchString = await window.showInputBox({
-    title: "Search items in the Topics view",
-    ignoreFocusOut: true,
-  });
-  if (!searchString) {
-    return;
-  }
-  await setContextValue(ContextValues.topicSearchApplied, true);
-  logger.debug("Searching topics");
-  topicSearchSet.fire(searchString);
-}
-
-async function clearTopicSearch() {
-  logger.debug("Clearing topic search");
-  await setContextValue(ContextValues.topicSearchApplied, false);
-  topicSearchSet.fire(null);
-}
-
-async function searchSchemas() {
-  const searchString = await window.showInputBox({
-    title: "Search items in the Schemas view",
-    ignoreFocusOut: true,
-  });
-  if (!searchString) {
-    return;
-  }
-  await setContextValue(ContextValues.schemaSearchApplied, true);
-  logger.debug("Searching schemas");
-  schemaSearchSet.fire(searchString);
-}
-
-async function clearSchemaSearch() {
-  logger.debug("Clearing schema search");
-  await setContextValue(ContextValues.schemaSearchApplied, false);
-  schemaSearchSet.fire(null);
-}
-
-async function searchFlinkStatements() {
-  const searchString = await window.showInputBox({
-    title: "Search items in the Flink Statements view",
-    ignoreFocusOut: true,
-  });
-  if (!searchString) {
-    return;
-  }
-  logger.debug("Searching Flink statements");
-  // not setting ContextValues.flinkStatementsSearchApplied here because the view provider will handle it
-  flinkStatementSearchSet.fire(searchString);
-}
-
-async function clearFlinkStatementsSearch() {
-  logger.debug("Clearing Flink statements search");
-  // not setting ContextValues.flinkStatementsSearchApplied here because the view provider will handle it
-  flinkStatementSearchSet.fire(null);
-}
-
 export function registerExtraCommands(): Disposable[] {
   return [
     registerCommandWithLogging("confluent.openCCloudLink", openCCloudLink),
@@ -142,16 +59,5 @@ export function registerExtraCommands(): Disposable[] {
     registerCommandWithLogging("confluent.copyResourceId", copyResourceId),
     registerCommandWithLogging("confluent.copyResourceName", copyResourceName),
     registerCommandWithLogging("confluent.copyResourceUri", copyResourceUri),
-    registerCommandWithLogging("confluent.resources.search", searchResources),
-    registerCommandWithLogging("confluent.resources.search.clear", clearResourceSearch),
-    registerCommandWithLogging("confluent.topics.search", searchTopics),
-    registerCommandWithLogging("confluent.topics.search.clear", clearTopicSearch),
-    registerCommandWithLogging("confluent.schemas.search", searchSchemas),
-    registerCommandWithLogging("confluent.schemas.search.clear", clearSchemaSearch),
-    registerCommandWithLogging("confluent.flink.statements.search", searchFlinkStatements),
-    registerCommandWithLogging(
-      "confluent.flink.statements.search.clear",
-      clearFlinkStatementsSearch,
-    ),
   ];
 }

--- a/src/commands/search.test.ts
+++ b/src/commands/search.test.ts
@@ -1,0 +1,195 @@
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import * as context from "../context/values";
+import {
+  flinkStatementSearchSet,
+  resourceSearchSet,
+  schemaSearchSet,
+  topicSearchSet,
+} from "../emitters";
+import {
+  searchResources,
+  clearResourceSearch,
+  searchTopics,
+  clearTopicSearch,
+  searchSchemas,
+  clearSchemaSearch,
+  searchFlinkStatements,
+  clearFlinkStatementsSearch,
+} from "./search";
+
+describe("commands/search.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let showInputBoxStub: sinon.SinonStub;
+  let setContextValueStub: sinon.SinonStub;
+  let resourceSearchSetFireStub: sinon.SinonStub;
+  let topicSearchSetFireStub: sinon.SinonStub;
+  let schemaSearchSetFireStub: sinon.SinonStub;
+  let flinkStatementSearchSetFireStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    showInputBoxStub = sandbox.stub(vscode.window, "showInputBox");
+
+    setContextValueStub = sandbox.stub(context, "setContextValue");
+
+    resourceSearchSetFireStub = sandbox.stub(resourceSearchSet, "fire");
+    topicSearchSetFireStub = sandbox.stub(topicSearchSet, "fire");
+    schemaSearchSetFireStub = sandbox.stub(schemaSearchSet, "fire");
+    flinkStatementSearchSetFireStub = sandbox.stub(flinkStatementSearchSet, "fire");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("searchResources() should exit early when no search string is provided", async () => {
+    // simulate the user cancelling the input box
+    showInputBoxStub.resolves(undefined);
+
+    await searchResources();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(resourceSearchSetFireStub);
+  });
+
+  it(`searchResources() should set ${context.ContextValues.resourceSearchApplied}=true and fire resourceSearchSet with the provided search string`, async () => {
+    const searchString = "test-search";
+    showInputBoxStub.resolves(searchString);
+
+    await searchResources();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledWith(
+      showInputBoxStub.firstCall,
+      sinon.match({
+        title: "Search items in the Resources view",
+        ignoreFocusOut: true,
+      }),
+    );
+    sinon.assert.calledWith(setContextValueStub, context.ContextValues.resourceSearchApplied, true);
+    sinon.assert.calledWith(resourceSearchSetFireStub, searchString);
+  });
+
+  it(`clearResourceSearch() should set ${context.ContextValues.resourceSearchApplied}=false and fire resourceSearchSet with null`, async () => {
+    await clearResourceSearch();
+
+    sinon.assert.calledWith(
+      setContextValueStub,
+      context.ContextValues.resourceSearchApplied,
+      false,
+    );
+    sinon.assert.calledWith(resourceSearchSetFireStub, null);
+  });
+
+  it("searchTopics() should exit early when no search string is provided", async () => {
+    // simulate the user cancelling the input box
+    showInputBoxStub.resolves(undefined);
+
+    await searchTopics();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(topicSearchSetFireStub);
+  });
+
+  it(`searchTopics() should set ${context.ContextValues.topicSearchApplied}=true and fire topicSearchSet with the provided search string`, async () => {
+    const searchString = "test-search";
+    showInputBoxStub.resolves(searchString);
+
+    await searchTopics();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledWith(
+      showInputBoxStub.firstCall,
+      sinon.match({
+        title: "Search items in the Topics view",
+        ignoreFocusOut: true,
+      }),
+    );
+    sinon.assert.calledWith(setContextValueStub, context.ContextValues.topicSearchApplied, true);
+    sinon.assert.calledWith(topicSearchSetFireStub, searchString);
+  });
+
+  it(`clearTopicSearch() should set ${context.ContextValues.topicSearchApplied}=false and fire topicSearchSet with null`, async () => {
+    await clearTopicSearch();
+
+    sinon.assert.calledWith(setContextValueStub, context.ContextValues.topicSearchApplied, false);
+    sinon.assert.calledWith(topicSearchSetFireStub, null);
+  });
+
+  it("searchSchemas() should exit early when no search string is provided", async () => {
+    // simulate the user cancelling the input box
+    showInputBoxStub.resolves(undefined);
+
+    await searchSchemas();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(schemaSearchSetFireStub);
+  });
+
+  it(`searchSchemas() should set ${context.ContextValues.schemaSearchApplied}=true and fire schemaSearchSet with the provided search string`, async () => {
+    const searchString = "test-search";
+    showInputBoxStub.resolves(searchString);
+
+    await searchSchemas();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledWith(
+      showInputBoxStub.firstCall,
+      sinon.match({
+        title: "Search items in the Schemas view",
+        ignoreFocusOut: true,
+      }),
+    );
+    sinon.assert.calledWith(setContextValueStub, context.ContextValues.schemaSearchApplied, true);
+    sinon.assert.calledWith(schemaSearchSetFireStub, searchString);
+  });
+
+  it(`clearSchemaSearch() should set ${context.ContextValues.schemaSearchApplied}=false and fire schemaSearchSet with null`, async () => {
+    await clearSchemaSearch();
+
+    sinon.assert.calledWith(setContextValueStub, context.ContextValues.schemaSearchApplied, false);
+    sinon.assert.calledWith(schemaSearchSetFireStub, null);
+  });
+
+  it("searchFlinkStatements() should exit early when no search string is provided", async () => {
+    // simulate the user cancelling the input box
+    showInputBoxStub.resolves(undefined);
+
+    await searchFlinkStatements();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.notCalled(flinkStatementSearchSetFireStub);
+  });
+
+  it("searchFlinkStatements() should fire flinkStatementSearchSet with the provided search string", async () => {
+    const searchString = "test-search";
+    showInputBoxStub.resolves(searchString);
+
+    await searchFlinkStatements();
+
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledWith(
+      showInputBoxStub.firstCall,
+      sinon.match({
+        title: "Search items in the Flink Statements view",
+        ignoreFocusOut: true,
+      }),
+    );
+    // context should not be set directly as we migrate to BaseViewProvider handling it
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.calledWith(flinkStatementSearchSetFireStub, searchString);
+  });
+
+  it("clearFlinkStatementsSearch() should fire flinkStatementSearchSet with null", async () => {
+    await clearFlinkStatementsSearch();
+
+    // context should not be set directly as we migrate to BaseViewProvider handling it
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.calledWith(flinkStatementSearchSetFireStub, null);
+  });
+});

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,0 +1,104 @@
+import { Disposable, window } from "vscode";
+import { registerCommandWithLogging } from ".";
+import { ContextValues, setContextValue } from "../context/values";
+import {
+  flinkStatementSearchSet,
+  resourceSearchSet,
+  schemaSearchSet,
+  topicSearchSet,
+} from "../emitters";
+import { Logger } from "../logging";
+
+const logger = new Logger("commands.search");
+
+export function registerSearchCommands(): Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.resources.search", searchResources),
+    registerCommandWithLogging("confluent.resources.search.clear", clearResourceSearch),
+    registerCommandWithLogging("confluent.topics.search", searchTopics),
+    registerCommandWithLogging("confluent.topics.search.clear", clearTopicSearch),
+    registerCommandWithLogging("confluent.schemas.search", searchSchemas),
+    registerCommandWithLogging("confluent.schemas.search.clear", clearSchemaSearch),
+    registerCommandWithLogging("confluent.flink.statements.search", searchFlinkStatements),
+    registerCommandWithLogging(
+      "confluent.flink.statements.search.clear",
+      clearFlinkStatementsSearch,
+    ),
+  ];
+}
+
+export async function searchResources() {
+  const searchString = await window.showInputBox({
+    title: "Search items in the Resources view",
+    ignoreFocusOut: true,
+  });
+  if (!searchString) {
+    return;
+  }
+  await setContextValue(ContextValues.resourceSearchApplied, true);
+  logger.debug("Searching resources");
+  resourceSearchSet.fire(searchString);
+}
+
+export async function clearResourceSearch() {
+  logger.debug("Clearing resource search");
+  await setContextValue(ContextValues.resourceSearchApplied, false);
+  resourceSearchSet.fire(null);
+}
+
+export async function searchTopics() {
+  const searchString = await window.showInputBox({
+    title: "Search items in the Topics view",
+    ignoreFocusOut: true,
+  });
+  if (!searchString) {
+    return;
+  }
+  await setContextValue(ContextValues.topicSearchApplied, true);
+  logger.debug("Searching topics");
+  topicSearchSet.fire(searchString);
+}
+
+export async function clearTopicSearch() {
+  logger.debug("Clearing topic search");
+  await setContextValue(ContextValues.topicSearchApplied, false);
+  topicSearchSet.fire(null);
+}
+
+export async function searchSchemas() {
+  const searchString = await window.showInputBox({
+    title: "Search items in the Schemas view",
+    ignoreFocusOut: true,
+  });
+  if (!searchString) {
+    return;
+  }
+  await setContextValue(ContextValues.schemaSearchApplied, true);
+  logger.debug("Searching schemas");
+  schemaSearchSet.fire(searchString);
+}
+
+export async function clearSchemaSearch() {
+  logger.debug("Clearing schema search");
+  await setContextValue(ContextValues.schemaSearchApplied, false);
+  schemaSearchSet.fire(null);
+}
+
+export async function searchFlinkStatements() {
+  const searchString = await window.showInputBox({
+    title: "Search items in the Flink Statements view",
+    ignoreFocusOut: true,
+  });
+  if (!searchString) {
+    return;
+  }
+  logger.debug("Searching Flink statements");
+  // not setting ContextValues.flinkStatementsSearchApplied here because the view provider will handle it
+  flinkStatementSearchSet.fire(searchString);
+}
+
+export async function clearFlinkStatementsSearch() {
+  logger.debug("Clearing Flink statements search");
+  // not setting ContextValues.flinkStatementsSearchApplied here because the view provider will handle it
+  flinkStatementSearchSet.fire(null);
+}

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -125,6 +125,8 @@ export const resourceSearchSet = new vscode.EventEmitter<string | null>();
 export const topicSearchSet = new vscode.EventEmitter<string | null>();
 /** The user set/unset a filter for the Schemas view. */
 export const schemaSearchSet = new vscode.EventEmitter<string | null>();
+/** The user set/unset a filter for the Flink Statements view. */
+export const flinkStatementSearchSet = new vscode.EventEmitter<string | null>();
 
 export const projectScaffoldUri = new vscode.EventEmitter<vscode.Uri>();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import { registerOrganizationCommands } from "./commands/organizations";
 import { registerSchemaRegistryCommands } from "./commands/schemaRegistry";
 import { registerSchemaCommands } from "./commands/schemas";
 import { registerSupportCommands } from "./commands/support";
+import { registerSearchCommands } from "./commands/search";
 import { registerTopicCommands } from "./commands/topics";
 import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL, IconNames } from "./constants";
 import { activateMessageViewer } from "./consume";
@@ -236,6 +237,7 @@ async function _activateExtension(
     ...registerFlinkComputePoolCommands(),
     ...registerFlinkStatementCommands(),
     ...registerDocumentCommands(),
+    ...registerSearchCommands(),
   ];
   logger.info("Commands registered");
 

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -364,8 +364,8 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     await provider.setSearch(null);
 
     assert.strictEqual(provider.itemSearchString, null);
-    assert.strictEqual(provider.searchMatches.size, 0);
-    assert.strictEqual(provider.totalItemCount, 0);
+    assert.strictEqual(provider.searchMatches.size, 0, "searchMatches should be cleared");
+    assert.strictEqual(provider.totalItemCount, 3, "totalItemCount should not change");
   });
 
   for (const arg of ["First", null]) {
@@ -390,13 +390,20 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   }
 
   for (const arg of ["First", null]) {
-    it(`should refresh the tree view when search is set (arg=${arg})`, async () => {
+    it(`should repait the tree view when search is set (arg=${arg})`, async () => {
       const provider = TestViewProvider.getInstance();
-      const refreshSpy = sandbox.spy(provider, "refresh");
+      const repaintSpy = sandbox.spy(provider["_onDidChangeTreeData"], "fire");
 
       await provider.setSearch(arg);
+      // Would normally be called by the tree view when children are requested
+      // after setSearch() but we call it directly here to get totalItemCount assigned.
+      await provider.getChildren();
 
-      sinon.assert.calledOnce(refreshSpy);
+      assert.strictEqual(provider.itemSearchString, arg);
+      assert.strictEqual(provider.searchMatches.size, 0);
+      assert.strictEqual(provider.totalItemCount, 3);
+
+      sinon.assert.calledOnce(repaintSpy);
     });
   }
 

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -345,23 +345,23 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     BaseViewProvider["instanceMap"].clear();
   });
 
-  it("should set internal search state when a value is passed", () => {
+  it("should set internal search state when a value is passed", async () => {
     const provider = TestViewProvider.getInstance();
 
-    provider.setSearch("First");
+    await provider.setSearch("First");
 
     assert.strictEqual(provider.itemSearchString, "First");
     assert.strictEqual(provider.searchMatches.size, 0);
     assert.strictEqual(provider.totalItemCount, 0);
   });
 
-  it("should clear internal search state when no value is passed", () => {
+  it("should clear internal search state when no value is passed", async () => {
     const provider = TestViewProvider.getInstance();
     provider.itemSearchString = "running";
     provider.searchMatches.add(TEST_CCLOUD_FLINK_STATEMENT);
     provider.totalItemCount = 3;
 
-    provider.setSearch(null);
+    await provider.setSearch(null);
 
     assert.strictEqual(provider.itemSearchString, null);
     assert.strictEqual(provider.searchMatches.size, 0);
@@ -369,11 +369,11 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   });
 
   for (const arg of ["First", null]) {
-    it(`should update the search context value (arg=${arg}) when .searchContextValue is set`, () => {
+    it(`should update the search context value (arg=${arg}) when .searchContextValue is set`, async () => {
       const provider = TestViewProvider.getInstance();
       // context value must be set for setContextValue to be called
       provider.searchContextValue = ContextValues.flinkStatementsSearchApplied;
-      provider.setSearch(arg);
+      await provider.setSearch(arg);
 
       sinon.assert.calledOnce(setContextValueStub);
       sinon.assert.calledWith(setContextValueStub, provider.searchContextValue, !!arg);
@@ -381,17 +381,28 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   }
 
   for (const arg of ["First", null]) {
-    it(`should not update the context value (arg=${arg}) when .searchContextValue is not set`, () => {
+    it(`should not update the context value (arg=${arg}) when .searchContextValue is not set`, async () => {
       const provider = TestViewProvider.getInstance();
-      provider.setSearch(arg);
+      await provider.setSearch(arg);
 
       sinon.assert.notCalled(setContextValueStub);
     });
   }
 
+  for (const arg of ["First", null]) {
+    it(`should refresh the tree view when search is set (arg=${arg})`, async () => {
+      const provider = TestViewProvider.getInstance();
+      const refreshSpy = sandbox.spy(provider, "refresh");
+
+      await provider.setSearch(arg);
+
+      sinon.assert.calledOnce(refreshSpy);
+    });
+  }
+
   it("should filter children based on search string", async () => {
     const provider = TestViewProvider.getInstance();
-    provider.setSearch("first");
+    await provider.setSearch("first");
 
     const matchingStatement = new FlinkStatement({
       ...TEST_CCLOUD_FLINK_STATEMENT,
@@ -415,9 +426,9 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     assert.strictEqual(provider.totalItemCount, 2);
   });
 
-  it("should update tree view message with search results when filterChildren() is called", () => {
+  it("should update tree view message with search results when filterChildren() is called", async () => {
     const provider = TestViewProvider.getInstance();
-    provider.setSearch("running");
+    await provider.setSearch("running");
 
     const items = [
       new FlinkStatement({

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -324,7 +324,7 @@ describe("viewProviders/base.ts BaseViewProvider setParentResource()", () => {
     sinon.assert.calledWith(setContextValueStub, provider.parentResourceChangedContextValue, true);
   });
 
-  it("Should be called when parentResourceChangedEmitter fires", async () => {
+  it("Should be called when parentResourceChangedEmitter fires", () => {
     const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
     const setParentResourceStub = sandbox.stub(provider, "setParentResource");
     provider.parentResourceChangedEmitter.fire(resource);
@@ -354,23 +354,23 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     BaseViewProvider["instanceMap"].clear();
   });
 
-  it("should set internal search state when a value is passed", async () => {
+  it("should set internal search state when a value is passed", () => {
     const provider = TestViewProvider.getInstance();
 
-    await provider.setSearch("First");
+    provider.setSearch("First");
 
     assert.strictEqual(provider.itemSearchString, "First");
     assert.strictEqual(provider.searchMatches.size, 0);
     assert.strictEqual(provider.totalItemCount, 0);
   });
 
-  it("should clear internal search state when no value is passed", async () => {
+  it("should clear internal search state when no value is passed", () => {
     const provider = TestViewProvider.getInstance();
     provider.itemSearchString = "running";
     provider.searchMatches.add(TEST_CCLOUD_FLINK_STATEMENT);
     provider.totalItemCount = 3;
 
-    await provider.setSearch(null);
+    provider.setSearch(null);
 
     assert.strictEqual(provider.itemSearchString, null);
     assert.strictEqual(provider.searchMatches.size, 0, "searchMatches should be cleared");
@@ -378,11 +378,11 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   });
 
   for (const arg of ["First", null]) {
-    it(`should update the search context value (arg=${arg}) when .searchContextValue is set`, async () => {
+    it(`should update the search context value (arg=${arg}) when .searchContextValue is set`, () => {
       const provider = TestViewProvider.getInstance();
       // context value must be set for setContextValue to be called
       provider.searchContextValue = ContextValues.flinkStatementsSearchApplied;
-      await provider.setSearch(arg);
+      provider.setSearch(arg);
 
       sinon.assert.calledOnce(setContextValueStub);
       sinon.assert.calledWith(setContextValueStub, provider.searchContextValue, !!arg);
@@ -390,9 +390,9 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   }
 
   for (const arg of ["First", null]) {
-    it(`should not update the context value (arg=${arg}) when .searchContextValue is not set`, async () => {
+    it(`should not update the context value (arg=${arg}) when .searchContextValue is not set`, () => {
       const provider = TestViewProvider.getInstance();
-      await provider.setSearch(arg);
+      provider.setSearch(arg);
 
       sinon.assert.notCalled(setContextValueStub);
     });
@@ -403,7 +403,7 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
       const provider = TestViewProvider.getInstance();
       const repaintSpy = sandbox.spy(provider["_onDidChangeTreeData"], "fire");
 
-      await provider.setSearch(arg);
+      provider.setSearch(arg);
       // Would normally be called by the tree view when children are requested
       // after setSearch() but we call it directly here to get totalItemCount assigned.
       await provider.getChildren();
@@ -416,9 +416,9 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     });
   }
 
-  it("should filter children based on search string", async () => {
+  it("should filter children based on search string", () => {
     const provider = TestViewProvider.getInstance();
-    await provider.setSearch("first");
+    provider.setSearch("first");
 
     const matchingStatement = new FlinkStatement({
       ...TEST_CCLOUD_FLINK_STATEMENT,
@@ -442,9 +442,9 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
     assert.strictEqual(provider.totalItemCount, 2);
   });
 
-  it("should update tree view message with search results when filterChildren() is called", async () => {
+  it("should update tree view message with search results when filterChildren() is called", () => {
     const provider = TestViewProvider.getInstance();
-    await provider.setSearch("running");
+    provider.setSearch("running");
 
     const items = [
       new FlinkStatement({

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -399,7 +399,7 @@ describe("viewProviders/base.ts BaseViewProvider setSearch()", () => {
   }
 
   for (const arg of ["First", null]) {
-    it(`should repait the tree view when search is set (arg=${arg})`, async () => {
+    it(`should repaint the tree view when search is set (arg=${arg})`, async () => {
       const provider = TestViewProvider.getInstance();
       const repaintSpy = sandbox.spy(provider["_onDidChangeTreeData"], "fire");
 

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -24,6 +24,7 @@ class TestViewProvider extends BaseViewProvider<FlinkComputePool, FlinkStatement
   loggerName = "viewProviders.test";
   viewId = "confluent-test";
 
+  parentResourceChangedEmitter = new EventEmitter<FlinkComputePool | null>();
   parentResourceChangedContextValue = ContextValues.flinkStatementsPoolSelected;
   readonly kind = "test";
 
@@ -321,6 +322,14 @@ describe("viewProviders/base.ts BaseViewProvider setParentResource()", () => {
     sinon.assert.calledOnce(updateTreeViewDescriptionStub);
     sinon.assert.calledOnce(setContextValueStub);
     sinon.assert.calledWith(setContextValueStub, provider.parentResourceChangedContextValue, true);
+  });
+
+  it("Should be called when parentResourceChangedEmitter fires", async () => {
+    const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+    const setParentResourceStub = sandbox.stub(provider, "setParentResource");
+    provider.parentResourceChangedEmitter.fire(resource);
+    sinon.assert.calledOnce(setParentResourceStub);
+    sinon.assert.calledWith(setParentResourceStub, resource);
   });
 });
 

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -217,7 +217,7 @@ export abstract class BaseViewProvider<
     await this.setSearch(null);
     // TODO: update this to adjust associated context value for focused resource(s)
 
-    // no need to .refresh() since adjusting search will handle it
+    await this.refresh();
   }
 
   /** Callback for  */
@@ -274,8 +274,8 @@ export abstract class BaseViewProvider<
       setContextValue(this.searchContextValue, searchString !== null);
     }
     // clear from any previous search filter
-    this.searchMatches = new Set();
-    this.totalItemCount = 0;
+    this.searchMatches.clear();
+
     // Inform the view that parent resource's children have changed and should
     // call getChildren() again.
     this._onDidChangeTreeData.fire();

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -90,6 +90,8 @@ export abstract class BaseViewProvider<
   /** Optional context value to adjust when the parent {@linkcode resource} is set/unset. */
   parentResourceChangedContextValue?: ContextValues;
 
+  /** Optional {@link EventEmitter} to listen for when the search string is set/unset. */
+  searchChangedEmitter?: EventEmitter<string | null>;
   /** Optional context value to adjust when the search string is set/unset. */
   searchContextValue?: ContextValues;
   /** String to filter items returned by `getChildren`, if provided. */
@@ -172,6 +174,7 @@ export abstract class BaseViewProvider<
     const ccloudConnectedSub: Disposable = ccloudConnected.event((connected: boolean) => {
       this.handleCCloudConnectionChange(connected);
     });
+    disposables.push(ccloudConnectedSub);
 
     const parentResourceChangedSub: Disposable | undefined =
       this.parentResourceChangedEmitter?.event(async (resource: P | null) => {
@@ -181,7 +184,15 @@ export abstract class BaseViewProvider<
       disposables.push(parentResourceChangedSub);
     }
 
-    disposables.push(ccloudConnectedSub, ...this.setCustomEventListeners());
+    const searchChangedSub: Disposable | undefined = this.searchChangedEmitter?.event(
+      (searchString: string | null) => {
+        this.setSearch(searchString);
+      },
+    );
+    if (searchChangedSub) {
+      disposables.push(searchChangedSub);
+    }
+
     return disposables;
   }
 
@@ -265,6 +276,7 @@ export abstract class BaseViewProvider<
     // clear from any previous search filter
     this.searchMatches = new Set();
     this.totalItemCount = 0;
+    void this.refresh();
   }
 
   /** Filter results from any {@link itemSearchString search string} applied to the current view. */

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -174,7 +174,6 @@ export abstract class BaseViewProvider<
     const ccloudConnectedSub: Disposable = ccloudConnected.event((connected: boolean) => {
       this.handleCCloudConnectionChange(connected);
     });
-    disposables.push(ccloudConnectedSub);
 
     const parentResourceChangedSub: Disposable | undefined =
       this.parentResourceChangedEmitter?.event(async (resource: P | null) => {
@@ -193,6 +192,7 @@ export abstract class BaseViewProvider<
       disposables.push(searchChangedSub);
     }
 
+    disposables.push(ccloudConnectedSub, ...this.setCustomEventListeners());
     return disposables;
   }
 

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -150,7 +150,7 @@ export abstract class BaseViewProvider<
     });
 
     if (this.resource !== resource) {
-      this.setSearch(null); // reset search when parent resource changes
+      await this.setSearch(null); // reset search when parent resource changes
     }
 
     if (resource) {
@@ -184,8 +184,8 @@ export abstract class BaseViewProvider<
     }
 
     const searchChangedSub: Disposable | undefined = this.searchChangedEmitter?.event(
-      (searchString: string | null) => {
-        this.setSearch(searchString);
+      async (searchString: string | null) => {
+        await this.setSearch(searchString);
       },
     );
     if (searchChangedSub) {
@@ -214,7 +214,7 @@ export abstract class BaseViewProvider<
     this.treeView.description = undefined;
     this.treeView.message = undefined;
 
-    this.setSearch(null);
+    await this.setSearch(null);
     // TODO: update this to adjust associated context value for focused resource(s)
 
     await this.refresh();
@@ -266,7 +266,7 @@ export abstract class BaseViewProvider<
   }
 
   /** Update internal state when the {@link itemSearchString search string} is set or unset. */
-  setSearch(searchString: string | null): void {
+  async setSearch(searchString: string | null): Promise<void> {
     // set/unset the filter so any calls to getChildren() will filter appropriately
     this.itemSearchString = searchString;
     if (this.searchContextValue) {
@@ -276,7 +276,7 @@ export abstract class BaseViewProvider<
     // clear from any previous search filter
     this.searchMatches = new Set();
     this.totalItemCount = 0;
-    void this.refresh();
+    await this.refresh();
   }
 
   /** Filter results from any {@link itemSearchString search string} applied to the current view. */

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -276,7 +276,9 @@ export abstract class BaseViewProvider<
     // clear from any previous search filter
     this.searchMatches = new Set();
     this.totalItemCount = 0;
-    await this.refresh();
+    // Inform the view that parent resource's children have changed and should
+    // call getChildren() again.
+    this._onDidChangeTreeData.fire();
   }
 
   /** Filter results from any {@link itemSearchString search string} applied to the current view. */

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -217,7 +217,7 @@ export abstract class BaseViewProvider<
     await this.setSearch(null);
     // TODO: update this to adjust associated context value for focused resource(s)
 
-    await this.refresh();
+    // no need to .refresh() since adjusting search will handle it
   }
 
   /** Callback for  */

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -150,7 +150,7 @@ export abstract class BaseViewProvider<
     });
 
     if (this.resource !== resource) {
-      await this.setSearch(null); // reset search when parent resource changes
+      this.setSearch(null); // reset search when parent resource changes
     }
 
     if (resource) {
@@ -184,8 +184,8 @@ export abstract class BaseViewProvider<
     }
 
     const searchChangedSub: Disposable | undefined = this.searchChangedEmitter?.event(
-      async (searchString: string | null) => {
-        await this.setSearch(searchString);
+      (searchString: string | null) => {
+        this.setSearch(searchString);
       },
     );
     if (searchChangedSub) {
@@ -214,7 +214,7 @@ export abstract class BaseViewProvider<
     this.treeView.description = undefined;
     this.treeView.message = undefined;
 
-    await this.setSearch(null);
+    this.setSearch(null);
     // TODO: update this to adjust associated context value for focused resource(s)
 
     await this.refresh();
@@ -266,7 +266,7 @@ export abstract class BaseViewProvider<
   }
 
   /** Update internal state when the {@link itemSearchString search string} is set or unset. */
-  async setSearch(searchString: string | null): Promise<void> {
+  setSearch(searchString: string | null): void {
     // set/unset the filter so any calls to getChildren() will filter appropriately
     this.itemSearchString = searchString;
     if (this.searchContextValue) {

--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -15,6 +15,7 @@ import {
   STATEMENT_POLLING_FREQUENCY_SECONDS,
   STATEMENT_POLLING_LIMIT,
 } from "../extensionSettings/constants";
+import { SEARCH_DECORATION_URI_SCHEME } from "./search";
 import { CCloudResourceLoader } from "../loaders";
 import { FlinkStatement, Phase } from "../models/flinkStatement";
 import * as telemetryEvents from "../telemetry/events";
@@ -360,6 +361,46 @@ describe("FlinkStatementsViewProvider", () => {
       const statement = createFlinkStatement();
       const treeItem = viewProvider.getTreeItem(statement);
       assert.strictEqual(treeItem.label, statement.name);
+    });
+
+    it("should add a search decoration when an item matches the provided search string", () => {
+      const statement = createFlinkStatement({
+        name: "test-statement-name",
+      });
+      viewProvider.itemSearchString = "test-statement";
+
+      const treeItem = viewProvider.getTreeItem(statement);
+
+      assert.ok(treeItem.resourceUri);
+      assert.strictEqual(treeItem.resourceUri?.scheme, SEARCH_DECORATION_URI_SCHEME);
+      // should contain the searchable text of the statement
+      assert.ok(treeItem.resourceUri?.path.includes(statement.name.toLowerCase()));
+    });
+
+    it("should not add a search decoration when an item doesn't match the provided search string", () => {
+      // shouldn't matter since search functionality should exclude this from even being sent to
+      // getTreeItem, but just to be explicit:
+      const statement = createFlinkStatement({
+        name: "unrelated-statement",
+      });
+      viewProvider.itemSearchString = "different-search-term";
+
+      const treeItem = viewProvider.getTreeItem(statement);
+
+      // resourceUri should not be set when no match
+      assert.strictEqual(treeItem.resourceUri, undefined);
+    });
+
+    it("should not add a search decoration when no search string is set", () => {
+      const statement = createFlinkStatement({
+        name: "test-statement",
+      });
+      viewProvider.itemSearchString = null;
+
+      const treeItem = viewProvider.getTreeItem(statement);
+
+      // resourceUri should not be set when no search string
+      assert.strictEqual(treeItem.resourceUri, undefined);
     });
   });
 

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -1,8 +1,16 @@
-import { Disposable, TreeDataProvider, TreeItem, workspace, WorkspaceConfiguration } from "vscode";
+import {
+  Disposable,
+  EventEmitter,
+  TreeDataProvider,
+  TreeItem,
+  workspace,
+  WorkspaceConfiguration,
+} from "vscode";
 import { ContextValues } from "../context/values";
 import {
   currentFlinkStatementsResourceChanged,
   flinkStatementDeleted,
+  flinkStatementSearchSet,
   flinkStatementUpdated,
 } from "../emitters";
 import {
@@ -43,6 +51,7 @@ export class FlinkStatementsViewProvider
   parentResourceChangedContextValue = ContextValues.flinkStatementsPoolSelected;
 
   searchContextValue = ContextValues.flinkStatementsSearchApplied;
+  searchChangedEmitter: EventEmitter<string | null> = flinkStatementSearchSet;
 
   // Map of resource id string -> resource currently in the tree view.
   private resourcesInTreeView: Map<string, FlinkStatement> = new Map();

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -5,6 +5,7 @@ import {
   TreeItem,
   workspace,
   WorkspaceConfiguration,
+  Uri,
 } from "vscode";
 import { ContextValues } from "../context/values";
 import {
@@ -21,6 +22,7 @@ import {
   STATEMENT_POLLING_FREQUENCY_SECONDS,
   STATEMENT_POLLING_LIMIT,
 } from "../extensionSettings/constants";
+import { itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
 import { FlinkStatementManager } from "../flinkSql/flinkStatementManager";
 import { CCloudResourceLoader, ResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
@@ -194,7 +196,18 @@ export class FlinkStatementsViewProvider
   }
 
   getTreeItem(element: FlinkStatement): TreeItem {
-    return new FlinkStatementTreeItem(element);
+    let treeItem = new FlinkStatementTreeItem(element);
+    if (this.itemSearchString) {
+      if (itemMatchesSearch(element, this.itemSearchString)) {
+        // special URI scheme to decorate the tree item with a dot to the right of the label,
+        // and color the label, description, and decoration so it stands out in the tree view
+        treeItem.resourceUri = Uri.parse(
+          `${SEARCH_DECORATION_URI_SCHEME}:/${element.searchableText()}`,
+        );
+      }
+      // no need to handle collapsible state adjustments here
+    }
+    return treeItem;
   }
 
   get computePool(): CCloudFlinkComputePool | null {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Adds search functionality to the Flink Statements view similar to how it's handled in the Resources, Topics, and Schemas views.


https://github.com/user-attachments/assets/c26b76bd-d4cb-4643-8b00-c1e736c146e8



Closes #1407 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This is the first use of the BaseViewProvider's search pattern, which required some slight adjustments to ensure we don't hit any race conditions (may have been related to https://github.com/confluentinc/vscode/issues/1977 ?), but overall it should reduce the amount of boilerplate needed to enable search for the Resources/Topics/Schemas view providers
- I moved all of the search-related commands to a dedicated `src/commands/search.ts` since `extra.ts` was getting too big. Easier for testing now, too.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
