### PR TITLE
MINOR fix: stop sending SyntaxErrors to Sentry from CCloud status polling

### DIFF
--- a/src/ccloudStatus/api.ts
+++ b/src/ccloudStatus/api.ts
@@ -15,9 +15,16 @@ export async function fetchCCloudStatus(): Promise<CCloudStatusSummary | undefin
     const data = await response.json();
     return CCloudStatusSummaryFromJSON(data);
   } catch (error) {
-    if (error instanceof TypeError && error.message === "fetch failed") {
-      return; // network error
+    const fetchError: boolean = error instanceof TypeError && error.message === "fetch failed";
+    const jsonError: boolean =
+      error instanceof SyntaxError && error.message.includes("Unexpected token");
+    // only send to Sentry if it's not a fetch or JSON parsing error, but still log it
+    let sentryContext: Record<string, unknown> = {};
+    if (!fetchError && !jsonError) {
+      sentryContext = {
+        extra: { functionName: "fetchCCloudStatus" },
+      };
     }
-    logError(error, "CCloud status", { extra: { functionName: "fetchCCloudStatus" } });
+    logError(error, "CCloud status", sentryContext);
   }
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We were previously only skipping network/fetch related errors, but now we're going to stop sending `SyntaxError: Unexpected token '<'` errors as well in the event https://status.confluent.cloud/api/v2/summary.json returns a raw HTML response.

Closes #1907

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
