### PR TITLE
remove CCloud email from LaunchDarkly client `identify()` calls

### DIFF
--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -176,7 +176,6 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       });
       (await getLaunchDarklyClient())?.identify({
         key: authenticatedConnection.status.authentication.user.id,
-        email: authenticatedConnection.status.authentication.user.username,
       });
     }
     // we want to continue regardless of whether or not the user dismisses the notification,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -508,10 +508,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
       userInfo: undefined,
       session: cloudSession,
     });
-    (await getLaunchDarklyClient())?.identify({
-      key: cloudSession.account.id,
-      email: cloudSession.account.label,
-    });
+    (await getLaunchDarklyClient())?.identify({ key: cloudSession.account.id });
   }
 
   logger.info("Confluent Cloud auth provider registered");


### PR DESCRIPTION
Isn't necessary, and if we need to flip any flags on a per-user basis we can do so via the CCloud user ID.