### PR TITLE
fix: convert single line back to multi

### DIFF
--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -86,8 +86,8 @@ export async function initializeLanguageClient(
               }
               return [];
             },
-            sendRequest: (type, params, token, next) => {
-              // Server does not accept line positions > 0 for completions, so we need to convert them to single-line
+            sendRequest: async (type, params, token, next) => {
+              // CCloud Flink SQL Server does not support multiline completions atm, so we need to convert ranges to single-line & back
               if (
                 typeof type === "object" &&
                 type.method &&
@@ -100,10 +100,25 @@ export async function initializeLanguageClient(
                   );
                   if (document) {
                     const originalPosition = (params as any).position;
+                    // 1. on the way out, convert position to {line: 0}
                     (params as any).position = convertToSingleLinePosition(
                       document,
                       new vscode.Position(originalPosition.line, originalPosition.character),
                     );
+                    // 2. get the completion items
+                    const result: any = await next(type, params, token);
+                    if (result) {
+                      const items: any = result.items;
+                      items.forEach((element: vscode.CompletionItem) => {
+                        // 3. to show correct completion position, translate result back to multi-line
+                        if (element.textEdit) {
+                          logger.trace("item has textEdit, manipulating range");
+                          let newRange = convertToMultiLineRange(document, element.textEdit.range);
+                          element.textEdit.range = newRange;
+                        }
+                      });
+                    }
+                    return result;
                   }
                 }
               }
@@ -174,4 +189,35 @@ function convertToSingleLinePosition(
   }
   singleLinePosition += position.character;
   return new vscode.Position(0, singleLinePosition);
+}
+
+/**
+ * Helper to convert a single-line range (line: 0, character: X) back to a multi-line range.
+ * Reverses the effect of convertToSingleLinePosition.
+ */
+function convertToMultiLineRange(
+  document: vscode.TextDocument,
+  singleLineRange: vscode.Range,
+): vscode.Range {
+  const text = document.getText();
+  const lines = text.split("\n");
+
+  function offsetToPosition(offset: number): vscode.Position {
+    let runningOffset = 0;
+    for (let line = 0; line < lines.length; line++) {
+      const lineLength = lines[line].length + 1; // +1 for newline
+      if (offset < runningOffset + lineLength) {
+        return new vscode.Position(line, offset - runningOffset);
+      }
+      runningOffset += lineLength;
+    }
+    // Fallback = last position
+    return new vscode.Position(lines.length - 1, lines[lines.length - 1].length);
+  }
+
+  const startOffset = singleLineRange.start.character;
+  const endOffset = singleLineRange.end.character;
+  const start = offsetToPosition(startOffset);
+  const end = offsetToPosition(endOffset);
+  return new vscode.Range(start, end);
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes https://github.com/confluentinc/vscode/issues/2102
- This PR adds middleware to convert previously edited single line position ranges _back to multiline again_ for completions to show correctly in the editor UI.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
- Since CCloud Flink Language Server does not support multi-line completions at this time, we were already converting the position ranges we send to be single-line (e.g. `{line:0}`. 
- Converting the range back inside `provideCompletionItems` middleware was not working and in investigating I found out that VS Code deprecated the items' `textEdit` param, so ["the shape of the Completion Item is not the same for LSP and VS Code API"](https://github.com/microsoft/vscode-languageserver-node/issues/1132#issuecomment-1337032278). 🫠 
- The lsp client library `vscode-languageserver/node` is already [removing `textEdit` if it exists](https://github.com/microsoft/vscode-languageserver-node/blob/main/client/src/common/completion.ts#L126), before providing completions. But our middleware is called _after_ that helpful removal, so my code never sees the range to adjust it. So we must manipulate the results in `sendRequest` before the library middleware gets to it. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
