### PR TITLE
MINOR fix(local): download sidecar if necessary before tests start

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1021,7 +1021,7 @@ export function install(done) {
   return done(result.status);
 }
 
-export async function downloadSidecar() {
+export function downloadSidecar() {
   let result;
   if (IS_WINDOWS) {
     result = spawnSync(

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -593,6 +593,10 @@ export async function lint() {
 testBuild.description =
   "Build test files for running tests via `gulp testRun` or through the VS Code test runner. Use --coverage to enable coverage reporting.";
 export async function testBuild() {
+  // make sure to download the appropriate sidecar executable before building for tests
+  const result = downloadSidecar();
+  if (result.error) throw result.error;
+
   const reportCoverage = IS_CI || process.argv.indexOf("--coverage", 2) >= 0;
   const testFiles = globSync(["src/**/*.test.ts", "src/testing.ts", "tests/**/*.ts"]);
   const entryMap = Object.fromEntries(


### PR DESCRIPTION
We've occasionally hit local hiccups where we would kick off tests after a sidecar version bump without explicitly running `gulp build` (directly or from the extension dev [task](https://github.com/confluentinc/vscode/blob/50f1996a2e68714fd0cf5129d22b868c2cc28fe0/.vscode/tasks.json#L9) launching), which would then throw up a big angry error

### Before
No download/check, global beforeEach failure:
<img width="840" alt="image" src="https://github.com/user-attachments/assets/2e735289-e903-4f59-809a-de98dac3f358" />
...
<img width="855" alt="image" src="https://github.com/user-attachments/assets/cd37b250-ac24-4659-90f9-f06629fd2a35" />


### After
Downloads if necessary:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/e02a351f-2622-4d4a-abdc-2a0a94ff10d5" />

