### PR TITLE
Sanitize Flink statement names

### DIFF
--- a/src/commands/utils/flinkStatements.test.ts
+++ b/src/commands/utils/flinkStatements.test.ts
@@ -77,4 +77,28 @@ describe("determineFlinkStatementName()", function () {
     const statementName = await determineFlinkStatementName();
     assert.strictEqual(statementName, `unknownuser-vscode-${expectedDatePart}`);
   });
+
+  it("Should remove all non-alphanumeric characters from the username", async function () {
+    getCCloudAuthSessionStub.resolves({
+      account: {
+        label: "VS_Code.Devs@confluent.io",
+        id: "u-abc123"
+      }
+    });
+
+    const statementName = await determineFlinkStatementName();
+    assert.strictEqual(statementName, `vscodedevs-vscode-${expectedDatePart}`);
+  });
+
+  it("Should remove remove leading numeric characters from the username", async function () {
+    getCCloudAuthSessionStub.resolves({
+      account: {
+        label: "42_VS_Code.Devs-42@confluent.io",
+        id: "u-abc123"
+      }
+    });
+
+    const statementName = await determineFlinkStatementName();
+    assert.strictEqual(statementName, `vscodedevs-42-vscode-${expectedDatePart}`);
+  });
 });

--- a/src/commands/utils/flinkStatements.ts
+++ b/src/commands/utils/flinkStatements.ts
@@ -100,7 +100,7 @@ export async function determineFlinkStatementName(): Promise<string> {
     // Can only be lowercase; probably to simplify the uniqueness check on the backend.
     .toLocaleLowerCase()
     // Strip any non-alphanumeric characters, except for hyphens.
-    .replace(/[^a-zA-Z0-9-]/g, "")
+    .replace(/[^a-z0-9-]/g, "")
     // Strip leading numeric characters.
     .replace(/^[0-9]+/, "");
 

--- a/src/commands/utils/flinkStatements.ts
+++ b/src/commands/utils/flinkStatements.ts
@@ -95,13 +95,18 @@ export async function determineFlinkStatementName(): Promise<string> {
   const dateString = new Date().toISOString().replace(/:/g, "-").replace(/\..*$/, "");
   parts.push(dateString);
 
-  // Can only be lowercase; probably to simplify the
-  // uniqueness check on the backend.
-  const proposed = parts.join("-").toLocaleLowerCase();
+  
+  const proposed = parts.join("-")
+    // Can only be lowercase; probably to simplify the uniqueness check on the backend.
+    .toLocaleLowerCase()
+    // Strip any non-alphanumeric characters, except for hyphens.
+    .replace(/[^a-zA-Z0-9-]/g, "")
+    // Strip leading numeric characters.
+    .replace(/^[0-9]+/, "");
 
   // TODO: Show the user the proposed name and let them edit it.
 
-  // Be sure to only submit lowercase after user edits.
+  // Be sure to only submit valid name after user edits.
 
   return proposed;
 }


### PR DESCRIPTION
## Summary of Changes

This change makes sure we submit only valid Flink statement names by removing all invalid characters before submission.

## Any additional details or context that should be provided?

Fixes #2011 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
