### PR TITLE
chore(CI): split `test` and `functional` into separate jobs per block

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,9 +25,33 @@ global_job_config:
       - checkout
 
 blocks:
-  # --- Build & Test (multi-platform/-arch) for VS Code (stable) ---
-  - name: "Build & Test (VS Code: linux x64)"
+  # --- Static Analysis ---
+  - name: "Static Analysis (TypeScript & ESLint)"
     dependencies: []
+    skip:
+      when: "change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
+      prologue:
+        commands:
+          - npm ci --prefer-offline --include=dev
+      jobs:
+        - name: "TypeScript Check"
+          commands:
+            - npx gulp check
+        - name: "ESLint"
+          commands:
+            - npx gulp lint
+      epilogue:
+        always:
+          commands:
+            - echo "Static analysis completed"
+
+  # --- Build & Test (multi-platform/-arch) for VS Code (stable) ---
+  - name: "Linux x64 Stable: Unit Tests (Mocha)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
     # Skip when:
     # - change in the release.svg file, signaling a `chore: none version bump vN.N.N` commit.
     # - change in the .versions/next.txt file, signaling a release PR merge commit.
@@ -49,10 +73,10 @@ blocks:
             else
               . vault-setup
             fi
-      jobs: &build-test-jobs-stable
-        - name: "Build & Test (VS Code)"
+      jobs:
+        - name: "Mocha Tests (VS Code)"
           commands:
-            - make test
+            - make test-mocha
           env_vars:
             - name: VSCODE_VERSION
               value: stable
@@ -70,19 +94,59 @@ blocks:
                 emit-sonarqube-data --run_only_sonar_scan
               fi
 
-  - name: "Build & Test (VS Code: linux arm64)"
-    dependencies: []
+  - name: "Linux x64 Stable: Webview Tests (Playwright)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
+    skip: *build-test-skip-stable
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
+      prologue: *build-test-prologue
+      jobs:
+        - name: "Playwright Tests (VS Code)"
+          commands:
+            - make test-playwright-webviews
+          env_vars:
+            - name: VSCODE_VERSION
+              value: stable
+      epilogue: *build-test-epilogue
+
+  - name: "Linux ARM64 Stable: Unit Tests (Mocha)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: *build-test-skip-stable
     task:
       agent:
         machine:
           type: s1-prod-ubuntu24-04-arm64-1
       prologue: *build-test-prologue
-      jobs: *build-test-jobs-stable
+      jobs:
+        - name: "Mocha Tests (VS Code)"
+          commands:
+            - make test-mocha
+          env_vars:
+            - name: VSCODE_VERSION
+              value: stable
       epilogue: *build-test-epilogue
 
-  - name: "Build & Test (VS Code: win32 x64)"
-    dependencies: []
+  - name: "Linux ARM64 Stable: Webview Tests (Playwright)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
+    skip: *build-test-skip-stable
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-arm64-1
+      prologue: *build-test-prologue
+      jobs:
+        - name: "Playwright Tests (VS Code)"
+          commands:
+            - make test-playwright-webviews
+          env_vars:
+            - name: VSCODE_VERSION
+              value: stable
+      epilogue: *build-test-epilogue
+
+  - name: "Windows x64 Stable: Unit Tests (Mocha)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: *build-test-skip-stable
     task:
       agent:
@@ -133,6 +197,10 @@ blocks:
             - npx playwright install
             - npx gulp ci
             - npx gulp test
+            # Note: Functional tests (npx gulp functional) are not run on Windows due to Playwright/browser automation issues
+          env_vars:
+            - name: VSCODE_VERSION
+              value: stable
       epilogue:
         always:
           commands:
@@ -149,16 +217,71 @@ blocks:
 
   # --- End Build & Test (multi-platform/-arch) for VS Code (stable) ---
 
