### PR TITLE
Remove unnecessary info notification when project generation is cancelled (#2024)

### DIFF
--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -4,10 +4,10 @@ import { posix } from "path";
 import { unzip } from "unzipit";
 import { ViewColumn } from "vscode";
 import {
-    ApplyScaffoldV1TemplateOperationRequest,
-    ScaffoldV1Template,
-    ScaffoldV1TemplateSpec,
-    TemplatesScaffoldV1Api,
+  ApplyScaffoldV1TemplateOperationRequest,
+  ScaffoldV1Template,
+  ScaffoldV1TemplateSpec,
+  TemplatesScaffoldV1Api,
 } from "./clients/scaffoldingService";
 import { ResponseError } from "./clients/sidecar";
 import { registerCommandWithLogging } from "./commands";
@@ -279,24 +279,24 @@ export async function applyTemplate(
 
     const SAVE_LABEL = "Save to directory";
     const fileUris = await vscode.window.showOpenDialog({
-    openLabel: SAVE_LABEL,
-    canSelectFiles: false,
-    canSelectFolders: true,
-    canSelectMany: false,
-    // Parameter might be ignored on some OSes (e.g. macOS)
-    title: SAVE_LABEL,
+      openLabel: SAVE_LABEL,
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      // Parameter might be ignored on some OSes (e.g. macOS)
+      title: SAVE_LABEL,
     });
 
     if (!fileUris || fileUris.length !== 1) {
-    logUsage(UserEvent.ProjectScaffoldingAction, {
+      logUsage(UserEvent.ProjectScaffoldingAction, {
         status: "cancelled before save",
         templateCollection: pickedTemplate.spec!.template_collection?.id,
         templateId: pickedTemplate.spec!.name,
         templateName: pickedTemplate.spec!.display_name,
         itemType: telemetrySource,
-    });
+      });
 
-    return { success: false, message: "Project generation cancelled before save." };
+      return { success: false, message: "Project generation cancelled before save." };
     }
 
     const destination = await getNonConflictingDirPath(fileUris[0], pickedTemplate);


### PR DESCRIPTION
## Summary of Changes

Removed the info notification that appears when the user cancels the "Save to directory" dialog during project generation (issue fixes #2024).
This notification was deemed unnecessary since the cancellation is already indicated within the form UI, and no further user action can be taken from the notification.
The change improves user experience by reducing redundant and potentially disruptive messages.

---

## Any additional details or context that should be provided?

**Before:** When the user cancelled saving the generated project folder, an info notification `"Project generation cancelled"` appeared.
**After:** The notification is suppressed on cancellation, relying solely on the form UI feedback.
This prevents unnecessary popup clutter without losing any meaningful user communication.

---

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

* [ ] Added new
* [ ] Updated existing
* [ ] Deleted existing

##### Other

* [ ] All new disposables (event listeners, views, channels, etc.) collected as `this.disposables` for eventual cleanup?
* [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
* [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging)?

  ```shell
  gulp clicktest
  ```
