### PR TITLE
Support query topic with Flink via context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this extension will be documented in this file.
 
 ### Added
 
+- On Confluent Cloud topics, context menu now offers the option to "Query with Flink SQL"
 - Any sidecar error logs will now include exception data in the "Confluent (Sidecar)" output
   channel, as well as the file saved from the "Save Sidecar Logs" or "Save Support File (.zip)"
   commands.

--- a/package.json
+++ b/package.json
@@ -651,6 +651,11 @@
         "category": "Confluent: Topics"
       },
       {
+        "command": "confluent.topics.query",
+        "title": "Query with Flink",
+        "category": "Confluent: Topics"
+      },
+      {
         "command": "confluent.topics.delete",
         "title": "Delete Topic",
         "category": "Confluent: Topics"
@@ -1216,6 +1221,10 @@
           "when": "false"
         },
         {
+          "command": "confluent.topics.query",
+          "when": "false"
+        },
+        {
           "command": "confluent.topics.openlatestschemas",
           "when": "false"
         },
@@ -1634,6 +1643,11 @@
         {
           "command": "confluent.openCCloudApiKeysUrl",
           "when": "view in confluent.viewsWithResources && (viewItem == ccloud-kafka-cluster || viewItem == ccloud-schema-registry)",
+          "group": "z_openInCloud"
+        },
+        {
+          "command": "confluent.topics.query",
+          "when": "view == confluent-topics && viewItem =~ /ccloud-kafka-topic.*/",
           "group": "z_openInCloud"
         },
         {

--- a/package.json
+++ b/package.json
@@ -652,7 +652,7 @@
       },
       {
         "command": "confluent.topics.query",
-        "title": "Query with Flink",
+        "title": "Query with Flink SQL",
         "category": "Confluent: Topics"
       },
       {

--- a/package.json
+++ b/package.json
@@ -1647,7 +1647,7 @@
         },
         {
           "command": "confluent.topics.query",
-          "when": "view == confluent-topics && viewItem =~ /ccloud-kafka-topic.*/",
+          "when": "view == confluent-topics && viewItem =~ /ccloud-kafka-topic.*-flinkable.*/",
           "group": "z_openInCloud"
         },
         {

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -950,22 +950,18 @@ describe("commands/topics.ts queryTopicWithFlink()", function () {
     await queryTopicWithFlink(TEST_CCLOUD_KAFKA_TOPIC);
 
     assert.ok(openTextDocumentStub.calledOnce);
-    const docOptions = openTextDocumentStub.firstCall.args[0];
-    assert.strictEqual(docOptions.language, FLINK_SQL_LANGUAGE_ID);
-
-    const expectedFullyQualifiedName = `\`${TEST_CCLOUD_ENVIRONMENT.name}\`.\`${TEST_CCLOUD_KAFKA_CLUSTER.name}\`.\`${TEST_CCLOUD_KAFKA_TOPIC.name}\``;
     const expectedQuery = `-- Query topic "${TEST_CCLOUD_KAFKA_TOPIC.name}" with Flink SQL
 -- Replace this with your actual Flink SQL query
 
 SELECT *
-FROM ${expectedFullyQualifiedName}
+FROM \`${TEST_CCLOUD_ENVIRONMENT.name}\`.\`${TEST_CCLOUD_KAFKA_CLUSTER.name}\`.\`${TEST_CCLOUD_KAFKA_TOPIC.name}\`
 LIMIT 10;`;
-
-    assert.strictEqual(docOptions.content, expectedQuery);
+    sinon.assert.calledWithExactly(openTextDocumentStub, {
+      language: FLINK_SQL_LANGUAGE_ID,
+      content: expectedQuery,
+    });
 
     assert.ok(showTextDocumentStub.calledOnce);
-    assert.strictEqual(showTextDocumentStub.firstCall.args[0], mockDocument);
-    assert.deepStrictEqual(showTextDocumentStub.firstCall.args[1], { preview: false });
     sinon.assert.calledWithExactly(showTextDocumentStub, mockDocument, { preview: false });
   });
 

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -966,6 +966,7 @@ LIMIT 10;`;
     assert.ok(showTextDocumentStub.calledOnce);
     assert.strictEqual(showTextDocumentStub.firstCall.args[0], mockDocument);
     assert.deepStrictEqual(showTextDocumentStub.firstCall.args[1], { preview: false });
+    sinon.assert.calledWithExactly(showTextDocumentStub, mockDocument, { preview: false });
   });
 
   it("should return early if topic is null or not a KafkaTopic instance", async function () {

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -484,8 +484,8 @@ async function produceMessages(
 }
 
 /** Open a new tab set to Flink SQL type with placeholder Flink query of the selected topic */
-async function queryTopicWithFlink(topic: KafkaTopic) {
-  if (!topic || !(topic instanceof KafkaTopic)) {
+export async function queryTopicWithFlink(topic: KafkaTopic) {
+  if (!topic || !(topic instanceof KafkaTopic) || !isCCloud(topic)) {
     return;
   }
 

--- a/src/loaders/loaderUtils.ts
+++ b/src/loaders/loaderUtils.ts
@@ -3,7 +3,8 @@ import { TopicData, TopicDataList, TopicV3Api } from "../clients/kafkaRest";
 import { Schema as ResponseSchema, SubjectsV1Api } from "../clients/schemaRegistryRest";
 import { isResponseError } from "../errors";
 import { Logger } from "../logging";
-import { KafkaCluster } from "../models/kafkaCluster";
+import { CCloudKafkaCluster, KafkaCluster } from "../models/kafkaCluster";
+import { isCCloud } from "../models/resource";
 import { Schema, SchemaType, Subject, subjectMatchesTopicName } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { KafkaTopic } from "../models/topic";
@@ -92,6 +93,13 @@ export function correlateTopicsWithSchemaSubjects(
       subjectMatchesTopicName(subject.name, topic.topic_name),
     );
 
+    // Check if the cluster has any Flink pools (for CCloud clusters only)
+    let isFlinkable = false;
+    if (isCCloud(cluster)) {
+      const ccloudCluster = cluster as CCloudKafkaCluster;
+      isFlinkable = !!(ccloudCluster.flinkPools && ccloudCluster.flinkPools.length > 0);
+    }
+
     return KafkaTopic.create({
       connectionId: cluster.connectionId,
       connectionType: cluster.connectionType,
@@ -104,6 +112,7 @@ export function correlateTopicsWithSchemaSubjects(
       clusterId: cluster.id,
       environmentId: cluster.environmentId,
       hasSchema: matchingSubjects.length > 0,
+      isFlinkable: isFlinkable,
       operations: toKafkaTopicOperations(topic.authorized_operations!),
       children: matchingSubjects,
     });

--- a/src/loaders/loaderUtils.ts
+++ b/src/loaders/loaderUtils.ts
@@ -97,7 +97,7 @@ export function correlateTopicsWithSchemaSubjects(
     let isFlinkable = false;
     if (isCCloud(cluster)) {
       const ccloudCluster = cluster as CCloudKafkaCluster;
-      isFlinkable = !!(ccloudCluster.flinkPools && ccloudCluster.flinkPools.length > 0);
+      isFlinkable = Array.isArray(ccloudCluster.flinkPools) && ccloudCluster.flinkPools.length > 0;
     }
 
     return KafkaTopic.create({

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -7,6 +7,7 @@ import {
   LOCAL_CONNECTION_ID,
   UTM_SOURCE_VSCODE,
 } from "../constants";
+import { CCloudFlinkComputePool } from "./flinkComputePool";
 import { CustomMarkdownString } from "./main";
 import {
   ConnectionId,
@@ -47,6 +48,7 @@ export class CCloudKafkaCluster extends KafkaCluster {
 
   // added separately from sidecar responses
   environmentId!: Enforced<EnvironmentId>;
+  flinkPools?: CCloudFlinkComputePool[];
 
   get ccloudUrl(): string {
     return `https://confluent.cloud/environments/${this.environmentId}/clusters/${this.id}?utm_source=${UTM_SOURCE_VSCODE}`;

--- a/src/models/topic.test.ts
+++ b/src/models/topic.test.ts
@@ -140,4 +140,26 @@ describe("KafkaTopicTreeItem constructor", () => {
       vscode.TreeItemCollapsibleState.None,
     );
   });
