### PR TITLE
Centralize the main work of loading and storing coarse resources.

### DIFF
--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -246,11 +246,12 @@ export class LocalEnvironment extends Environment {
  * Type of the concrete Environment subclasses.
  * Excludes the abstract base class which lacks a constructor.
  */
-type EnvironmentSubclass =
+export type EnvironmentSubclass =
   | typeof CCloudEnvironment
   | typeof DirectEnvironment
   | typeof LocalEnvironment;
 
+export type ConcreteEnvironment = CCloudEnvironment | DirectEnvironment | LocalEnvironment;
 /**
  * Mapping of connection types to their corresponding Environment subclass.
  * @see getEnvironmentClass

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -89,6 +89,8 @@ export type KafkaClusterSubclass =
   | typeof DirectKafkaCluster
   | typeof LocalKafkaCluster;
 
+export type ConcreteKafkaCluster = CCloudKafkaCluster | DirectKafkaCluster | LocalKafkaCluster;
+
 /** Mapping of connection type to corresponding KafkaCluster subclass */
 const kafkaClusterClassByConnectionType: Record<UsedConnectionType, KafkaClusterSubclass> = {
   [ConnectionType.Ccloud]: CCloudKafkaCluster,

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -72,11 +72,15 @@ export class LocalSchemaRegistry extends SchemaRegistry {
 }
 
 /** Types of the concrete subclasses. Excludes the abstract base class which lacks a constructor. */
-type SchemaRegistrySubclass =
+export type SchemaRegistrySubclass =
   | typeof CCloudSchemaRegistry
   | typeof DirectSchemaRegistry
   | typeof LocalSchemaRegistry;
 
+export type ConcreteSchemaRegistry =
+  | CCloudSchemaRegistry
+  | DirectSchemaRegistry
+  | LocalSchemaRegistry;
 /**
  *  Mapping of our used connection types -> concrete SchemaRegistry subclass.
  *  See {@link getSchemaRegistryClass}.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- ResourceManager get/set methods for the coarse resources (environments, Kafka clusters, schema registries) all followed the same general pattern. Push that pattern down into new private generic methods `storeCoarseResources()` and `loadCoarseResources()`. Retain the per-resource-type public methods which determine what per-resource-family and per-connection-type parameters to provide.
- Needed new type families describe *instances* of the concrete coarse resource classes, as opposed to types describing the concrete resource classes themselves.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2066 
- Cleans up a lot of the imports in `resourceManager.ts`, removes ~70 lines.
- Clears the way to change how these two centralized methods work, saving into per-connection-id storage keys and no more mutex or toplevel maps, not per-connection-type mega storage keys, #2069, #2070.

<img width="719" alt="image" src="https://github.com/user-attachments/assets/06b0d062-d428-4dd7-b0ea-503a3f649848" />




## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
