### PR TITLE
chore(CI): set up standalone promotion for sonarqube

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -104,7 +104,12 @@ blocks:
         machine:
           type: s1-prod-ubuntu24-04-arm64-1
       prologue: *build-test-prologue
-      jobs: *build-test-jobs
+      jobs:
+        <<: *build-test-jobs
+        env_vars:
+          - name: VSCODE_VERSION
+            value: stable
+            # Don't set RUN_SONARQUBE_SCAN here, since we'll only run on the linux x64 stable block
       epilogue: *build-test-epilogue
 
   - name: "Windows x64 Stable: Tests"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,8 +77,6 @@ blocks:
           env_vars:
             - name: VSCODE_VERSION
               value: stable
-            - name: RUN_SONARQUBE_SCAN
-              value: "true"
         - name: "Playwright: Webview Tests (VS Code)"
           commands:
             - make test-playwright-webviews
@@ -88,12 +86,16 @@ blocks:
             - make remove-test-env
             - make ci-bin-sem-cache-store
             - make store-test-results-to-semaphore
-            # Ensures that we run the SonarQube scan only in this block, and not in the other blocks
-            # where this epilogue is referenced.
+            # Upload coverage artifacts for SonarQube promotion
             - |
-              if [[ "${RUN_SONARQUBE_SCAN}" == "true" ]]; then 
-                sem-version java 21
-                emit-sonarqube-data --run_only_sonar_scan
+              if [ -f "coverage/lcov.info" ]; then
+                artifact push workflow coverage/lcov.info
+                echo "Uploaded Mocha coverage artifacts"
+              fi
+            - |
+              if [ -f "coverage/lcov-functional.info" ]; then
+                artifact push workflow coverage/lcov-functional.info
+                echo "Uploaded Playwright coverage artifacts"
               fi
 
   - name: "Linux ARM64 Stable: Tests"
@@ -104,12 +106,7 @@ blocks:
         machine:
           type: s1-prod-ubuntu24-04-arm64-1
       prologue: *build-test-prologue
-      jobs:
-        <<: *build-test-jobs
-        env_vars:
-          - name: VSCODE_VERSION
-            value: stable
-            # Don't set RUN_SONARQUBE_SCAN here, since we'll only run on the linux x64 stable block
+      jobs: *build-test-jobs
       epilogue: *build-test-epilogue
 
   - name: "Windows x64 Stable: Tests"
@@ -298,6 +295,10 @@ after_pipeline:
           - test-results gen-pipeline-report || echo "Could not publish pipeline test result report due to probably no test results to publish"
 
 promotions:
+  - name: SonarQube Analysis
+    pipeline_file: sonarqube.yml
+    auto_promote:
+      when: "result = 'passed' and (branch = 'main' or pull_request =~ '.*')"
   - name: Multi-Arch VSIX Packaging and Upload
     pipeline_file: multi-arch-packaging.yml
     auto_promote:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -298,7 +298,7 @@ promotions:
   - name: SonarQube Analysis
     pipeline_file: sonarqube.yml
     auto_promote:
-      when: "result = 'passed' and (branch = 'main' or pull_request =~ '.*')"
+      when: "(branch =~ '.*' or pull_request) and change_in(['src/**/*', 'tests/**/*'], {default_branch: 'main', branch_range: '$SEMAPHORE_GIT_COMMIT_RANGE', pipeline_file: 'ignore'})"
   - name: Multi-Arch VSIX Packaging and Upload
     pipeline_file: multi-arch-packaging.yml
     auto_promote:

--- a/.semaphore/sonarqube.yml
+++ b/.semaphore/sonarqube.yml
@@ -1,0 +1,50 @@
+version: v1.0
+name: sonarqube-analysis
+
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+
+blocks:
+  - name: "SonarQube Analysis"
+    task:
+      prologue:
+        commands:
+          - |
+            if [[ "${SEMAPHORE_ORGANIZATION_URL}" == *".semaphoreci.com" ]]; then
+              echo "Skipping Vault setup for Semaphore CI"
+            else
+              . vault-setup
+            fi
+      jobs:
+        - name: "Download coverage artifacts and run SonarQube scan"
+          commands:
+            # Download coverage artifacts from the main pipeline
+            - |
+              if artifact pull workflow coverage/lcov.info; then
+                echo "Downloaded Mocha coverage artifacts"
+                mkdir -p coverage
+                mv lcov.info coverage/
+              else
+                echo "Warning: Mocha coverage artifacts not found"
+              fi
+            - |
+              if artifact pull workflow coverage/lcov-functional.info; then
+                echo "Downloaded Playwright coverage artifacts"
+                mkdir -p coverage
+                mv lcov-functional.info coverage/
+              else
+                echo "Warning: Playwright coverage artifacts not found"
+              fi
+            # Verify coverage files exist
+            - |
+              echo "Coverage files found:"
+              ls -la coverage/ || echo "No coverage directory found"
+            # Run SonarQube scan with all available coverage data
+            - sem-version java 21
+            - emit-sonarqube-data --run_only_sonar_scan


### PR DESCRIPTION
Follow-up to #2051: sonarqube was double-commenting on PRs because both the linux x64 agent had `RUN_SONARQUBE_SCAN` in the `&build-test-jobs` anchor, which was then used by the linux arm64 agent in its `*build-test-jobs` anchor:
https://github.com/confluentinc/vscode/blob/e97000e04f3ed28e815b7ffbdf65267d23702e2f/.semaphore/semaphore.yml#L73-L81

Instead of messing around with more environment variables and making CI even more complicated, this PR just sets up a standalone promotion to run once for any branch/PR that changes anything in `src/` or `tests`/.

Also closes #2057.