### PR TITLE
fix: flink sql diagnostics should clear on changes

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -300,4 +300,44 @@ describe("FlinkLanguageClientManager", () => {
       sinon.assert.notCalled(maybeStartStub);
     });
   });
+
+  describe("document tracking", () => {
+    it("should add open flink documents to the tracking set when initializing", () => {
+      const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
+      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
+      sandbox.stub(vscode.workspace, "textDocuments").value([fakeDocument]);
+
+      // Re-initialize the singleton so the constructor runs
+      (FlinkLanguageClientManager as any).instance = null;
+      flinkManager = FlinkLanguageClientManager.getInstance();
+
+      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 1);
+      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()), true);
+    });
+
+    it("should track documents when opened", () => {
+      const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
+      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
+      sandbox.stub(vscode.workspace, "textDocuments").value([fakeDocument]);
+
+      flinkManager.trackDocument(fakeUri);
+
+      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 1);
+      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()), true);
+    });
+
+    it("should untrack documents when closed", () => {
+      const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
+      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
+      flinkManager.trackDocument(fakeUri);
+
+      flinkManager.untrackDocument(fakeUri);
+
+      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 0);
+      assert.strictEqual(
+        (flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()),
+        false,
+      );
+    });
+  });
 });

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -8,6 +8,7 @@ import {
   TEST_CCLOUD_FLINK_COMPUTE_POOL_ID,
 } from "../../tests/unit/testResources/flinkComputePool";
 import * as flinkSqlProvider from "../codelens/flinkSqlProvider";
+import { FLINKSTATEMENT_URI_SCHEME } from "../documentProviders/flinkStatement";
 import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../extensionSettings/constants";
 import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
@@ -330,6 +331,23 @@ describe("FlinkLanguageClientManager", () => {
       const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
       flinkManager.trackDocument(fakeUri);
       flinkManager.untrackDocument(fakeUri);
+
+      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 0);
+      assert.strictEqual(
+        (flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()),
+        false,
+      );
+    });
+
+    it("should not track readonly statements", () => {
+      const fakeUri = vscode.Uri.parse(`${FLINKSTATEMENT_URI_SCHEME}:///fake/path/test.flinksql`);
+      const fakeDocument = {
+        languageId: "flinksql",
+        uri: fakeUri,
+      } as vscode.TextDocument;
+      sandbox.stub(vscode.workspace, "textDocuments").value([fakeDocument]);
+
+      flinkManager.trackDocument(fakeUri);
 
       assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 0);
       assert.strictEqual(

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -329,7 +329,6 @@ describe("FlinkLanguageClientManager", () => {
     it("should untrack documents when closed", () => {
       const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
       flinkManager.trackDocument(fakeUri);
-
       flinkManager.untrackDocument(fakeUri);
 
       assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 0);

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -328,7 +328,6 @@ describe("FlinkLanguageClientManager", () => {
 
     it("should untrack documents when closed", () => {
       const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
-      const fakeDocument = { languageId: "flinksql", uri: fakeUri } as vscode.TextDocument;
       flinkManager.trackDocument(fakeUri);
 
       flinkManager.untrackDocument(fakeUri);

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -67,7 +67,7 @@ export class FlinkLanguageClientManager implements Disposable {
     // make sure we dispose the output channel when the manager is disposed
     const outputChannel: LogOutputChannel = getFlinkSQLLanguageServerOutputChannel();
     this.disposables.push(outputChannel);
-    this.initializeOpenDocumentTracking();
+    this.initializeDocumentTracking();
     this.registerListeners();
 
     // This is true here when a user opens a new workspace after authenticating with CCloud in another one
@@ -96,7 +96,7 @@ export class FlinkLanguageClientManager implements Disposable {
     }
   }
 
-  private initializeOpenDocumentTracking(): void {
+  private initializeDocumentTracking(): void {
     workspace.textDocuments.forEach((doc) => {
       if (doc.languageId === "flinksql" && doc.uri.scheme !== FLINKSTATEMENT_URI_SCHEME) {
         this.trackDocument(doc.uri);

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -128,10 +128,15 @@ export class FlinkLanguageClientManager implements Disposable {
         return;
       }
 
-      const documentUri = event.document.uri.toString();
-      if (this.openFlinkSqlDocuments.has(documentUri) && this.languageClient?.diagnostics) {
-        logger.debug(`Clearing diagnostics for document: ${documentUri}`);
+      const uriString = event.document.uri.toString();
+      if (
+        this.openFlinkSqlDocuments.has(uriString) &&
+        this.languageClient?.diagnostics?.get(event.document.uri)
+      ) {
+        logger.debug(`Clearing diagnostics for document: ${uriString}`);
         this.languageClient.diagnostics.set(event.document.uri, []);
+      } else {
+        logger.trace(`Not clearing diagnostics for document: ${uriString}`);
       }
     });
 

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -180,10 +180,10 @@ export class FlinkLanguageClientManager implements Disposable {
     // Clear outdated diagnostics on document change; CCloud Flink SQL Server won't publish cleared diagnostics
     this.disposables.push(
       workspace.onDidChangeTextDocument((event) => {
-        if (event.document.uri.toString().includes("output")) {
+        const uriString = event.document.uri.toString();
+        if (uriString.startsWith("output:")) {
           return;
         }
-        const uriString = event.document.uri.toString();
         if (
           this.openFlinkSqlDocuments.has(uriString) &&
           this.languageClient?.diagnostics?.get(event.document.uri)


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes an issue where the outdated diagnostics would not always be cleared for document changes.

- Adds document tracking so that we can match URIs to changes in the listener
- Adds a mutex for initializing the language client so that multiple listeners can't call init at the same time -- we never want more than one client instance.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This issue had two underlying causes:
  - First, we were previously comparing the `onchange` document event URI to the uri that's saved when we start the client, to decide whether to clear. Of course this doesn't work for subsequent docs using the same client connection. 🤦 
  - Second, sometimes the listeners calling `maybeStart...` could get in a race condition, attempting to initialize the client within milliseconds of each other and thereby bypassing the checks for existing clients & opening more than one instance/connection. The diagnostics could get cleared on one instance but not the other, among other odd issues this causes. 
- The new patterns here will help with future work to harden the client. Now we'll easily be able to close sessions when all the docs close, and fix an issue where the client won't start if you have an open doc before you sign in to CCloud. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [X] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [X] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
