### PR TITLE
split up `copilot-instructions.md` into separate instructions/ files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,84 +1,25 @@
-# Confluent VS Code Extension Development
+# Confluent VS Code Extension
 
-This VS Code extension makes it easy for developers to build stream processing applications using
-Confluent technology. It provides integration with Confluent Cloud products and Apache Kafka®
-compatible clusters within Visual Studio Code.
+This VS Code extension helps developers build stream processing applications using Confluent
+technology. The extension integrates with Confluent Cloud products and Apache Kafka® compatible
+clusters within VS Code.
 
-## Technology Stack
+## Core Principles
 
-- TypeScript VS Code extension with strict type checking
-- Single sidecar process manages multiple workspaces concurrently
-- Integration with Confluent Cloud APIs, Apache Kafka® clusters, Schema Registry, and Flink compute
-  pools
-- Build system uses Gulp with TypeScript compilation
-- Auto-generated OpenAPI clients from specs in `src/clients/sidecar-openapi-specs/` using
-  `openapi-generator`'s `typescript-fetch` generator
-- Extension provides Kafka topic management, schema evolution, and stream processing application
-  development
+- **Type Safety**: Create TypeScript code with explicit types and no use of `any`
+- **Clean Architecture**: Follow established patterns and directory organization
+- **User Experience**: Design intuitive interfaces and write actionable error messages
+- **Testing**: Unit test all code components with proper isolation
+- **Performance**: Efficiently cache and load resources to ensure responsiveness
 
-## Code Organization and Architecture
+## Key Technologies
 
-- Use consistent directory structure for related functionality (e.g., `src/featureFlags/`,
-  `src/models/`)
-- File names should be descriptive and match their primary purpose
-- Place test files adjacent to source files with `.test.ts` suffix
-- Use ResourceLoader instances for different connection types (CCloud, Direct, Local) to load and
-  cache resources
-- Store state through ResourceManager with locking mechanisms to prevent race conditions
-- Context values control UI state and command availability through VS Code's context system
-- Auto-generated code in `src/clients/` should never be modified directly - update OpenAPI specs
-  instead
+- TypeScript with strict type checking
+- VS Code Extension API
+- Confluent Cloud and Apache Kafka® ecosystem
+- Sidecar architecture for multi-workspace management
+- GraphQL and OpenAPI-generated clients
 
-## TypeScript and VS Code Extension Patterns
+## Important Guidelines
 
-- Use explicit types and interfaces, never use `any` type
-- Prefer `async/await` over Promise chains for better readability
-- Use `Promise.all` for concurrent operations when possible
-- Follow functional programming patterns where appropriate
-- Use classes for encapsulating related functionality and state for better organization and
-  testability
-- Variable and function names should be self-documenting to reduce the need for inline comments
-- Keep functions small and follow the single-responsibility principle
-- Follow VS Code extension API patterns for commands, tree providers, quickpicks, and webviews
-- Keep track of and handle `vscode.Disposable` resources properly to avoid memory leaks
-- Use existing ResourceLoader and ResourceManager patterns rather than creating new data fetching
-  approaches
-- Use VS Code's configuration API for user settings
-
-## Error Handling and User Experience
-
-- Use `logError()` utility for consistent error logging with stack traces and response details
-- Use `showErrorNotificationWithButtons()` for user-facing errors with "Open Logs" and "File Issue"
-  buttons
-- Error messages should be actionable with clear next steps for users
-- Wrap async operations in try/catch blocks and handle specific error types
-- Include telemetry considerations when adding new error scenarios
-- Provide graceful degradation when external services are unavailable
-- Use VS Code's progress API for long-running operations
-
-## Webview Development
-
-- Webviews use vanilla TypeScript with custom HTML templates
-- Use template literal functions for HTML generation with variable substitution
-- Follow message passing patterns between extension and webview contexts
-- Custom elements and reactive patterns using ObservableScope
-- Implement proper CSP (Content Security Policy) headers
-
-# Testing
-
-This VS Code extension uses the Mocha BDD interface with "sinon" and "assert" packages for unit
-testing, and Playwright for functional/e2e testing.
-
-- Use descriptive test names that explain the expected behavior with the "should" prefix
-- Group related tests using `describe` blocks for better organization
-- Always use a `SinonSandbox` instance when setting up stubs, spies, or fakes to ensure proper
-  cleanup
-- Use sinon Assert API for assertions involving stubs, spies, or fakes (e.g.,
-  `sinon.assert.called(stub)` instead of `assert.equal(stub.called, true)`)
-- Use `sandbox.createStubInstance(ClassNameHere)` to create `SinonStubbedInstance` for class mocking
-- Leverage fixtures in the `test/unit/testResources/` directory for consistent test data
-  representing models from `src/models/`
-  - Create new fixture instances only when slight variations are necessary or when fixtures are
-    missing
-- Test files should be placed adjacent to source files with `.test.ts` suffix
-- Mock/stub external dependencies and API calls in unit tests to isolate the unit of work
+- Never modify auto-generated code in `src/clients/` - update OpenAPI specs instead

