### PR TITLE
MINOR: rename `graphql/environments.ts` to `graphql/ccloud.ts`

### DIFF
--- a/src/graphql/ccloud.test.ts
+++ b/src/graphql/ccloud.test.ts
@@ -5,9 +5,9 @@ import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notif
 import { getSidecarStub } from "../../tests/stubs/sidecar";
 
 import { SidecarHandle } from "../sidecar";
-import { getEnvironments } from "./environments";
+import { getCCloudResources } from "./ccloud";
 
-describe("environments.ts getEnvironments()", () => {
+describe("ccloud.ts getCCloudResources()", () => {
   let sandbox: sinon.SinonSandbox;
   let sidecarStub: sinon.SinonStubbedInstance<SidecarHandle>;
   let showErrorNotificationStub: sinon.SinonStub;
@@ -25,7 +25,7 @@ describe("environments.ts getEnvironments()", () => {
   it("Returns empty array and shows notification if query raises an error", async () => {
     sidecarStub.query.rejects(new Error("Query failed"));
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.deepStrictEqual(result, []);
     sinon.assert.calledOnce(showErrorNotificationStub);
@@ -34,7 +34,7 @@ describe("environments.ts getEnvironments()", () => {
   it("Returns empty array if no environments are returned", async () => {
     sidecarStub.query.resolves({ ccloudConnectionById: { environments: null } });
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.deepStrictEqual(result, []);
     sinon.assert.notCalled(showErrorNotificationStub);
@@ -43,7 +43,7 @@ describe("environments.ts getEnvironments()", () => {
   it("Returns empty array if no environments are found", async () => {
     sidecarStub.query.resolves({ ccloudConnectionById: { environments: [] } });
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.deepStrictEqual(result, []);
     sinon.assert.notCalled(showErrorNotificationStub);
@@ -52,7 +52,7 @@ describe("environments.ts getEnvironments()", () => {
   it("Handles degenerate environments from graphql", async () => {
     sidecarStub.query.resolves({ ccloudConnectionById: { environments: [null, null] } });
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.deepStrictEqual(result, []);
     sinon.assert.notCalled(showErrorNotificationStub);
@@ -91,7 +91,7 @@ describe("environments.ts getEnvironments()", () => {
     };
     sidecarStub.query.resolves(mockEnvironments);
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].id, "env1");
@@ -136,7 +136,7 @@ describe("environments.ts getEnvironments()", () => {
     };
     sidecarStub.query.resolves(mockEnvironments);
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].kafkaClusters.length, 1);
@@ -170,7 +170,7 @@ describe("environments.ts getEnvironments()", () => {
     };
     sidecarStub.query.resolves(mockEnvironments);
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].flinkComputePools.length, 1);
@@ -204,7 +204,7 @@ describe("environments.ts getEnvironments()", () => {
     };
     sidecarStub.query.resolves(mockEnvironments);
 
-    const result = await getEnvironments();
+    const result = await getCCloudResources();
 
     assert.strictEqual(result.length, 2);
     assert.strictEqual(result[0].name, "Environment 1");

--- a/src/graphql/ccloud.ts
+++ b/src/graphql/ccloud.ts
@@ -13,7 +13,7 @@ import { getSidecar } from "../sidecar";
  * Fetches {@link CCloudEnvironment}s based on a connection ID, sorted by `name`.
  * @remarks Nested `kafkaClusters` are also sorted by name.
  */
-export async function getEnvironments(): Promise<CCloudEnvironment[]> {
+export async function getCCloudResources(): Promise<CCloudEnvironment[]> {
   let envs: CCloudEnvironment[] = [];
 
   const query = graphql(`

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -18,7 +18,7 @@ import {
   StatementsSqlV1Api,
 } from "../clients/flinkSql";
 import { CCLOUD_CONNECTION_ID } from "../constants";
-import * as graphqlEnvs from "../graphql/environments";
+import * as graphqlCCloud from "../graphql/ccloud";
 import * as graphqlOrgs from "../graphql/organizations";
 import { restFlinkStatementToModel } from "../models/flinkStatement";
 import * as sidecar from "../sidecar";
@@ -279,7 +279,7 @@ describe("CCloudResourceLoader", () => {
     let getCurrentOrganizationStub: sinon.SinonStub;
 
     beforeEach(() => {
-      getEnvironmentsStub = sandbox.stub(graphqlEnvs, "getEnvironments");
+      getEnvironmentsStub = sandbox.stub(graphqlCCloud, "getCCloudResources");
       getCurrentOrganizationStub = sandbox.stub(graphqlOrgs, "getCurrentOrganization");
     });
 

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -5,7 +5,7 @@ import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudConnected } from "../emitters";
 import { isResponseErrorWithStatus } from "../errors";
-import { getEnvironments } from "../graphql/environments";
+import { getCCloudResources } from "../graphql/ccloud";
 import { getCurrentOrganization } from "../graphql/organizations";
 import { Logger } from "../logging";
 import { CCloudEnvironment } from "../models/environment";
@@ -81,8 +81,8 @@ export class CCloudResourceLoader extends CachingResourceLoader<
 
   /** Fulfill ResourceLoader::getEnvironmentsFromGraphQL */
   protected async getEnvironmentsFromGraphQL(): Promise<CCloudEnvironment[]> {
-    // Drive the GQL query. Sigh, poorly named function, since is ccloud-specific.
-    return await getEnvironments();
+    // Drive the GQL query.
+    return await getCCloudResources();
   }
 
   /** Fulfill ResourceLoader::reset(), taking care of clearing in-memory cached organization. */


### PR DESCRIPTION
Also update its core function `getEnvironments()` to `getCCloudResources()` to match its [direct](https://github.com/confluentinc/vscode/blob/e97000e04f3ed28e815b7ffbdf65267d23702e2f/src/graphql/direct.ts#L23) and [local](https://github.com/confluentinc/vscode/blob/e97000e04f3ed28e815b7ffbdf65267d23702e2f/src/graphql/local.ts#L12) variants.