### PR TITLE
fix: remove extra cleanup call

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -328,7 +328,6 @@ export class FlinkLanguageClientManager implements Disposable {
    */
   private async restartLanguageClient(): Promise<void> {
     if (!this.lastDocUri) return; // We should never get here
-    await this.cleanupLanguageClient();
     try {
       await this.maybeStartLanguageClient(this.lastDocUri);
       // Reset counter on successful reconnection


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fixes some of the error notifications coming from reconnections in the flink sql language client by removing an extra call to cleanup