-  - name: "Build & Test (VS Code Insiders: linux x64)"
-    dependencies: []
+  # --- Build & Test (multi-platform/-arch) for VS Code (insiders) ---
+  - name: "Linux x64 Insiders: Unit Tests (Mocha)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: &build-test-skip-insiders
       when: "branch != 'main' AND change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
     task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
       prologue: *build-test-prologue
-      jobs: &build-test-jobs-insiders
-        - name: "Build & Test (VS Code Insiders)"
+      jobs:
+        - name: "Mocha Tests (VS Code Insiders)"
           commands:
-            - make test
+            - make test-mocha
+          env_vars:
+            - name: VSCODE_VERSION
+              value: insiders
+      epilogue: *build-test-epilogue
+
+  - name: "Linux x64 Insiders: Webview Tests (Playwright)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
+    skip: *build-test-skip-insiders
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-amd64-1
+      prologue: *build-test-prologue
+      jobs:
+        - name: "Playwright Tests (VS Code Insiders)"
+          commands:
+            - make test-playwright-webviews
+          env_vars:
+            - name: VSCODE_VERSION
+              value: insiders
+      epilogue: *build-test-epilogue
+
+  - name: "Linux ARM64 Insiders: Unit Tests (Mocha)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
+    skip: *build-test-skip-insiders
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-arm64-1
+      prologue: *build-test-prologue
+      jobs:
+        - name: "Mocha Tests (VS Code Insiders)"
+          commands:
+            - make test-mocha
+          env_vars:
+            - name: VSCODE_VERSION
+              value: insiders
+      epilogue: *build-test-epilogue
+
+  - name: "Linux ARM64 Insiders: Webview Tests (Playwright)"
+    dependencies: ["Static Analysis (TypeScript & ESLint)"]
+    skip: *build-test-skip-insiders
+    task:
+      agent:
+        machine:
+          type: s1-prod-ubuntu24-04-arm64-1
+      prologue: *build-test-prologue
+      jobs:
+        - name: "Playwright Tests (VS Code Insiders)"
+          commands:
+            - make test-playwright-webviews
           env_vars:
             - name: VSCODE_VERSION
               value: insiders
@@ -166,7 +289,8 @@ blocks:
 
   - name: "Bump microversion"
     dependencies:
-      - "Build & Test (VS Code: linux x64)"
+      - "Linux x64 Stable: Unit Tests (Mocha)"
+      - "Linux x64 Stable: Webview Tests (Playwright)"
     skip:
       # For main branch:    Always bump microversion on every commit (except those that bump next.txt
       #                       to set the next version under development)
@@ -185,7 +309,8 @@ blocks:
 
   - name: "Set next version under development"
     dependencies:
-      - "Build & Test (VS Code: linux x64)"
+      - "Linux x64 Stable: Unit Tests (Mocha)"
+      - "Linux x64 Stable: Webview Tests (Playwright)"
     run:
       when: "branch = 'main' and change_in('/.versions/next.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -50,7 +50,7 @@ blocks:
             - echo "Static analysis completed"
 
   # --- Build & Test (multi-platform/-arch) for VS Code (stable) ---
-  - name: "Linux x64 Stable: Unit Tests (Mocha)"
+  - name: "Linux x64 Stable: Tests"
     dependencies: ["Static Analysis (TypeScript & ESLint)"]
     # Skip when:
     # - change in the release.svg file, signaling a `chore: none version bump vN.N.N` commit.
@@ -73,13 +73,16 @@ blocks:
             else
               . vault-setup
             fi
-      jobs:
-        - name: "Mocha Tests (VS Code)"
+      jobs: &build-test-jobs
+        - name: "Mocha: Unit Tests (VS Code)"
           commands:
             - make test-mocha
           env_vars:
             - name: VSCODE_VERSION
               value: stable
+        - name: "Playwright: Webview Tests (VS Code)"
+          commands:
+            - make test-playwright-webviews
       epilogue: &build-test-epilogue
         always:
           commands:
