### PR TITLE
MINOR: only `gulp build` in make `test*` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ remove-test-env:
 # Run only unit (Mocha) tests (split for CI parallelization)
 .PHONY: test-mocha
 test-mocha: setup-test-env install-test-dependencies install-dependencies
-	npx gulp ci
+	npx gulp build
 	@if [ $$(uname -s) = "Linux" ]; then \
 			xvfb-run -a npx gulp test; \
 	elif [ $$(uname -s) = "Darwin" ]; then \
@@ -53,7 +53,7 @@ test-mocha: setup-test-env install-test-dependencies install-dependencies
 # Run only webview (Playwright) tests (split for CI parallelization)
 .PHONY: test-playwright-webviews
 test-playwright-webviews: setup-test-env install-test-dependencies install-dependencies
-	npx gulp ci
+	npx gulp build
 	npx gulp functional
 
 # Validates bump based on current version (in package.json)


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/vscode/pull/2039 to shave off a small amount of work from the test blocks by just running `gulp build` instead of `gulp ci`:
https://github.com/confluentinc/vscode/blob/d94ca96d05356099f216aabfe26035637bdad2cd/Gulpfile.js#L35
(Likely won't save any time since `check` and `lint` are faster than `build`)

We don't need to run `gulp ci` here since the `gulp check`/`gulp lint` pieces are already covered in their own block:
https://github.com/confluentinc/vscode/blob/d94ca96d05356099f216aabfe26035637bdad2cd/.semaphore/semaphore.yml#L40-L46
