### PR TITLE
MINOR: remove old `openExternal` function

### DIFF
--- a/src/authn/ccloudStateHandling.ts
+++ b/src/authn/ccloudStateHandling.ts
@@ -1,4 +1,3 @@
-import { env, Uri } from "vscode";
 import {
   AuthError,
   AuthErrors,
@@ -149,13 +148,4 @@ export async function handleUpdatedConnection(connection: Connection): Promise<v
       });
     }
   }
-}
-
-export function openExternal(uri: Uri) {
-  if (process.env.NODE_ENV === "testing") {
-    // XXX never remove this log, tests rely on it
-    logger.info("actionOpenExternal", uri.toString());
-    return Promise.resolve(true);
-  }
-  return env.openExternal(uri);
 }

--- a/src/utils/privateNetworking.test.ts
+++ b/src/utils/privateNetworking.test.ts
@@ -1,13 +1,12 @@
 import assert from "assert";
 import sinon from "sinon";
-import { Uri } from "vscode";
+import { env, Uri } from "vscode";
 import {
   TEST_CCLOUD_KAFKA_CLUSTER,
   TEST_CCLOUD_PROVIDER,
   TEST_CCLOUD_REGION,
   TEST_CCLOUD_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
-import * as ccloudStateHandling from "../authn/ccloudStateHandling";
 import * as notifications from "../notifications";
 import {
   containsPrivateNetworkPattern,
@@ -106,7 +105,7 @@ describe("utils/privateNetworking.ts showPrivateNetworkingHelpNotification()", (
 
   it("should show a notification with default values when no options provided", () => {
     const showErrorStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
-    const openExternalStub = sandbox.stub(ccloudStateHandling, "openExternal");
+    const openExternalStub = sandbox.stub(env, "openExternal");
 
     showPrivateNetworkingHelpNotification();
 

--- a/src/utils/privateNetworking.ts
+++ b/src/utils/privateNetworking.ts
@@ -1,5 +1,4 @@
-import { Uri } from "vscode";
-import { openExternal } from "../authn/ccloudStateHandling";
+import { env, Uri } from "vscode";
 import {
   DEFAULT_ERROR_NOTIFICATION_BUTTONS,
   showErrorNotificationWithButtons,
@@ -52,7 +51,9 @@ export function showPrivateNetworkingHelpNotification(
   const message = `Unable to connect to ${typeInfo}${resourceInfo}${urlSuffix}. This appears to be a private networking configuration issue. Verify your network settings and VPN configuration to access private Confluent resources.`;
   const buttons = {
     ["View Docs"]: () =>
-      openExternal(Uri.parse("https://docs.confluent.io/cloud/current/networking/overview.html")),
+      env.openExternal(
+        Uri.parse("https://docs.confluent.io/cloud/current/networking/overview.html"),
+      ),
     ...DEFAULT_ERROR_NOTIFICATION_BUTTONS,
   };
   void showErrorNotificationWithButtons(message, buttons);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up from https://github.com/confluentinc/vscode/pull/2127#discussion_r2178708460:
> This hasn't actually been used since before this repo went public. Back in the early prototype days, this was used for a test that was deleted back in PR 463 (in the old repo). Nothing uses it now.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
