### PR TITLE
MINOR fix(E2E): adjust extension dev path for webviews

### DIFF
--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -82,8 +82,7 @@ export const test = testBase.extend<VSCodeFixture>({
         "--disable-extensions",
         // additional args needed for the Electron launch:
         `--user-data-dir=${tempDir}`,
-        `--extensionDevelopmentPath=${extensionPath}`,
-        `--install-extension=${vsixPath}`,
+        `--extensionDevelopmentPath=${workspacePath}`,
         "--new-window",
         workspacePath,
       ],


### PR DESCRIPTION
Follow-up from https://github.com/confluentinc/vscode/pull/2077 where we were incorrectly pointing at the `vscode/` directory for the extension dev path instead of `vscode/out/`, which caused a bunch of errors loading webview files (and then caused more test failures since the locators couldn't find the specified elements).

## Before
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/c7d17cfe-bd84-46ee-b09a-9b69f2785b9b" />

## After
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/f23c114e-1286-4dea-939e-e59018e2877d" />

(I have no idea why the theme color changed between the two.)