### PR TITLE
add date/time picker to topic mesage viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Date/time picker for message viewer when consuming from a specific point in time.
+
 ## 1.6.0
 
 ### Added

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -1,0 +1,128 @@
+import * as assert from "assert";
+import { datetimeLocalToTimestamp, timestampToDatetimeLocal } from "./dateUtils";
+
+describe("utils/dateUtils.ts timestampToDatetimeLocal()", () => {
+  it("should convert epoch milliseconds to datetime-local format", () => {
+    const timestamp: number = Date.now();
+
+    const result: string = timestampToDatetimeLocal(timestamp);
+
+    assert.strictEqual(typeof result, "string");
+    assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/);
+  });
+
+  it("should handle converting unix epoch correctly", () => {
+    const epochTimestamp = 0;
+
+    const result: string = timestampToDatetimeLocal(epochTimestamp);
+
+    assert.strictEqual(typeof result, "string");
+    assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/);
+  });
+
+  it("should pad single digits correctly", () => {
+    // timestamp that has single digit month, day, hour, minute, second
+    // (February 3rd, 2025 at 01:02:03.004)
+    const timestamp: number = new Date(2025, 1, 3, 1, 2, 3, 4).getTime();
+
+    const result: string = timestampToDatetimeLocal(timestamp);
+
+    assert.match(result, /2025-02-03T01:02:03\.004/);
+  });
+});
+
+// these are a bit overkill since datetimeLocalToTimestamp just wraps `new Date(datetimeLocal).getTime()`
+// but should be fine for guarding against possible future breaking changes
+describe("utils/dateUtils.ts datetimeLocalToTimestamp()", () => {
+  it("should convert datetime-local format to epoch milliseconds", () => {
+    const datetimeLocal = "2025-01-01T12:30:45.123";
+
+    const result: number = datetimeLocalToTimestamp(datetimeLocal);
+
+    assert.strictEqual(typeof result, "number");
+    assert.ok(result > 0);
+  });
+
+  it("should handle datetime without milliseconds", () => {
+    const datetimeLocal = "2024-01-01T12:30:45";
+
+    const result: number = datetimeLocalToTimestamp(datetimeLocal);
+
+    assert.strictEqual(typeof result, "number");
+    assert.ok(result > 0);
+  });
+
+  it("should handle minimum datetime values", () => {
+    const datetimeLocal = "1970-01-01T00:00:00.000";
+
+    const result: number = datetimeLocalToTimestamp(datetimeLocal);
+
+    // should be close to 0 for UTC, not going to assert exact value due to timezone differences
+    assert.strictEqual(typeof result, "number");
+  });
+});
+
+describe("utils/dateUtils.ts round-trip datetime conversions", () => {
+  it("should maintain precision in round-trip conversion", () => {
+    const originalTimestamp: number = Date.now();
+
+    const datetimeLocal: string = timestampToDatetimeLocal(originalTimestamp);
+    const roundTripTimestamp: number = datetimeLocalToTimestamp(datetimeLocal);
+
+    assert.strictEqual(roundTripTimestamp, originalTimestamp);
+  });
+
+  it("should handle multiple round-trip conversions", () => {
+    const testTimestamps = [
+      0, // epoch
+      new Date(2000, 0, 1, 0, 0, 0, 0).getTime(), // Y2K
+      new Date(2025, 0, 1, 0, 0, 0, 0).getTime(), // 2025-01-01
+      Date.now(), // current time
+    ];
+
+    testTimestamps.forEach((timestamp) => {
+      const datetimeLocal: string = timestampToDatetimeLocal(timestamp);
+      const roundTrip: number = datetimeLocalToTimestamp(datetimeLocal);
+
+      assert.strictEqual(
+        roundTrip,
+        timestamp,
+        `round-trip conversion failed for timestamp ${timestamp}`,
+      );
+    });
+  });
+});
+
+describe("utils/dateUtils.ts format validation", () => {
+  it("should produce valid datetime-local format for various timestamps", () => {
+    const testCases = [
+      { timestamp: 0, description: "epoch" },
+      { timestamp: new Date(2000, 0, 1, 0, 0, 0, 0).getTime(), description: "Y2K" },
+      { timestamp: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(), description: "2025-01-01" },
+      { timestamp: Date.now(), description: "current time" },
+    ];
+    testCases.forEach(({ timestamp, description }) => {
+      const result = timestampToDatetimeLocal(timestamp);
+      assert.match(
+        result,
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/,
+        `Should produce valid format for ${description}`,
+      );
+
+      const parsed: number = datetimeLocalToTimestamp(result);
+      assert.strictEqual(parsed, timestamp, `${description}: ${timestamp} expected, got ${parsed}`);
+    });
+  });
+
+  it("should handle edge case dates", () => {
+    // leap year (e.g. Feb 29, 2024)
+    const leapYearDate: number = new Date(2024, 1, 29, 12, 0, 0, 0).getTime();
+    const formatted: string = timestampToDatetimeLocal(leapYearDate);
+    assert.match(formatted, /2024-02-29T12:00:00\.000/);
+
+    // last timestamp of the year (e.g. Dec 31, 2024)
+    const endOfYear: number = new Date(2024, 11, 31, 23, 59, 59, 999).getTime();
+    const formattedEOY: string = timestampToDatetimeLocal(endOfYear);
+    assert.match(formattedEOY, /2024-12-31T23:59:59\.999/);
+  });
+});

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -1,128 +1,134 @@
 import * as assert from "assert";
 import { datetimeLocalToTimestamp, timestampToDatetimeLocal } from "./dateUtils";
 
