### PR TITLE
fix(logging): add sidecar `exception` data to output channel and formatted log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Any sidecar error logs will now include exception data in the "Confluent (Sidecar)" output
+  channel, as well as the file saved from the "Save Sidecar Logs" or "Save Support File (.zip)"
+  commands.
+
 ### Changed
 
 - Updated ide-sidecar version to v0.216.0

--- a/src/sidecar/logging.test.ts
+++ b/src/sidecar/logging.test.ts
@@ -7,12 +7,18 @@ import { SIDECAR_LOGFILE_NAME } from "./constants";
 import {
   appendSidecarLogToOutputChannel,
   determineSidecarStartupFailureReason,
+  formatSidecarLogLine,
   gatherSidecarOutputs,
   getSidecarLogfilePath,
   parseSidecarLogLine,
   SIDECAR_OUTPUT_CHANNEL,
 } from "./logging";
-import { SidecarLogFormat, SidecarOutputs, SidecarStartupFailureReason } from "./types";
+import {
+  SidecarLogExceptionFormat,
+  SidecarLogFormat,
+  SidecarOutputs,
+  SidecarStartupFailureReason,
+} from "./types";
 
 const fakeLogObj = {
   timestamp: "2025-01-01T10:30:00.000Z",
@@ -29,6 +35,25 @@ const fakeLogObj = {
   processName: "ide-sidecar",
   processId: 12345,
 } satisfies SidecarLogFormat;
+
+const fakeMdcData = { foo: "bar", baz: "123" };
+
+const fakeException = {
+  exceptionType: "java.lang.NullPointerException",
+  message: "Cannot invoke method on null object",
+  frames: [
+    {
+      class: "com.example.Service",
+      method: "processData",
+      line: 42,
+    },
+    {
+      class: "com.example.Controller",
+      method: "handleRequest",
+      line: 123,
+    },
+  ],
+} satisfies SidecarLogExceptionFormat;
 
 describe("sidecar/logging.ts", () => {
   describe("divineSidecarStartupFailureReason()", () => {
@@ -477,6 +502,232 @@ describe("sidecar/logging.ts", () => {
       const result = parseSidecarLogLine(JSON.stringify(emptyValues));
 
       assert.strictEqual(result, null);
+    });
+  });
+
+  describe("formatSidecarLogLine()", () => {
+    it("should format a log object with all options enabled by default", () => {
+      const result: string = formatSidecarLogLine(fakeLogObj);
+
+      assert.strictEqual(
+        result,
+        `${fakeLogObj.timestamp} [${fakeLogObj.level.padEnd(5)}] [${fakeLogObj.loggerName}] ${fakeLogObj.message}`,
+      );
+    });
+
+    it("should format a log object without `timestamp` when disabled", () => {
+      const result: string = formatSidecarLogLine(fakeLogObj, {
+        withTimestamp: false,
+        withLevel: true,
+        withMdc: true,
+      });
+
+      assert.strictEqual(
+        result,
+        `[${fakeLogObj.level.padEnd(5)}] [${fakeLogObj.loggerName}] ${fakeLogObj.message}`,
+      );
+    });
+
+    it("should format a log object without `level` when disabled", () => {
+      const result: string = formatSidecarLogLine(fakeLogObj, {
+        withTimestamp: true,
+        withLevel: false,
+        withMdc: true,
+      });
+
+      assert.strictEqual(
+        result,
+        `${fakeLogObj.timestamp} [${fakeLogObj.loggerName}] ${fakeLogObj.message}`,
+      );
+    });
+
+    it("should format a log object with only `message` and `logger` when both `withTimestamp` and `withLevel` are disabled", () => {
+      const result: string = formatSidecarLogLine(fakeLogObj, {
+        withTimestamp: false,
+        withLevel: false,
+        withMdc: true,
+      });
+
+      assert.strictEqual(result, `[${fakeLogObj.loggerName}] ${fakeLogObj.message}`);
+    });
+
+    it("should pad `level` to 5 characters", () => {
+      const debugLog = { ...fakeLogObj, level: "DEBUG" };
+      const result: string = formatSidecarLogLine(debugLog);
+
+      assert.strictEqual(
+        result,
+        `${debugLog.timestamp} [${debugLog.level.padEnd(5)}] [${debugLog.loggerName}] ${debugLog.message}`,
+      );
+    });
+
+    it("should handle long `level` values by padding", () => {
+      const customLog = { ...fakeLogObj, level: "THISLOGLEVELDOESNOTEXIST" };
+      const result: string = formatSidecarLogLine(customLog);
+
+      assert.strictEqual(
+        result,
+        `${customLog.timestamp} [${customLog.level.padEnd(5)}] [${customLog.loggerName}] ${customLog.message}`,
+      );
+    });
+
+    it("should use default timestamp/level/message values when missing", () => {
+      // hopefully shouldn't happen, but just in case
+      const incompleteLog = {
+        level: undefined,
+        loggerName: undefined,
+        message: undefined,
+        timestamp: undefined,
+      } as any;
+
+      const result: string = formatSidecarLogLine(incompleteLog);
+
+      // regex match since it falls back to new Date().toISOString()
+      assert.match(result, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[INFO \] \[unknown\] $/);
+    });
+
+    it("should format log with MDC data when enabled", () => {
+      const logWithMdc = { ...fakeLogObj, mdc: fakeMdcData };
+
+      const result: string = formatSidecarLogLine(logWithMdc);
+
+      assert.strictEqual(
+        result,
+        `${logWithMdc.timestamp} [${logWithMdc.level.padEnd(5)}] [${logWithMdc.loggerName}] ${logWithMdc.message} ${JSON.stringify(fakeMdcData)}`,
+      );
+    });
+
+    it("should not include MDC data when disabled", () => {
+      const logWithMdc = { ...fakeLogObj, mdc: fakeMdcData };
+
+      const result: string = formatSidecarLogLine(logWithMdc, {
+        withTimestamp: true,
+        withLevel: true,
+        withMdc: false,
+      });
+
+      assert.strictEqual(
+        result,
+        `${logWithMdc.timestamp} [${logWithMdc.level.padEnd(5)}] [${logWithMdc.loggerName}] ${logWithMdc.message}`,
+      );
+    });
+
+    it("should not include empty `mdc` data", () => {
+      const logWithEmptyMdc = { ...fakeLogObj, mdc: {} };
+
+      const result: string = formatSidecarLogLine(logWithEmptyMdc);
+
+      assert.strictEqual(
+        result,
+        `${logWithEmptyMdc.timestamp} [${logWithEmptyMdc.level.padEnd(5)}] [${logWithEmptyMdc.loggerName}] ${logWithEmptyMdc.message}`,
+      );
+    });
+
+    it("should format a log object with `exception` details", () => {
+      const logWithException = {
+        ...fakeLogObj,
+        level: "ERROR",
+        message: "Operation failed",
+        exception: fakeException,
+      };
+
+      const result: string = formatSidecarLogLine(logWithException);
+
+      const expectedResult: string = [
+        `${logWithException.timestamp} [${logWithException.level.padEnd(5)}] [${logWithException.loggerName}] ${logWithException.message} [Exception: ${fakeException.exceptionType} - ${fakeException.message}]`,
+        `    at ${fakeException.frames[0].class}.${fakeException.frames[0].method} (${fakeException.frames[0].class}:${fakeException.frames[0].line})`,
+        `    at ${fakeException.frames[1].class}.${fakeException.frames[1].method} (${fakeException.frames[1].class}:${fakeException.frames[1].line})`,
+      ].join("\n");
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    it("should handle `exception` with missing `exceptionType`", () => {
+      const logWithIncompleteException = {
+        ...fakeLogObj,
+        level: "ERROR",
+        exception: {
+          exceptionType: "", // will default to "UnknownException"
+          message: "Something went wrong",
+          frames: [],
+        },
+      };
+
+      const result: string = formatSidecarLogLine(logWithIncompleteException);
+
+      assert.strictEqual(
+        result,
+        `${logWithIncompleteException.timestamp} [${logWithIncompleteException.level.padEnd(5)}] [${logWithIncompleteException.loggerName}] ${logWithIncompleteException.message} [Exception: UnknownException - ${logWithIncompleteException.exception.message}]`,
+      );
+    });
+
+    it("should handle `exception` with empty `frames` array", () => {
+      const logWithEmptyFrames = {
+        ...fakeLogObj,
+        level: "ERROR",
+        exception: {
+          exceptionType: "CustomException",
+          message: "Something went wrong",
+          frames: [],
+        },
+      };
+
+      const result: string = formatSidecarLogLine(logWithEmptyFrames);
+
+      assert.strictEqual(
+        result,
+        `${logWithEmptyFrames.timestamp} [${logWithEmptyFrames.level.padEnd(5)}] [${logWithEmptyFrames.loggerName}] ${logWithEmptyFrames.message} [Exception: ${logWithEmptyFrames.exception.exceptionType} - ${logWithEmptyFrames.exception.message}]`,
+      );
+    });
+
+    it("should format a log object with `mdc` and `exception`", () => {
+      const complexLog = {
+        ...fakeLogObj,
+        level: "ERROR",
+        message: "Request processing failed",
+        mdc: fakeMdcData,
+        exception: fakeException,
+      };
+
+      const result = formatSidecarLogLine(complexLog);
+
+      const expectedResult: string = [
+        `${complexLog.timestamp} [${complexLog.level.padEnd(5)}] [${complexLog.loggerName}] ${complexLog.message} ${JSON.stringify(complexLog.mdc)} [Exception: ${fakeException.exceptionType} - ${fakeException.message}]`,
+        `    at ${fakeException.frames[0].class}.${fakeException.frames[0].method} (${fakeException.frames[0].class}:${fakeException.frames[0].line})`,
+        `    at ${fakeException.frames[1].class}.${fakeException.frames[1].method} (${fakeException.frames[1].class}:${fakeException.frames[1].line})`,
+      ].join("\n");
+
+      assert.strictEqual(result, expectedResult);
+    });
+
+    for (const exceptionValue of [null, undefined]) {
+      it(`should handle a log object where \`exception\` is ${exceptionValue}`, () => {
+        const logWithNullException = {
+          ...fakeLogObj,
+          exception: exceptionValue,
+        } as any;
+
+        const result: string = formatSidecarLogLine(logWithNullException);
+
+        assert.strictEqual(
+          result,
+          `${logWithNullException.timestamp} [${logWithNullException.level.padEnd(5)}] [${logWithNullException.loggerName}] ${logWithNullException.message}`,
+        );
+      });
+    }
+
+    it("should handle undefined `mdc`", () => {
+      const logWithUndefinedMdc = {
+        ...fakeLogObj,
+        mdc: undefined,
+      } as any;
+
+      const result: string = formatSidecarLogLine(logWithUndefinedMdc);
+
+      assert.strictEqual(
+        result,
+        `${logWithUndefinedMdc.timestamp} [${logWithUndefinedMdc.level.padEnd(5)}] [${logWithUndefinedMdc.loggerName}] ${logWithUndefinedMdc.message}`,
+      );
     });
   });
 });

--- a/src/sidecar/logging.test.ts
+++ b/src/sidecar/logging.test.ts
@@ -9,9 +9,26 @@ import {
   determineSidecarStartupFailureReason,
   gatherSidecarOutputs,
   getSidecarLogfilePath,
+  parseSidecarLogLine,
   SIDECAR_OUTPUT_CHANNEL,
 } from "./logging";
-import { SidecarOutputs, SidecarStartupFailureReason } from "./types";
+import { SidecarLogFormat, SidecarOutputs, SidecarStartupFailureReason } from "./types";
+
+const fakeLogObj = {
+  timestamp: "2025-01-01T10:30:00.000Z",
+  level: "INFO",
+  loggerName: "io.confluent.test",
+  message: "Test message",
+  sequence: 1,
+  loggerClassName: "org.jboss.logging.Logger",
+  threadName: "main",
+  threadId: 1,
+  mdc: {},
+  ndc: "",
+  hostName: "localhost",
+  processName: "ide-sidecar",
+  processId: 12345,
+} satisfies SidecarLogFormat;
 
 describe("sidecar/logging.ts", () => {
   describe("divineSidecarStartupFailureReason()", () => {
@@ -301,6 +318,165 @@ describe("sidecar/logging.ts", () => {
       assert.throws(() => {
         getSidecarLogfilePath();
       }, /get\(\) called before determine\(\) was awaited./);
+    });
+  });
+
+  describe("parseSidecarLogLine()", () => {
+    it("should parse valid JSON log line with all required fields", () => {
+      const result: SidecarLogFormat | null = parseSidecarLogLine(JSON.stringify(fakeLogObj));
+
+      assert.ok(result);
+      assert.strictEqual(result.timestamp, fakeLogObj.timestamp);
+      assert.strictEqual(result.level, fakeLogObj.level);
+      assert.strictEqual(result.loggerName, fakeLogObj.loggerName);
+      assert.strictEqual(result.message, fakeLogObj.message);
+    });
+
+    it("should parse minimally-valid JSON log line with only required fields", () => {
+      const minimalLog = {
+        level: "WARN",
+        loggerName: "test.logger",
+        message: "Warning message",
+      };
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(JSON.stringify(minimalLog));
+
+      assert.notStrictEqual(result, null);
+      assert.strictEqual(result!.level, minimalLog.level);
+      assert.strictEqual(result!.loggerName, minimalLog.loggerName);
+      assert.strictEqual(result!.message, minimalLog.message);
+    });
+
+    it("should parse log line with MDC data", () => {
+      const logWithMdc = {
+        ...fakeLogObj,
+        level: "DEBUG",
+        loggerName: "test.mdc",
+        message: "Debug with context",
+        mdc: {
+          userId: "user123",
+          requestId: "req-456",
+          sessionId: "session-789",
+        },
+      };
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(JSON.stringify(logWithMdc));
+
+      assert.ok(result);
+      assert.strictEqual(result.level, logWithMdc.level);
+      assert.deepStrictEqual(result.mdc, logWithMdc.mdc);
+    });
+
+    it("should parse log line with exception details", () => {
+      const logWithException = {
+        ...fakeLogObj,
+        level: "ERROR",
+        loggerName: "test.exception",
+        message: "Something went wrong",
+        exception: {
+          exceptionType: "java.lang.NullPointerException",
+          message: "Cannot invoke method on null object",
+          frames: [
+            {
+              class: "com.example.Service",
+              method: "processData",
+              line: 42,
+            },
+            {
+              class: "com.example.Controller",
+              method: "handleRequest",
+              line: 123,
+            },
+          ],
+        },
+      };
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(JSON.stringify(logWithException));
+
+      assert.ok(result);
+      assert.ok(result.exception);
+      assert.strictEqual(result.exception.exceptionType, logWithException.exception.exceptionType);
+      assert.strictEqual(result.exception.message, logWithException.exception.message);
+      assert.strictEqual(result.exception.frames.length, logWithException.exception.frames.length);
+      assert.strictEqual(
+        result.exception.frames[0].class,
+        logWithException.exception.frames[0].class,
+      );
+      assert.strictEqual(
+        result.exception.frames[0].method,
+        logWithException.exception.frames[0].method,
+      );
+      assert.strictEqual(
+        result.exception.frames[0].line,
+        logWithException.exception.frames[0].line,
+      );
+    });
+
+    it("should return null for invalid JSON", () => {
+      const invalidJson = "not valid json {";
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(invalidJson);
+
+      assert.strictEqual(result, null);
+    });
+
+    it("should return null when missing `level`", () => {
+      const missingLevel = {
+        ...fakeLogObj,
+        level: undefined,
+      };
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(JSON.stringify(missingLevel));
+
+      assert.strictEqual(result, null);
+    });
+
+    it("should return null when missing `loggerName`", () => {
+      const missingLoggerName = {
+        ...fakeLogObj,
+        loggerName: undefined,
+      };
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(
+        JSON.stringify(missingLoggerName),
+      );
+
+      assert.strictEqual(result, null);
+    });
+
+    it("should return null when missing `message`", () => {
+      const missingMessage = {
+        level: "INFO",
+        loggerName: "test.logger",
+      };
+
+      const result: SidecarLogFormat | null = parseSidecarLogLine(JSON.stringify(missingMessage));
+
+      assert.strictEqual(result, null);
+    });
+
+    it("should handle empty string input", () => {
+      const result: SidecarLogFormat | null = parseSidecarLogLine("");
+
+      assert.strictEqual(result, null);
+    });
+
+    it("should handle whitespace-only input", () => {
+      const result: SidecarLogFormat | null = parseSidecarLogLine("   \n\t  ");
+
+      assert.strictEqual(result, null);
+    });
+
+    it("should handle valid JSON with empty string values for required fields", () => {
+      const emptyValues = {
+        level: "",
+        loggerName: "",
+        message: "",
+      };
+
+      const result = parseSidecarLogLine(JSON.stringify(emptyValues));
+
+      assert.strictEqual(result, null);
     });
   });
 });

--- a/src/sidecar/logging.ts
+++ b/src/sidecar/logging.ts
@@ -89,19 +89,14 @@ export function formatSidecarLogLine(
   }
 
   // always add exception details if present
-  if (
-    log.exception !== undefined &&
-    log.exception !== null &&
-    (log.exception.exceptionType ||
-      log.exception.message ||
-      (Array.isArray(log.exception.frames) && log.exception.frames.length > 0))
-  ) {
+  if (log.exception && (log.exception.exceptionType || log.exception.message)) {
     const exceptionType = log.exception.exceptionType || "UnknownException";
     const exceptionMessage = log.exception.message || "";
     formattedLine += ` [Exception: ${exceptionType} - ${exceptionMessage}]`;
-    for (const frame of log.exception.frames) {
-      formattedLine += `\n    at ${frame.class}.${frame.method} (${frame.class}:${frame.line})`;
-    }
+    if (Array.isArray(log.exception.frames) && log.exception.frames.length > 0)
+      for (const frame of log.exception.frames) {
+        formattedLine += `\n    at ${frame.class}.${frame.method} (${frame.class}:${frame.line})`;
+      }
   }
   return formattedLine;
 }

--- a/src/sidecar/logging.ts
+++ b/src/sidecar/logging.ts
@@ -49,18 +49,59 @@ export function parseSidecarLogLine(rawLogLine: string): SidecarLogFormat | null
   }
 }
 
-/** Format a {@link SidecarLogFormat} log object into more human-readable string. */
-export function formatSidecarLogLine(log: SidecarLogFormat): string {
+/**
+ * Format a log object into more human-readable string.
+ * @param log The {@link SidecarLogFormat} log object to format.
+ * @param options Formatting options:
+ * - `withTimestamp`: Whether to include the `timestamp` in the formatted string (default: `true`).
+ * - `withLevel`: Whether to include the log `level` in the formatted string (default: `true`).
+ * - `withMdc`: Whether to include the `mdc` (Mapped Diagnostic Context) data in the formatted string (default: `true`).
+ */
+export function formatSidecarLogLine(
+  log: SidecarLogFormat,
+  options?: {
+    withTimestamp: boolean;
+    withLevel: boolean;
+    withMdc: boolean;
+  },
+): string {
+  const withTimestamp: boolean = options?.withTimestamp ?? true;
+  const withLevel: boolean = options?.withLevel ?? true;
+  const withMdc: boolean = options?.withMdc ?? true;
+
   const timestamp = log.timestamp || new Date().toISOString();
   const level = log.level?.padEnd(5) || "INFO ";
   const loggerName = log.loggerName || "unknown";
   const message = log.message || "";
 
-  let formattedLine = `${timestamp} ${level} [${loggerName}] ${message}`;
+  let formattedLine = `[${loggerName}] ${message}`;
+  if (withLevel) {
+    formattedLine = `[${level}] ${formattedLine}`;
+  }
+  if (withTimestamp) {
+    formattedLine = `${timestamp} ${formattedLine}`;
+  }
+
   // add MDC data if present
-  if (log.mdc && Object.keys(log.mdc).length > 0) {
+  if (withMdc && log.mdc && Object.keys(log.mdc).length > 0) {
     const mdcString = JSON.stringify(log.mdc);
-    formattedLine += ` ${mdcString}`;
+    formattedLine = `${formattedLine} ${mdcString}`;
+  }
+
+  // always add exception details if present
+  if (
+    log.exception !== undefined &&
+    log.exception !== null &&
+    (log.exception.exceptionType ||
+      log.exception.message ||
+      (Array.isArray(log.exception.frames) && log.exception.frames.length > 0))
+  ) {
+    const exceptionType = log.exception.exceptionType || "UnknownException";
+    const exceptionMessage = log.exception.message || "";
+    formattedLine += ` [Exception: ${exceptionType} - ${exceptionMessage}]`;
+    for (const frame of log.exception.frames) {
+      formattedLine += `\n    at ${frame.class}.${frame.method} (${frame.class}:${frame.line})`;
+    }
   }
   return formattedLine;
 }
@@ -190,15 +231,24 @@ export function appendSidecarLogToOutputChannel(line: string) {
     return;
   }
 
-  let logMsg = `[${log.loggerName}] ${log.message}`;
-
+  // minimal formatting since the log output channel already has a timestamp and we'll pass any
+  // MDC data as args. (any exception details will be formatted into the log message string)
+  let logMsg = formatSidecarLogLine(log, {
+    withTimestamp: false,
+    withLevel: false,
+    withMdc: false,
+  });
   const logArgs = [];
   if (log.mdc && Object.keys(log.mdc).length > 0) {
     logArgs.push(log.mdc);
   }
 
   try {
-    const formattedLine = formatSidecarLogLine(log);
+    const formattedLine = formatSidecarLogLine(log, {
+      withTimestamp: true,
+      withLevel: true,
+      withMdc: true,
+    });
     const formattedLogStream = getFormattedSidecarLogStream();
     formattedLogStream.write(`${formattedLine}\n`);
   } catch (e) {

--- a/src/sidecar/types.ts
+++ b/src/sidecar/types.ts
@@ -13,6 +13,17 @@ export interface SidecarLogFormat {
   hostName: string;
   processName: string;
   processId: number;
+  exception?: SidecarLogExceptionFormat;
+}
+
+export interface SidecarLogExceptionFormat {
+  exceptionType: string;
+  message: string;
+  frames: {
+    class: string;
+    method: string;
+    line: number;
+  }[];
 }
 
 export interface SidecarOutputs {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

### Before
We were previously dropping `exception` data completely. 

### After
We include the exception type, message, and any available frames in both the log file available for saving from the "Save Sidecar Logs" command (left) as well as the "Confluent (Sidecar)" log output channel (right):
<img width="1937" alt="image" src="https://github.com/user-attachments/assets/a2e004ae-8111-4792-a15b-d1dec6dd8b3c" />

Closes #2090.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
