### PR TITLE
Suppress metadata logging for Copilot-generated virtual documents

### DIFF
--- a/src/documentMetadataManager.ts
+++ b/src/documentMetadataManager.ts
@@ -28,13 +28,21 @@ export class DocumentMetadataManager {
     return DocumentMetadataManager.instance;
   }
 
+  private isCopilotVirtualDocument(document: TextDocument): boolean {
+    return document.uri.scheme === "vscode-chat-code-block";
+  }
+
   private async handleDocumentOpen(document: TextDocument) {
+    if (this.isCopilotVirtualDocument(document)) return;
+
     logger.debug("document opened", {
       uri: document.uri.toString(),
     });
   }
 
   private async handleDocumentClose(document: TextDocument) {
+    if (this.isCopilotVirtualDocument(document)) return;
+
     logger.debug("document closed", {
       uri: document.uri.toString(),
     });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
This PR addresses issue #1741 by suppressing log noise from document lifecycle events triggered by Copilot’s virtual documents (`vscode-chat-code-block` scheme). These are transient documents opened when Copilot displays inline code blocks, and logging them adds unnecessary verbosity without meaningful diagnostic value.

#### Implementation
- Added inline checks in `handleDocumentOpen` and `handleDocumentClose` to skip logging for `TextDocument` events with the `vscode-chat-code-block` URI scheme

- Applied this check to `handleDocumentOpen` and `handleDocumentClose` to skip logging Copilot-generated virtual documents

- Maintained existing behavior for real files, untitled documents, and other relevant document types

#### Alternatives Considered
Filtering based on specific URI patterns (e.g., UUID fragments), but scheme-level filtering (vscode-chat-code-block) is more stable and intention-revealing
-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
#### Before
Copilot responses with embedded code blocks generated multiple spurious `document opened` and `document closed` log entries during a chat session

#### After
These virtual documents are now ignored in the metadata manager's logging, reducing noise and improving clarity for real file events

#### Follow-on Work
Consider expanding this filtering approach if other virtual or synthetic document schemes emerge in the future.
-

## Pull request checklist

<!-- Please check if your PR fulfills the following (if applicable): -->

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [X] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [X] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
## Summary of Changes

- Added inline URI scheme checks in `handleDocumentOpen` and `handleDocumentClose` to avoid logging for documents opened by Copilot responses (with the `vscode-chat-code-block` scheme).
- This prevents noisy debug logs from being generated when Copilot inserts code blocks into the chat interface.

## Any additional details or context that should be provided?

- **Before:** Every temporary `vscode-chat-code-block` document triggered debug logs for open/close, leading to cluttered output.
- **After:** These documents are now silently ignored, improving log signal-to-noise ratio.
- **Related issue:** Fixes #1741
- No impact on actual document metadata handling or behavior.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as `this.disposables` for eventual cleanup?
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/.github/CONTRIBUTING.md#testing)?
  ```shell
  gulp clicktest
```
