### PR TITLE
fix: avoid backticks filtering out completion items from vscode UI

### DIFF
--- a/src/flinkSql/languageClient.test.ts
+++ b/src/flinkSql/languageClient.test.ts
@@ -1,7 +1,11 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
-import { convertToMultiLineRange, convertToSingleLinePosition } from "./languageClient";
+import {
+  adaptCompletionItems,
+  convertToMultiLineRange,
+  convertToSingleLinePosition,
+} from "./languageClient";
 
 describe("flinkSql/languageClient.ts position conversion functions", () => {
   let sandbox: sinon.SinonSandbox;
@@ -262,5 +266,65 @@ describe("flinkSql/languageClient.ts position conversion functions", () => {
         `Failed for position ${originalPosition.line}:${originalPosition.character}`,
       );
     }
+  });
+});
+
+describe("adaptCompletionItems", () => {
+  it("should remove filterText if the completion does not have backticks", () => {
+    const document = {
+      getText: (range?: vscode.Range) => {
+        if (range) {
+          return "";
+        }
+        return "SELECT * FROM my_table";
+      },
+    } as vscode.TextDocument;
+
+    const result = {
+      items: [
+        {
+          label: "my_table",
+          textEdit: {
+            range: new vscode.Range(0, 14, 0, 22),
+            newText: "my_table",
+          },
+          filterText: "`my_table`",
+        },
+      ],
+    };
+
+    const adaptedResult = adaptCompletionItems(result, document);
+    const adaptedItem = adaptedResult.items[0];
+
+    assert.strictEqual(adaptedItem.filterText, undefined, "filterText should be undefined");
+  });
+
+  it("should not change filterText if backticks are present", () => {
+    const document = {
+      getText: (range?: vscode.Range) => {
+        if (range) {
+          return "`my_table`";
+        }
+        return "SELECT * FROM `my_table`";
+      },
+    } as vscode.TextDocument;
+
+    const result = {
+      items: [
+        {
+          label: "my_table",
+          textEdit: {
+            range: new vscode.Range(0, 14, 0, 24),
+            newText: "`my_table`",
+          },
+          filterText: "`my_table`",
+        },
+      ],
+    };
+
+    const adaptedResult = adaptCompletionItems(result, document);
+    const adaptedItem = adaptedResult.items[0];
+
+    assert.strictEqual(adaptedItem.filterText, "`my_table`", "filterText should not be changed");
   });
 });

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -61,28 +61,6 @@ export async function initializeLanguageClient(
           outputChannel: getFlinkSQLLanguageServerOutputChannel(),
           progressOnInitialization: true,
           middleware: {
-            provideCompletionItem: async (document, position, context, token, next) => {
-              const result: any = await next(document, position, context, token);
-              if (result) {
-                const items: any = result.items;
-                items.forEach((element: vscode.CompletionItem) => {
-                  // The server sends backticks in the filterText for all Resource completions, but vscode languageclient
-                  // will filter out these items if the completion range doesn't start with a backtick, so we remove them
-                  if (
-                    element.filterText &&
-                    element.filterText.startsWith("`") &&
-                    element.filterText.endsWith("`")
-                  ) {
-                    element.filterText = element.filterText.substring(
-                      1,
-                      element.filterText.length - 1,
-                    );
-                  }
-                });
-                return result;
-              }
-              return [];
-            },
             sendRequest: async (type, params, token, next) => {
               // CCloud Flink SQL Server does not support multiline completions atm, so we need to convert ranges to single-line & back
               if (
@@ -111,6 +89,16 @@ export async function initializeLanguageClient(
                         if (element.textEdit) {
                           let newRange = convertToMultiLineRange(document, element.textEdit.range);
                           element.textEdit.range = newRange;
+                        }
+                        // ALSO, the server adds backticks for all Resource completions even if not typed in the editor
+                        // To align with vscode's sort/filter we remove these params, causing it to fall back on the label for filter/insert
+                        if (
+                          element.filterText &&
+                          element.filterText.startsWith("`") &&
+                          element.filterText.endsWith("`")
+                        ) {
+                          element.filterText = undefined;
+                          element.insertText = undefined;
                         }
                       });
                     }

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -90,15 +90,18 @@ export async function initializeLanguageClient(
                           let newRange = convertToMultiLineRange(document, element.textEdit.range);
                           element.textEdit.range = newRange;
                         }
-                        // ALSO, the server adds backticks for all Resource completions even if not typed in the editor
-                        // To align with vscode's sort/filter we remove these params, causing it to fall back on the label for filter/insert
-                        if (
-                          element.filterText &&
-                          element.filterText.startsWith("`") &&
-                          element.filterText.endsWith("`")
-                        ) {
-                          element.filterText = undefined;
-                          element.insertText = undefined;
+                        // CCloud Flink SQL Server adds backticks for all Resource completions even if not typed in the editor doc
+                        // To align with vscode's expectations we remove the filterText if the editor's range does not already begin or end with backtick
+                        // ...causing it to fall back on the label for filtering
+                        if (element.textEdit) {
+                          const editorRangeText = document.getText(element.textEdit.range);
+                          const filter = element.filterText;
+                          const filterTicks = filter?.startsWith("`") && filter?.endsWith("`");
+                          const editTicks =
+                            editorRangeText.startsWith("`") && editorRangeText.endsWith("`");
+                          if (filterTicks && !editTicks) {
+                            element.filterText = undefined;
+                          }
                         }
                       });
                     }

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -80,32 +80,9 @@ export async function initializeLanguageClient(
                       document,
                       new vscode.Position(originalPosition.line, originalPosition.character),
                     );
