### PR TITLE
cleanup(E2E): remove `vscode-test-playwright` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,8 +81,7 @@
         "sanitize-html": "^2.14.0",
         "sinon": "^18.0.1",
         "typescript": "^5.4.2",
-        "typescript-eslint": "^8.25.0",
-        "vscode-test-playwright": "^0.0.1-beta"
+        "typescript-eslint": "^8.25.0"
       },
       "engines": {
         "vscode": "^1.97.0"
@@ -4604,15 +4603,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@vscode/vsce/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -7712,6 +7702,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -11507,6 +11510,7 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13867,15 +13871,13 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -14512,19 +14514,6 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
-    },
-    "node_modules/vscode-test-playwright": {
-      "version": "0.0.1-beta",
-      "resolved": "https://registry.npmjs.org/vscode-test-playwright/-/vscode-test-playwright-0.0.1-beta.tgz",
-      "integrity": "sha512-mfbGg6yV7r8d7LeuQ+eFn78WIrqZtUWhwmQ2Ih915GpxQ1iScl+kB5pLFYX/GzOjPqv3ZO3to21CFuFN2GnqhQ==",
-      "dev": true,
-      "dependencies": {
-        "@vscode/test-electron": "^2.4.1",
-        "ws": "^8.18.0"
-      },
-      "peerDependencies": {
-        "@playwright/test": ">= 1.41.0 < 2"
-      }
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -1988,8 +1988,7 @@
     "sanitize-html": "^2.14.0",
     "sinon": "^18.0.1",
     "typescript": "^5.4.2",
-    "typescript-eslint": "^8.25.0",
-    "vscode-test-playwright": "^0.0.1-beta"
+    "typescript-eslint": "^8.25.0"
   },
   "dependencies": {
     "@segment/analytics-node": "^2.1.2",

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -34,7 +34,8 @@ export const test = testBase.extend<VSCodeFixture>({
     // locate the VS Code executable path based on the platform
     let executablePath: string;
     if (process.platform === "darwin") {
-      executablePath = path.join(vscodeInstallPath, "Contents", "MacOS", "Electron");
+      // on macOS, the install path is already the full path to the executable
+      executablePath = vscodeInstallPath;
     } else if (process.platform === "win32") {
       executablePath = path.join(
         vscodeInstallPath,
@@ -71,6 +72,7 @@ export const test = testBase.extend<VSCodeFixture>({
       executablePath,
       args: [
         "--no-sandbox",
+        "--disable-extensions",
         "--disable-gpu-sandbox",
         "--disable-dev-shm-usage",
         "--disable-updates",
@@ -109,6 +111,7 @@ export const test = testBase.extend<VSCodeFixture>({
 
     const page = await electronApp.firstWindow();
     if (!page) {
+      // usually this means the launch args were incorrect and/or the app didn't start correctly
       throw new Error("Failed to get first window from VS Code");
     }
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -71,24 +71,22 @@ export const test = testBase.extend<VSCodeFixture>({
     const electronApp = await electron.launch({
       executablePath,
       args: [
+        // same as the Mocha test args in Gulpfile.js:
         "--no-sandbox",
-        "--disable-extensions",
-        "--disable-gpu-sandbox",
-        "--disable-dev-shm-usage",
-        "--disable-updates",
-        "--skip-welcome",
+        "--profile-temp",
         "--skip-release-notes",
+        "--skip-welcome",
+        "--disable-gpu",
+        "--disable-updates",
         "--disable-workspace-trust",
+        "--disable-extensions",
+        // additional args needed for the Electron launch:
         `--user-data-dir=${tempDir}`,
         `--extensionDevelopmentPath=${extensionPath}`,
         `--install-extension=${vsixPath}`,
         "--new-window",
         workspacePath,
       ],
-      env: {
-        ...process.env,
-        NODE_ENV: "test",
-      },
     });
 
     if (!electronApp) {

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -1,0 +1,122 @@
+import {
+  _electron as electron,
+  ElectronApplication,
+  Page,
+  test as testBase,
+} from "@playwright/test";
+import { downloadAndUnzipVSCode } from "@vscode/test-electron";
+import { mkdtempSync } from "fs";
+import { globSync } from "glob";
+import { tmpdir } from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface VSCodeFixture {
+  page: Page;
+  electronApp: ElectronApplication;
+}
+
+export const test = testBase.extend<VSCodeFixture>({
+  electronApp: async ({}, use) => {
+    // create a temporary directory for this test run
+    const tempDir = mkdtempSync(path.join(tmpdir(), "vscode-test-"));
+
+    const vscodeInstallPath: string = await downloadAndUnzipVSCode(
+      process.env.VSCODE_VERSION || "stable",
+    );
+    console.log("VS Code install path:", vscodeInstallPath);
+
+    const vscodeVersion = process.env.VSCODE_VERSION || "stable";
+
+    // locate the VS Code executable path based on the platform
+    let executablePath: string;
+    if (process.platform === "darwin") {
+      executablePath = path.join(vscodeInstallPath, "Contents", "MacOS", "Electron");
+    } else if (process.platform === "win32") {
+      executablePath = path.join(
+        vscodeInstallPath,
+        vscodeVersion === "insiders" ? "Code - Insiders.exe" : "Code.exe",
+      );
+    } else {
+      // may be in the install path or in the root directory; need to see which one exists and
+      // is executable
+      const directExecutable = vscodeInstallPath;
+      const insidersOrStable = vscodeVersion === "insiders" ? "code-insiders" : "code";
+      const rootExecutable = path.join(vscodeInstallPath, insidersOrStable);
+      executablePath = directExecutable.endsWith(insidersOrStable)
+        ? directExecutable
+        : rootExecutable;
+    }
+
+    const extensionPath: string = path.resolve(__dirname, "..", "..");
+    const workspacePath: string = path.resolve(extensionPath, "out");
+    const vsixFiles: string[] = globSync(path.resolve(workspacePath, "*.vsix"));
+    const vsixPath = vsixFiles[0];
+    if (!vsixPath) {
+      // shouldn't happen during normal `gulp e2e`
+      throw new Error("No VSIX file found in the out/ directory. Run 'npx gulp bundle' first.");
+    }
+
+    console.log(`Launching VS Code (${vscodeVersion}) with:`);
+    console.log("  Executable:", executablePath);
+    console.log("  Extension path:", extensionPath);
+    console.log("  VSIX path:", vsixPath);
+    console.log("  Temp dir:", tempDir);
+
+    // launch VS Code with Electron using args pattern from vscode-test
+    const electronApp = await electron.launch({
+      executablePath,
+      args: [
+        "--no-sandbox",
+        "--disable-gpu-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-updates",
+        "--skip-welcome",
+        "--skip-release-notes",
+        "--disable-workspace-trust",
+        `--user-data-dir=${tempDir}`,
+        `--extensionDevelopmentPath=${extensionPath}`,
+        `--install-extension=${vsixPath}`,
+        "--new-window",
+        workspacePath,
+      ],
+      env: {
+        ...process.env,
+        NODE_ENV: "test",
+      },
+    });
+
+    if (!electronApp) {
+      throw new Error("Failed to launch VS Code electron app");
+    }
+
+    await use(electronApp);
+
+    try {
+      await electronApp.close();
+    } catch (error) {
+      console.warn("Error closing electron app:", error);
+    }
+  },
+
+  page: async ({ electronApp }, use) => {
+    if (!electronApp) {
+      throw new Error("electronApp is null - failed to launch VS Code");
+    }
+
+    const page = await electronApp.firstWindow();
+    if (!page) {
+      throw new Error("Failed to get first window from VS Code");
+    }
+
+    // wait for VS Code to be ready
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForSelector(".monaco-workbench", { timeout: 30000 });
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from "@playwright/test";
 import { configDotenv } from "dotenv";
-import { globSync } from "glob";
 import path from "path";
 import { fileURLToPath } from "url";
-import { VSCodeTestOptions, VSCodeWorkerOptions } from "vscode-test-playwright";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,10 +10,9 @@ configDotenv({
   path: path.join(__dirname, "..", "..", ".env"),
 });
 
-const vsix: string = globSync(path.resolve(__dirname, "..", "..", "out", "*.vsix")).at(0) as string;
 const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
 
-export default defineConfig<VSCodeTestOptions, VSCodeWorkerOptions>({
+export default defineConfig({
   testDir: path.join(__dirname, "specs"),
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -26,19 +23,13 @@ export default defineConfig<VSCodeTestOptions, VSCodeWorkerOptions>({
   },
   reporter: "html",
   use: {
-    // We run the tests against the bundled VSIX file.
-    extensions: [vsix],
-    // The test VS Code window instance is launched with the `out` directory
-    // opened. This lets us load fixture files (the fixtures are copied over in the Gulp task `e2e`)
-    // Make sure to run `gulp bundle` if you changed the extension `src` code.
-    baseDir: path.join(__dirname, "..", "..", "out"),
-    // Enables Playwright tracing to help with debugging. Super useful!
-    vscodeTrace: "on",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {
       name: vscodeVersion,
-      use: { vscodeVersion },
     },
   ],
 });

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -10,7 +10,7 @@ configDotenv({
   path: path.join(__dirname, "..", "..", ".env"),
 });
 
-const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
+const vscodeVersion = process.env.VSCODE_VERSION || "stable";
 
 export default defineConfig({
   testDir: path.join(__dirname, "specs"),
@@ -23,6 +23,7 @@ export default defineConfig({
   },
   reporter: "html",
   use: {
+    // headless: process.env.CI ? true : false,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/tests/e2e/specs/confluent.spec.ts
+++ b/tests/e2e/specs/confluent.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "vscode-test-playwright";
+import { test } from "../baseTest";
 
 import { openConfluentExtension } from "./utils/confluent";
 import { login } from "./utils/confluentCloud";

--- a/tests/e2e/specs/flinkStatement.spec.ts
+++ b/tests/e2e/specs/flinkStatement.spec.ts
@@ -1,5 +1,5 @@
 import { FrameLocator } from "@playwright/test";
-import { test } from "vscode-test-playwright";
+import { test } from "../baseTest";
 import { openConfluentExtension } from "./utils/confluent";
 import { login } from "./utils/confluentCloud";
 import {

--- a/tests/e2e/specs/schemas.spec.ts
+++ b/tests/e2e/specs/schemas.spec.ts
@@ -1,6 +1,6 @@
 import { Page, expect } from "@playwright/test";
 import { stubMultipleDialogs } from "electron-playwright-helpers";
-import { test } from "vscode-test-playwright";
+import { test } from "../baseTest";
 import { openConfluentExtension } from "./utils/confluent";
 import { login } from "./utils/confluentCloud";
 import { openFixtureFile } from "./utils/flinkStatement";

--- a/tests/e2e/specs/utils/confluent.ts
+++ b/tests/e2e/specs/utils/confluent.ts
@@ -17,11 +17,4 @@ export async function openConfluentExtension(page: Page): Promise<void> {
     state: "visible",
     timeout: 30_000,
   });
-
-  // Close any notifications that pop up on load. These make it impossible to
-  // interact with UI elements hidden behind them.
-  const clearableNotifications = await page.getByLabel(/Clear Notification/).all();
-  for (const notification of clearableNotifications) {
-    await notification.click();
-  }
 }


### PR DESCRIPTION
This PR mainly sets up the `baseTest` module to handle all the lower-level E2E + Electron setup that was handled by https://github.com/ruifigueira/vscode-test-playwright.

`gulp e2e` from a terminal still works as intended to launch a VS Code (stable) window and run the tests like before. Bonus: each test isn't downloading a fresh copy of VS Code anymore. 🎉 

However, `VSCODE_VERSION=insiders gulp e2e` doesn't work quite right -- even though it launches a VS Code Insiders window for testing, the CCloud auth callback URI is still using the `vscode` scheme instead of `vscode-insiders`. I'm not too concerned about that for this PR since we aren't normally running these tests against Insiders anyway.

Also worth noting (for anyone that runs `gulp e2e` for this PR), some of the tests are currently failing due to unrelated-to-this-PR functional changes in the main extension code (e.g. schema evolution and deleting a schema/subject).