### PR TITLE
Generalize Kafka cluster storage methods as was done for schema registry storage.

### DIFF
--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -13,7 +13,7 @@ import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { FlinkStatement, restFlinkStatementToModel } from "../models/flinkStatement";
 import { CCloudKafkaCluster } from "../models/kafkaCluster";
 import { CCloudOrganization } from "../models/organization";
-import { IFlinkQueryable, isCCloud } from "../models/resource";
+import { EnvironmentId, IFlinkQueryable, isCCloud } from "../models/resource";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
 import { getSidecar, SidecarHandle } from "../sidecar";
@@ -166,7 +166,7 @@ export class CCloudResourceLoader extends ResourceLoader {
         if (env.schemaRegistry) schemaRegistries.push(env.schemaRegistry);
       });
       await Promise.all([
-        resourceManager.setCCloudKafkaClusters(kafkaClusters),
+        resourceManager.setKafkaClusters(CCLOUD_CONNECTION_ID, kafkaClusters),
         resourceManager.setSchemaRegistries(CCLOUD_CONNECTION_ID, schemaRegistries),
       ]);
 
@@ -217,14 +217,19 @@ export class CCloudResourceLoader extends ResourceLoader {
    * Get the CCloud kafka clusters in the given environment ID.
    */
   public async getKafkaClustersForEnvironmentId(
-    environmentId: string,
+    environmentId: EnvironmentId,
     forceDeepRefresh?: boolean,
   ): Promise<CCloudKafkaCluster[]> {
     if (environmentId === undefined) {
-      throw new Error(`Cannot fetch clusters w/o an environmentId.`);
+      throw new Error("Cannot fetch clusters w/o an environmentId.");
     }
+
     await this.ensureCoarseResourcesLoaded(forceDeepRefresh);
-    return await getResourceManager().getCCloudKafkaClustersForEnvironment(environmentId);
+
+    return await getResourceManager().getKafkaClustersForEnvironmentId(
+      CCLOUD_CONNECTION_ID,
+      environmentId,
+    );
   }
 
   /**

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -8,7 +8,15 @@ import {
   UTM_SOURCE_VSCODE,
 } from "../constants";
 import { CustomMarkdownString } from "./main";
-import { ConnectionId, EnvironmentId, IResourceBase, isCCloud, ISearchable } from "./resource";
+import {
+  ConnectionId,
+  connectionIdToType,
+  EnvironmentId,
+  IResourceBase,
+  isCCloud,
+  ISearchable,
+  UsedConnectionType,
+} from "./resource";
 
 /** Base class for all KafkaClusters */
 export abstract class KafkaCluster extends Data implements IResourceBase, ISearchable {
@@ -16,8 +24,9 @@ export abstract class KafkaCluster extends Data implements IResourceBase, ISearc
   abstract connectionType: ConnectionType;
   iconName: IconNames = IconNames.KAFKA_CLUSTER;
 
-  abstract name: string;
-  abstract environmentId: EnvironmentId | undefined;
+  abstract environmentId: EnvironmentId;
+
+  name!: Enforced<string>;
 
   id!: Enforced<string>;
   bootstrapServers!: Enforced<string>;
@@ -33,7 +42,6 @@ export class CCloudKafkaCluster extends KafkaCluster {
   readonly connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   readonly connectionType: ConnectionType = ConnectionType.Ccloud;
 
-  name!: Enforced<string>;
   provider!: Enforced<string>;
   region!: Enforced<string>;
 
@@ -58,8 +66,6 @@ export class DirectKafkaCluster extends KafkaCluster {
   readonly connectionId!: Enforced<ConnectionId>; // dynamically assigned at connection creation time
   readonly connectionType: ConnectionType = ConnectionType.Direct;
 
-  name!: Enforced<string>;
-
   // we only support one Kafka cluster and one Schema Registry per connection, so we can treat the
   // connection ID as the environment ID
   get environmentId(): EnvironmentId {
@@ -72,11 +78,28 @@ export class LocalKafkaCluster extends KafkaCluster {
   readonly connectionId: ConnectionId = LOCAL_CONNECTION_ID;
   readonly connectionType: ConnectionType = ConnectionType.Local;
 
-  name!: Enforced<string>;
-
   get environmentId(): EnvironmentId {
     return this.connectionId as unknown as EnvironmentId;
   }
+}
+
+/** The concrete subclasses. Excludes the abstract base class which lacks a constructor. */
+export type KafkaClusterSubclass =
+  | typeof CCloudKafkaCluster
+  | typeof DirectKafkaCluster
+  | typeof LocalKafkaCluster;
+
+/** Mapping of connection type to corresponding KafkaCluster subclass */
+const kafkaClusterClassByConnectionType: Record<UsedConnectionType, KafkaClusterSubclass> = {
+  [ConnectionType.Ccloud]: CCloudKafkaCluster,
+  [ConnectionType.Direct]: DirectKafkaCluster,
+  [ConnectionType.Local]: LocalKafkaCluster,
+};
+
+/** Returns the appropriate KafkaCluster subclass based on the connection type. */
+export function getKafkaClusterClass(connectionId: ConnectionId): KafkaClusterSubclass {
+  const connectionType = connectionIdToType(connectionId);
+  return kafkaClusterClassByConnectionType[connectionType];
 }
 
 /** The representation of a {@link KafkaCluster} as a {@link TreeItem} in the VS Code UI. */

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -71,7 +71,7 @@ export class LocalSchemaRegistry extends SchemaRegistry {
   // environmentId should map to the connectionId
 }
 
-/** The concrete subclasses. Excludes the abstract base class which lacks a constructor. */
+/** Types of the concrete subclasses. Excludes the abstract base class which lacks a constructor. */
 type SchemaRegistrySubclass =
   | typeof CCloudSchemaRegistry
   | typeof DirectSchemaRegistry


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Get rid of the `CCloudKafkaCluster* `and `LocalKafkaCluster*` resource manager methods in favor of generic methods for storing and getting KafkaCluster subclass arrays given a connection ID, as well as a somewhat convienence method for also extracting the subset for a single `EnvironmentId`, matching the corresponding API at the `ResourceLoader` level.
  - Methods removed:
     - `setCCloudKafkaClusters()`: Functionally replaced by `setKafkaClusters(ConnID, KafkaCluster[])`.
     - `getCCloudKafkaClusters()`: Functionally replaced by `getKafkaClusters(ConnId)`.
     - `getCCloudKafkaClustersForEnvironment()`:  Functionally replaced by `getKafkaClustersForEnvironmentId(ConnId, EnvId)`.
     - `deleteCCloudKafkaClusters()`: Functionally replaced by `setKafkaClusters(ConnId, [])`.
     - `getCCloudKafkaCluster()`: No callers.
     -  `setLocalKafkaClusters()`: Sole misguided caller removed,  Functionally replaced by `setKafkaClusters(ConnID, KafkaCluster[])`.
     -  `getLocalKafkaClusters()`: No callers.  Functionally replaced by `getKafkaClusters(ConnId)`.
     - `getLocalKafkaCluster()`: No callers.
     - `getClusterForTopic()`: No callers. 
     - `deleteLocalKafkaClusters(): No callers. 
- Code ends up being Highly Parallel with the code for schema registries. So parallel in fact that we may decide to make the innards of the get/set methods be one degree more generic then have the Kafka cluster and Schema registry variants wrap the underlying workhorses (in a future PR).

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- While here:
  - Tighten up the `KafkaCluster` type hierarchy:
      - Make`environmentId` required at at the base class level (no longer possibly undefined; all subclasses have carried concrete environmentId values for a while now).
      - Move declaration of `name` to the base class also, was independently defined at each subclass.
  - Tighten up type usage within `getSchemaRegistries()`, s`etSchemaRegistries()` .
  - Stop setting local kafka clusters into resource manager from `ResourceViewProvider` helper code. There was no peer statement to load them back. `NewResourceViewProvider` will end up properly caching and fetching from cache in a uniform manner.
- Closes #2060

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