+
+  it("should append context value with -flinkable if the cluster has matchking flink pool in the same provider/region", () => {
+    const flinkableTopicTreeItem = new KafkaTopicTreeItem(
+      KafkaTopic.create({ ...TEST_CCLOUD_KAFKA_TOPIC, isFlinkable: true }),
+    );
+    assert.strictEqual(flinkableTopicTreeItem.contextValue!.includes("-flinkable"), true);
+  });
+
+  it("should not append context value with -flinkable if the cluster has matchking flink pool in the same provider/region", () => {
+    const nonFlinkableTopicTreeItem = new KafkaTopicTreeItem(
+      KafkaTopic.create({ ...TEST_CCLOUD_KAFKA_TOPIC, isFlinkable: false }),
+    );
+    assert.strictEqual(nonFlinkableTopicTreeItem.contextValue!.includes("-flinkable"), false);
+  });
+
+  it("set context value for topic with muliple attributes such as schema and flinkable correctly", () => {
+    const topicWithBothTreeItem = new KafkaTopicTreeItem(
+      KafkaTopic.create({ ...TEST_CCLOUD_KAFKA_TOPIC, hasSchema: true, isFlinkable: true }),
+    );
+    assert.strictEqual(topicWithBothTreeItem.contextValue!.includes("-with-schema"), true);
+    assert.strictEqual(topicWithBothTreeItem.contextValue!.includes("-flinkable"), true);
+  });
 });

--- a/src/models/topic.ts
+++ b/src/models/topic.ts
@@ -29,6 +29,7 @@ export class KafkaTopic extends Data implements IResourceBase, ISearchable {
   // CCloud env IDs are unique, direct/local env IDs match their connection IDs
   environmentId!: EnvironmentId;
   hasSchema: boolean = false;
+  isFlinkable: boolean = false;
 
   /** Schema subjects; only used with Topics view search. */
   children: Subject[] = [];
@@ -71,6 +72,11 @@ export class KafkaTopicTreeItem extends vscode.TreeItem {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
     } else {
       this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+    }
+
+    // Check if the topic is flinkable and append the flag
+    if (this.resource.isFlinkable) {
+      this.contextValue += "-flinkable";
     }
 
     // user-facing properties


### PR DESCRIPTION
## Summary of Changes

- Add "Query with Flink" option to the context menu when right-clicked on a Confluent Cloud topic.
- A new editor tab will open, with language mode set to Flink SQL, and prepopulated with a default `SELECT *` query

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

<img width="700" alt="Screenshot 2025-06-26 at 2 48 47 PM" src="https://github.com/user-attachments/assets/8259bd72-5bdb-4989-a235-707eacdaf0e6" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
