### PR TITLE
docs: Add private networking with Flink as known limitation [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ errors. The [@sentry/rollup-plugin](https://www.npmjs.com/package/@sentry/rollup
   - macOS: macOS 13 and above (built on macOS 13.5)
   - Running the extension on older operating systems may result in the sidecar process failing to
     start, which prevents the extension from establishing a successful handshake.
-- We do not yet support private networking when working with Flink resources.
+- We do not yet support private networking when working with Confluent Cloud for Apache Flink®.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ errors. The [@sentry/rollup-plugin](https://www.npmjs.com/package/@sentry/rollup
   - macOS: macOS 13 and above (built on macOS 13.5)
   - Running the extension on older operating systems may result in the sidecar process failing to
     start, which prevents the extension from establishing a successful handshake.
+- We do not yet support private networking when working with Flink resources.
 
 ## Support
 


### PR DESCRIPTION
## Summary of Changes

This change mentions that we do not yet support using private networking with Flink resources.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
