### PR TITLE
fix schema evolution E2E tests

### DIFF
--- a/src/flinkStatementResultsManager.test.ts
+++ b/src/flinkStatementResultsManager.test.ts
@@ -7,7 +7,7 @@ import {
   createTestResultsManagerContext,
 } from "../tests/createResultsManager";
 import { eventually } from "../tests/eventually";
-import { loadFixture } from "../tests/fixtures/utils";
+import { loadFixtureFromFile } from "../tests/fixtures/utils";
 import { createResponseError } from "../tests/unit/testUtils";
 import {
   GetSqlv1StatementResult200Response,
@@ -22,10 +22,10 @@ import {
 } from "./webview/flink-statement-results";
 
 function createMockStatement(): FlinkStatement {
-  const fakeFlinkStatement = loadFixture(
+  const fakeFlinkStatement = loadFixtureFromFile(
     "flink-statement-results-processing/fake-flink-statement.json",
   );
-  const mockStatement = new FlinkStatement(fakeFlinkStatement);
+  const mockStatement = new FlinkStatement(JSON.parse(fakeFlinkStatement));
   mockStatement.metadata = {
     ...mockStatement.metadata,
     created_at: new Date(),
@@ -37,9 +37,10 @@ function createMockStatement(): FlinkStatement {
 describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () => {
   let sandbox: sinon.SinonSandbox;
   let ctx: FlinkStatementResultsManagerTestContext;
-  const expectedParsedResults = loadFixture(
+  const resultsString = loadFixtureFromFile(
     "flink-statement-results-processing/expected-parsed-results.json",
   );
+  const expectedParsedResults = JSON.parse(resultsString);
   let vm: FlinkStatementResultsViewModel;
   const statement: FlinkStatement = createMockStatement();
 

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import * as sinon from "sinon";
 
-import { loadFixture } from "../../tests/fixtures/utils";
+import { loadFixtureFromFile } from "../../tests/fixtures/utils";
 import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import { createFlinkStatement } from "../../tests/unit/testResources/flinkStatement";
@@ -206,9 +206,10 @@ describe("CCloudResourceLoader", () => {
     });
 
     it("should return the statement if found", async () => {
-      const mockResponse = loadFixture(
+      const responseString = loadFixtureFromFile(
         "flink-statement-results-processing/create-statement-response.json",
-      ) as GetSqlv1Statement200Response;
+      );
+      const mockResponse = JSON.parse(responseString) as GetSqlv1Statement200Response;
 
       flinkSqlStatementsApi.getSqlv1Statement.resolves(mockResponse);
 

--- a/src/quickpicks/uris.ts
+++ b/src/quickpicks/uris.ts
@@ -88,6 +88,7 @@ export async function uriQuickpick(
   });
 
   const quickPick = window.createQuickPick();
+  quickPick.ignoreFocusOut = true;
   quickPick.items = quickpickItems;
 
   if (documents.length > 0) {

--- a/tests/createResultsManager.ts
+++ b/tests/createResultsManager.ts
@@ -126,9 +126,10 @@ export async function createTestResultsManagerContext(
     });
 
     // Verify the results match expected format
-    const expectedParsedResults = loadFixtureFromFile(
+    const expected: string = loadFixtureFromFile(
       "flink-statement-results-processing/expected-parsed-results.json",
     );
+    const expectedParsedResults = JSON.parse(expected);
     assert.deepStrictEqual(results, { results: expectedParsedResults });
   }, 10_000);
 

--- a/tests/createResultsManager.ts
+++ b/tests/createResultsManager.ts
@@ -12,7 +12,7 @@ import {
   ResultsViewerStorageState,
 } from "../src/webview/flink-statement-results";
 import { eventually } from "./eventually";
-import { loadFixture } from "./fixtures/utils";
+import { loadFixtureFromFile } from "./fixtures/utils";
 
 class FakeWebviewStorage<T> implements WebviewStorage<T> {
   private storage: T | undefined;
@@ -80,9 +80,12 @@ export async function createTestResultsManagerContext(
 
   const notifyUIStub = sandbox.stub();
 
-  const stmtResults = Array.from({ length: 5 }, (_, i) =>
-    loadFixture(`flink-statement-results-processing/get-statement-results-${i + 1}.json`),
-  );
+  const stmtResults = Array.from({ length: 5 }, (_, i) => {
+    const resultsString = loadFixtureFromFile(
+      `flink-statement-results-processing/get-statement-results-${i + 1}.json`,
+    );
+    return JSON.parse(resultsString);
+  });
 
   // Update the refreshFlinkStatement stub to return the mock statement
   refreshFlinkStatementStub.returns(Promise.resolve(statement));
@@ -123,7 +126,7 @@ export async function createTestResultsManagerContext(
     });
 
     // Verify the results match expected format
-    const expectedParsedResults = loadFixture(
+    const expectedParsedResults = loadFixtureFromFile(
       "flink-statement-results-processing/expected-parsed-results.json",
     );
     assert.deepStrictEqual(results, { results: expectedParsedResults });

--- a/tests/e2e/objects/editor/TextDocument.ts
+++ b/tests/e2e/objects/editor/TextDocument.ts
@@ -1,10 +1,7 @@
 import { Locator, Page } from "@playwright/test";
 import { executeVSCodeCommand } from "../../utils/commands";
 
-/**
- * Object representing a VS Code text editor document/tab.
- * Provides methods for common document operations like selecting all, replacing content, etc.
- */
+/** Object representing a VS Code text editor document. */
 export class TextDocument {
   constructor(
     private readonly page: Page,

--- a/tests/e2e/objects/editor/TextDocument.ts
+++ b/tests/e2e/objects/editor/TextDocument.ts
@@ -29,7 +29,7 @@ export class TextDocument {
   /** Save the currently-focused document. */
   async save(): Promise<void> {
     await this.locator.click();
-    await this.page.keyboard.press("ControlOrMeta+s");
+    await this.editorContent.press("ControlOrMeta+s");
   }
 
   /** Close the currently-focused document. */
@@ -42,13 +42,13 @@ export class TextDocument {
   /** Select all content in the document. */
   async selectAll(): Promise<void> {
     await this.locator.click();
-    await this.page.keyboard.press("ControlOrMeta+a");
+    await this.editorContent.press("ControlOrMeta+a");
   }
 
   /** Delete all content in the document. */
   async deleteAll(): Promise<void> {
     await this.selectAll();
-    await this.page.keyboard.press("Backspace");
+    await this.editorContent.press("Backspace");
   }
 
   /**

--- a/tests/e2e/objects/editor/TextDocument.ts
+++ b/tests/e2e/objects/editor/TextDocument.ts
@@ -21,6 +21,11 @@ export class TextDocument {
     return this.page.getByRole("tab", { name: this.documentTitle });
   }
 
+  /** The editor content area where text is displayed and edited. */
+  get editorContent(): Locator {
+    return this.locator.getByRole("code");
+  }
+
   /** Save the currently-focused document. */
   async save(): Promise<void> {
     await this.locator.click();
@@ -54,13 +59,12 @@ export class TextDocument {
    */
   async insertContent(content: string): Promise<void> {
     await this.locator.click();
-    await this.page.keyboard.type(content);
+    // we can't use `locator.fill()` since it doesn't work nicely with the monaco editor elements,
+    // but we can't use `page.keyboard.type()` directly since it might miss/skip some characters
+    await this.editorContent.pressSequentially(content);
   }
 
-  /**
-   * Replace all content in the document with new content.
-   * Uses clipboard to avoid VS Code auto-indentation issues.
-   */
+  /** Replace all content in the document with new content. */
   async replaceContent(content: string): Promise<void> {
     await this.deleteAll();
     await this.insertContent(content);

--- a/tests/e2e/objects/editor/TextDocument.ts
+++ b/tests/e2e/objects/editor/TextDocument.ts
@@ -1,0 +1,68 @@
+import { Locator, Page } from "@playwright/test";
+import { executeVSCodeCommand } from "../../utils/commands";
+
+/**
+ * Object representing a VS Code text editor document/tab.
+ * Provides methods for common document operations like selecting all, replacing content, etc.
+ */
+export class TextDocument {
+  constructor(
+    private readonly page: Page,
+    private readonly documentTitle: string,
+  ) {}
+
+  /** The main locator for this document's editor instance. */
+  get locator(): Locator {
+    return this.page.locator(`.editor-instance[aria-label*="${this.documentTitle}"]`);
+  }
+
+  /** The tab element for this document. */
+  get tab(): Locator {
+    return this.page.getByRole("tab", { name: this.documentTitle });
+  }
+
+  /** Save the currently-focused document. */
+  async save(): Promise<void> {
+    await this.locator.click();
+    await this.page.keyboard.press("ControlOrMeta+s");
+  }
+
+  /** Close the currently-focused document. */
+  async close(): Promise<void> {
+    await this.locator.click();
+    // use the command ID since "View: Close Editor" will fuzzy match with others
+    await executeVSCodeCommand(this.page, "workbench.action.closeActiveEditor");
+  }
+
+  /** Select all content in the document. */
+  async selectAll(): Promise<void> {
+    await this.locator.click();
+    await this.page.keyboard.press("ControlOrMeta+a");
+  }
+
+  /** Delete all content in the document. */
+  async deleteAll(): Promise<void> {
+    await this.selectAll();
+    await this.page.keyboard.press("Backspace");
+  }
+
+  /**
+   * Insert content at the current cursor position.
+   *
+   * NOTE: Use `configureVSCodeSettings()` during test setup to disable auto-formatting for more
+   * reliable test results.
+   */
+  async insertContent(content: string): Promise<void> {
+    await this.locator.click();
+    await this.page.keyboard.type(content);
+  }
+
+  /**
+   * Replace all content in the document with new content.
+   * Uses clipboard to avoid VS Code auto-indentation issues.
+   */
+  async replaceContent(content: string): Promise<void> {
+    await this.deleteAll();
+    await this.insertContent(content);
+  }
+}

--- a/tests/e2e/objects/editor/TextDocument.ts
+++ b/tests/e2e/objects/editor/TextDocument.ts
@@ -59,8 +59,7 @@ export class TextDocument {
    */
   async insertContent(content: string): Promise<void> {
     await this.locator.click();
-    // we can't use `locator.fill()` since it doesn't work nicely with the monaco editor elements,
-    // but we can't use `page.keyboard.type()` directly since it might miss/skip some characters
+    // we can't use `.fill()` here since it doesn't work nicely with the monaco editor elements
     await this.editorContent.pressSequentially(content);
   }
 

--- a/tests/e2e/objects/quickInputs/InputBox.ts
+++ b/tests/e2e/objects/quickInputs/InputBox.ts
@@ -24,20 +24,13 @@ export class InputBox {
     return this.locator.locator(".quick-input-message");
   }
 
-  /** Clear the input box and type new `text`. */
-  async fill(text: string): Promise<void> {
-    await this.input.click();
-    await this.page.keyboard.press("ControlOrMeta+a");
-    await this.page.keyboard.type(text);
-  }
-
   /** Press Enter to confirm the input. */
   async confirm(): Promise<void> {
-    await this.page.keyboard.press("Enter");
+    await this.locator.press("Enter");
   }
 
   /** Press Escape to cancel the input. */
   async cancel(): Promise<void> {
-    await this.page.keyboard.press("Escape");
+    await this.locator.press("Escape");
   }
 }

--- a/tests/e2e/objects/quickInputs/InputBox.ts
+++ b/tests/e2e/objects/quickInputs/InputBox.ts
@@ -1,0 +1,43 @@
+import { Locator, Page } from "@playwright/test";
+
+/** Object representing a VS Code text input box. */
+export class InputBox {
+  constructor(public readonly page: Page) {}
+
+  /** The main input box widget locator. */
+  get locator(): Locator {
+    return this.page.locator(".quick-input-widget");
+  }
+
+  /** Get the input field within the input box. */
+  get input(): Locator {
+    return this.locator.locator("input");
+  }
+
+  /** Get the placeholder text from the input field. */
+  get placeholder(): Locator {
+    return this.input;
+  }
+
+  /** Get validation message if present. */
+  get validationMessage(): Locator {
+    return this.locator.locator(".quick-input-message");
+  }
+
+  /** Clear the input box and type new `text`. */
+  async fill(text: string): Promise<void> {
+    await this.input.click();
+    await this.page.keyboard.press("ControlOrMeta+a");
+    await this.page.keyboard.type(text);
+  }
+
+  /** Press Enter to confirm the input. */
+  async confirm(): Promise<void> {
+    await this.page.keyboard.press("Enter");
+  }
+
+  /** Press Escape to cancel the input. */
+  async cancel(): Promise<void> {
+    await this.page.keyboard.press("Escape");
+  }
+}

--- a/tests/e2e/objects/quickInputs/Quickpick.ts
+++ b/tests/e2e/objects/quickInputs/Quickpick.ts
@@ -11,6 +11,18 @@ export class Quickpick {
     return this.page.locator(".quick-input-widget");
   }
 
+  /** The quickpick header container. */
+  get header(): Locator {
+    return this.locator.locator(".quick-input-header");
+  }
+
+  /** The quickpick input field where you can type to filter items. */
+  get textInput(): Locator {
+    return this.header.locator(
+      ".quick-input-and-message .quick-input-filter .quick-input-box .monaco-findInput .monaco-inputbox .ibwrapper input.input",
+    );
+  }
+
   /** Get all quickpick items (rows). Use Playwright's filter methods to narrow down the selection. */
   get items(): Locator {
     return this.locator.locator(".monaco-list-row");

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -119,7 +119,7 @@ export class ResourcesView extends View {
    * Only visible when the {@link localItem "Local" item} is expanded.
    */
   get localSchemaRegistries(): Locator {
-    return this.schemaRegistries.filter({ hasText: "confluent-local" });
+    return this.schemaRegistries.filter({ hasText: "local-sr" });
   }
 
   /**

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -75,9 +75,10 @@ export class ResourcesView extends View {
    * Only visible when a {@link ccloudEnvironments CCloud environment item} is expanded.
    */
   get ccloudKafkaClusters(): Locator {
-    return this.kafkaClusters
-      .filter({ hasNotText: "confluent-local" })
-      .filter({ hasNotText: "Kafka Cluster" });
+    // third nested element: Confluent Cloud item -> environment item -> Kafka cluster item
+    return this.body
+      .locator("[role='treeitem'][aria-level='3']")
+      .filter({ has: this.page.locator(".codicon-confluent-kafka-cluster") });
   }
 
   /**
@@ -97,7 +98,40 @@ export class ResourcesView extends View {
     return this.kafkaClusters.filter({ hasText: "Kafka Cluster" });
   }
 
-  // FUTURE: add Schema Registry and Flink compute pool getter methods
+  /** Locator for all Schema Registry tree items. */
+  get schemaRegistries(): Locator {
+    return this.treeItems.filter({ has: this.page.locator(".codicon-confluent-schema-registry") });
+  }
+
+  /**
+   * Locator for CCloud Schema Registry tree items.
+   * Only visible when a {@link ccloudEnvironments CCloud environment item} is expanded.
+   */
+  get ccloudSchemaRegistries(): Locator {
+    // third nested element: Confluent Cloud item -> environment item -> Schema Registry item
+    return this.body
+      .locator("[role='treeitem'][aria-level='3']")
+      .filter({ has: this.page.locator(".codicon-confluent-schema-registry") });
+  }
+
+  /**
+   * Locator for local Schema Registry tree items.
+   * Only visible when the {@link localItem "Local" item} is expanded.
+   */
+  get localSchemaRegistries(): Locator {
+    return this.schemaRegistries.filter({ hasText: "confluent-local" });
+  }
+
+  /**
+   * Locator for direct connection Schema Registry tree items.
+   * Only visible when a {@link directConnections "Direct Connections" item} is available and
+   * expanded.
+   */
+  get directSchemaRegistries(): Locator {
+    return this.schemaRegistries.filter({ hasText: "Schema Registry" });
+  }
+
+  // FUTURE: add Flink compute pool getter methods
 
   /**
    * Open the Direct Connection form by clicking "Add New Connection" -> "Enter manually".

--- a/tests/e2e/objects/views/SchemasView.ts
+++ b/tests/e2e/objects/views/SchemasView.ts
@@ -11,7 +11,11 @@ export class SchemasView extends View {
     super(page, /Schemas.*Section/);
   }
 
-  /** Click the "Search" nav action in the view title area. */
+  /**
+   * Click the "Search" nav action in the view title area.
+   *
+   * NOTE: This requires a Schema Registry to be selected first.
+   */
   async clickSearch(): Promise<void> {
     await this.clickNavAction("Search");
   }
@@ -21,17 +25,29 @@ export class SchemasView extends View {
     await this.clickNavAction("Create New Schema");
   }
 
-  /** Click the "Upload Schema to Schema Registry" nav action in the view title area. */
+  /**
+   * Click the "Upload Schema to Schema Registry" nav action in the view title area.
+   *
+   * NOTE: This requires a Schema Registry to be selected first.
+   */
   async clickUploadSchema(): Promise<void> {
     await this.clickNavAction("Upload Schema to Schema Registry");
   }
 
-  /** Click the "Select Schema Registry" nav action in the view title area. */
+  /**
+   * Click the "Select Schema Registry" nav action in the view title area.
+   *
+   * NOTE: This requires at least one connection with a Schema Registry to be available.
+   */
   async clickSelectSchemaRegistry(): Promise<void> {
     await this.clickNavAction("Select Schema Registry");
   }
 
-  /** Click the "Refresh" nav action in the view title area. */
+  /**
+   * Click the "Refresh" nav action in the view title area.
+   *
+   * NOTE: This requires a Schema Registry to be selected first.
+   */
   async clickRefresh(): Promise<void> {
     await this.clickNavAction("Refresh");
   }
@@ -48,13 +64,5 @@ export class SchemasView extends View {
   get schemaVersions(): Locator {
     // we don't use `this.subjects` because these are sibling elements to subjects in the DOM
     return this.body.locator("[role='treeitem'][aria-level='2']");
-  }
-
-  /**
-   * Get a specific subject by name.
-   * @param subjectName The name of the subject to find
-   */
-  getSubjectByName(subjectName: string): Locator {
-    return this.subjects.filter({ hasText: subjectName });
   }
 }

--- a/tests/e2e/objects/views/SchemasView.ts
+++ b/tests/e2e/objects/views/SchemasView.ts
@@ -1,0 +1,60 @@
+import { Locator, Page } from "@playwright/test";
+import { View } from "./View";
+
+/**
+ * Object representing the "Schemas"
+ * {@link https://code.visualstudio.com/api/ux-guidelines/views#tree-views view} in the "Confluent"
+ * {@link https://code.visualstudio.com/api/ux-guidelines/views#view-containers view container}.
+ */
+export class SchemasView extends View {
+  constructor(page: Page) {
+    super(page, /Schemas.*Section/);
+  }
+
+  /** Click the "Search" nav action in the view title area. */
+  async clickSearch(): Promise<void> {
+    await this.clickNavAction("Search");
+  }
+
+  /** Click the "Create New Schema" nav action in the view title area. */
+  async clickCreateNewSchema(): Promise<void> {
+    await this.clickNavAction("Create New Schema");
+  }
+
+  /** Click the "Upload Schema to Schema Registry" nav action in the view title area. */
+  async clickUploadSchema(): Promise<void> {
+    await this.clickNavAction("Upload Schema to Schema Registry");
+  }
+
+  /** Click the "Select Schema Registry" nav action in the view title area. */
+  async clickSelectSchemaRegistry(): Promise<void> {
+    await this.clickNavAction("Select Schema Registry");
+  }
+
+  /** Click the "Refresh" nav action in the view title area. */
+  async clickRefresh(): Promise<void> {
+    await this.clickNavAction("Refresh");
+  }
+
+  /** Get all (root-level) subject items in the view. */
+  get subjects(): Locator {
+    return this.body.locator("[role='treeitem'][aria-level='1']");
+  }
+
+  /**
+   * Get all schema version items in the view.
+   * (One level below {@link subjects subject items}.)
+   */
+  get schemaVersions(): Locator {
+    // we don't use `this.subjects` because these are sibling elements to subjects in the DOM
+    return this.body.locator("[role='treeitem'][aria-level='2']");
+  }
+
+  /**
+   * Get a specific subject by name.
+   * @param subjectName The name of the subject to find
+   */
+  getSubjectByName(subjectName: string): Locator {
+    return this.subjects.filter({ hasText: subjectName });
+  }
+}

--- a/tests/e2e/objects/views/viewItems/SubjectItem.ts
+++ b/tests/e2e/objects/views/viewItems/SubjectItem.ts
@@ -1,6 +1,11 @@
 import { ViewItem } from "./ViewItem";
 
 export class SubjectItem extends ViewItem {
+  /** Click the "View Latest Schema" inline action. */
+  async clickViewLatestSchema(): Promise<void> {
+    await this.clickInlineAction("View Latest Schema");
+  }
+
   /** Click the "Evolve Latest Schema" inline action to open the schema evolution workflow. */
   async clickEvolveLatestSchema(): Promise<void> {
     await this.clickInlineAction("Evolve Latest Schema");

--- a/tests/e2e/objects/views/viewItems/SubjectItem.ts
+++ b/tests/e2e/objects/views/viewItems/SubjectItem.ts
@@ -1,0 +1,13 @@
+import { ViewItem } from "./ViewItem";
+
+export class SubjectItem extends ViewItem {
+  /** Click the "Evolve Latest Schema" inline action to open the schema evolution workflow. */
+  async clickEvolveLatestSchema(): Promise<void> {
+    await this.clickInlineAction("Evolve Latest Schema");
+  }
+
+  /** Click the "Upload Schema to Schema Registry for Subject" inline action. */
+  async uploadSchemaForSubject(): Promise<void> {
+    await this.clickInlineAction("Upload Schema to Schema Registry for Subject");
+  }
+}

--- a/tests/e2e/specs/flinkStatement.spec.ts
+++ b/tests/e2e/specs/flinkStatement.spec.ts
@@ -9,57 +9,66 @@ import {
   verifyStatementStatus,
 } from "./utils/flinkStatement";
 
-test.describe("Flink statements and statement results viewer", () => {
-  let webview: FrameLocator;
-
-  test.beforeEach(async ({ page, electronApp }) => {
-    // Open the extension
-    await openConfluentExtension(page);
-
-    // Login to Confluent Cloud
-    await login(page, electronApp, process.env.E2E_USERNAME!, process.env.E2E_PASSWORD!);
-  });
-
-  test.afterEach(async () => {
-    // Stop the statement
-    await stopStatement(webview);
-  });
-
-  const testCases = [
-    {
-      name: "SELECT statement",
-      fileName: "select.flink.sql",
-      eventualExpectedStatus: "RUNNING",
-      expectedStats: "Showing 1..100 of 200 results (total: 200).",
+test.describe.fixme(
+  "Flink statements and statement results viewer",
+  {
+    annotation: {
+      type: "issue",
+      description: "https://github.com/confluentinc/vscode/issues/2112",
     },
-    {
-      name: "EXPLAIN statement",
-      fileName: "explain.flink.sql",
-      eventualExpectedStatus: "COMPLETED",
-      expectedStats: "Showing 1..1 of 1 results (total: 1).",
-    },
-    {
-      name: "DESCRIBE statement",
-      fileName: "describe.flink.sql",
-      eventualExpectedStatus: "COMPLETED",
-      expectedStats: "Showing 1..5 of 5 results (total: 5).",
-    },
-  ];
+  },
+  () => {
+    let webview: FrameLocator;
 
-  for (const testCase of testCases) {
-    test(`should submit Flink statement - ${testCase.name}`, async ({ page }) => {
-      // Submit the statement
-      await submitFlinkStatement(page, testCase.fileName);
+    test.beforeEach(async ({ page, electronApp }) => {
+      // Open the extension
+      await openConfluentExtension(page);
 
-      webview = page.locator("iframe").contentFrame().locator("iframe").contentFrame();
-
-      // Wait for statement to run and verify status
-      await verifyStatementStatus(webview, testCase.eventualExpectedStatus);
-
-      // Verify results stats
-      await verifyResultsStats(webview, testCase.expectedStats);
-
-      // TODO: Verify results are correct for each test case
+      // Login to Confluent Cloud
+      await login(page, electronApp, process.env.E2E_USERNAME!, process.env.E2E_PASSWORD!);
     });
-  }
-});
+
+    test.afterEach(async () => {
+      // Stop the statement
+      await stopStatement(webview);
+    });
+
+    const testCases = [
+      {
+        name: "SELECT statement",
+        fileName: "select.flink.sql",
+        eventualExpectedStatus: "RUNNING",
+        expectedStats: "Showing 1..100 of 200 results (total: 200).",
+      },
+      {
+        name: "EXPLAIN statement",
+        fileName: "explain.flink.sql",
+        eventualExpectedStatus: "COMPLETED",
+        expectedStats: "Showing 1..1 of 1 results (total: 1).",
+      },
+      {
+        name: "DESCRIBE statement",
+        fileName: "describe.flink.sql",
+        eventualExpectedStatus: "COMPLETED",
+        expectedStats: "Showing 1..5 of 5 results (total: 5).",
+      },
+    ];
+
+    for (const testCase of testCases) {
+      test(`should submit Flink statement - ${testCase.name}`, async ({ page }) => {
+        // Submit the statement
+        await submitFlinkStatement(page, testCase.fileName);
+
+        webview = page.locator("iframe").contentFrame().locator("iframe").contentFrame();
+
+        // Wait for statement to run and verify status
+        await verifyStatementStatus(webview, testCase.eventualExpectedStatus);
+
+        // Verify results stats
+        await verifyResultsStats(webview, testCase.expectedStats);
+
+        // TODO: Verify results are correct for each test case
+      });
+    }
+  },
+);

--- a/tests/e2e/specs/schemas.spec.ts
+++ b/tests/e2e/specs/schemas.spec.ts
@@ -110,7 +110,7 @@ test.describe("Schema Management", () => {
       // select the subject to delete
       const subjectInputBox = new InputBox(page);
       await expect(subjectInputBox.placeholder).toBeVisible();
-      await subjectInputBox.fill(subjectName);
+      await subjectInputBox.input.fill(subjectName);
       await subjectInputBox.confirm();
 
       // select the Hard Delete option
@@ -122,7 +122,7 @@ test.describe("Schema Management", () => {
       // enter the confirmation text input
       const confirmationBox = new InputBox(page);
       await expect(confirmationBox.input).toBeVisible();
-      await confirmationBox.fill(deletionConfirmation);
+      await confirmationBox.input.fill(deletionConfirmation);
       await confirmationBox.confirm();
 
       // the system dialog is automatically handled by the stub above, no need to handle it here
@@ -357,7 +357,7 @@ test.describe("Schema Management", () => {
     const generatedSubjectName = `customer-${randomValue}-value`;
     const subjectInputBox = new InputBox(page);
     await expect(subjectInputBox.input).toBeVisible();
-    await subjectInputBox.fill(generatedSubjectName);
+    await subjectInputBox.input.fill(generatedSubjectName);
     await subjectInputBox.confirm();
 
     // clear out and close the untitled document after uploading so we only have one editor open

--- a/tests/e2e/specs/schemas.spec.ts
+++ b/tests/e2e/specs/schemas.spec.ts
@@ -1,238 +1,383 @@
-import { Page, expect } from "@playwright/test";
+import { expect, Locator, Page } from "@playwright/test";
 import { stubMultipleDialogs } from "electron-playwright-helpers";
+import { loadFixtureFromFile } from "../../fixtures/utils";
 import { test } from "../baseTest";
+import { TextDocument } from "../objects/editor/TextDocument";
+import { Notification } from "../objects/notifications/Notification";
+import { NotificationArea } from "../objects/notifications/NotificationArea";
+import { InputBox } from "../objects/quickInputs/InputBox";
+import { Quickpick } from "../objects/quickInputs/Quickpick";
+import { ResourcesView } from "../objects/views/ResourcesView";
+import { SchemasView } from "../objects/views/SchemasView";
+import { SubjectItem } from "../objects/views/viewItems/SubjectItem";
+import {
+  DirectConnectionForm,
+  FormConnectionType,
+  SupportedAuthType,
+} from "../objects/webviews/DirectConnectionFormWebview";
+import { executeVSCodeCommand } from "../utils/commands";
+import { configureVSCodeSettings } from "../utils/settings";
 import { openConfluentExtension } from "./utils/confluent";
 import { login } from "./utils/confluentCloud";
-import { openFixtureFile } from "./utils/flinkStatement";
 
-async function createNewSubject(page: Page, subjectName: string, schemaFile: string) {
-  await openFixtureFile(page, schemaFile);
-
-  await page.getByLabel(/Schemas.*Section/).click();
-  await page.getByLabel(/Schemas.*Section/).hover();
-  await page.getByLabel("Select Schema Registry").click();
-  await expect(page.getByPlaceholder("Select a Schema Registry")).toBeVisible();
-  await page.getByPlaceholder("Select a Schema Registry").click();
-
-  // Select the first option.
-  await page.keyboard.press("Enter");
-
-  await page.getByLabel(/Schemas.*Section/).hover();
-  await page.getByLabel("Upload Schema to Schema Registry", { exact: true }).click();
-
-  await page.getByPlaceholder("Select a file").click();
-  await page.keyboard.type(schemaFile);
-  await page.keyboard.press("Enter");
-
-  await page.getByText("Create new subject").click();
-  await page.getByLabel("Schema Subject").click();
-  await page.getByLabel("Schema Subject").press("ControlOrMeta+a");
-  await page.getByLabel("Schema Subject").fill(subjectName);
-  await page.getByLabel("Schema Subject").press("Enter");
-
-  await expect(
-    page.getByText(/Schema registered to new subject.*/, { exact: true }).first(),
-  ).toBeVisible();
-}
-
-async function evolveSchema(page: Page, subjectName: string, fixtureFile: string) {
-  await openFixtureFile(page, fixtureFile);
-  // Copy the schema to the clipboard.
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("ControlOrMeta+c");
-
-  await page.getByLabel(subjectName).first().hover({ timeout: 200 });
-  await page.getByRole("button", { name: "Evolve Latest Schema" }).click();
-  // Wait for the unsaved schema document to open.
-  await page.waitForTimeout(1000);
-
-  await page.getByRole("tab", { name: subjectName }).first().click();
-  // Wait for the tab to be focused.
-  await page.waitForTimeout(200);
-  // Paste the schema into the tab.
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("Backspace");
-  await page.keyboard.press("ControlOrMeta+v");
-
-  // The unsaved file buffer will start with the subject name, so we can just use that.
-  await uploadSchema(page, subjectName);
-}
+/** Schema types and their corresponding file extensions to test. */
+const SCHEMA_TYPES = [
+  ["AVRO", "avsc"],
+  ["JSON", "json"],
+  ["PROTOBUF", "proto"],
+] as const;
 
 /**
- * Upload a schema to the Schema Registry. Caller is expected to have opened
- * and focused the file buffer with the schema to upload.
+ * E2E test suite for testing the whole schema management flow in the extension.
+ * {@see https://github.com/confluentinc/vscode/issues/1839}
  *
- * @param page - The Playwright page object.
- * @param subjectName - The name of the subject to upload the schema to.
+ * Test flow:
+ * 1. Set up connection:
+ *    a. CCLOUD: Log in to Confluent Cloud from the sidebar auth flow
+ *    b. DIRECT: Fill out the Add New Connection form and submit with Schema Registry connection details
+ * 2. Select a Schema Registry
+ * 3. Create a new subject with an initial schema version
+ * 4. Try to evolve the schema to a new version
+ *    a. Valid/compatible schema update
+ *    b. Invalid/incompatible schema update
+ * 5. Clean up by deleting the subject
  */
-async function uploadSchema(page: any, subjectName: string) {
-  await page.getByLabel(/Schemas.*Section/).hover();
-  await expect(page.getByLabel("Upload Schema to Schema Registry", { exact: true })).toBeVisible();
-  await page.getByLabel("Upload Schema to Schema Registry", { exact: true }).click();
 
-  await expect(page.getByPlaceholder("Select a file")).toBeVisible();
-  await page.getByPlaceholder("Select a file").click();
-  // Select the first option.
-  await page.keyboard.press("Enter");
+test.describe("Schema Management", () => {
+  let resourcesView: ResourcesView;
+  // this is set after the connections are set up based on their beforeEach hooks
+  let schemasView: SchemasView;
 
-  await page.keyboard.type("AVRO");
-  await page.keyboard.press("Enter");
-
-  await page.keyboard.type(subjectName);
-  await page.keyboard.press("Enter");
-}
-
-async function deleteSubject(page: any, subjectName: string) {
-  await page.keyboard.press("Shift+ControlOrMeta+P");
-  await page.keyboard.type("Delete Subject");
-  await page.keyboard.press("Enter");
-
-  await expect(page.getByPlaceholder("Select existing subject")).toBeVisible();
-  await page.keyboard.type(subjectName);
-  await page.keyboard.press("Enter");
-
-  await page.getByLabel("Hard Delete").click();
-
-  const validationMessage = await page
-    .getByPlaceholder(/Enter "hard .*" to confirm/)
-    .getAttribute("placeholder");
-  const match = validationMessage?.match(/Enter "hard (.*)" to confirm/);
-  if (match) {
-    const requiredText = match[1];
-    await page.keyboard.type(`hard ${requiredText}`);
-    await page.keyboard.press("Enter");
-  }
-
-  await expect(
-    page.getByText(/Subject customer-.*-value and.*hard deleted./, { exact: true }).first(),
-  ).toBeVisible();
-}
-
-test.describe("Schema related functionality", () => {
   let subjectName: string;
+  // most tests only create one schema version, but the "should evolve schema to second version" test
+  // should create a second version, which will change this to the subject name itself
+  let deletionConfirmation = "v1";
 
-  test.beforeEach(async ({ page }) => {
-    await openConfluentExtension(page);
-  });
+  test.beforeEach(async ({ page, electronApp }) => {
+    subjectName = "";
 
-  test.afterEach(async ({ page }) => {
-    if (subjectName) {
-      await deleteSubject(page, subjectName);
-    }
-  });
-
-  /**
-   * Steps:
-   * 1. Create a new subject.
-   * 2. Evolve the schema using an incompatible schema and verify that the evolution fails.
-   * 3. Evolve the schema using a compatible schema and verify that the evolution succeeds.
-   * 4. Delete the subject.
-   */
-  async function testSchemaEvolution({ page }: { page: Page }) {
-    const randomValue = Math.random().toString(36).substring(2, 15);
-    subjectName = `customer-${randomValue}-value`;
-
-    await createNewSubject(page, subjectName, "customer.avsc");
-    await evolveSchema(page, subjectName, "customer_bad_evolution.avsc");
-
-    await expect(
-      page.getByLabel(
-        "Conflict with prior schema version: The field 'age' at path '/fields/4' in the new schema has no default value and is missing in the old schema, source: Confluent, notification",
-        { exact: true },
-      ),
-    ).toBeVisible();
-
-    await evolveSchema(page, subjectName, "customer_good_evolution.avsc");
-
-    await expect(
-      page.getByText(/^New version 2 registered to existing subject "customer-.*-value"$/, {
-        exact: true,
-      }),
-    ).toBeVisible();
-  }
-
-  test.describe("using Confluent Cloud connection", () => {
-    test.beforeEach(async ({ page, electronApp }) => {
-      await login(page, electronApp, process.env.E2E_USERNAME!, process.env.E2E_PASSWORD!);
+    // disable auto-formatting and language detection to avoid issues with the editor
+    // NOTE: this can't be done in a .beforeAll hook since it won't persist for each test run
+    await configureVSCodeSettings(page, electronApp, {
+      "workbench.editor.languageDetection": false,
+      "editor.autoClosingBrackets": "never",
+      "editor.autoClosingQuotes": "never",
+      "editor.autoIndent": "none",
+      "editor.autoSurround": "never",
+      "editor.formatOnType": false,
+      "editor.insertSpaces": false,
+      "json.format.enable": false,
+      "json.validate.enable": false,
     });
 
-    test("create a new subject and evolve it", testSchemaEvolution);
+    await openConfluentExtension(page);
+    resourcesView = new ResourcesView(page);
+    await expect(resourcesView.header).toHaveAttribute("aria-expanded", "true");
   });
 
-  test.describe("using direct connection to Confluent Cloud Schema Registry using SR API Key", () => {
-    test.beforeEach(async ({ page, electronApp }) => {
-      // Stub the dialog that tells you the connection was created
+  test.afterEach(async ({ page, electronApp }) => {
+    // reset VS Code settings to defaults
+    await configureVSCodeSettings(page, electronApp, {});
+
+    // delete the subject if it was created during the test
+    if (subjectName) {
+      // stub the system dialog (warning modal) that appears when hard-deleting
       await stubMultipleDialogs(electronApp, [
         {
           method: "showMessageBox",
           value: {
-            response: 0, // Simulates clicking "OK"
+            response: 0, // simulate clicking "Yes, Hard Delete" (first button)
             checkboxChecked: false,
           },
         },
       ]);
 
-      await page.getByLabel("Resources Section").hover();
-      await page.getByLabel("Add New Connection").click();
-      await page.getByLabel("Enter manually").locator("a").click();
-      const webview = page.locator("iframe").contentFrame().locator("iframe").contentFrame();
+      // replace this with right-click context actions once this issue is resolved:
+      // https://github.com/confluentinc/vscode/issues/1875
+      await executeVSCodeCommand(page, "Confluent: Delete All Schemas in Subject");
 
-      const { apiKey, apiSecret, endpoint } = extractConfluentCredentials();
+      // select the subject to delete
+      const subjectInputBox = new InputBox(page);
+      await expect(subjectInputBox.placeholder).toBeVisible();
+      await subjectInputBox.fill(subjectName);
+      await subjectInputBox.confirm();
 
-      await webview.locator("#name").click();
-      await page.waitForTimeout(100);
-      await page.keyboard.type("Playwright");
+      // select the Hard Delete option
+      const deletionQuickpick = new Quickpick(page);
+      const hardDelete = deletionQuickpick.items.filter({ hasText: "Hard Delete" });
+      await expect(hardDelete).not.toHaveCount(0);
+      await hardDelete.click();
 
-      await webview.locator("#formconnectiontype").click();
-      await page.waitForTimeout(100);
+      // enter the confirmation text input
+      const confirmationBox = new InputBox(page);
+      await expect(confirmationBox.input).toBeVisible();
+      await confirmationBox.fill(deletionConfirmation);
+      await confirmationBox.confirm();
 
-      await webview.locator("#formconnectiontype").selectOption("Confluent Cloud");
+      // the system dialog is automatically handled by the stub above, no need to handle it here
 
-      await webview.locator('[id="schema_registry\\.uri"]').click();
-      // Wait for the input to be focused.
-      await page.waitForTimeout(100);
-      await page.keyboard.type(endpoint);
+      const notificationArea = new NotificationArea(page);
+      const deletionNotifications = notificationArea.infoNotifications.filter({
+        hasText: /hard deleted/,
+      });
+      await expect(deletionNotifications.first()).toBeVisible();
+    }
+  });
 
-      await webview.locator('[id="schema_registry\\.auth_type"]').click();
-      await webview.locator('[id="schema_registry\\.auth_type"]').selectOption("API");
+  for (const [schemaType, fileExtension] of SCHEMA_TYPES) {
+    const schemaFile = `schemas/customer.${fileExtension}`;
 
-      await webview.locator('[id="schema_registry\\.credentials\\.api_key"]').click();
-      await page.waitForTimeout(100);
-      await page.keyboard.type(apiKey);
+    /** Main tests covered by each connection type test block. */
+    const schemaTests = () => {
+      test(`${schemaType}: should create a new subject and upload the first schema version`, async ({
+        page,
+      }) => {
+        subjectName = await createSchemaVersion(page, schemaType, schemaFile);
 
-      await webview.locator('[id="schema_registry\\.credentials\\.api_secret"]').click();
-      await page.waitForTimeout(100);
-      await page.keyboard.type(apiSecret);
+        const notificationArea = new NotificationArea(page);
+        const successNotifications: Locator = notificationArea.infoNotifications.filter({
+          hasText: /Schema registered to new subject/,
+        });
+        await expect(successNotifications.first()).toBeVisible();
 
-      // First test
-      await webview.getByRole("button", { name: "Test" }).click();
-      await expect(webview.getByText("Connection test succeeded")).toBeVisible();
+        const subjectLocator: Locator = schemasView.getSubjectByName(subjectName);
+        await expect(subjectLocator).toBeVisible();
+      });
 
-      await webview.getByRole("button", { name: "Save" }).click();
+      test(`${schemaType}: should create a new schema version with valid/compatible changes`, async ({
+        page,
+      }) => {
+        subjectName = await createSchemaVersion(page, schemaType, schemaFile);
+        // try to evolve the newly-created schema
+        const subjectLocator: Locator = schemasView.getSubjectByName(subjectName);
+        const subjectItem = new SubjectItem(page, subjectLocator.first());
+        await subjectItem.clickEvolveLatestSchema();
 
-      // TODO: Check that connection was established successfully.
+        // new editor should open with a `<subject name>.v2-draft.confluent.<schema type>` title
+        const expectedTabName = `${subjectName}.v2-draft.confluent.${fileExtension}`;
+        const evolutionDocument = new TextDocument(page, expectedTabName);
+        await expect(evolutionDocument.tab).toBeVisible();
+        // make sure the new document is focused before performing operations
+        await evolutionDocument.tab.click();
+        await expect(evolutionDocument.locator).toBeVisible();
+
+        // enter new (valid) schema content into the new editor
+        const goodEvolutionFile = `schemas/customer_good_evolution.${fileExtension}`;
+        const schemaContent: string = loadFixtureFromFile(goodEvolutionFile);
+        await evolutionDocument.replaceContent(schemaContent);
+
+        // attempt to upload from the subject item (instead of the Schemas view nav action)
+        await subjectItem.uploadSchemaForSubject();
+        await selectCurrentDocumentFromQuickpick(page, expectedTabName);
+        await selectSchemaTypeFromQuickpick(page, schemaType);
+
+        const notificationArea = new NotificationArea(page);
+        const successNotifications = notificationArea.infoNotifications.filter({
+          hasText: /New version 2 registered to existing subject/,
+        });
+        await expect(successNotifications.first()).toBeVisible();
+
+        // update deletion confirmation from "v1" to the subject name for proper cleanup
+        // since there are now two versions
+        deletionConfirmation = subjectName;
+      });
+
+      test(`${schemaType}: should reject invalid/incompatible schema evolution and not create a second version`, async ({
+        page,
+      }) => {
+        subjectName = await createSchemaVersion(page, schemaType, schemaFile);
+        // try to evolve the newly-created schema
+        const subjectLocator: Locator = schemasView.getSubjectByName(subjectName);
+        const subjectItem = new SubjectItem(page, subjectLocator.first());
+        await subjectItem.clickEvolveLatestSchema();
+
+        // new editor should open with a `<subject name>.v2-draft.confluent.<schema type>` title
+        const expectedTabName = `${subjectName}.v2-draft.confluent.${fileExtension}`;
+        const badEvolutionDocument = new TextDocument(page, expectedTabName);
+        await expect(badEvolutionDocument.tab).toBeVisible();
+        // make sure the new document is focused before performing operations
+        await badEvolutionDocument.tab.click();
+        await expect(badEvolutionDocument.locator).toBeVisible();
+
+        // enter new (invalid) schema content into the new editor
+        const badEvolutionFile = `schemas/customer_bad_evolution.${fileExtension}`;
+        const schemaContent: string = loadFixtureFromFile(badEvolutionFile);
+        await badEvolutionDocument.replaceContent(schemaContent);
+
+        // attempt to upload from the subject item (instead of the Schemas view nav action)
+        await subjectItem.uploadSchemaForSubject();
+        await selectCurrentDocumentFromQuickpick(page, expectedTabName);
+        await selectSchemaTypeFromQuickpick(page, schemaType);
+
+        const notificationArea = new NotificationArea(page);
+        const errorNotifications: Locator = notificationArea.errorNotifications.filter({
+          hasText: "Conflict with prior schema version",
+        });
+        await expect(errorNotifications.first()).toBeVisible();
+
+        // since we didn't create a second schema version, we should still be able to delete
+        // the subject based on the fact that there is still only one version
+        deletionConfirmation = "v1";
+      });
+    };
+
+    test.describe("CCLOUD Connection", () => {
+      test.beforeEach(async ({ page, electronApp }) => {
+        // CCloud connection setup:
+        await login(page, electronApp, process.env.E2E_USERNAME!, process.env.E2E_PASSWORD!);
+        // make sure the "Confluent Cloud" item in the Resources view is expanded and doesn't show the
+        // "(Not Connected)" description
+        const ccloudItem: Locator = resourcesView.confluentCloudItem;
+        await expect(ccloudItem).toBeVisible();
+        await expect(ccloudItem).not.toHaveText("(Not Connected)");
+        await expect(ccloudItem).toHaveAttribute("aria-expanded", "true");
+
+        // expand the first (CCloud) environment to show Kafka clusters, Schema Registry, and maybe
+        // Flink compute pools
+        await expect(resourcesView.ccloudEnvironments).not.toHaveCount(0);
+        const firstEnvironment: Locator = resourcesView.ccloudEnvironments.first();
+        // environments are collapsed by default, so we need to expand it first
+        await firstEnvironment.click();
+        await expect(firstEnvironment).toHaveAttribute("aria-expanded", "true");
+
+        // then click on the first (CCloud) Schema Registry to focus it in the Schemas view
+        await expect(resourcesView.ccloudSchemaRegistries).not.toHaveCount(0);
+        const firstSchemaRegistry: Locator = resourcesView.ccloudSchemaRegistries.first();
+        await firstSchemaRegistry.click();
+        // NOTE: we don't care about testing SR selection from the Resources view vs the Schemas
+        // view for these tests, so we're just picking from the Resources view here
+        schemasView = new SchemasView(page);
+        await expect(schemasView.header).toHaveAttribute("aria-expanded", "true");
+      });
+
+      schemaTests();
     });
 
-    test("create a new subject and evolve it", testSchemaEvolution);
-  });
+    test.describe("DIRECT Connection", () => {
+      test.beforeEach(async ({ page }) => {
+        // direct connection setup:
+        const connectionForm: DirectConnectionForm = await resourcesView.addNewConnectionManually();
+        const connectionName = "Playwright";
+        await connectionForm.fillConnectionName(connectionName);
+        await connectionForm.selectConnectionType(FormConnectionType.ConfluentCloud);
+        // only configure the Schema Registry connection
+        await connectionForm.fillSchemaRegistryUri(process.env.E2E_SR_URL!);
+        await connectionForm.selectSchemaRegistryAuthType(SupportedAuthType.API);
+        await connectionForm.fillSchemaRegistryCredentials({
+          api_key: process.env.E2E_SR_API_KEY!,
+          api_secret: process.env.E2E_SR_API_SECRET!,
+        });
+
+        await connectionForm.testButton.click();
+        await expect(connectionForm.successMessage).toBeVisible();
+        await connectionForm.saveButton.click();
+
+        // make sure we see the notification indicating the connection was created
+        const notificationArea = new NotificationArea(page);
+        const notifications: Locator = notificationArea.infoNotifications.filter({
+          hasText: "New Connection Created",
+        });
+        await expect(notifications).toHaveCount(1);
+        const notification = new Notification(page, notifications.first());
+        await notification.dismiss();
+        // don't wait for the "Waiting for <connection> to be usable..." progress notification since
+        // it may disappear quickly
+
+        // wait for the Resources view to refresh and show the new direct connection
+        await expect(resourcesView.directConnections).not.toHaveCount(0);
+        await expect(resourcesView.directConnections.first()).toHaveText(connectionName);
+
+        // expand the first direct connection to show its Schema Registry
+        await expect(resourcesView.directConnections).not.toHaveCount(0);
+        const firstConnection: Locator = resourcesView.directConnections.first();
+        // direct connections are collapsed by default, so we need to expand it first
+        await firstConnection.click();
+        await expect(firstConnection).toHaveAttribute("aria-expanded", "true");
+
+        // then click on the first (CCloud) Schema Registry to focus it in the Schemas view
+        const directSchemaRegistries: Locator = resourcesView.directSchemaRegistries;
+        await expect(directSchemaRegistries).not.toHaveCount(0);
+        const firstSchemaRegistry: Locator = directSchemaRegistries.first();
+        await firstSchemaRegistry.click();
+        // NOTE: we don't care about testing SR selection from the Resources view vs the Schemas
+        // view for these tests, so we're just picking from the Resources view here
+        schemasView = new SchemasView(page);
+        await expect(schemasView.header).toHaveAttribute("aria-expanded", "true");
+      });
+
+      schemaTests();
+    });
+  }
+
+  /**
+   * Creates a new schema version and subject by going through the full flow:
+   * 1. Opens schema creation workflow
+   * 2. Selects schema type
+   * 3. Enters schema content
+   * 4. Uploads and creates new subject
+   * @returns The generated subject name for cleanup
+   */
+  async function createSchemaVersion(
+    page: Page,
+    schemaType: string,
+    schemaFile: string,
+  ): Promise<string> {
+    await schemasView.clickCreateNewSchema();
+    await selectSchemaTypeFromQuickpick(page, schemaType);
+
+    // enter schema content into editor
+    const schemaContent: string = loadFixtureFromFile(schemaFile);
+    const untitledDocument = new TextDocument(page, "Untitled-1");
+    await expect(untitledDocument.locator).toBeVisible();
+    await untitledDocument.insertContent(schemaContent);
+
+    await schemasView.clickUploadSchema();
+
+    // select editor/file name in the first quickpick
+    await selectCurrentDocumentFromQuickpick(page, "Untitled");
+    await selectSchemaTypeFromQuickpick(page, schemaType);
+
+    // select "Create new subject" in the next quickpick
+    const subjectQuickpick = new Quickpick(page);
+    await expect(subjectQuickpick.locator).toBeVisible();
+    const createNewSubjectItem: Locator = subjectQuickpick.items.filter({
+      hasText: "Create new subject",
+    });
+    await expect(createNewSubjectItem).not.toHaveCount(0);
+    await createNewSubjectItem.click();
+
+    // enter subject name in the input box and submit
+    const randomValue: string = Math.random().toString(36).substring(2, 15);
+    const generatedSubjectName = `customer-${randomValue}-value`;
+    const subjectInputBox = new InputBox(page);
+    await expect(subjectInputBox.input).toBeVisible();
+    await subjectInputBox.fill(generatedSubjectName);
+    await subjectInputBox.confirm();
+
+    // if we made it this far, we can return the subject so the .afterEach() hook can delete the
+    // subject (and schema version) that was just created
+    return generatedSubjectName;
+  }
+
+  /** Select an item from the document quickpick based on a title to match. */
+  async function selectCurrentDocumentFromQuickpick(
+    page: Page,
+    documentTitle: string,
+  ): Promise<void> {
+    const fileQuickpick = new Quickpick(page);
+    await expect(fileQuickpick.locator).toBeVisible();
+    const currentFileItem: Locator = fileQuickpick.items.filter({ hasText: documentTitle });
+    await expect(currentFileItem).not.toHaveCount(0);
+    await currentFileItem.click();
+  }
+
+  /** Select a schema type (AVRO/JSON/PROTOBUF) from the schema type quickpick. */
+  async function selectSchemaTypeFromQuickpick(page: Page, schemaType: string): Promise<void> {
+    const confirmSchemaTypeQuickpick = new Quickpick(page);
+    await expect(confirmSchemaTypeQuickpick.locator).toBeVisible();
+    const schemaTypeItem: Locator = confirmSchemaTypeQuickpick.items.filter({
+      hasText: schemaType,
+    });
+    await schemaTypeItem.click();
+  }
 });
-
-/**
- * Extracts the API key, secret, and endpoint from the E2E_SR_API_KEY environment variable. The
- * environment variable contains the text of the downloaded API key from Confluent Cloud, which contains
- * the API key, secret, and endpoint (as well as Resource scope, Environment, and Resource, which we
- * don't need).
- * @returns { apiKey: string, apiSecret: string, endpoint: string }
- */
-function extractConfluentCredentials() {
-  const e2e_sr_api_key = process.env.E2E_SR_API_KEY!;
-  const apiKeyMatch = e2e_sr_api_key.match(/API key:\s*([A-Z0-9]+)/)!;
-  const apiSecretMatch = e2e_sr_api_key.match(/API secret:\s*([A-Za-z0-9]+)/)!;
-  const endpointMatch = e2e_sr_api_key.match(/Endpoint:\s*(\S+)/)!;
-
-  return {
-    apiKey: apiKeyMatch[1],
-    apiSecret: apiSecretMatch[1],
-    endpoint: endpointMatch[1],
-  };
-}

--- a/tests/e2e/specs/schemas.spec.ts
+++ b/tests/e2e/specs/schemas.spec.ts
@@ -149,7 +149,7 @@ test.describe("Schema Management", () => {
         });
         await expect(successNotifications.first()).toBeVisible();
 
-        const subjectLocator: Locator = schemasView.getSubjectByName(subjectName);
+        const subjectLocator: Locator = schemasView.subjects.filter({ hasText: subjectName });
         await expect(subjectLocator).toBeVisible();
       });
 
@@ -158,7 +158,7 @@ test.describe("Schema Management", () => {
       }) => {
         subjectName = await createSchemaVersion(page, schemaType, schemaFile);
         // try to evolve the newly-created schema
-        const subjectLocator: Locator = schemasView.getSubjectByName(subjectName);
+        const subjectLocator: Locator = schemasView.subjects.filter({ hasText: subjectName });
         const subjectItem = new SubjectItem(page, subjectLocator.first());
         await subjectItem.clickEvolveLatestSchema();
 
@@ -195,7 +195,7 @@ test.describe("Schema Management", () => {
       }) => {
         subjectName = await createSchemaVersion(page, schemaType, schemaFile);
         // try to evolve the newly-created schema
-        const subjectLocator: Locator = schemasView.getSubjectByName(subjectName);
+        const subjectLocator: Locator = schemasView.subjects.filter({ hasText: subjectName });
         const subjectItem = new SubjectItem(page, subjectLocator.first());
         await subjectItem.clickEvolveLatestSchema();
 

--- a/tests/e2e/specs/schemas.spec.ts
+++ b/tests/e2e/specs/schemas.spec.ts
@@ -149,6 +149,7 @@ test.describe("Schema Management", () => {
         // set up the connection based on type
         await connectionSetup(page, electronApp);
         schemasView = new SchemasView(page);
+        await expect(schemasView.header).toHaveAttribute("aria-expanded", "true");
       });
 
       for (const [schemaType, fileExtension] of schemaTypes) {

--- a/tests/e2e/specs/topicMessageViewer.spec.ts
+++ b/tests/e2e/specs/topicMessageViewer.spec.ts
@@ -64,7 +64,7 @@ test.describe("Topics Listing & Message Viewer", () => {
       await firstEnvironment.click();
       await expect(firstEnvironment).toHaveAttribute("aria-expanded", "true");
 
-      // then click on the first (CCloud) Kafka cluster to select it
+      // then click on the first (CCloud) Kafka cluster to focus it in the Topics view
       await expect(resourcesView.ccloudKafkaClusters).not.toHaveCount(0);
       const firstKafkaCluster: Locator = resourcesView.ccloudKafkaClusters.first();
       await firstKafkaCluster.click();
@@ -126,19 +126,20 @@ test.describe("Topics Listing & Message Viewer", () => {
       const connectionName = "Playwright";
       await connectionForm.fillConnectionName(connectionName);
       await connectionForm.selectConnectionType(FormConnectionType.ConfluentCloud);
+      // only configure the Kafka connection
       await connectionForm.fillKafkaBootstrapServers(process.env.E2E_KAFKA_BOOTSTRAP_SERVERS!);
       await connectionForm.selectKafkaAuthType(SupportedAuthType.API);
       await connectionForm.fillKafkaCredentials({
         api_key: process.env.E2E_KAFKA_API_KEY!,
         api_secret: process.env.E2E_KAFKA_API_SECRET!,
       });
+
       await connectionForm.testButton.click();
       await expect(connectionForm.successMessage).toBeVisible();
       await connectionForm.saveButton.click();
 
       // make sure we see the notification indicating the connection was created
       const notificationArea = new NotificationArea(page);
-      // only wait on the progress notification to resolve if it's visible at all
       const notifications = notificationArea.infoNotifications.filter({
         hasText: "New Connection Created",
       });
@@ -156,7 +157,7 @@ test.describe("Topics Listing & Message Viewer", () => {
     test("should select a Kafka cluster from the Resources view, list topics, and open message viewer", async ({
       page,
     }) => {
-      // expand the first direct connection to show its Kafka cluster and Schema Registry
+      // expand the first direct connection to show its Kafka cluster
       await expect(resourcesView.directConnections).not.toHaveCount(0);
       const firstConnection = resourcesView.directConnections.first();
       // direct connections are collapsed by default, so we need to expand it first

--- a/tests/e2e/utils/commands.ts
+++ b/tests/e2e/utils/commands.ts
@@ -1,0 +1,19 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { Quickpick } from "../objects/quickInputs/Quickpick";
+
+/**
+ * Executes a VS Code command using the command palette.
+ * @param commandFilter - The name or `id` of the command to execute.
+ */
+export async function executeVSCodeCommand(page: Page, commandFilter: string): Promise<void> {
+  await page.keyboard.press("Shift+ControlOrMeta+P");
+
+  const commandPalette = new Quickpick(page);
+  await expect(commandPalette.locator).toBeVisible();
+
+  // ">" prefix needed to filter commands, otherwise it will try to match files
+  await commandPalette.textInput.fill(`>${commandFilter}`);
+  const commands: Locator = commandPalette.items;
+  await expect(commands).not.toHaveCount(0);
+  await commands.first().click();
+}

--- a/tests/e2e/utils/settings.ts
+++ b/tests/e2e/utils/settings.ts
@@ -16,7 +16,7 @@ export async function configureVSCodeSettings(
   // XXX: VS Code will have some file-formatting settings enabled by default. As a result of this,
   // we can't really insert text directly without risking it being auto-formatted, auto-indented,
   // pairs auto-closed/etc. Instead, we write to the clipboard and paste directly into the document.
-  electronApp.context().grantPermissions(["clipboard-write"]);
+  await electronApp.context().grantPermissions(["clipboard-write"]);
   await page.evaluate(
     (content) => navigator.clipboard.writeText(content),
     JSON.stringify(settings, null, 2),

--- a/tests/e2e/utils/settings.ts
+++ b/tests/e2e/utils/settings.ts
@@ -1,0 +1,28 @@
+import { ElectronApplication, Page } from "@playwright/test";
+import { TextDocument } from "../objects/editor/TextDocument";
+import { executeVSCodeCommand } from "./commands";
+
+/** Configures VS Code settings via the (temporary) User Settings JSON file. */
+export async function configureVSCodeSettings(
+  page: Page,
+  electronApp: ElectronApplication,
+  settings: Record<string, any>,
+): Promise<void> {
+  await executeVSCodeCommand(page, "Preferences: Open User Settings (JSON)");
+
+  const settingsJson = new TextDocument(page, "settings.json");
+  await settingsJson.locator.waitFor({ state: "visible" });
+
+  // XXX: VS Code will have some file-formatting settings enabled by default. As a result of this,
+  // we can't really insert text directly without risking it being auto-formatted, auto-indented,
+  // pairs auto-closed/etc. Instead, we write to the clipboard and paste directly into the document.
+  electronApp.context().grantPermissions(["clipboard-write"]);
+  await page.evaluate(
+    (content) => navigator.clipboard.writeText(content),
+    JSON.stringify(settings, null, 2),
+  );
+  await settingsJson.deleteAll();
+  await page.keyboard.press("ControlOrMeta+v");
+  await settingsJson.save();
+  await settingsJson.close();
+}

--- a/tests/fixtures/schemas/customer.json
+++ b/tests/fixtures/schemas/customer.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Customer",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "address": {
+      "type": "string"
+    },
+    "phone": {
+      "type": "string"
+    }
+  },
+  "required": ["name", "email", "address", "phone"],
+  "additionalProperties": false
+}

--- a/tests/fixtures/schemas/customer.proto
+++ b/tests/fixtures/schemas/customer.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package examples;
+
+message Customer {
+  string name = 1;
+  string email = 2;
+  string address = 3;
+  string phone = 4;
+}

--- a/tests/fixtures/schemas/customer_bad_evolution.avsc
+++ b/tests/fixtures/schemas/customer_bad_evolution.avsc
@@ -1,27 +1,11 @@
 {
   "type": "record",
-  "name": "Customer",
+  "name": "Orders",
   "namespace": "examples",
   "fields": [
     {
-      "name": "name",
+      "name": "foo",
       "type": "string"
-    },
-    {
-      "name": "email",
-      "type": "string"
-    },
-    {
-      "name": "address",
-      "type": "string"
-    },
-    {
-      "name": "phone",
-      "type": "string"
-    },
-    {
-      "name": "age",
-      "type": "int"
     }
   ]
 }

--- a/tests/fixtures/schemas/customer_bad_evolution.json
+++ b/tests/fixtures/schemas/customer_bad_evolution.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Orders",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "type": "string"
+    }
+  },
+  "required": ["foo"],
+  "additionalProperties": false
+}

--- a/tests/fixtures/schemas/customer_bad_evolution.proto
+++ b/tests/fixtures/schemas/customer_bad_evolution.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package examples;
+
+message Orders {
+  string foo = 1;
+}

--- a/tests/fixtures/schemas/customer_good_evolution.json
+++ b/tests/fixtures/schemas/customer_good_evolution.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Customer",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "address": {
+      "type": "string"
+    },
+    "phone": {
+      "type": "string"
+    },
+    "age": {
+      "oneOf": [
+        { "type": "integer" },
+        { "type": "null" }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "name",
+    "email",
+    "address",
+    "phone"
+  ],
+  "additionalProperties": false
+}

--- a/tests/fixtures/schemas/customer_good_evolution.proto
+++ b/tests/fixtures/schemas/customer_good_evolution.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package examples;
+
+message Customer {
+  string name = 1;
+  string email = 2;
+  string address = 3;
+  string phone = 4;
+  // In Avro, "age" is ["null", "int"], default null.
+  // In Protobuf, use google.protobuf.Int32Value for optional int.
+  // Requires import of wrappers.proto.
+  google.protobuf.Int32Value age = 5;
+}
+
+import "google/protobuf/wrappers.proto";

--- a/tests/fixtures/utils.ts
+++ b/tests/fixtures/utils.ts
@@ -1,13 +1,17 @@
 import * as fs from "fs";
 import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /**
- * Loads a JSON fixture file from the fixtures directory
+ * Loads a fixture file from the fixtures directory. Callers will need to parse the resulting string
+ * output as needed.
  * @param relativePath - Path relative to the fixtures directory (e.g. 'flink-statement-results-processing/get-statement-results-1.json')
- * @returns The parsed JSON content of the fixture file
+ * @returns The string content of the file
  */
-export function loadFixture(relativePath: string): any {
+export function loadFixtureFromFile(relativePath: string): string {
   const fixturePath = path.join(__dirname, relativePath);
-  const content = fs.readFileSync(fixturePath, "utf8");
-  return JSON.parse(content);
+  return fs.readFileSync(fixturePath, "utf8");
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Partially a fix to update the schema/subject deletion behavior that changed in https://github.com/confluentinc/vscode/pull/2027, but turned into some more general cleanup and refactoring of existing tests to be less flaky, use (some existing, some new) page object models, and expand coverage to include JSON and protobuf schemas.

Now we have:
- AVRO vs JSON vs PROTOBUF schema types
- CCLOUD vs DIRECT connection types
- test scenarios:
  - basic schema upload and subject creation
  - happy path: schema evolution with existing subject, adding new schema version
  - unhappy path: invalid schema evolution with error notification, no new schema version

<img width="794" alt="image" src="https://github.com/user-attachments/assets/0b4e3338-b75f-49d9-8f2c-00c593b5446a" />

Closes #2080

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- The `loadFixture` utility function was renamed and repurposed to return the string contents of a file so we could use it with `.proto` fixtures
- We may want to set up a generic "confirm/cancel" utility for tests to reuse since this may quickly turn into copy/paste boilerplate fodder: https://github.com/confluentinc/vscode/blob/7adfb766899fe7e544751bf022320e4c98b0ef6a/tests/e2e/specs/schemas.spec.ts#L88-L99

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