@@ -94,24 +97,7 @@ blocks:
                 emit-sonarqube-data --run_only_sonar_scan
               fi
 
-  - name: "Linux x64 Stable: Webview Tests (Playwright)"
-    dependencies: ["Static Analysis (TypeScript & ESLint)"]
-    skip: *build-test-skip-stable
-    task:
-      agent:
-        machine:
-          type: s1-prod-ubuntu24-04-amd64-1
-      prologue: *build-test-prologue
-      jobs:
-        - name: "Playwright Tests (VS Code)"
-          commands:
-            - make test-playwright-webviews
-          env_vars:
-            - name: VSCODE_VERSION
-              value: stable
-      epilogue: *build-test-epilogue
-
-  - name: "Linux ARM64 Stable: Unit Tests (Mocha)"
+  - name: "Linux ARM64 Stable: Tests"
     dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: *build-test-skip-stable
     task:
@@ -119,33 +105,10 @@ blocks:
         machine:
           type: s1-prod-ubuntu24-04-arm64-1
       prologue: *build-test-prologue
-      jobs:
-        - name: "Mocha Tests (VS Code)"
-          commands:
-            - make test-mocha
-          env_vars:
-            - name: VSCODE_VERSION
-              value: stable
+      jobs: *build-test-jobs
       epilogue: *build-test-epilogue
 
-  - name: "Linux ARM64 Stable: Webview Tests (Playwright)"
-    dependencies: ["Static Analysis (TypeScript & ESLint)"]
-    skip: *build-test-skip-stable
-    task:
-      agent:
-        machine:
-          type: s1-prod-ubuntu24-04-arm64-1
-      prologue: *build-test-prologue
-      jobs:
-        - name: "Playwright Tests (VS Code)"
-          commands:
-            - make test-playwright-webviews
-          env_vars:
-            - name: VSCODE_VERSION
-              value: stable
-      epilogue: *build-test-epilogue
-
-  - name: "Windows x64 Stable: Unit Tests (Mocha)"
+  - name: "Windows x64 Stable: Tests"
     dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: *build-test-skip-stable
     task:
@@ -191,7 +154,7 @@ blocks:
             $E2E_PASSWORD = $(vault kv get -field=E2E_PASSWORD v1/ci/kv/vscodeextension/testing)
             Add-Content -Path .env -Value "E2E_PASSWORD=$E2E_PASSWORD"
       jobs:
-        - name: "Build & Test (VS Code)"
+        - name: "Mocha: Unit Tests (VS Code)"
           commands:
             - npm ci --prefer-offline --include=dev
             - npx playwright install
@@ -218,7 +181,7 @@ blocks:
   # --- End Build & Test (multi-platform/-arch) for VS Code (stable) ---
 
   # --- Build & Test (multi-platform/-arch) for VS Code (insiders) ---
-  - name: "Linux x64 Insiders: Unit Tests (Mocha)"
+  - name: "Linux x64 Insiders: Tests"
     dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: &build-test-skip-insiders
       when: "branch != 'main' AND change_in(['/release.svg', '/.versions/next.txt'], {pipeline_file: 'ignore', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', default_branch: 'main'})"
@@ -234,26 +197,12 @@ blocks:
           env_vars:
             - name: VSCODE_VERSION
               value: insiders
-      epilogue: *build-test-epilogue
-
-  - name: "Linux x64 Insiders: Webview Tests (Playwright)"
-    dependencies: ["Static Analysis (TypeScript & ESLint)"]
-    skip: *build-test-skip-insiders
-    task:
-      agent:
-        machine:
-          type: s1-prod-ubuntu24-04-amd64-1
-      prologue: *build-test-prologue
-      jobs:
         - name: "Playwright Tests (VS Code Insiders)"
           commands:
             - make test-playwright-webviews
-          env_vars:
-            - name: VSCODE_VERSION
-              value: insiders
       epilogue: *build-test-epilogue
 
