### PR TITLE
Generalize environment caching. Flesh out a few more test cases.

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -283,7 +283,7 @@ describe("CCloudResourceLoader", () => {
     });
 
     function setGetEnvironmentsResult(results: CCloudEnvironment[]) {
-      stubbedResourceManager.getCCloudEnvironments.resolves(results);
+      stubbedResourceManager.getEnvironments.resolves(results);
     }
 
     it("should return true if there are Flink compute pools", async () => {
@@ -322,7 +322,11 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.calledOnce(getEnvironmentsStub);
       sinon.assert.calledOnce(getCurrentOrganizationStub);
       assert.strictEqual(loader["organization"], null);
-      sinon.assert.calledOnceWithExactly(stubbedResourceManager.setCCloudEnvironments, []);
+      sinon.assert.calledOnceWithExactly(
+        stubbedResourceManager.setEnvironments,
+        CCLOUD_CONNECTION_ID,
+        [],
+      );
       sinon.assert.calledOnceWithExactly(
         stubbedResourceManager.setKafkaClusters,
         CCLOUD_CONNECTION_ID,
@@ -344,9 +348,11 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.calledOnce(getEnvironmentsStub);
       sinon.assert.calledOnce(getCurrentOrganizationStub);
       assert.strictEqual(loader["organization"], TEST_CCLOUD_ORGANIZATION);
-      sinon.assert.calledOnceWithExactly(stubbedResourceManager.setCCloudEnvironments, [
-        TEST_CCLOUD_ENVIRONMENT,
-      ]);
+      sinon.assert.calledOnceWithExactly(
+        stubbedResourceManager.setEnvironments,
+        CCLOUD_CONNECTION_ID,
+        [TEST_CCLOUD_ENVIRONMENT],
+      );
       sinon.assert.calledOnceWithExactly(
         stubbedResourceManager.setKafkaClusters,
         CCLOUD_CONNECTION_ID,

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -155,7 +155,7 @@ export class CCloudResourceLoader extends ResourceLoader {
 
       // Store the environments, clusters, schema registries in the resource manager
       const environments: CCloudEnvironment[] = gqlResults[0];
-      await resourceManager.setCCloudEnvironments(environments);
+      await resourceManager.setEnvironments(CCLOUD_CONNECTION_ID, environments);
 
       // Collect all of the CCloudKafkaCluster and CCloudSchemaRegistries into individual arrays
       // before storing them via the resource manager.
@@ -190,13 +190,13 @@ export class CCloudResourceLoader extends ResourceLoader {
    */
   public async getEnvironments(forceDeepRefresh: boolean = false): Promise<CCloudEnvironment[]> {
     await this.ensureCoarseResourcesLoaded(forceDeepRefresh);
-    return await getResourceManager().getCCloudEnvironments();
+    return await getResourceManager().getEnvironments(CCLOUD_CONNECTION_ID);
   }
 
   /** Are there any Flink compute pools at all? */
   public async hasFlinkComputePools(): Promise<boolean> {
     await this.ensureCoarseResourcesLoaded();
-    const environments = await getResourceManager().getCCloudEnvironments();
+    const environments = await getResourceManager().getEnvironments(CCLOUD_CONNECTION_ID);
     return environments.some((env) => env.flinkComputePools.length > 0);
   }
 

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -25,11 +25,13 @@ import {
 import { CustomMarkdownString } from "./main";
 import {
   ConnectionId,
+  connectionIdToType,
   EnvironmentId,
   IResourceBase,
   isCCloud,
   isDirect,
   ISearchable,
+  UsedConnectionType,
 } from "./resource";
 import {
   CCloudSchemaRegistry,
@@ -238,6 +240,32 @@ export class LocalEnvironment extends Environment {
     this.kafkaClusters = props.kafkaClusters;
     this.schemaRegistry = props.schemaRegistry;
   }
+}
+
+/**
+ * Type of the concrete Environment subclasses.
+ * Excludes the abstract base class which lacks a constructor.
+ */
+type EnvironmentSubclass =
+  | typeof CCloudEnvironment
+  | typeof DirectEnvironment
+  | typeof LocalEnvironment;
+
+/**
+ * Mapping of connection types to their corresponding Environment subclass.
+ * @see getEnvironmentClass
+ */
+const environmentClassByConnectionType: Record<UsedConnectionType, EnvironmentSubclass> = {
+  [ConnectionType.Ccloud]: CCloudEnvironment,
+  [ConnectionType.Direct]: DirectEnvironment,
+  [ConnectionType.Local]: LocalEnvironment,
+};
+
+/**
+ * Returns the appropriate Environment subclass for the given connection ID.
+ */
+export function getEnvironmentClass(connectionId: ConnectionId): EnvironmentSubclass {
+  return environmentClassByConnectionType[connectionIdToType(connectionId)];
 }
 
 /** The representation of an {@link Environment} as a {@link TreeItem} in the VS Code UI. */

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -6,8 +6,12 @@ import {
   TEST_CCLOUD_KAFKA_CLUSTER,
   TEST_CCLOUD_KAFKA_TOPIC,
   TEST_CCLOUD_SCHEMA_REGISTRY,
+  TEST_CCLOUD_SUBJECT,
+  TEST_DIRECT_ENVIRONMENT,
+  TEST_DIRECT_KAFKA_CLUSTER,
   TEST_DIRECT_SCHEMA_REGISTRY,
   TEST_LOCAL_KAFKA_CLUSTER,
+  TEST_LOCAL_KAFKA_TOPIC,
   TEST_LOCAL_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import {
@@ -18,13 +22,14 @@ import { TEST_CCLOUD_FLINK_COMPUTE_POOL_ID } from "../../tests/unit/testResource
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import {
   ConnectionSpec,
+  ConnectionType,
   KafkaClusterConfigFromJSON,
   KafkaClusterConfigToJSON,
 } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID, LOCAL_CONNECTION_ID } from "../constants";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
-import { ConnectionId, EnvironmentId } from "../models/resource";
+import { ConnectionId, EnvironmentId, ISchemaRegistryResource } from "../models/resource";
 import { Subject } from "../models/schema";
 import {
   CCloudSchemaRegistry,
@@ -46,21 +51,13 @@ import {
 import { UriMetadata, UriMetadataMap } from "./types";
 import { clearWorkspaceState, getWorkspaceState } from "./utils";
 
-describe("ResourceManager (CCloud) environment methods", function () {
-  let environments: CCloudEnvironment[];
+describe("ResourceManager getEnvironments() / setEnvironments() / getEnvironmentKey()", function () {
+  let rm: ResourceManager;
 
   before(async () => {
     // extension needs to be activated before any storage management can be done
     await getTestExtensionContext();
-    environments = [
-      new CCloudEnvironment({ ...TEST_CCLOUD_ENVIRONMENT, id: "test-env-id-1" as EnvironmentId }),
-      new CCloudEnvironment({ ...TEST_CCLOUD_ENVIRONMENT, id: "test-env-id-2" as EnvironmentId }),
-    ];
-  });
-
-  beforeEach(async () => {
-    // fresh slate for each test
-    await clearWorkspaceState();
+    rm = getResourceManager();
   });
 
   afterEach(async () => {
@@ -68,55 +65,73 @@ describe("ResourceManager (CCloud) environment methods", function () {
     await clearWorkspaceState();
   });
 
-  it("setCCloudEnvironments() should correctly store Environments", async () => {
-    const resourceManager = getResourceManager();
-    await resourceManager.setCCloudEnvironments(environments);
-    // verify the environments were stored correctly
-    let storedEnvironments: CCloudEnvironment[] = await resourceManager.getCCloudEnvironments();
+  it("getEnvironmentKey() works for CCLOUD_CONNECTION_ID", () => {
+    const key = rm.getEnvironmentKey(CCLOUD_CONNECTION_ID);
+    assert.strictEqual(key, WorkspaceStorageKeys.CCLOUD_ENVIRONMENTS);
+  });
+
+  for (const connId of [LOCAL_CONNECTION_ID, TEST_DIRECT_CONNECTION_ID]) {
+    it(`getEnvironmentKey() throws for unsupported connection ID ${connId}`, () => {
+      assert.throws(
+        () => rm.getEnvironmentKey(connId),
+        (err) => {
+          return err instanceof Error && err.message.includes("Unsupported connectionId");
+        },
+        `Expected error for connection ID ${connId}`,
+      );
+    });
+  }
+
+  it("setEnvironments() should throw an error if given mixed connection IDs", async () => {
+    const mixedEnvironments = [TEST_CCLOUD_ENVIRONMENT, TEST_DIRECT_ENVIRONMENT];
+
+    await assert.rejects(
+      rm.setEnvironments(CCLOUD_CONNECTION_ID, mixedEnvironments),
+      (err) => {
+        return err instanceof Error && err.message.includes("Connection ID mismatch");
+      },
+      "Expected error when setting mixed connection IDs",
+    );
+  });
+
+  it("getEnvironments() should return an empty array if no environments are found", async () => {
+    // no preloading, the workspace store should return undefined.
+    const storedEnvironments: CCloudEnvironment[] = await rm.getEnvironments(CCLOUD_CONNECTION_ID);
+    assert.deepStrictEqual(storedEnvironments, []);
+  });
+
+  it("setEnvironments() / getEnvironments() should correctly store CCloud environments", async () => {
+    // set the environment in extension storage before retrieving it
+    await rm.setEnvironments(CCLOUD_CONNECTION_ID, [TEST_CCLOUD_ENVIRONMENT]);
+    // verify the environment was stored correctly
+    const storedEnvironments: CCloudEnvironment[] = await rm.getEnvironments(CCLOUD_CONNECTION_ID);
     assert.ok(storedEnvironments);
-    assert.deepStrictEqual(storedEnvironments, environments);
-  });
-
-  it("getCCloudEnvironments() should correctly retrieve Environments", async () => {
-    const resourceManager = getResourceManager();
-    // set the environments in extension storage before retrieving them
-    await resourceManager.setCCloudEnvironments(environments);
-    // verify the environments were retrieved correctly
-    const retrievedEnvironments: CCloudEnvironment[] =
-      await resourceManager.getCCloudEnvironments();
-    assert.deepStrictEqual(retrievedEnvironments, environments);
-  });
-
-  it("getCCloudEnvironment() should correctly retrieve an Environment", async () => {
-    // set the environments in extension storage before retrieving one
-    await getResourceManager().setCCloudEnvironments(environments);
-    // verify the environment was retrieved correctly
-    const environment: CCloudEnvironment | null = await getResourceManager().getCCloudEnvironment(
-      environments[0].id,
+    assert.deepStrictEqual(storedEnvironments, [TEST_CCLOUD_ENVIRONMENT]);
+    assert.ok(
+      storedEnvironments[0] instanceof CCloudEnvironment,
+      "Expected stored environment to be CCloudEnvironment",
     );
-    assert.deepStrictEqual(environment, environments[0]);
   });
 
-  it("getCCloudEnvironment() should return null if the environment is not found", async () => {
-    const resourceManager = getResourceManager();
-    // set the environments in extension storage before retrieving one
-    await resourceManager.setCCloudEnvironments(environments);
-    // verify the environment was not found
-    const missingEnvironment: CCloudEnvironment | null =
-      await resourceManager.getCCloudEnvironment("nonexistent-env-id");
-    assert.strictEqual(missingEnvironment, null);
-  });
+  it("setEnvironments() should overwrite existing environments", async () => {
+    // set the environment in extension storage before retrieving it
+    await rm.setEnvironments(CCLOUD_CONNECTION_ID, [TEST_CCLOUD_ENVIRONMENT]);
+    // verify the environment was stored correctly
+    let storedEnvironments: CCloudEnvironment[] = await rm.getEnvironments(CCLOUD_CONNECTION_ID);
+    assert.ok(storedEnvironments);
+    assert.deepStrictEqual(storedEnvironments, [TEST_CCLOUD_ENVIRONMENT]);
 
-  it("deleteCCloudEnvironments() should correctly delete Environments", async () => {
-    // set the environments in extension storage before deleting them
-    const resourceManager = getResourceManager();
-    await resourceManager.setCCloudEnvironments(environments);
-    await resourceManager.deleteCCloudEnvironments();
-    // verify the environments were deleted correctly
-    const missingEnvironments: CCloudEnvironment[] | undefined = await getWorkspaceState().get(
-      WorkspaceStorageKeys.CCLOUD_ENVIRONMENTS,
-    );
-    assert.deepStrictEqual(missingEnvironments, undefined);
+    // now overwrite with a new environment
+    const newEnvironment = new CCloudEnvironment({
+      ...TEST_CCLOUD_ENVIRONMENT,
+      id: `new-env-id-${randomUUID()}` as EnvironmentId,
+      name: `New Environment ${randomUUID()}`,
+    });
+    await rm.setEnvironments(CCLOUD_CONNECTION_ID, [newEnvironment]);
+    // verify the environment was overwritten correctly
+    storedEnvironments = await rm.getEnvironments(CCLOUD_CONNECTION_ID);
+    assert.ok(storedEnvironments);
+    assert.deepStrictEqual(storedEnvironments, [newEnvironment]);
   });
 });
 
@@ -269,7 +284,7 @@ describe("ResourceManager kafka cluster methods", function () {
   });
 });
 
-describe("ResourceManager (CCloud) Schema Registry methods", function () {
+describe("ResourceManager setTopicsForCluster() / getTopicsForCluster() / topicKeyForCluster()", function () {
   before(async () => {
     // extension needs to be activated before any storage management can be done
     await getTestExtensionContext();
@@ -283,6 +298,36 @@ describe("ResourceManager (CCloud) Schema Registry methods", function () {
   afterEach(async () => {
     // clean up after each test
     await clearWorkspaceState();
+  });
+
+  it("topicKeyForCluster() works for CCloud clusters", () => {
+    const key = getResourceManager().topicKeyForCluster(TEST_CCLOUD_KAFKA_CLUSTER);
+    assert.strictEqual(key, WorkspaceStorageKeys.CCLOUD_KAFKA_TOPICS);
+  });
+
+  for (const unsupportedKafkaCluster of [TEST_LOCAL_KAFKA_CLUSTER, TEST_DIRECT_KAFKA_CLUSTER]) {
+    it(`topicKeyForCluster() throws for unsupported cluster ${unsupportedKafkaCluster.id}`, () => {
+      assert.throws(
+        () => getResourceManager().topicKeyForCluster(unsupportedKafkaCluster),
+        (err) => {
+          return err instanceof Error && err.message.includes("Unknown cluster type");
+        },
+        `Expected error for cluster ${unsupportedKafkaCluster.id}`,
+      );
+    });
+  }
+
+  it("setTopicsForCluster() should throw an error if given mixed connection IDs", async () => {
+    // from mixed kafka clusters (and even connections!)
+    const mixedTopics = [TEST_CCLOUD_KAFKA_TOPIC, TEST_LOCAL_KAFKA_TOPIC];
+
+    await assert.rejects(
+      getResourceManager().setTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER, mixedTopics),
+      (err) => {
+        return err instanceof Error && err.message.includes("Cluster ID mismatch in topics");
+      },
+      "Expected error when setting mixed connection IDs",
+    );
   });
 
   it("CCLOUD: getTopicsForCluster() should return undefined if no cached topics for this cluster", async () => {
@@ -476,6 +521,14 @@ describe("ResourceManager Schema Registry methods", function () {
       );
     });
   }
+
+  it("getSchemaRegistries() returns empty array if no connection id key is found in map", async () => {
+    await getWorkspaceState().update(WorkspaceStorageKeys.CCLOUD_SCHEMA_REGISTRIES, "{}");
+
+    const storedRegistries: CCloudSchemaRegistry[] =
+      await rm.getSchemaRegistries(CCLOUD_CONNECTION_ID);
+    assert.deepStrictEqual(storedRegistries, []);
+  });
 
   it("setSchemaRegistries() error when given mixed connection id array", async () => {
     const ccloudSchemaRegistry = CCloudSchemaRegistry.create(TEST_CCLOUD_SCHEMA_REGISTRY);
@@ -703,6 +756,23 @@ describe("ResourceManager SR subject methods", function () {
     });
   }
 
+  it("subjectKeyForSchemaRegistry() should throw for unsupported connection IDs", () => {
+    const wonkySchemaRegistry: ISchemaRegistryResource = {
+      connectionId: "wonky-connection-id" as ConnectionId,
+      connectionType: ConnectionType.Platform, // unsupported connection type
+      environmentId: "wonky-env-id" as EnvironmentId,
+      schemaRegistryId: "wonky",
+    };
+
+    assert.throws(
+      () => resourceManager.subjectKeyForSchemaRegistry(wonkySchemaRegistry),
+      (err) => {
+        return err instanceof Error && err.message === "Unknown schema registry connection type";
+      },
+      "Expected error for unsupported connection ID",
+    );
+  });
+
   it("getSubjects() should return undefined if no cached subjects for this schema registry", async () => {
     for (const sr of [
       TEST_CCLOUD_SCHEMA_REGISTRY,
@@ -859,18 +929,34 @@ describe("ResourceManager general utility methods", function () {
   it("CCLOUD: deleteCCloudResources() should correctly delete all CCloud resources", async () => {
     // set the CCloud resources before deleting them
     const resourceManager = getResourceManager();
+    await resourceManager.setEnvironments(CCLOUD_CONNECTION_ID, [TEST_CCLOUD_ENVIRONMENT]);
     await resourceManager.setKafkaClusters(CCLOUD_CONNECTION_ID, [TEST_CCLOUD_KAFKA_CLUSTER]);
     await resourceManager.setSchemaRegistries(CCLOUD_CONNECTION_ID, [TEST_CCLOUD_SCHEMA_REGISTRY]);
     await resourceManager.setTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER, ccloudTopics);
+    await resourceManager.setSubjects(TEST_CCLOUD_SCHEMA_REGISTRY, [TEST_CCLOUD_SUBJECT]);
 
     await resourceManager.deleteCCloudResources();
 
-    // verify the resources were deleted correctly
-    const missingClusters = await resourceManager.getKafkaClusters(CCLOUD_CONNECTION_ID);
+    // verify all the ccloudy resources were deleted.
+
+    const missingEnvironments =
+      await resourceManager.getEnvironments<CCloudEnvironment>(CCLOUD_CONNECTION_ID);
+    assert.deepStrictEqual(missingEnvironments, []);
+
+    const missingClusters =
+      await resourceManager.getKafkaClusters<CCloudKafkaCluster>(CCLOUD_CONNECTION_ID);
     assert.deepStrictEqual(missingClusters, []);
+
     const missingSchemaRegistries =
       await resourceManager.getSchemaRegistries<CCloudSchemaRegistry>(CCLOUD_CONNECTION_ID);
     assert.deepStrictEqual(missingSchemaRegistries, []);
+
+    // For reasons, these two represent emptyness with undefined, not empty arrays. Ah, consistency!
+    const missingTopics = await resourceManager.getTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER);
+    assert.deepStrictEqual(missingTopics, undefined);
+
+    const missingSubjects = await resourceManager.getSubjects(TEST_CCLOUD_SCHEMA_REGISTRY);
+    assert.deepStrictEqual(missingSubjects, undefined);
   });
 });
 
@@ -1102,5 +1188,17 @@ describe("ResourceManager utility functions", function () {
     assert.strictEqual(result.size, 2);
     assert.strictEqual(result.get("key1"), "value1");
     assert.strictEqual(result.get("key2"), "value2");
+  });
+});
+
+describe("ResourceManager.runWithMutex()", function () {
+  it("raises if cannot find mutex for key", async () => {
+    const resourceManager = getResourceManager();
+    await assert.rejects(
+      () => resourceManager["runWithMutex"]("nonexistent" as WorkspaceStorageKeys, async () => {}),
+      (err) => {
+        return err instanceof Error && err.message === "No mutex found for key: nonexistent";
+      },
+    );
   });
 });

--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -97,6 +97,7 @@ describe("ResourceManager getEnvironments() / setEnvironments() / getEnvironment
   it("getEnvironments() should return an empty array if no environments are found", async () => {
     // no preloading, the workspace store should return undefined.
     const storedEnvironments: CCloudEnvironment[] = await rm.getEnvironments(CCLOUD_CONNECTION_ID);
+    // ... which then gets promoted to an empty array.
     assert.deepStrictEqual(storedEnvironments, []);
   });
 
@@ -937,7 +938,7 @@ describe("ResourceManager general utility methods", function () {
 
     await resourceManager.deleteCCloudResources();
 
-    // verify all the ccloudy resources were deleted.
+    // verify all the CCloud resources were deleted.
 
     const missingEnvironments =
       await resourceManager.getEnvironments<CCloudEnvironment>(CCLOUD_CONNECTION_ID);
@@ -951,7 +952,7 @@ describe("ResourceManager general utility methods", function () {
       await resourceManager.getSchemaRegistries<CCloudSchemaRegistry>(CCLOUD_CONNECTION_ID);
     assert.deepStrictEqual(missingSchemaRegistries, []);
 
-    // For reasons, these two represent emptyness with undefined, not empty arrays. Ah, consistency!
+    // For reasons, these two represent emptiness with undefined, not empty arrays. Ah, consistency!
     const missingTopics = await resourceManager.getTopicsForCluster(TEST_CCLOUD_KAFKA_CLUSTER);
     assert.deepStrictEqual(missingTopics, undefined);
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -204,7 +204,7 @@ export class ResourceManager {
     }
 
     logger.debug(
-      `Found ${vanillaJSONenvironments.length} kafka environments for connection ${connectionId}`,
+      `Found ${vanillaJSONenvironments.length} environments for connection ${connectionId}`,
     );
 
     // Promote each from-json vanilla object member to be the proper instance of Environment sub-type, return.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Do for environment caching what was done for kafka clusters, schema registries --- remove the CCloud hard dependency.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2063.
- Also round out a few additional tests so that `resourceManager.ts` test coverage is now:

![image](https://github.com/user-attachments/assets/71bbdb2e-ccff-457a-bfc8-2925112b411c)

## Next steps

- Reduce duplication between getting / setting environments, kafka clusters, schema registries. All of these share the same general structure, but vary by storage key determination function / result; the concrete resource type class lookup, and how to construct the concrete resource type (constructing an Environment is a little different than constructing the other two.) Model those differences then make interior private shared implementations. (#2063)
- Relax key restrictions to allow direct and local resources to be cached (#2065).
- Migrate coarse resource caching from exactly `CCloudResourceLoader `down into a lower level so that the other connection type loaders can benefit (#2066).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