-describe("utils/dateUtils.ts timestampToDatetimeLocal()", () => {
-  it("should convert epoch milliseconds to datetime-local format", () => {
-    const timestamp: number = Date.now();
+describe("utils/dateUtils.ts", () => {
+  describe("timestampToDatetimeLocal()", () => {
+    it("should convert epoch milliseconds to datetime-local format", () => {
+      const timestamp: number = Date.now();
 
-    const result: string = timestampToDatetimeLocal(timestamp);
+      const result: string = timestampToDatetimeLocal(timestamp);
 
-    assert.strictEqual(typeof result, "string");
-    assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/);
-  });
-
-  it("should handle converting unix epoch correctly", () => {
-    const epochTimestamp = 0;
-
-    const result: string = timestampToDatetimeLocal(epochTimestamp);
-
-    assert.strictEqual(typeof result, "string");
-    assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/);
-  });
-
-  it("should pad single digits correctly", () => {
-    // timestamp that has single digit month, day, hour, minute, second
-    // (February 3rd, 2025 at 01:02:03.004)
-    const timestamp: number = new Date(2025, 1, 3, 1, 2, 3, 4).getTime();
-
-    const result: string = timestampToDatetimeLocal(timestamp);
-
-    assert.match(result, /2025-02-03T01:02:03\.004/);
-  });
-});
-
-// these are a bit overkill since datetimeLocalToTimestamp just wraps `new Date(datetimeLocal).getTime()`
-// but should be fine for guarding against possible future breaking changes
-describe("utils/dateUtils.ts datetimeLocalToTimestamp()", () => {
-  it("should convert datetime-local format to epoch milliseconds", () => {
-    const datetimeLocal = "2025-01-01T12:30:45.123";
-
-    const result: number = datetimeLocalToTimestamp(datetimeLocal);
-
-    assert.strictEqual(typeof result, "number");
-    assert.ok(result > 0);
-  });
-
-  it("should handle datetime without milliseconds", () => {
-    const datetimeLocal = "2024-01-01T12:30:45";
-
-    const result: number = datetimeLocalToTimestamp(datetimeLocal);
-
-    assert.strictEqual(typeof result, "number");
-    assert.ok(result > 0);
-  });
-
-  it("should handle minimum datetime values", () => {
-    const datetimeLocal = "1970-01-01T00:00:00.000";
-
-    const result: number = datetimeLocalToTimestamp(datetimeLocal);
-
-    // should be close to 0 for UTC, not going to assert exact value due to timezone differences
-    assert.strictEqual(typeof result, "number");
-  });
-});
-
-describe("utils/dateUtils.ts round-trip datetime conversions", () => {
-  it("should maintain precision in round-trip conversion", () => {
-    const originalTimestamp: number = Date.now();
-
-    const datetimeLocal: string = timestampToDatetimeLocal(originalTimestamp);
-    const roundTripTimestamp: number = datetimeLocalToTimestamp(datetimeLocal);
-
-    assert.strictEqual(roundTripTimestamp, originalTimestamp);
-  });
-
-  it("should handle multiple round-trip conversions", () => {
-    const testTimestamps = [
-      0, // epoch
-      new Date(2000, 0, 1, 0, 0, 0, 0).getTime(), // Y2K
-      new Date(2025, 0, 1, 0, 0, 0, 0).getTime(), // 2025-01-01
-      Date.now(), // current time
-    ];
-
-    testTimestamps.forEach((timestamp) => {
-      const datetimeLocal: string = timestampToDatetimeLocal(timestamp);
-      const roundTrip: number = datetimeLocalToTimestamp(datetimeLocal);
-
-      assert.strictEqual(
-        roundTrip,
-        timestamp,
-        `round-trip conversion failed for timestamp ${timestamp}`,
-      );
+      assert.strictEqual(typeof result, "string");
+      assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/);
     });
-  });
-});
 
-describe("utils/dateUtils.ts format validation", () => {
-  it("should produce valid datetime-local format for various timestamps", () => {
-    const testCases = [
-      { timestamp: 0, description: "epoch" },
-      { timestamp: new Date(2000, 0, 1, 0, 0, 0, 0).getTime(), description: "Y2K" },
-      { timestamp: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(), description: "2025-01-01" },
-      { timestamp: Date.now(), description: "current time" },
-    ];
-    testCases.forEach(({ timestamp, description }) => {
-      const result = timestampToDatetimeLocal(timestamp);
-      assert.match(
-        result,
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/,
-        `Should produce valid format for ${description}`,
-      );
+    it("should handle converting unix epoch correctly", () => {
+      const epochTimestamp = 0;
 
-      const parsed: number = datetimeLocalToTimestamp(result);
-      assert.strictEqual(parsed, timestamp, `${description}: ${timestamp} expected, got ${parsed}`);
+      const result: string = timestampToDatetimeLocal(epochTimestamp);
+
+      assert.strictEqual(typeof result, "string");
+      assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/);
+    });
+
+    it("should pad single digits correctly", () => {
+      // timestamp that has single digit month, day, hour, minute, second
+      // (February 3rd, 2025 at 01:02:03.004)
+      const timestamp: number = new Date(2025, 1, 3, 1, 2, 3, 4).getTime();
+
+      const result: string = timestampToDatetimeLocal(timestamp);
+
+      assert.match(result, /2025-02-03T01:02:03\.004/);
     });
   });
 
-  it("should handle edge case dates", () => {
-    // leap year (e.g. Feb 29, 2024)
-    const leapYearDate: number = new Date(2024, 1, 29, 12, 0, 0, 0).getTime();
-    const formatted: string = timestampToDatetimeLocal(leapYearDate);
-    assert.match(formatted, /2024-02-29T12:00:00\.000/);
+  // these are a bit overkill since datetimeLocalToTimestamp just wraps `new Date(datetimeLocal).getTime()`
+  // but should be fine for guarding against possible future breaking changes
+  describe("datetimeLocalToTimestamp()", () => {
+    it("should convert datetime-local format to epoch milliseconds", () => {
+      const datetimeLocal = "2025-01-01T12:30:45.123";
 
-    // last timestamp of the year (e.g. Dec 31, 2024)
-    const endOfYear: number = new Date(2024, 11, 31, 23, 59, 59, 999).getTime();
-    const formattedEOY: string = timestampToDatetimeLocal(endOfYear);
-    assert.match(formattedEOY, /2024-12-31T23:59:59\.999/);
+      const result: number = datetimeLocalToTimestamp(datetimeLocal);
+
+      assert.strictEqual(typeof result, "number");
+      assert.ok(result > 0);
+    });
+
+    it("should handle datetime without milliseconds", () => {
+      const datetimeLocal = "2024-01-01T12:30:45";
+
+      const result: number = datetimeLocalToTimestamp(datetimeLocal);
+
+      assert.strictEqual(typeof result, "number");
+      assert.ok(result > 0);
+    });
+
+    it("should handle minimum datetime values", () => {
+      const datetimeLocal = "1970-01-01T00:00:00.000";
+
+      const result: number = datetimeLocalToTimestamp(datetimeLocal);
+
+      // should be close to 0 for UTC, not going to assert exact value due to timezone differences
+      assert.strictEqual(typeof result, "number");
+    });
+  });
+
+  describe("round-trip datetime conversions", () => {
+    it("should maintain precision in round-trip conversion", () => {
+      const originalTimestamp: number = Date.now();
+
+      const datetimeLocal: string = timestampToDatetimeLocal(originalTimestamp);
+      const roundTripTimestamp: number = datetimeLocalToTimestamp(datetimeLocal);
+
+      assert.strictEqual(roundTripTimestamp, originalTimestamp);
+    });
+
+    it("should handle multiple round-trip conversions", () => {
+      const testTimestamps = [
+        0, // epoch
+        new Date(2000, 0, 1, 0, 0, 0, 0).getTime(), // Y2K
+        new Date(2025, 0, 1, 0, 0, 0, 0).getTime(), // 2025-01-01
+        Date.now(), // current time
+      ];
+
+      testTimestamps.forEach((timestamp) => {
+        const datetimeLocal: string = timestampToDatetimeLocal(timestamp);
+        const roundTrip: number = datetimeLocalToTimestamp(datetimeLocal);
+
+        assert.strictEqual(
+          roundTrip,
+          timestamp,
+          `round-trip conversion failed for timestamp ${timestamp}`,
+        );
+      });
+    });
+  });
+
+  describe("format validation", () => {
+    it("should produce valid datetime-local format for various timestamps", () => {
+      const testCases = [
+        { timestamp: 0, description: "epoch" },
+        { timestamp: new Date(2000, 0, 1, 0, 0, 0, 0).getTime(), description: "Y2K" },
+        { timestamp: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(), description: "2025-01-01" },
+        { timestamp: Date.now(), description: "current time" },
+      ];
+      testCases.forEach(({ timestamp, description }) => {
+        const result = timestampToDatetimeLocal(timestamp);
+        assert.match(
+          result,
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$/,
+          `Should produce valid format for ${description}`,
+        );
+
+        const parsed: number = datetimeLocalToTimestamp(result);
+        assert.strictEqual(
+          parsed,
+          timestamp,
+          `${description}: ${timestamp} expected, got ${parsed}`,
+        );
+      });
+    });
+
+    it("should handle edge case dates", () => {
+      // leap year (e.g. Feb 29, 2024)
+      const leapYearDate: number = new Date(2024, 1, 29, 12, 0, 0, 0).getTime();
+      const formatted: string = timestampToDatetimeLocal(leapYearDate);
+      assert.match(formatted, /2024-02-29T12:00:00\.000/);
+
+      // last timestamp of the year (e.g. Dec 31, 2024)
+      const endOfYear: number = new Date(2024, 11, 31, 23, 59, 59, 999).getTime();
+      const formattedEOY: string = timestampToDatetimeLocal(endOfYear);
+      assert.match(formattedEOY, /2024-12-31T23:59:59\.999/);
+    });
   });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * Converts epoch milliseconds timestamp to datetime-local format (`YYYY-MM-DDTHH:mm:ss.sss`).
+ * (Opposite of {@link datetimeLocalToTimestamp})
+ */
+export function timestampToDatetimeLocal(timestamp: number): string {
+  // NOTE: Date methods automatically convert to browser's local timezone
+  const date = new Date(timestamp);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+  const milliseconds = String(date.getMilliseconds()).padStart(3, "0");
+  // YYYY-MM-DDTHH:mm:ss.sss
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}`;
+}
+
+// this is mainly for symmetry; we could just as easily use `new Date(datetimeLocal).getTime()`
+/**
+ * Converts datetime-local format (`YYYY-MM-DDTHH:mm:ss.sss`) to epoch milliseconds.
+ * (Opposite of {@link timestampToDatetimeLocal})
+ */
+export function datetimeLocalToTimestamp(datetimeLocal: string): number {
+  // NOTE: Date constructor automatically interprets input as local time
+  const date = new Date(datetimeLocal);
+  return date.getTime();
+}

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -76,20 +76,21 @@
               >
                 <vscode-option value="latest">Latest</vscode-option>
                 <vscode-option value="beginning">From beginning</vscode-option>
-                <vscode-option value="timestamp">From timestamp</vscode-option>
+                <vscode-option value="timestamp">From date/time</vscode-option>
               </vscode-dropdown>
             </div>
 
             <template data-if="this.consumeMode() === 'timestamp'">
               <div class="dropdown-container">
                 <label for="consume-mode-timestamp">Timestamp</label>
-                <vscode-text-field
+                <input
+                  type="datetime-local"
                   id="consume-mode-timestamp"
-                  data-prop-value="this.consumeModeTimestamp()"
-                  data-on-change="this.handleConsumeModeTimestampChange(event.target.value)"
-                  placeholder="Timestamp"
-                >
-                </vscode-text-field>
+                  class="datetime-input"
+                  data-prop-value="this.consumeModeTimestampFormatted()"
+                  data-on-change="this.handleConsumeModeTimestampFormattedChange(event.target.value)"
+                  step="1"
+                />
               </div>
             </template>
 
@@ -641,6 +642,32 @@
       }
       .timer.paused {
         opacity: 0.5;
+      }
+
+      .datetime-input {
+        background: var(--vscode-input-background);
+        border: 1px solid var(--vscode-input-border);
+        border-radius: calc(var(--corner-radius-round) * 1px);
+        color: var(--vscode-input-foreground);
+        font-family: var(--font-family);
+        font-size: var(--type-ramp-base-font-size);
+        height: calc(var(--input-height) * 1px);
+        padding: 2px 8px;
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .datetime-input:focus {
+        outline: none;
+      }
+      .datetime-input:hover {
+        border-color: var(--vscode-input-border);
+      }
+      /* Override the default validation coloring for datetime-local input */
+      .datetime-input:user-invalid,
+      .datetime-input:invalid,
+      .datetime-input:valid {
+        border-color: var(--vscode-input-border);
+        box-shadow: none;
       }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -76,13 +76,13 @@
               >
                 <vscode-option value="latest">Latest</vscode-option>
                 <vscode-option value="beginning">From beginning</vscode-option>
-                <vscode-option value="timestamp">From date/time</vscode-option>
+                <vscode-option value="timestamp">From specific date/time</vscode-option>
               </vscode-dropdown>
             </div>
 
             <template data-if="this.consumeMode() === 'timestamp'">
               <div class="dropdown-container">
-                <label for="consume-mode-timestamp">Timestamp</label>
+                <label for="consume-mode-timestamp">Start date and time</label>
                 <input
                   type="datetime-local"
                   id="consume-mode-timestamp"

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -76,21 +76,34 @@
               >
                 <vscode-option value="latest">Latest</vscode-option>
                 <vscode-option value="beginning">From beginning</vscode-option>
-                <vscode-option value="timestamp">From specific date/time</vscode-option>
+                <vscode-option value="timestamp">From date/time</vscode-option>
               </vscode-dropdown>
             </div>
 
             <template data-if="this.consumeMode() === 'timestamp'">
               <div class="dropdown-container">
                 <label for="consume-mode-timestamp">Start date and time</label>
-                <input
-                  type="datetime-local"
-                  id="consume-mode-timestamp"
-                  class="datetime-input"
-                  data-prop-value="this.consumeModeTimestampFormatted()"
-                  data-on-change="this.handleConsumeModeTimestampFormattedChange(event.target.value)"
-                  step="0.001"
-                />
+                <div class="datetime-input-group">
+                  <input
+                    type="text"
+                    id="consume-mode-timestamp"
+                    class="datetime-input"
+                    placeholder="YYYY-MM-DD HH:mm:ss.sss or paste any datetime format"
+                    data-prop-value="this.consumeModeTimestampFormatted()"
+                    data-on-change="this.handleConsumeModeTimestampFormattedChange(event.target.value)"
+                    data-on-blur="this.handleConsumeModeTimestampBlur(event.target.value)"
+                  />
+                  <input
+                    type="datetime-local"
+                    id="datetime-picker-button"
+                    class="datetime-picker-styled-button"
+                    data-prop-value="this.consumeModeTimestampFormatted()"
+                    data-on-change="this.handleDatetimePickerChange(event.target.value)"
+                    step="0.001"
+                    aria-label="Open date and time picker"
+                    title="Open date and time picker"
+                  />
+                </div>
               </div>
             </template>
 
@@ -655,12 +668,107 @@
         padding: 2px 8px;
         width: 100%;
         box-sizing: border-box;
+        flex: 1;
       }
       .datetime-input:focus {
         outline: none;
+        border-color: var(--focus-border);
       }
       .datetime-input:hover {
         border-color: var(--vscode-input-border);
+      }
+
+      .datetime-input-group {
+        display: flex;
+        gap: 4px;
+        align-items: center;
+        width: 100%;
+      }
+
+      .datetime-picker-styled-button {
+        background: var(--vscode-button-background);
+        border: 1px solid var(--vscode-button-border, var(--vscode-button-background));
+        border-radius: calc(var(--corner-radius-round) * 1px);
+        cursor: pointer;
+        font-family: var(--font-family);
+        height: calc(var(--input-height) * 1px);
+        width: calc(var(--input-height) * 1px);
+        min-width: calc(var(--input-height) * 1px);
+        max-width: calc(var(--input-height) * 1px);
+        padding: 0;
+        position: relative;
+        flex-shrink: 0;
+
+        /* Make text invisible but keep calendar icon */
+        color: transparent;
+
+        /* Remove default appearance to better control styling */
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+      }
+
+      .datetime-picker-styled-button:hover {
+        background: var(--vscode-button-hoverBackground);
+      }
+
+      .datetime-picker-styled-button:focus {
+        outline: none;
+        border-color: var(--focus-border);
+        background: var(--vscode-button-background);
+      }
+
+      /* Hide all text content */
+      .datetime-picker-styled-button::-webkit-datetime-edit {
+        display: none;
+      }
+
+      .datetime-picker-styled-button::-webkit-datetime-edit-text,
+      .datetime-picker-styled-button::-webkit-datetime-edit-month-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-day-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-year-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-hour-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-minute-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-second-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-millisecond-field,
+      .datetime-picker-styled-button::-webkit-datetime-edit-meridiem-field {
+        display: none;
+      }
+
+      /* Hide the native calendar picker indicator */
+      .datetime-picker-styled-button::-webkit-calendar-picker-indicator {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        cursor: pointer;
+        background: none;
+        opacity: 0;
+        /* Keep it invisible but still clickable */
+      }
+
+      /* Add VS Code calendar icon using a pseudo-element */
+      .datetime-picker-styled-button::before {
+        content: "\eab0"; /* codicon-calendar */
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-family: "codicon", monospace;
+        font-size: 16px;
+        color: var(--vscode-button-foreground);
+        pointer-events: none;
+        z-index: 1;
+        line-height: 1;
+      }
+
+      .datetime-picker-styled-button:hover::before {
+        color: var(--vscode-button-foreground);
       }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -82,13 +82,18 @@
 
             <template data-if="this.consumeMode() === 'timestamp'">
               <div class="dropdown-container datetime-container">
-                <label for="consume-mode-timestamp">Start date and time</label>
+                <label for="consume-mode-timestamp">
+                  Start date and time (<span
+                    data-text="this.timestampDisplayMode() === 'local' ? 'Local' : 'UTC'"
+                  ></span
+                  >)
+                </label>
                 <div class="datetime-input-group">
                   <input
                     type="text"
                     id="consume-mode-timestamp"
                     class="datetime-input"
-                    placeholder="YYYY-MM-DD HH:mm:ss.sss or paste any datetime format"
+                    placeholder="YYYY-MM-DD HH:mm:ss.sss, unix timestamp, or paste any datetime format"
                     data-prop-value="this.consumeModeTimestampFormatted()"
                     data-on-change="this.handleDatetimeChange(event.target.value)"
                     data-on-blur="this.handleDatetimeChange(event.target.value)"
@@ -231,8 +236,9 @@
           <label class="histogram-label"
             ><span data-text="this.messageCount().total.toLocaleString()"></span> messages streamed
             since
-            <span data-text="this.formatTimestamp()(this.timestampExtent()[0])"></span> (UTC)</label
-          >
+            <span data-text="this.formatTimestamp()(this.timestampExtent()[0])"></span>
+            <span data-text="this.timestampDisplayMode() === 'local' ? 'Local' : 'UTC'"></span
+          ></label>
         </template>
         <template data-if="!this.shouldShowMessagesStat()">
           <label class="histogram-label">&nbsp;</label>
@@ -329,15 +335,20 @@
                 </template>
               </div>
               <hr />
-              <vscode-radio-group
-                orientation="vertical"
-                data-attr-value="this.messageTimestampFormat()"
-                data-on-change="this.updateTimestampFormat(event.target.value)"
-              >
-                <label slot="label">Timestamp format</label>
-                <vscode-radio value="iso">ISO</vscode-radio>
-                <vscode-radio value="unix">Unix epoch</vscode-radio>
-              </vscode-radio-group>
+              <div class="flex-column" style="--gap: 0.5rem">
+                <label>Timestamp display</label>
+                <div class="timezone-switch-container">
+                  <label class="timezone-switch-label">
+                    <vscode-checkbox
+                      data-prop-checked="this.timestampDisplayMode() === 'local'"
+                      data-on-change="this.toggleTimestampDisplayMode()"
+                    ></vscode-checkbox>
+                    <span
+                      data-text="this.timestampDisplayMode() === 'local' ? 'Local Time' : 'UTC'"
+                    ></span>
+                  </label>
+                </div>
+              </div>
             </section>
 
             <tbody>
@@ -774,6 +785,21 @@
 
       .datetime-picker-styled-button:hover::before {
         color: var(--vscode-button-foreground);
+      }
+
+      .timezone-switch-container {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .timezone-switch-label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        font-size: var(--vscode-font-size);
+        color: var(--vscode-editor-foreground);
       }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -89,7 +89,7 @@
                   class="datetime-input"
                   data-prop-value="this.consumeModeTimestampFormatted()"
                   data-on-change="this.handleConsumeModeTimestampFormattedChange(event.target.value)"
-                  step="1"
+                  step="0.001"
                 />
               </div>
             </template>
@@ -661,13 +661,6 @@
       }
       .datetime-input:hover {
         border-color: var(--vscode-input-border);
-      }
-      /* Override the default validation coloring for datetime-local input */
-      .datetime-input:user-invalid,
-      .datetime-input:invalid,
-      .datetime-input:valid {
-        border-color: var(--vscode-input-border);
-        box-shadow: none;
       }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -93,7 +93,7 @@
                     type="text"
                     id="consume-mode-timestamp"
                     class="datetime-input"
-                    placeholder="YYYY-MM-DD HH:mm:ss.sss, unix timestamp, or paste any datetime format"
+                    placeholder="YYYY-MM-DD HH:mm:ss.sss or unix timestamp"
                     data-prop-value="this.consumeModeTimestampFormatted()"
                     data-on-change="this.handleDatetimeChange(event.target.value)"
                     data-on-blur="this.handleDatetimeChange(event.target.value)"

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -81,7 +81,7 @@
             </div>
 
             <template data-if="this.consumeMode() === 'timestamp'">
-              <div class="dropdown-container">
+              <div class="dropdown-container datetime-container">
                 <label for="consume-mode-timestamp">Start date and time</label>
                 <div class="datetime-input-group">
                   <input
@@ -534,6 +534,10 @@
         width: 100%;
       }
 
+      .datetime-container {
+        min-width: 16rem; /* Wider to accommodate full timestamp */
+      }
+
       [popover].partition-control {
         width: fit-content;
         min-width: 10rem;
@@ -698,6 +702,7 @@
         padding: 0;
         position: relative;
         flex-shrink: 0;
+        box-sizing: border-box; /* Ensure consistent box model with text input */
 
         /* Make text invisible but keep calendar icon */
         color: transparent;

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -90,15 +90,15 @@
                     class="datetime-input"
                     placeholder="YYYY-MM-DD HH:mm:ss.sss or paste any datetime format"
                     data-prop-value="this.consumeModeTimestampFormatted()"
-                    data-on-change="this.handleConsumeModeTimestampFormattedChange(event.target.value)"
-                    data-on-blur="this.handleConsumeModeTimestampBlur(event.target.value)"
+                    data-on-change="this.handleDatetimeChange(event.target.value)"
+                    data-on-blur="this.handleDatetimeChange(event.target.value)"
                   />
                   <input
                     type="datetime-local"
                     id="datetime-picker-button"
                     class="datetime-picker-styled-button"
                     data-prop-value="this.consumeModeTimestampFormatted()"
-                    data-on-change="this.handleDatetimePickerChange(event.target.value)"
+                    data-on-change="this.handleDatetimeChange(event.target.value)"
                     step="0.001"
                     aria-label="Open date and time picker"
                     title="Open date and time picker"

--- a/src/webview/message-viewer.html
+++ b/src/webview/message-viewer.html
@@ -237,8 +237,9 @@
             ><span data-text="this.messageCount().total.toLocaleString()"></span> messages streamed
             since
             <span data-text="this.formatTimestamp()(this.timestampExtent()[0])"></span>
-            <span data-text="this.timestampDisplayMode() === 'local' ? 'Local' : 'UTC'"></span
-          ></label>
+            (<span data-text="this.timestampDisplayMode() === 'local' ? 'Local' : 'UTC'"></span
+            >)</label
+          >
         </template>
         <template data-if="!this.shouldShowMessagesStat()">
           <label class="histogram-label">&nbsp;</label>

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -472,8 +472,49 @@ export class MessageViewerViewModel extends ViewModel {
 
   /** Handler to convert the webview's datetime string input to internal numeric timestamp. */
   async handleConsumeModeTimestampFormattedChange(datetimeLocal: string) {
-    const timestamp: number = datetimeLocalToTimestamp(datetimeLocal);
-    await this.handleConsumeModeTimestampChange(timestamp);
+    try {
+      const timestamp: number = datetimeLocalToTimestamp(datetimeLocal);
+      if (isNaN(timestamp)) {
+        // Invalid date - could show error feedback here
+        return;
+      }
+      // Check if the new timestamp is different from the current one
+      const currentTimestamp = this.consumeModeTimestamp();
+      if (timestamp !== currentTimestamp) {
+        await this.handleConsumeModeTimestampChange(timestamp);
+      }
+    } catch {
+      // Handle parsing errors gracefully
+      console.warn("Invalid datetime format:", datetimeLocal);
+    }
+  }
+
+  /** Handler for blur event on text input to validate and reformat */
+  async handleConsumeModeTimestampBlur(datetimeLocal: string) {
+    try {
+      const timestamp: number = datetimeLocalToTimestamp(datetimeLocal);
+      if (!isNaN(timestamp)) {
+        // Check if the new timestamp is different from the current one
+        const currentTimestamp = this.consumeModeTimestamp();
+        if (timestamp !== currentTimestamp) {
+          // Reformat to standardized format on blur
+          await this.handleConsumeModeTimestampChange(timestamp);
+        }
+      }
+    } catch {
+      // Reset to last valid value on invalid input
+      const currentTimestamp = this.consumeModeTimestamp();
+      if (currentTimestamp != null) {
+        // Trigger UI update to reset to last valid formatted value
+        this.consumeModeTimestamp((prev) => prev);
+      }
+    }
+  }
+
+  /** Handler for datetime picker input changes */
+  handleDatetimePickerChange(datetimeLocal: string) {
+    // Directly apply the datetime picker change to the main input
+    this.handleConsumeModeTimestampFormattedChange(datetimeLocal);
   }
 
   /** Numeric limit of messages that need to be consumed. */

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -608,15 +608,7 @@ class MessageViewerViewModel extends ViewModel {
         return (timestamp: number) => {
           const date = new Date(timestamp);
           if (displayMode === "local") {
-            // Format as local ISO-like string (YYYY-MM-DDTHH:mm:ss.sss)
-            const year = date.getFullYear();
-            const month = String(date.getMonth() + 1).padStart(2, "0");
-            const day = String(date.getDate()).padStart(2, "0");
-            const hours = String(date.getHours()).padStart(2, "0");
-            const minutes = String(date.getMinutes()).padStart(2, "0");
-            const seconds = String(date.getSeconds()).padStart(2, "0");
-            const milliseconds = String(date.getMilliseconds()).padStart(3, "0");
-            return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}`;
+            return timestampToDatetimeLocal(timestamp);
           } else {
             return date.toISOString();
           }

--- a/src/webview/message-viewer.ts
+++ b/src/webview/message-viewer.ts
@@ -49,7 +49,7 @@ type ConsumeMode = "latest" | "beginning" | "timestamp";
  * available for the UI. It also talks to the "backend": sends and receives
  * messages from the host environment that manages stream consumption.
  */
-export class MessageViewerViewModel extends ViewModel {
+class MessageViewerViewModel extends ViewModel {
   page = this.signal(storage.get()?.page ?? 0);
   pageSize = this.signal(100);
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This PR swaps the text input for adding a timestamp (milliseconds since epoch) for a combo text input + date/time picker when setting the consume mode to `From date/time` (previously `From timestamp`):

<img width="1080" height="405" alt="image" src="https://github.com/user-attachments/assets/e414df7d-05bd-4ce6-b82c-d6b760e9aae9" />

https://github.com/user-attachments/assets/fd8ad402-ba39-432c-93fe-5df592ee1c86

To do this, we're taking the existing text field -- (converted from `vscode-text-field` to a regular text `input` since `vscode-webview-ui-toolkit` is [no longer supported](https://github.com/confluentinc/vscode/issues/842)) -- and adding a datetime-local `input` right next to it, but styling it like a button.

> [!NOTE]
> This is because [the default behavior of that kind of input](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/datetime-local) prevents pasting (timestamp- or ISO-formatted) strings and only allows typing in the individual date/time sections rather than pasting over the whole value.

So the button is effectively just acting as our way of opening the picker:
<img width="388" height="276" alt="image" src="https://github.com/user-attachments/assets/19acfa0a-e01b-406f-8509-dccf4ba170b0" />

This worked fine on its own, but quickly floated a problem of timezones:
- data is being displayed in UTC
- datetime-local wants to use the browser-local timezone

As a result, we had to start explicitly tracking which timezone was being used and add some conversions to go back and forth between local and UTC:
<img width="301" height="412" alt="image" src="https://github.com/user-attachments/assets/75512388-5d44-4803-966c-cc7878d7e76a" />

And as an added nice-to-have, the text input will try to parse timestamp values pasted based on the currently-selected timezone:

https://github.com/user-attachments/assets/22da705e-eadc-4596-95a3-a8dc513f40e8




| Local | UTC |
|--------|--------|
| <img width="791" height="599" alt="image" src="https://github.com/user-attachments/assets/92a9a2b4-b969-434f-98f7-15f6264a2a90" /> | <img width="796" height="629" alt="image" src="https://github.com/user-attachments/assets/c80fe2c2-2b1c-4893-a770-27bbf986f016" /> | 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
  - *I started going down the path of trying to create tests against `message-viewer.ts` but there is a non-trivial amount of state that has to be managed and I honestly don't even know where to start. Opting for punting to a future branch that can refactor for testability
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
