### PR TITLE
Lookup & use names instead of ids for language server workspace settings

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -2,16 +2,20 @@ import * as assert from "assert";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
-import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
+import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import {
   TEST_CCLOUD_FLINK_COMPUTE_POOL,
   TEST_CCLOUD_FLINK_COMPUTE_POOL_ID,
 } from "../../tests/unit/testResources/flinkComputePool";
+import * as flinkSqlProvider from "../codelens/flinkSqlProvider";
 import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../extensionSettings/constants";
 import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { CCloudKafkaCluster } from "../models/kafkaCluster";
 import * as ccloud from "../sidecar/connections/ccloud";
+import { UriMetadataKeys } from "../storage/constants";
+import { ResourceManager } from "../storage/resourceManager";
 import { FlinkLanguageClientManager } from "./flinkLanguageClientManager";
 
 describe("FlinkLanguageClientManager", () => {
@@ -20,6 +24,8 @@ describe("FlinkLanguageClientManager", () => {
   let hasCCloudAuthSessionStub: sinon.SinonStub;
   let flinkManager: FlinkLanguageClientManager;
   let ccloudLoaderStub: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+  let getCatalogDatabaseFromMetadataStub: sinon.SinonStub;
+  let resourceManagerStub: sinon.SinonStubbedInstance<ResourceManager>;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -32,8 +38,20 @@ describe("FlinkLanguageClientManager", () => {
     hasCCloudAuthSessionStub = sandbox.stub(ccloud, "hasCCloudAuthSession");
     hasCCloudAuthSessionStub.returns(false);
     ccloudLoaderStub = getStubbedCCloudResourceLoader(sandbox);
+    getCatalogDatabaseFromMetadataStub = sandbox.stub(
+      flinkSqlProvider,
+      "getCatalogDatabaseFromMetadata",
+    );
 
+    resourceManagerStub = sandbox.createStubInstance(ResourceManager);
+    sandbox.stub(ResourceManager, "getInstance").returns(resourceManagerStub);
     const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+    const database: CCloudKafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
+    // simulate stored compute pool + database metadata
+    resourceManagerStub.getUriMetadata.resolves({
+      [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: pool.id,
+      [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
+    });
     const envWithPool: CCloudEnvironment = new CCloudEnvironment({
       ...TEST_CCLOUD_ENVIRONMENT,
       flinkComputePools: [pool],
@@ -96,6 +114,98 @@ describe("FlinkLanguageClientManager", () => {
 
       const result = await flinkManager.validateFlinkSettings(TEST_CCLOUD_FLINK_COMPUTE_POOL_ID);
       assert.strictEqual(result, true);
+    });
+  });
+
+  describe("getFlinkSqlSettings", () => {
+    const testUri = vscode.Uri.parse("file:///test.flink.sql");
+
+    it("should return null for all settings if not configured", async () => {
+      const configMock = {
+        get: sandbox.stub().returns(null),
+      };
+      configStub.returns(configMock);
+      resourceManagerStub.getUriMetadata.resolves(undefined);
+
+      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+
+      assert.deepStrictEqual(settings, {
+        computePoolId: null,
+        databaseName: null,
+        catalogName: null,
+      });
+    });
+
+    it("should return configs from workspace if set and uri metadata is undefined", async () => {
+      const configMock = {
+        get: sandbox.stub(),
+      };
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("config-pool-id");
+      configMock.get.withArgs(FLINK_CONFIG_DATABASE).returns("config-db-id");
+      configStub.returns(configMock);
+      resourceManagerStub.getUriMetadata.resolves(undefined);
+
+      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+
+      assert.deepStrictEqual(settings, {
+        computePoolId: "config-pool-id",
+        // these are correctly null since fake DB id yields no results in getCatalogDatabaseFromMetadataStub
+        databaseName: null,
+        catalogName: null,
+      });
+    });
+
+    it("should return db and catalog names with settings if found", async () => {
+      const configMock = {
+        get: sandbox.stub(),
+      };
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns(TEST_CCLOUD_FLINK_COMPUTE_POOL_ID);
+      configMock.get.withArgs(FLINK_CONFIG_DATABASE).returns("test-db");
+      configStub.returns(configMock);
+
+      // Mock the getCatalogDatabaseFromMetadata function to return catalog and database names
+      getCatalogDatabaseFromMetadataStub.resolves({
+        catalog: { name: "test-catalog-name" },
+        database: { name: "test-db-name" },
+      });
+
+      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+
+      sinon.assert.calledOnce(getCatalogDatabaseFromMetadataStub);
+      assert.deepStrictEqual(settings, {
+        computePoolId: TEST_CCLOUD_FLINK_COMPUTE_POOL_ID,
+        databaseName: "test-db-name",
+        catalogName: "test-catalog-name",
+      });
+    });
+
+    it("should prioritize URI metadata over workspace config settings", async () => {
+      const configMock = {
+        get: sandbox.stub(),
+      };
+      configMock.get.withArgs(FLINK_CONFIG_COMPUTE_POOL).returns("config-pool");
+      configMock.get.withArgs(FLINK_CONFIG_DATABASE).returns("config-db");
+      configStub.returns(configMock);
+
+      resourceManagerStub.getUriMetadata.resolves({
+        flinkComputePoolId: "metadata-pool",
+        flinkDatabaseId: "metadata-db",
+      });
+
+      getCatalogDatabaseFromMetadataStub.resolves({
+        catalog: { name: "metadata-catalog-name" },
+        database: { name: "metadata-db-name" },
+      });
+
+      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+
+      assert.deepStrictEqual(settings, {
+        computePoolId: "metadata-pool",
+        databaseName: "metadata-db-name",
+        catalogName: "metadata-catalog-name",
+      });
+      sinon.assert.calledOnce(resourceManagerStub.getUriMetadata);
+      sinon.assert.calledOnce(getCatalogDatabaseFromMetadataStub);
     });
   });
 });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes https://github.com/confluentinc/vscode/issues/2002
- These values are returned as-is in diagnostics messages, so it's a better UX with the names. 

<img width="1011" alt="Screenshot 2025-06-25 at 8 10 57 AM" src="https://github.com/user-attachments/assets/2b003796-386e-4cea-80e0-3c71091b04d4" />

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
