### PR TITLE
fix: preemptively clear outdated language client diagnostics

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -315,8 +315,7 @@ export class FlinkLanguageClientManager implements Disposable {
         this.disposables.push(this.languageClient);
         this.lastDocUri = uri;
         this.lastWebSocketUrl = url;
-        // Adds an on change listener for our doc to clear language client diagnostics
-        // This is necessary because the language server intermittently does not publish new diagnostics after changes
+        // Clear outdated diagnostics on change, since the CCloud Flink SQL Server intermittently won't publish new diagnostics
         this.disposables.push(
           workspace.onDidChangeTextDocument((event) => {
             if (event.document.uri.toString() === uri.toString()) {

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -315,6 +315,15 @@ export class FlinkLanguageClientManager implements Disposable {
         this.disposables.push(this.languageClient);
         this.lastDocUri = uri;
         this.lastWebSocketUrl = url;
+        // Adds an on change listener for our doc to clear language client diagnostics
+        // This is necessary because the language server intermittently does not publish new diagnostics after changes
+        this.disposables.push(
+          workspace.onDidChangeTextDocument((event) => {
+            if (event.document.uri.toString() === uri.toString()) {
+              this.languageClient?.diagnostics?.set(event.document.uri, []);
+            }
+          }),
+        );
         logger.trace("Flink SQL language client successfully initialized");
         this.notifyConfigChanged();
       }

--- a/src/flinkSql/languageClient.ts
+++ b/src/flinkSql/languageClient.ts
@@ -16,7 +16,7 @@ import { getFlinkSQLLanguageServerOutputChannel } from "./logging";
 import { WebsocketTransport } from "./websocketTransport";
 
 const logger = new Logger("flinkSql.languageClient.Client");
-
+const FLINK_DIAGNOSTIC_COLLECTION_NAME = "confluent.flinkSql";
 /** Initialize the FlinkSQL language client and connect to the language server websocket.
  * Creates a WebSocket (ws), then on ws.onopen makes the WebsocketTransport class for server, and then creates the Client.
  * Provides middleware for completions and diagnostics in ClientOptions
@@ -60,6 +60,7 @@ export async function initializeLanguageClient(
           ],
           outputChannel: getFlinkSQLLanguageServerOutputChannel(),
           progressOnInitialization: true,
+          diagnosticCollectionName: FLINK_DIAGNOSTIC_COLLECTION_NAME,
           middleware: {
             sendRequest: async (type, params, token, next) => {
               // CCloud Flink SQL Server does not support multiline completions atm, so we need to convert ranges to single-line & back


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #1776 
- The language server backend will intermittently fail to send the expected `publishDiagnostics` message, so in this PR we add code to manually clear out diagnostics when the doc changes, avoiding showing any outdated error messages in the UI. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- A similar workaround is in place for CCloud UI
- **To Test** 
  - Make sure the language client flag is enabled, you're logged into CCloud, and you have an open `flink.sql` document.
  - Write an invalid statement & pause until you observe the diagnostics error. 
  - Add/change the doc. Expectation: the error disappears. (Before this change, the error would not get cleared even if you corrected it in the doc)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [X] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
