### PR TITLE
minor: remove synchronize option

### DIFF
--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -59,9 +59,6 @@ export async function initializeLanguageClient(
             { pattern: "**/*.flink.sql" },
           ],
           outputChannel: getFlinkSQLLanguageServerOutputChannel(),
-          synchronize: {
-            fileEvents: vscode.workspace.createFileSystemWatcher("**/*.flink.sql"),
-          },
           progressOnInitialization: true,
           middleware: {
             provideCompletionItem: async (document, position, context, token, next) => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- While digging through language server logs I noticed some warnings like this: `jsonrpc2: code -32601 message: method not supported: workspace/didChangeWatchedFiles`
- These methods are sent if the client library's synchronize option is set, but aren't necessary for the language server features we are using. I'm **removing it to reduce the log noise.** 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Similar log warnings are showing for `textDocument/didClose`. It would be a bit more lift to remove this call (it always gets sent from language client lib), so I'm leaving it. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