--- a/.github/instructions/error-handling.instructions.md
+++ b/.github/instructions/error-handling.instructions.md
@@ -1,0 +1,32 @@
+---
+applyTo: "**/*.ts"
+description: "Error handling patterns and user experience guidelines"
+---
+
+# Error Handling and User Experience
+
+When handling errors in the Confluent extension for VS Code:
+
+## Error Logging and Reporting
+
+- Always use the `logError()` utility for consistent error logging that captures:
+  - Stack traces for debugging
+  - HTTP response details (when applicable)
+  - Contextual information about what operation failed
+- Implement `showErrorNotificationWithButtons()` for user-facing errors that include:
+  - "Open Logs" button to help users find detailed error information
+  - "File Issue" button to streamline bug reporting
+
+## User-Facing Error Messages
+
+- Write actionable error messages that clearly explain:
+  - What happened in plain language
+  - Why it happened (when possible)
+  - What the user can do to resolve the issue
+  - Where to find more information if needed
+
+## Error Recovery
+
+- Implement graceful degradation when services are unavailable
+- Provide clear paths to reconnect or retry failed operations
+- Cache previous successful responses when possible to handle intermittent failures

--- a/.github/instructions/playwright-testing.instructions.md
+++ b/.github/instructions/playwright-testing.instructions.md
@@ -1,0 +1,36 @@
+---
+applyTo: "tests/e2e/**,src/webviews/**.spec.ts"
+description: "End-to-end testing with Playwright"
+---
+
+# E2E Testing with Playwright
+
+E2E tests should be run with `npx gulp e2e`. Webview tests should be run with `npx gulp functional`.
+When developing end-to-end tests for this VS Code extension:
+
+## Test Organization
+
+- Functional webview tests go in `src/webviews/**.spec.ts`
+- Full E2E tests go in `tests/e2e/specs/**.spec.ts`
+- Consult `eslint.config.mjs` for linting rules specific to Playwright tests
+
+## Page Object Models
+
+- Use the Page Object Model (POM) pattern to encapsulate UI interactions:
+  - All POM classes go in `tests/e2e/objects/`
+  - POMs should only handle UI interactions and should not include `expect`s or assertions
+  - Properly type all UI element selectors and interaction methods
+
+## Test Structure
+
+- Write tests to validate complete user workflows
+- Include proper setup and teardown for test environments
+- Create isolated tests that can run independently
+- Add meaningful comments explaining the user scenario being tested
+
+## Testing Best Practices
+
+- Focus tests on user-facing functionality rather than implementation details
+- Use descriptive test names that explain the user scenario
+- Include proper waiting mechanisms for UI elements and async operations
+- Add retry logic where appropriate for potentially flaky UI operations

