### PR TITLE
fix: block GraphQL queries for direct connections in `ATTEMPTING` states to prevent race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,12 @@ All notable changes to this extension will be documented in this file.
 - Fixed an issue where the "File Issue" button would not work if the extension failed to activate
   properly. [#1823](https://github.com/confluentinc/vscode/issues/1823)
 - Improved sidecar startup diagnostics and presentation to the user in various cases.
-- Sidecar will now start to check newly created connections immediately upon creation or modification.
-  Previously erroneously waited until the next periodic check occurred.
+- Sidecar will now start to check newly created connections immediately upon creation or
+  modification. Previously erroneously waited until the next periodic check occurred.
 - Sidecar now properly handles SSL certificates encoded in PEM files.
+- Fixed a race condition where some "direct" connections would incorrectly show as "not connected"
+  after being created/updated and would require a manual refresh to show the correct state.
+  [[#1988](https://github.com/confluentinc/vscode/issues/1988)]
 
 ## 1.3.0
 

--- a/src/graphql/direct.test.ts
+++ b/src/graphql/direct.test.ts
@@ -10,14 +10,17 @@ import {
   TEST_DIRECT_CONNECTION_FORM_SPEC,
   TEST_DIRECT_CONNECTION_ID,
 } from "../../tests/unit/testResources/connection";
-import { ConnectionType } from "../clients/sidecar";
+import { ConnectedState, ConnectionType, Status } from "../clients/sidecar";
 import * as errorModule from "../errors";
 import { DirectEnvironment } from "../models/environment";
 import { DirectKafkaCluster } from "../models/kafkaCluster";
 import { DirectSchemaRegistry } from "../models/schemaRegistry";
 import * as notifications from "../notifications";
 import { SidecarHandle } from "../sidecar";
+import { ConnectionStateWatcher } from "../sidecar/connections/watcher";
 import { CustomConnectionSpec, ResourceManager } from "../storage/resourceManager";
+import * as telemetry from "../telemetry/events";
+import { ConnectionEventAction, ConnectionEventBody } from "../ws/messageTypes";
 import { getDirectResources } from "./direct";
 
 /**
@@ -43,19 +46,55 @@ const fakeDirectConnectionByIdResult = {
   },
 };
 
+/** `CREATED` event body for a Connection with Kafka and Schema Registry statuses of `ATTEMPTING`. */
+const fakeAttemptingConnectionEvent: ConnectionEventBody = {
+  action: ConnectionEventAction.CREATED,
+  connection: {
+    ...TEST_DIRECT_CONNECTION,
+    status: {
+      kafka_cluster: { state: ConnectedState.Attempting },
+      schema_registry: { state: ConnectedState.Attempting },
+      authentication: { status: Status.NoToken },
+    },
+  },
+};
+
+/** `CONNECTED` event body for a Connection with Kafka and Schema Registry statuses of `SUCCESS`. */
+const fakeStableConnectionEvent: ConnectionEventBody = {
+  action: ConnectionEventAction.CONNECTED,
+  connection: {
+    ...TEST_DIRECT_CONNECTION,
+    status: {
+      kafka_cluster: { state: ConnectedState.Success },
+      schema_registry: { state: ConnectedState.Success },
+      authentication: { status: Status.NoToken },
+    },
+  },
+};
+
 describe("graphql/direct.ts getDirectResources()", () => {
   let sandbox: sinon.SinonSandbox;
 
   let sidecarStub: sinon.SinonStubbedInstance<SidecarHandle>;
   let logErrorStub: sinon.SinonStub;
+  let logUsageStub: sinon.SinonStub;
   let showErrorNotificationStub: sinon.SinonStub;
+  let showWarningNotificationStub: sinon.SinonStub;
   let stubbedResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
+  let connectionStateWatcherStub: sinon.SinonStubbedInstance<ConnectionStateWatcher>;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
     // create the stub for the sidecar (which will automatically stub the .query method)
     sidecarStub = getSidecarStub(sandbox);
+
+    // stub the ConnectionStateWatcher for Connection-related websocket event handling
+    connectionStateWatcherStub = sandbox.createStubInstance(ConnectionStateWatcher);
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(fakeAttemptingConnectionEvent);
+    // simulate immediately resolving waitForConnectionUpdate and not timing out (returning null)
+    connectionStateWatcherStub.waitForConnectionUpdate.resolves(TEST_DIRECT_CONNECTION);
+    sandbox.stub(ConnectionStateWatcher, "getInstance").returns(connectionStateWatcherStub);
 
     // for stubbing the stored (test) direct connection spec
     stubbedResourceManager = sandbox.createStubInstance(ResourceManager);
@@ -73,7 +112,11 @@ describe("graphql/direct.ts getDirectResources()", () => {
 
     // helper stubs
     logErrorStub = sandbox.stub(errorModule, "logError");
+    logUsageStub = sandbox.stub(telemetry, "logUsage");
     showErrorNotificationStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
+    showWarningNotificationStub = sandbox
+      .stub(notifications, "showWarningNotificationWithButtons")
+      .resolves();
   });
 
   afterEach(() => {
@@ -230,5 +273,178 @@ describe("graphql/direct.ts getDirectResources()", () => {
       result.formConnectionType,
       TEST_DIRECT_CONNECTION_FORM_SPEC.formConnectionType,
     );
+  });
+
+  it("should call waitForConnectionUpdate when the Kafka cluster is in an ATTEMPTING state", async () => {
+    const kafkaAttemptingEvent: ConnectionEventBody = {
+      ...fakeAttemptingConnectionEvent,
+      connection: {
+        ...fakeAttemptingConnectionEvent.connection,
+        status: {
+          ...fakeAttemptingConnectionEvent.connection.status,
+          kafka_cluster: { state: ConnectedState.Attempting }, // not yet connected
+          schema_registry: { state: ConnectedState.Success },
+        },
+      },
+    };
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(kafkaAttemptingEvent);
+    // connectionStateWatcherStub.waitForConnectionUpdate resolves with a Connection by default
+    sidecarStub.query.resolves(fakeDirectConnectionByIdResult);
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.getLatestConnectionEvent);
+    sinon.assert.calledOnceWithExactly(
+      connectionStateWatcherStub.getLatestConnectionEvent,
+      TEST_DIRECT_CONNECTION_ID,
+    );
+    sinon.assert.calledOnce(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.calledOnce(sidecarStub.query);
+  });
+
+  it("should call waitForConnectionUpdate when the Schema Registry is in an ATTEMPTING state", async () => {
+    const schemaRegistryAttemptingEvent: ConnectionEventBody = {
+      ...fakeAttemptingConnectionEvent,
+      connection: {
+        ...fakeAttemptingConnectionEvent.connection,
+        status: {
+          ...fakeAttemptingConnectionEvent.connection.status,
+          kafka_cluster: { state: ConnectedState.Success },
+          schema_registry: { state: ConnectedState.Attempting }, // not yet connected
+        },
+      },
+    };
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(schemaRegistryAttemptingEvent);
+    // connectionStateWatcherStub.waitForConnectionUpdate resolves with a Connection by default
+    sidecarStub.query.resolves(fakeDirectConnectionByIdResult);
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.getLatestConnectionEvent);
+    sinon.assert.calledOnceWithExactly(
+      connectionStateWatcherStub.getLatestConnectionEvent,
+      TEST_DIRECT_CONNECTION_ID,
+    );
+    sinon.assert.calledOnce(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.calledOnce(sidecarStub.query);
+  });
+
+  it("should call waitForConnectionUpdate when the Kafka cluster and Schema Registry are in ATTEMPTING states", async () => {
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(fakeAttemptingConnectionEvent);
+    // connectionStateWatcherStub.waitForConnectionUpdate resolves with a Connection by default
+    sidecarStub.query.resolves(fakeDirectConnectionByIdResult);
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.getLatestConnectionEvent);
+    sinon.assert.calledOnce(connectionStateWatcherStub.waitForConnectionUpdate);
+  });
+
+  it("should skip calling waitForConnectionUpdate when the connection is already in stable state", async () => {
+    // reuse the stable event with CONNECTED and SUCCESS states
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(fakeStableConnectionEvent);
+    sidecarStub.query.resolves(fakeDirectConnectionByIdResult);
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.getLatestConnectionEvent);
+    // connection is already stable, no need to call waitForConnectionUpdate
+    sinon.assert.notCalled(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.calledOnce(sidecarStub.query);
+  });
+
+  it("should skip calling waitForConnectionUpdate when the connection is in a DISCONNECTED/FAILED state", async () => {
+    const failedEvent: ConnectionEventBody = {
+      ...fakeStableConnectionEvent,
+      action: ConnectionEventAction.DISCONNECTED,
+      connection: {
+        ...fakeStableConnectionEvent.connection,
+        status: {
+          kafka_cluster: { state: ConnectedState.Failed },
+          schema_registry: { state: ConnectedState.Failed },
+          authentication: { status: Status.NoToken },
+        },
+      },
+    };
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(failedEvent);
+    sidecarStub.query.resolves({
+      directConnectionById: {
+        ...fakeDirectConnectionByIdResult.directConnectionById,
+        kafkaCluster: null, // no Kafka cluster returned
+        schemaRegistry: null, // no Schema Registry returned
+      },
+    });
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.getLatestConnectionEvent);
+    // connection is already stable, no need to call waitForConnectionUpdate
+    sinon.assert.notCalled(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.calledOnce(sidecarStub.query);
+  });
+
+  it("should proceed immediately when no connection status is available", async () => {
+    // this shouldn't happen in practice, but we can test it
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(null);
+    // no idea what the GraphQL query would return in this scenario, but we'll assume the websocket
+    // side is the only part that's in a weird state and the GraphQL side is okay
+    sidecarStub.query.resolves(fakeDirectConnectionByIdResult);
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.getLatestConnectionEvent);
+    // no status to check, so no need to wait for connection update
+    sinon.assert.notCalled(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.calledOnce(sidecarStub.query);
+  });
+
+  it("should show a warning notification if the watcher times out waiting for the connection to stabilize", async () => {
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(fakeAttemptingConnectionEvent);
+    // simulate a timeout by having waitForConnectionUpdate return null
+    connectionStateWatcherStub.waitForConnectionUpdate.resolves(null);
+    sidecarStub.query.resolves({
+      directConnectionById: {
+        ...fakeDirectConnectionByIdResult.directConnectionById,
+        kafkaCluster: null, // no Kafka cluster returned
+        schemaRegistry: null, // no Schema Registry returned
+      },
+    });
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.calledOnce(showWarningNotificationStub);
+    sinon.assert.calledOnce(logUsageStub);
+    sinon.assert.calledOnce(sidecarStub.query);
+  });
+
+  it("should not show a warning notification when the watcher returns a Connection", async () => {
+    connectionStateWatcherStub.getLatestConnectionEvent.returns(fakeAttemptingConnectionEvent);
+    // no timeout, so the watcher returns a Connection
+    connectionStateWatcherStub.waitForConnectionUpdate.resolves(TEST_DIRECT_CONNECTION);
+    sidecarStub.query.resolves(fakeDirectConnectionByIdResult);
+
+    const result: DirectEnvironment | undefined =
+      await getDirectResources(TEST_DIRECT_CONNECTION_ID);
+
+    assert.ok(result);
+    sinon.assert.calledOnce(connectionStateWatcherStub.waitForConnectionUpdate);
+    sinon.assert.notCalled(showWarningNotificationStub);
+    sinon.assert.notCalled(logUsageStub);
+    sinon.assert.calledOnce(sidecarStub.query);
   });
 });

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -69,8 +69,8 @@ export async function getDirectResources(
           status.kafka_cluster?.state !== ConnectedState.Attempting &&
           status.schema_registry?.state !== ConnectedState.Attempting
         );
-        // use default 15sec timeout
       },
+      // use default 15sec timeout
     );
     if (!connection) {
       logger.warn("timed out waiting for direct connection to stabilize before submitting query", {

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -1,15 +1,21 @@
 import { graphql } from "gql.tada";
-import { ConnectedState, ConnectionStatus, ConnectionType } from "../clients/sidecar";
+import { commands } from "vscode";
+import { ConnectedState, Connection, ConnectionStatus, ConnectionType } from "../clients/sidecar";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { DirectEnvironment } from "../models/environment";
 import { DirectKafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "../models/resource";
 import { DirectSchemaRegistry } from "../models/schemaRegistry";
-import { showErrorNotificationWithButtons } from "../notifications";
+import {
+  DEFAULT_ERROR_NOTIFICATION_BUTTONS,
+  showErrorNotificationWithButtons,
+  showWarningNotificationWithButtons,
+} from "../notifications";
 import { getSidecar } from "../sidecar";
 import { ConnectionStateWatcher } from "../sidecar/connections/watcher";
 import { CustomConnectionSpec, getResourceManager } from "../storage/resourceManager";
+import { logUsage, UserEvent } from "../telemetry/events";
 import { ConnectionEventBody } from "../ws/messageTypes";
 
 const logger = new Logger("graphql.direct");
@@ -36,7 +42,9 @@ export async function getDirectResources(
     }
   `);
 
-  // make sure the connection is in a stable (SUCCESS/FAILED) state
+  // make sure the connection is in a stable (SUCCESS/FAILED) state, because if it's still ATTEMPTING,
+  // we run into weird race conditions where the GraphQL result may be missing child resources when
+  // the websocket event fires, and the ResourceViewProvider can't reconcile those
   const watcher = ConnectionStateWatcher.getInstance();
   const latestStatus: ConnectionStatus | undefined =
     watcher.getLatestConnectionEvent(connectionId)?.connection.status;
@@ -49,15 +57,47 @@ export async function getDirectResources(
       kafkaClusterState: latestStatus?.kafka_cluster?.state,
       schemaRegistryState: latestStatus?.schema_registry?.state,
     });
-    // block actually making the GQL query if the connected state is still ATTEMPTING
-    await watcher.waitForConnectionUpdate(connectionId, (event: ConnectionEventBody) => {
-      const status = event.connection.status;
-      return (
-        status.kafka_cluster?.state !== ConnectedState.Attempting &&
-        status.schema_registry?.state !== ConnectedState.Attempting
+    const connection: Connection | null = await watcher.waitForConnectionUpdate(
+      connectionId,
+      (event: ConnectionEventBody) => {
+        // block until we see a websocket event that indicates the connection is no longer ATTEMPTING
+        // for either Kafka or Schema Registry, based on the configuration
+        // (so whether it's SUCCESS or FAILED, we can move on with the GraphQL query and know the
+        // connection isn't in a transient state)
+        const status = event.connection.status;
+        return (
+          status.kafka_cluster?.state !== ConnectedState.Attempting &&
+          status.schema_registry?.state !== ConnectedState.Attempting
+        );
+        // use default 15sec timeout
+      },
+    );
+    if (!connection) {
+      logger.warn("timed out waiting for direct connection to stabilize before submitting query", {
+        connectionId,
+      });
+      // we timed out waiting for the connection to stabilize, so the query will not return any
+      // Kafka/Schema Registry resources and will appear broken
+      const spec: CustomConnectionSpec | null =
+        await getResourceManager().getDirectConnection(connectionId);
+      showWarningNotificationWithButtons(
+        `Unable to fetch resources for connection "${spec?.name}": timed out waiting for connection to stabilize.`,
+        {
+          "View Connection Details": () =>
+            commands.executeCommand("confluent.connections.direct.edit", connectionId),
+          ...DEFAULT_ERROR_NOTIFICATION_BUTTONS,
+        },
       );
-      // use default 15sec timeout
-    });
+      // log telemetry for this case, so we can see how often it happens
+      logUsage(UserEvent.DirectConnectionAction, {
+        action: "timed out waiting for connection to stabilize before GraphQL query",
+        type: spec?.formConnectionType,
+        specifiedConnectionType: spec?.specifiedConnectionType,
+        withKafka: !!spec?.kafka_cluster,
+        withSchemaRegistry: !!spec?.schema_registry,
+        failedReason: "connection still in ATTEMPTING state",
+      });
+    }
   }
 
   const sidecar = await getSidecar();


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The main problem behind #1988 was a race condition between:
- the time we would see websocket events transitioning a connection from `ATTEMPTED` to a stable state (`SUCCESS`/`FAILED`)
- the time we started and got results back from GraphQL to populate the Resources view

Since the logs showed correct behavior from the websocket perspective, that hinted at problems either in the `ResourceViewProvider` and/or the handling of the [direct connection GraphQL query](https://github.com/confluentinc/vscode/blob/03c72ccca060525f45abad1b1afef52643ad96dd/src/graphql/direct.ts#L12). Since `ResourceViewProvider` is more of a middleman, the most focused fix appeared to be on the GraphQL side where we could look at the latest websocket events for a given connection and decide whether to proceed with the query or block. 

Now, newly created direct connections (whether from initial activation and "rehydration" of connections or from creating/importing a connection after activation) as well as updated connections will not kick off GraphQL queries until we know they are in either a non-`ATTEMPTING` transient state.


https://github.com/user-attachments/assets/3f7b9242-08b2-4c23-b07f-234e2df396ff


Closes #1988.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- While debugging this issue, @jlrobins and I were reminded of how much cleaner the `ResourceViewProvider` could be, so https://github.com/confluentinc/vscode/issues/1994 was started as a long-term effort to refactor for more focused connection-based updates and easier maintainability. As a result of that discussion, even more `debug` logs have been added to help track expected behavior.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
