### PR TITLE
(Copilot) add prep invocation to listTopics

### DIFF
--- a/src/chat/tools/listTopics.ts
+++ b/src/chat/tools/listTopics.ts
@@ -56,20 +56,19 @@ export class ListTopicsTool extends BaseLanguageModelTool<IListTopicsParameters>
       .appendMarkdown(`## List Kafka Topics\n`)
       .appendMarkdown(`This tool will retrieve topics with the following criteria:\n`);
 
-    if (input.kafkaClusterId) {
-      confirmationMessage.appendMarkdown(`\n- **Kafka Cluster ID**: ${input.kafkaClusterId}`);
-    }
-    if (input.environmentId) {
-      confirmationMessage.appendMarkdown(`\n- **Environment ID**: ${input.environmentId}`);
-    }
-    if (input.connectionId) {
-      confirmationMessage.appendMarkdown(`\n- **Connection ID**: ${input.connectionId}`);
-    }
-    if (input.topicNameSubstring) {
-      confirmationMessage.appendMarkdown(
-        `\n- **Topic Name Filter**: "${input.topicNameSubstring}"`,
-      );
-    }
+    const criteria = [
+      { label: 'Kafka Cluster ID', value: input.kafkaClusterId },
+      { label: 'Environment ID', value: input.environmentId },
+      { label: 'Connection ID', value: input.connectionId },
+      { label: 'Topic Name Filter', value: input.topicNameSubstring, quoted: true },
+    ];
+
+    criteria.forEach(({ label, value, quoted }) => {
+      if (value) {
+        const displayValue = quoted ? `"${value}"` : value;
+        confirmationMessage.appendMarkdown(`\n- **${label}**: ${displayValue}`);
+      }
+    });
 
     confirmationMessage
       .appendMarkdown(`\n\n**Additional Information:**`)
@@ -226,4 +225,5 @@ export class ListTopicsTool extends BaseLanguageModelTool<IListTopicsParameters>
 
     return new TextOnlyToolResultPart(toolCall.callId, resultParts);
   }
+}
 }

--- a/src/chat/tools/listTopics.ts
+++ b/src/chat/tools/listTopics.ts
@@ -75,7 +75,7 @@ export class ListTopicsTool extends BaseLanguageModelTool<IListTopicsParameters>
       .appendMarkdown(`\n\n**Additional Information:**`)
       .appendMarkdown(`\n- Results will be limited to 30 topics maximum`)
       .appendMarkdown(`\n- Topic summaries will include partition count and configuration details`)
-      .appendMarkdown(`\n- Filtering is case-insensitive when using topic name substring`)
+      .appendMarkdown(`\n- Filtering is case-sensitive when using topic name substring`)
       .appendMarkdown(`\n\nDo you want to proceed?`);
 
     const confirmationMessages: LanguageModelToolConfirmationMessages = {


### PR DESCRIPTION
## Summary of Changes

Adds a `prepareInvocation` method to the listTopics tool. 

<img width="589" alt="Screenshot 2025-07-01 at 12 50 36 PM" src="https://github.com/user-attachments/assets/1b66ab69-528f-4c10-a1b2-ca5913ce99a9" />


## Any additional details or context that should be provided?

> Note: I also change the filter function to be case-sensitive, as [Kafka topics themselves are case-sensitive](https://lists.apache.org/thread/7mq1jo2v0tqfpf90hx1l8ssmgh4qk6nn). 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