-                    // 2. get the completion items
+                    // 2. grab the completion items so we can adapt them
                     const result: any = await next(type, params, token);
-                    if (result) {
-                      const items: any = result.items;
-                      items.forEach((element: vscode.CompletionItem) => {
-                        // 3. to show correct completion position, translate result back to multi-line
-                        if (element.textEdit) {
-                          let newRange = convertToMultiLineRange(document, element.textEdit.range);
-                          element.textEdit.range = newRange;
-                        }
-                        // CCloud Flink SQL Server adds backticks for all Resource completions even if not typed in the editor doc
-                        // To align with vscode's expectations we remove the filterText if the editor's range does not already begin or end with backtick
-                        // ...causing it to fall back on the label for filtering
-                        if (element.textEdit) {
-                          const editorRangeText = document.getText(element.textEdit.range);
-                          const filter = element.filterText;
-                          const filterTicks = filter?.startsWith("`") && filter?.endsWith("`");
-                          const editTicks =
-                            editorRangeText.startsWith("`") && editorRangeText.endsWith("`");
-                          if (filterTicks && !editTicks) {
-                            element.filterText = undefined;
-                          }
-                        }
-                      });
-                    }
-                    return result;
+                    return adaptCompletionItems(result, document);
                   }
                 }
               }
@@ -207,4 +184,39 @@ export function convertToMultiLineRange(
   const start = offsetToPosition(startOffset);
   const end = offsetToPosition(endOffset);
   return new vscode.Range(start, end);
+}
+
+/**
+ * Manipulates completion items returned from the Flink SQL language server to align with VS Code's expectations.
+ * 1. Converts single-line ranges from the server back to multi-line ranges for correct display in the editor.
+ * 2. Removes backticks from `filterText` for resource completions if the editor text does not contain them.
+ *
+ * @param result The completion list from the language server response.
+ * @param document The text document for which the completions were requested.
+ * @returns The updated completion list.
+ */
+export function adaptCompletionItems(result: any, document: vscode.TextDocument): any {
+  if (result) {
+    const items: any = result.items;
+    items.forEach((element: vscode.CompletionItem) => {
+      // To show correct completion position, translate result back to multi-line
+      if (element.textEdit) {
+        let newRange = convertToMultiLineRange(document, element.textEdit.range);
+        element.textEdit.range = newRange;
+      }
+      // CCloud Flink SQL Server adds backticks for all Resource completions even if not typed in the editor doc
+      // To align with vscode's expectations we remove the filterText if the editor's range does not already begin or end with backtick
+      // ...causing it to fall back on the label for filtering
+      if (element.textEdit) {
+        const editorRangeText = document.getText(element.textEdit.range);
+        const filter = element.filterText;
+        const filterTicks = filter?.startsWith("`") && filter?.endsWith("`");
+        const editTicks = editorRangeText.startsWith("`") && editorRangeText.endsWith("`");
+        if (filterTicks && !editTicks) {
+          element.filterText = undefined;
+        }
+      }
+    });
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes https://github.com/confluentinc/vscode/issues/1814

- Logic for handling backticks added by the server moves to `sendRequest` to get ahead of other manipulations in the `languageclient/node` library -- see description on https://github.com/confluentinc/vscode/pull/2107 for similar moves that ***should be merged before this one***
- Now we check the document's completion range & avoid removing filters if the editor document does actually have them. 

## Any additional details or context that should be provided?

- See [linked issue](https://github.com/confluentinc/vscode/issues/1814) for more details. In `languageClient.ts`, in the middleware for `provideCompletionItem` we were already doing some special handling for backticks added by the server to avoid vscode filtering out completions, but it wasn't working quite right. 
- Note: we don't remove the `insertText` since we will follow the CCloud pattern of always inserting backticks around the Proper Names. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
