### PR TITLE
Language server - handle more "maybe start" scenarios

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -226,5 +226,78 @@ describe("FlinkLanguageClientManager", () => {
       sinon.assert.calledOnce(maybeStartStub);
       sinon.assert.calledWith(maybeStartStub, fakeUri);
     });
+
+    it("should initialize language client when has auth session & visible flinksql document (no active flinksql document)", async () => {
+      hasCCloudAuthSessionStub.returns(true);
+
+      // Non-flinksql active editor
+      const nonFlinkDocument = {
+        languageId: "typescript",
+        uri: vscode.Uri.parse("file:///non/flink/doc.ts"),
+      } as vscode.TextDocument;
+      const nonFlinkEditor = { document: nonFlinkDocument } as vscode.TextEditor;
+      sandbox.stub(vscode.window, "activeTextEditor").value(nonFlinkEditor);
+
+      // Visible flinksql editor
+      const fakeUri = vscode.Uri.parse("file:///fake/path/visible.flinksql");
+      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
+      const fakeEditor = { document: fakeDocument } as vscode.TextEditor;
+      sandbox.stub(vscode.window, "visibleTextEditors").value([fakeEditor]);
+
+      const maybeStartStub = sandbox
+        .stub(FlinkLanguageClientManager.prototype, "maybeStartLanguageClient")
+        .resolves();
+
+      // Re-initialize the singleton so the constructor runs
+      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager.getInstance();
+
+      sinon.assert.calledOnce(maybeStartStub);
+      sinon.assert.calledWith(maybeStartStub, fakeUri);
+    });
+
+    it("should not initialize language client when has auth session but no flinksql document is open", async () => {
+      hasCCloudAuthSessionStub.returns(true);
+
+      // No active editor
+      sandbox.stub(vscode.window, "activeTextEditor").value(undefined);
+
+      // No visible flinksql editors
+      const nonFlinkDocument = {
+        languageId: "typescript",
+        uri: vscode.Uri.parse("file:///non/flink/doc.ts"),
+      } as vscode.TextDocument;
+      const nonFlinkEditor = { document: nonFlinkDocument } as vscode.TextEditor;
+      sandbox.stub(vscode.window, "visibleTextEditors").value([nonFlinkEditor]);
+
+      const maybeStartStub = sandbox
+        .stub(FlinkLanguageClientManager.prototype, "maybeStartLanguageClient")
+        .resolves();
+
+      // Re-initialize the singleton so the constructor runs
+      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager.getInstance();
+
+      sinon.assert.notCalled(maybeStartStub);
+    });
+
+    it("should not initialize language client when not authenticated with CCloud", async () => {
+      hasCCloudAuthSessionStub.returns(false);
+
+      const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
+      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
+      const fakeEditor = { document: fakeDocument } as vscode.TextEditor;
+      sandbox.stub(vscode.window, "activeTextEditor").value(fakeEditor);
+
+      const maybeStartStub = sandbox
+        .stub(FlinkLanguageClientManager.prototype, "maybeStartLanguageClient")
+        .resolves();
+
+      // Re-initialize the singleton so the constructor runs
+      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager.getInstance();
+
+      sinon.assert.notCalled(maybeStartStub);
+    });
   });
 });

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -208,4 +208,23 @@ describe("FlinkLanguageClientManager", () => {
       sinon.assert.calledOnce(getCatalogDatabaseFromMetadataStub);
     });
   });
+  describe("constructor behavior", () => {
+    it("should initialize language client when has auth session & active flinksql document", async () => {
+      hasCCloudAuthSessionStub.returns(true);
+      const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
+      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
+      const fakeEditor = { document: fakeDocument } as vscode.TextEditor;
+      sandbox.stub(vscode.window, "activeTextEditor").value(fakeEditor);
+      const maybeStartStub = sandbox
+        .stub(FlinkLanguageClientManager.prototype, "maybeStartLanguageClient")
+        .resolves();
+
+      // Re-initialize the singleton so the constructor runs
+      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager.getInstance();
+
+      sinon.assert.calledOnce(maybeStartStub);
+      sinon.assert.calledWith(maybeStartStub, fakeUri);
+    });
+  });
 });

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -104,6 +104,23 @@ export class FlinkLanguageClientManager implements Disposable {
       }),
     );
 
+    // Active editor should cover documents opening,
+    // but we still listen for open event since it's also called when the language id changes
+    this.disposables.push(
+      workspace.onDidOpenTextDocument(async (doc) => {
+        if (doc.languageId === "flinksql") {
+          const activeEditor = window.activeTextEditor;
+          // No-op if the document is not the active editor (let the active editor listener handle it)
+          if (activeEditor && activeEditor.document.uri.toString() !== doc.uri.toString()) {
+            return;
+          } else {
+            logger.trace("Initializing language client for changed active Flink SQL document");
+            await this.maybeStartLanguageClient(doc.uri);
+          }
+        }
+      }),
+    );
+
     // Listen for CCloud authentication
     this.disposables.push(
       ccloudConnected.event(async (connected) => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
Adds a few more scenarios that we need to pay attention to so the language server can try to start anytime we have a flink doc open: 
1. If a flink document is already opened and you are already authenticated with CCloud, the language server should try to start. Closes https://github.com/confluentinc/vscode/issues/1725 
1. If the active document language changes to flinksql, the language server should try to start. Closes https://github.com/confluentinc/vscode/issues/2003

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