--- a/.github/instructions/typescript-vscode.instructions.md
+++ b/.github/instructions/typescript-vscode.instructions.md
@@ -1,0 +1,55 @@
+---
+applyTo: "**/*.ts,package.json"
+description: "TypeScript patterns and VS Code extension development best practices"
+---
+
+# TypeScript and VS Code Extension Development
+
+When writing TypeScript code for this VS Code extension:
+
+## Type Safety and Code Quality
+
+- Always use explicit types and interfaces, never use `any`
+- Use discriminated unions for handling different states or types
+- Prefer `enum` for fixed sets of related constants instead of union types
+- Add JSDoc comments to exported functions, classes, and interfaces
+
+## Asynchronous Programming
+
+- Use `async/await` over Promise chains for better readability
+- Implement `Promise.all` for concurrent operations when possible
+- Always handle promise rejections properly with try/catch blocks
+
+## Code Style and Organization
+
+- Write self-documenting variable and function names
+- Keep functions small and focused on a single responsibility
+- Use classes to encapsulate related functionality and state for better organization and testability
+- Follow functional programming patterns where appropriate
+
+## VS Code Extension Patterns
+
+- Properly handle `vscode.Disposable` resources to prevent memory leaks
+- Use the extension's established command patterns for consistency
+- Implement tree providers, quickpicks, and webviews according to VS Code patterns
+- Use the existing ResourceLoader and ResourceManager patterns for data fetching
+- Follow VS Code extension API patterns for commands, tree providers, quickpicks, and webviews
+
+## Configuration and Settings
+
+- Use VS Code's configuration API to access and update settings:
+  ```typescript
+  vscode.workspace.getConfiguration("confluent");
+  ```
+- Handle configuration changes with `vscode.workspace.onDidChangeConfiguration`
+- Validate settings values before using them in critical operations
+- Implement proper typing for all configuration values
+- Use workspace-scoped settings for project-specific configurations
+- Use user-scoped settings for user preferences
+
+## Extension Settings in package.json
+
+- Provide clear default values for all settings
+- Document all settings in package.json with descriptions and valid values
+- Use appropriate setting types (boolean, string, array, object)
+- Group related settings with appropriate naming conventions

--- a/.github/instructions/unit-testing.instructions.md
+++ b/.github/instructions/unit-testing.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "**/*.test.ts"
+description: "Unit testing practices with Mocha, Sinon, and Assert"
+---
+
+# Unit Testing with Mocha, Sinon, and Assert
+
+Tests should be run with `npx gulp test`. When writing unit tests for this extension:
+
+## Test Structure and Naming
+
+- Write descriptive test names with the "should" prefix that clearly explain the expected behavior
+- Group related tests using `describe` blocks for better organization and readability
+- Place test files adjacent to source files with the `.test.ts` suffix
+
+## Mocking and Stubbing
+
+- When dealing with Sinon stubs/mocks/fakes, always create a `SinonSandbox` instance in the
+  `beforeEach` hook to ensure proper teardown and isolation between tests
+- Use `sandbox.createStubInstance(Class)` to create typed `SinonStubbedInstance` for class mocking
+- Use the Sinon Assert API for verifying stub/spy behavior:
+  ```typescript
+  sinon.assert.calledWith(myStub, expectedArg); // Instead of assert.equal(myStub.calledWith(expectedArg), true)
+  ```
+- Mock all external dependencies including VS Code APIs and network requests
+
+## Test Data
+
+- Use fixtures from `test/unit/testResources/` for reusable test data representing `src/models/`
+  entities
+- Only create new fixture instances when necessary variations are needed
+- When modifying fixtures, document the reasons for the variations
+
+## Testing Best Practices
+
+- Test the public API of modules, not implementation details
+- Focus on testing behavior, not implementation
+- Write independent tests that don't rely on each other's state, refactoring modules to separate
+  concerns and help stubbing when necessary
+- Verify edge cases and error handling paths


### PR DESCRIPTION
Continuation of https://github.com/confluentinc/vscode/pull/1611 and https://github.com/confluentinc/vscode/pull/1880 to follow the emphasis of `*.instruction.md` files from recently updated VS Code docs: https://code.visualstudio.com/docs/copilot/copilot-customization

The main purpose here is to limit context/instructions when working on specific files. For example, we don't want to overload Copilot with E2E test context when working in a specific area of `src/sidecar/connections/`.