-  - name: "Linux ARM64 Insiders: Unit Tests (Mocha)"
+  - name: "Linux ARM64 Insiders: Tests"
     dependencies: ["Static Analysis (TypeScript & ESLint)"]
     skip: *build-test-skip-insiders
     task:
@@ -262,35 +211,20 @@ blocks:
           type: s1-prod-ubuntu24-04-arm64-1
       prologue: *build-test-prologue
       jobs:
-        - name: "Mocha Tests (VS Code Insiders)"
+        - name: "Mocha: Unit Tests (VS Code Insiders)"
           commands:
             - make test-mocha
           env_vars:
             - name: VSCODE_VERSION
               value: insiders
-      epilogue: *build-test-epilogue
-
-  - name: "Linux ARM64 Insiders: Webview Tests (Playwright)"
-    dependencies: ["Static Analysis (TypeScript & ESLint)"]
-    skip: *build-test-skip-insiders
-    task:
-      agent:
-        machine:
-          type: s1-prod-ubuntu24-04-arm64-1
-      prologue: *build-test-prologue
-      jobs:
-        - name: "Playwright Tests (VS Code Insiders)"
+        - name: "Playwright: Webview Tests (VS Code Insiders)"
           commands:
             - make test-playwright-webviews
-          env_vars:
-            - name: VSCODE_VERSION
-              value: insiders
       epilogue: *build-test-epilogue
 
   - name: "Bump microversion"
     dependencies:
-      - "Linux x64 Stable: Unit Tests (Mocha)"
-      - "Linux x64 Stable: Webview Tests (Playwright)"
+      - "Linux x64 Stable: Tests"
     skip:
       # For main branch:    Always bump microversion on every commit (except those that bump next.txt
       #                       to set the next version under development)
@@ -309,8 +243,7 @@ blocks:
 
   - name: "Set next version under development"
     dependencies:
-      - "Linux x64 Stable: Unit Tests (Mocha)"
-      - "Linux x64 Stable: Webview Tests (Playwright)"
+      - "Linux x64 Stable: Tests"
     run:
       when: "branch = 'main' and change_in('/.versions/next.txt', {pipeline_file: 'ignore', default_branch: 'main'})"
     task:

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,9 @@ remove-test-env:
 	@echo "Removing .env file"
 	@rm -f .env
 
-.PHONY: test
-test: setup-test-env install-test-dependencies install-dependencies
+# Run only unit (Mocha) tests (split for CI parallelization)
+.PHONY: test-mocha
+test-mocha: setup-test-env install-test-dependencies install-dependencies
 	npx gulp ci
 	@if [ $$(uname -s) = "Linux" ]; then \
 			xvfb-run -a npx gulp test; \
@@ -48,6 +49,11 @@ test: setup-test-env install-test-dependencies install-dependencies
 	else \
 			npx gulp test; \
 	fi
+
+# Run only webview (Playwright) tests (split for CI parallelization)
+.PHONY: test-playwright-webviews
+test-playwright-webviews: setup-test-env install-test-dependencies install-dependencies
+	npx gulp ci
 	npx gulp functional
 
 # Validates bump based on current version (in package.json)


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Instead of each job running `gulp test` and then `gulp functional`, this PR lets them run as separate jobs inside a single "tests" block (per agent). This reduces the total running time for a given block to 4-5min instead of 6-7 minutes. (Aside from Windows, which usually takes longer due to waiting for an available agent/runner.)

This also:
- updates some names for clarity (making it slightly easier to add E2E playwright tests)
- adds a `linux arm64` step to run against VS Code Insiders (helpful to compare against any failing tests in the `linux x64` VS Code stable block)
- adds `gulp check` and `gulp lint` its own block that has to pass before the tests kick off. (We don't want to waste resources if at least one more commit will be required for formatting, error correction, type fixes, etc.)

<img width="1113" alt="image" src="https://github.com/user-attachments/assets/4b2d287e-431c-4a3c-b471-5a725625ef73" />


Closes #2015