### PR TITLE
chore: more language client logs

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -26,7 +26,7 @@ import {
   getFlinkSQLLanguageServerOutputChannel,
 } from "./logging";
 
-const logger = new Logger("flinkLanguageClientManager");
+const logger = new Logger("flinkSql.languageClient.ClientManager");
 
 export interface FlinkSqlSettings {
   databaseId: string | null;
@@ -222,7 +222,7 @@ export class FlinkLanguageClientManager implements Disposable {
   /**
    * Builds the WebSocket URL for the Flink SQL Language Server
    * @param computePoolId The ID of the compute pool to use
-   * @returns (string) WebSocket URL, or Error if pool info couldn't be retrieved
+   * @returns (string) WebSocket URL, or null if pool info couldn't be retrieved
    */
   private async buildFlinkSqlWebSocketUrl(computePoolId: string): Promise<string | null> {
     const poolInfo = await this.lookupComputePoolInfo(computePoolId);

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -36,8 +36,8 @@ export interface FlinkSqlSettings {
 /**
  * Singleton class that handles Flink configuration settings and language client management.
  * - Listens for CCloud authentication events, flinksql language file open, settings changes
- * - Fetches and manages Flink compute pool resources
- * - Manages Flink SQL Language Client lifecycle & settings
+ * - Fetches and manages information about the active Editor's Flink compute pool resources
+ * - Manages Flink SQL Language Client lifecycle & related settings
  */
 export class FlinkLanguageClientManager implements Disposable {
   private static instance: FlinkLanguageClientManager | null = null;
@@ -275,6 +275,7 @@ export class FlinkLanguageClientManager implements Disposable {
     }
     if (this.isLanguageClientConnected() && url === this.lastWebSocketUrl) {
       // If we already have a client, it's alive, the compute pool matches, so we're good
+      logger.debug("Language client already connected to correct url, no need to reinitialize");
       return;
     } else {
       logger.debug("Cleaning up and reinitializing", {

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -332,7 +332,6 @@ export class FlinkLanguageClientManager implements Disposable {
    */
   private async restartLanguageClient(): Promise<void> {
     if (!this.lastDocUri) return; // We should never get here
-    await this.cleanupLanguageClient();
     try {
       await this.maybeStartLanguageClient(this.lastDocUri);
       // Reset counter on successful reconnection

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -320,6 +320,9 @@ export class FlinkLanguageClientManager implements Disposable {
       return;
     }
 
+    logger.debug(
+      `Attempting to reconnect websocket. (${this.reconnectCounter + 1}/${this.MAX_RECONNECT_ATTEMPTS})`,
+    );
     this.reconnectCounter++;
     this.restartLanguageClient();
   }

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -16,7 +16,7 @@ import { getSecretStorage } from "../storage/utils";
 import { getFlinkSQLLanguageServerOutputChannel } from "./logging";
 import { WebsocketTransport } from "./websocketTransport";
 
-const logger = new Logger("flinkSql.languageClient");
+const logger = new Logger("flinkSql.languageClient.Client");
 
 /** Initialize the FlinkSQL language client and connect to the language server websocket
  * @returns A promise that resolves to the language client, or null if initialization failed

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -18,11 +18,12 @@ import { WebsocketTransport } from "./websocketTransport";
 
 const logger = new Logger("flinkSql.languageClient.Client");
 
-/** Initialize the FlinkSQL language client and connect to the language server websocket
+/** Initialize the FlinkSQL language client and connect to the language server websocket.
+ * Creates a WebSocket (ws), then on ws.onopen makes the WebsocketTransport class for server, and then creates the Client.
+ * Provides middleware for completions and diagnostics in ClientOptions
+ * @param url The URL of the language server websocket
+ * @param onWebSocketDisconnect Callback for WebSocket disconnection events
  * @returns A promise that resolves to the language client, or null if initialization failed
- * Prerequisites:
- * - User is authenticated with CCloud
- * - User has selected a compute pool
  */
 export async function initializeLanguageClient(
   url: string,

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -6,7 +6,6 @@ import {
   LanguageClient,
   LanguageClientOptions,
   Message,
-  RevealOutputChannelOn,
   Trace,
 } from "vscode-languageclient/node";
 import { WebSocket } from "ws";
@@ -63,7 +62,6 @@ export async function initializeLanguageClient(
           synchronize: {
             fileEvents: vscode.workspace.createFileSystemWatcher("**/*.flink.sql"),
           },
-          revealOutputChannelOn: RevealOutputChannelOn.Info,
           progressOnInitialization: true,
           middleware: {
             provideCompletionItem: async (document, position, context, token, next) => {

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -6,6 +6,7 @@ import {
   LanguageClient,
   LanguageClientOptions,
   Message,
+  RevealOutputChannelOn,
   Trace,
 } from "vscode-languageclient/node";
 import { WebSocket } from "ws";
@@ -58,6 +59,12 @@ export async function initializeLanguageClient(
             { pattern: "**/*.flink.sql" },
           ],
           outputChannel: getFlinkSQLLanguageServerOutputChannel(),
+          traceOutputChannel: getFlinkSQLLanguageServerOutputChannel(),
+          synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher("**/*.flink.sql"),
+          },
+          revealOutputChannelOn: RevealOutputChannelOn.Info,
+          progressOnInitialization: true,
           middleware: {
             didOpen: (document, next) => {
               return next(document);

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -60,16 +60,12 @@ export async function initializeLanguageClient(
             { pattern: "**/*.flink.sql" },
           ],
           outputChannel: getFlinkSQLLanguageServerOutputChannel(),
-          traceOutputChannel: getFlinkSQLLanguageServerOutputChannel(),
           synchronize: {
             fileEvents: vscode.workspace.createFileSystemWatcher("**/*.flink.sql"),
           },
           revealOutputChannelOn: RevealOutputChannelOn.Info,
           progressOnInitialization: true,
           middleware: {
-            didOpen: (document, next) => {
-              return next(document);
-            },
             provideCompletionItem: async (document, position, context, token, next) => {
               const result: any = await next(document, position, context, token);
               if (result) {

--- a/src/flinkSql/logging.ts
+++ b/src/flinkSql/logging.ts
@@ -21,5 +21,6 @@ export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
  * created when the language client is restarted.
  */
 export function clearFlinkSQLLanguageServerOutputChannel(): void {
+  languageServerOutputChannel?.dispose();
   languageServerOutputChannel = undefined;
 }

--- a/src/flinkSql/logging.ts
+++ b/src/flinkSql/logging.ts
@@ -21,6 +21,5 @@ export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
  * created when the language client is restarted.
  */
 export function clearFlinkSQLLanguageServerOutputChannel(): void {
-  languageServerOutputChannel?.dispose();
   languageServerOutputChannel = undefined;
 }

--- a/src/flinkSql/websocketTransport.ts
+++ b/src/flinkSql/websocketTransport.ts
@@ -10,7 +10,7 @@ import {
 import { WebSocket } from "ws";
 import { Logger } from "../logging";
 
-const logger = new Logger("websocketTransport");
+const logger = new Logger("flinkSql.languageClient.WebsocketTransport");
 
 /** Create a WebSocket that reads/writes messages in Language Server Protocol + JSON-RPC
  * Used by the FlinkSQL LanguageClient to communicate with the ccloud language server

--- a/src/flinkSql/websocketTransport.ts
+++ b/src/flinkSql/websocketTransport.ts
@@ -12,9 +12,6 @@ import { Logger } from "../logging";
 
 const logger = new Logger("flinkSql.languageClient.WebsocketTransport");
 
-/** Create a WebSocket that reads/writes messages in Language Server Protocol + JSON-RPC
- * Used by the FlinkSQL LanguageClient to communicate with the ccloud language server
- */
 class WebsocketMessageReader implements MessageReader {
   private socket: WebSocket;
   private messageEmitter = new EventEmitter<Message>();
@@ -124,6 +121,12 @@ class WebsocketMessageWriter implements MessageWriter {
   }
 }
 
+/** Wraps & exposes a websocket as the `MessageTransports` type
+ * Creates a reader and writer to emit messages, errors, close events in LSP-required JSON-RPC
+ * @param socket - The WebSocket connection to use for communication with the language server
+ * @returns An object implementing the `MessageTransports` interface with a reader and writer
+ * @see LanguageClient.ts
+ */
 export class WebsocketTransport implements MessageTransports {
   public reader: MessageReader;
   public writer: MessageWriter;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Sets existing logs for the language client and related processes to `trace` level where appropriate, so they won't cause as much noise for end users
- Update `logger` names for easier filtering
- Additional and more verbose logging to better observe the client lifecycle
- Clarify and update doc blocks
- Potential improvement / bug fix? The cleanup handler call was duplicated during the reconnect flow and is [removed here](https://github.com/confluentinc/vscode/commit/58bf7a0dc56cbad9be1143ccae7e07668b0c4b7a). 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
