### PR TITLE
run E2E smoke test(s) in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ yarn-error.log
 .parallelperf.*
 tests/baselines/reference/dt
 .failed-tests
-TEST-results.xml
+TEST-result*.xml
 .eslintcache
 *v8.log
 /lib/

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -100,6 +100,14 @@ blocks:
                 artifact push workflow coverage/lcov-functional.info --force
                 echo "Uploaded Playwright coverage artifacts"
               fi
+            # Upload Playwright artifacts, if available
+            - |
+              if [ -d test-results ]; then
+                artifact push workflow test-results
+              fi
+              if [ -d playwright-report ]; then
+                artifact push workflow playwright-report  
+              fi
 
   - name: "Linux ARM64 Stable: Tests"
     dependencies: ["Static Analysis (TypeScript & ESLint)"]

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -82,7 +82,7 @@ blocks:
             - make test-playwright-webviews
         - name: "Playwright: E2E Smoke Tests (VS Code)"
           commands:
-            - make test-playwright-e2e-smoke
+            - make test-playwright-e2e TEST_SUITE=@smoke
       epilogue: &build-test-epilogue
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,6 +80,9 @@ blocks:
         - name: "Playwright: Webview Tests (VS Code)"
           commands:
             - make test-playwright-webviews
+        - name: "Playwright: E2E Tests (VS Code)"
+          commands:
+            - make test-playwright-e2e-smoke
       epilogue: &build-test-epilogue
         always:
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,7 +80,7 @@ blocks:
         - name: "Playwright: Webview Tests (VS Code)"
           commands:
             - make test-playwright-webviews
-        - name: "Playwright: E2E Tests (VS Code)"
+        - name: "Playwright: E2E Smoke Tests (VS Code)"
           commands:
             - make test-playwright-e2e-smoke
       epilogue: &build-test-epilogue

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -174,12 +174,27 @@ blocks:
             - Remove-Item .env -ErrorAction SilentlyContinue
             # Windows version of store-test-results-to-semaphore
             - |
+              Write-Output "Publishing test results to Semaphore..."
               $TestResultFile = Join-Path -Path $PWD -ChildPath "TEST-result.xml"
               if (Test-Path $TestResultFile) {
-                  Write-Output "Publishing test results from $TestResultFile"
+                  Write-Output "Publishing Mocha test results from $TestResultFile"
                   test-results publish $TestResultFile --force
               } else {
-                  Write-Output "Test results not found at $TestResultFile"
+                  Write-Output "Mocha test results not found at $TestResultFile"
+              }
+              $TestResultE2EFile = Join-Path -Path $PWD -ChildPath "TEST-result-e2e.xml"
+              if (Test-Path $TestResultE2EFile) {
+                  Write-Output "Publishing E2E test results from $TestResultE2EFile"
+                  test-results publish $TestResultE2EFile --name "E2E Tests" --force
+              } else {
+                  Write-Output "E2E test results not found at $TestResultE2EFile"
+              }
+              $TestResultWebviewFile = Join-Path -Path $PWD -ChildPath "TEST-result-webview.xml"
+              if (Test-Path $TestResultWebviewFile) {
+                  Write-Output "Publishing Webview test results from $TestResultWebviewFile"
+                  test-results publish $TestResultWebviewFile --name "Webview Tests" --force
+              } else {
+                  Write-Output "Webview test results not found at $TestResultWebviewFile"
               }
 
   # --- End Build & Test (multi-platform/-arch) for VS Code (stable) ---

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -103,10 +103,10 @@ blocks:
             # Upload Playwright artifacts, if available
             - |
               if [ -d test-results ]; then
-                artifact push workflow test-results
+                artifact push workflow test-results --destination test-results-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m) --force
               fi
               if [ -d playwright-report ]; then
-                artifact push workflow playwright-report  
+                artifact push workflow playwright-report --destination playwright-report-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m) --force
               fi
 
   - name: "Linux ARM64 Stable: Tests"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,11 @@ test-playwright-webviews: setup-test-env install-test-dependencies install-depen
 # Run only E2E (Playwright) smoke test(s)
 .PHONY: test-playwright-e2e-smoke
 test-playwright-e2e-smoke: setup-test-env install-test-dependencies install-dependencies
-	npx gulp e2e -t @smoke
+	@if [ $$(uname -s) = "Linux" ]; then \
+			xvfb-run -a npx gulp e2e -t @smoke; \
+	else \
+			npx gulp e2e -t @smoke; \
+	fi
 
 # Validates bump based on current version (in package.json)
 # and the version to be bumped to (in .versions/next.txt)

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,21 @@ test-playwright-webviews: setup-test-env install-test-dependencies install-depen
 	npx gulp build
 	npx gulp functional
 
-# Run only E2E (Playwright) smoke test(s)
-.PHONY: test-playwright-e2e-smoke
-test-playwright-e2e-smoke: setup-test-env install-test-dependencies install-dependencies
-	@if [ $$(uname -s) = "Linux" ]; then \
-			xvfb-run -a npx gulp e2e -t @smoke; \
+# Run E2E (Playwright) tests with optional test name
+# Usage: make test-playwright-e2e (runs all tests)
+# Usage: make test-playwright-e2e TEST_SUITE=@smoke
+# Usage: make test-playwright-e2e TEST_SUITE=@regression
+.PHONY: test-playwright-e2e
+test-playwright-e2e: setup-test-env install-test-dependencies install-dependencies
+	@if [ -n "$(TEST_SUITE)" ] && [ "$(TEST_SUITE)" != "" ]; then \
+			TEST_SUITE_ARG="-t $(TEST_SUITE)"; \
 	else \
-			npx gulp e2e -t @smoke; \
+			TEST_SUITE_ARG=""; \
+	fi; \
+	if [ $$(uname -s) = "Linux" ]; then \
+			xvfb-run -a npx gulp e2e $$TEST_SUITE_ARG; \
+	else \
+			npx gulp e2e $$TEST_SUITE_ARG; \
 	fi
 
 # Validates bump based on current version (in package.json)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,20 @@ test-playwright-webviews: setup-test-env install-test-dependencies install-depen
 # Run only E2E (Playwright) smoke test(s)
 .PHONY: test-playwright-e2e-smoke
 test-playwright-e2e-smoke: setup-test-env install-test-dependencies install-dependencies
-	npx gulp e2e -t @smoke
+	npx gulp build
+	@if [ $$(uname -s) = "Linux" ]; then \
+			xvfb-run -a npx gulp e2e -t @smoke; \
+	elif [ $$(uname -s) = "Darwin" ]; then \
+			if pgrep -x "Dock" > /dev/null; then \
+					echo "GUI session is active."; \
+					npx gulp e2e -t @smoke; \
+			else \
+					echo "No active GUI session. Aborting tests."; \
+					exit 1; \
+			fi \
+	else \
+			npx gulp e2e -t @smoke; \
+	fi
 
 # Validates bump based on current version (in package.json)
 # and the version to be bumped to (in .versions/next.txt)

--- a/Makefile
+++ b/Makefile
@@ -64,20 +64,7 @@ test-playwright-webviews: setup-test-env install-test-dependencies install-depen
 # Run only E2E (Playwright) smoke test(s)
 .PHONY: test-playwright-e2e-smoke
 test-playwright-e2e-smoke: setup-test-env install-test-dependencies install-dependencies
-	npx gulp build
-	@if [ $$(uname -s) = "Linux" ]; then \
-			xvfb-run -a npx gulp e2e -t @smoke; \
-	elif [ $$(uname -s) = "Darwin" ]; then \
-			if pgrep -x "Dock" > /dev/null; then \
-					echo "GUI session is active."; \
-					npx gulp e2e -t @smoke; \
-			else \
-					echo "No active GUI session. Aborting tests."; \
-					exit 1; \
-			fi \
-	else \
-			npx gulp e2e -t @smoke; \
-	fi
+	npx gulp e2e -t @smoke
 
 # Validates bump based on current version (in package.json)
 # and the version to be bumped to (in .versions/next.txt)

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ test-playwright-webviews: setup-test-env install-test-dependencies install-depen
 	npx gulp build
 	npx gulp functional
 
+# Run only E2E (Playwright) smoke test(s)
+.PHONY: test-playwright-e2e-smoke
+test-playwright-e2e-smoke: setup-test-env install-test-dependencies install-dependencies
+	npx gulp e2e -t @smoke
+
 # Validates bump based on current version (in package.json)
 # and the version to be bumped to (in .versions/next.txt)
 .PHONY: validate-bump

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -1,4 +1,6 @@
 TEST_RESULT_FILE = $(CURDIR)/TEST-result.xml
+TEST_RESULT_E2E_FILE = $(CURDIR)/TEST-result-e2e.xml
+TEST_RESULT_WEBVIEW_FILE = $(CURDIR)/TEST-result-webview.xml
 
 # How many days cache entries can stay in the semaphore cache before they are considered stale
 SEM_CACHE_DURATION_DAYS ?= 7
@@ -9,14 +11,29 @@ os_name_and_arch := $(shell echo $$(uname -s)-$$(uname -m) | tr '[:upper:]' '[:l
 
 .PHONY: store-test-results-to-semaphore
 store-test-results-to-semaphore:
+	@echo "Publishing test results to Semaphore..."
 ifneq ($(wildcard $(TEST_RESULT_FILE)),)
 ifeq ($(TEST_RESULT_NAME),)
 	test-results publish $(TEST_RESULT_FILE) --force
+	@echo "Published Mocha test results from $(TEST_RESULT_FILE)"
 else
 	test-results publish $(TEST_RESULT_FILE) --name "$(TEST_RESULT_NAME)"
+	@echo "Published Mocha test results from $(TEST_RESULT_FILE) with name $(TEST_RESULT_NAME)"
 endif
 else
-	@echo "test results not found at $(TEST_RESULT_FILE)"
+	@echo "Mocha test results not found at $(TEST_RESULT_FILE)"
+endif
+ifneq ($(wildcard $(TEST_RESULT_E2E_FILE)),)
+	test-results publish $(TEST_RESULT_E2E_FILE) --name "E2E Tests" --force
+	@echo "Published E2E test results from $(TEST_RESULT_E2E_FILE)"
+else
+	@echo "E2E test results not found at $(TEST_RESULT_E2E_FILE)"
+endif
+ifneq ($(wildcard $(TEST_RESULT_WEBVIEW_FILE)),)
+	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "Webview Tests" --force
+	@echo "Published Webview test results from $(TEST_RESULT_WEBVIEW_FILE)"
+else
+	@echo "Webview test results not found at $(TEST_RESULT_WEBVIEW_FILE)"
 endif
 
 # Only write to the cache from main builds because of security reasons.

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -24,13 +24,13 @@ else
 	@echo "Mocha test results not found at $(TEST_RESULT_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_E2E_FILE)),)
-	test-results publish $(TEST_RESULT_E2E_FILE) --name "E2E Tests" --force
+	test-results publish $(TEST_RESULT_E2E_FILE) --force
 	@echo "Published E2E test results from $(TEST_RESULT_E2E_FILE)"
 else
 	@echo "E2E test results not found at $(TEST_RESULT_E2E_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_WEBVIEW_FILE)),)
-	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "Webview Tests" --force
+	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --force
 	@echo "Published Webview test results from $(TEST_RESULT_WEBVIEW_FILE)"
 else
 	@echo "Webview test results not found at $(TEST_RESULT_WEBVIEW_FILE)"

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -7,7 +7,8 @@ SEM_CACHE_DURATION_DAYS ?= 7
 current_time := $(shell date +"%s")
 # OS Name
 os_name := $(shell uname -s)
-os_name_and_arch := $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/') $$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')")
+os_name_and_arch := $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')_$$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')")
+platform_arch := $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/') $$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')")
 
 .PHONY: store-test-results-to-semaphore
 store-test-results-to-semaphore:
@@ -24,13 +25,13 @@ else
 	@echo "Mocha test results not found at $(TEST_RESULT_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_E2E_FILE)),)
-	test-results publish $(TEST_RESULT_E2E_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: E2E ($(os_name_and_arch))" --force
+	test-results publish $(TEST_RESULT_E2E_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: E2E ($(platform_arch))" --force
 	@echo "Published E2E test results from $(TEST_RESULT_E2E_FILE)"
 else
 	@echo "E2E test results not found at $(TEST_RESULT_E2E_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_WEBVIEW_FILE)),)
-	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: Webview ($(os_name_and_arch))" --force
+	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: Webview ($(platform_arch))" --force
 	@echo "Published Webview test results from $(TEST_RESULT_WEBVIEW_FILE)"
 else
 	@echo "Webview test results not found at $(TEST_RESULT_WEBVIEW_FILE)"

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -24,13 +24,13 @@ else
 	@echo "Mocha test results not found at $(TEST_RESULT_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_E2E_FILE)),)
-	test-results publish $(TEST_RESULT_E2E_FILE) --force
+	test-results publish $(TEST_RESULT_E2E_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: E2E ($$(uname -s | tr '[:upper:]' '[:lower:]') $$(uname -m))" --force
 	@echo "Published E2E test results from $(TEST_RESULT_E2E_FILE)"
 else
 	@echo "E2E test results not found at $(TEST_RESULT_E2E_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_WEBVIEW_FILE)),)
-	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --force
+	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: Webview ($$(uname -s | tr '[:upper:]' '[:lower:]') $$(uname -m))" --force
 	@echo "Published Webview test results from $(TEST_RESULT_WEBVIEW_FILE)"
 else
 	@echo "Webview test results not found at $(TEST_RESULT_WEBVIEW_FILE)"

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -7,7 +7,7 @@ SEM_CACHE_DURATION_DAYS ?= 7
 current_time := $(shell date +"%s")
 # OS Name
 os_name := $(shell uname -s)
-os_name_and_arch := $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')")
+os_name_and_arch := $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/') $$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/')")
 
 .PHONY: store-test-results-to-semaphore
 store-test-results-to-semaphore:

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -7,7 +7,7 @@ SEM_CACHE_DURATION_DAYS ?= 7
 current_time := $(shell date +"%s")
 # OS Name
 os_name := $(shell uname -s)
-os_name_and_arch := $(shell echo $$(uname -s)-$$(uname -m) | tr '[:upper:]' '[:lower:]')
+os_name_and_arch := $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')")
 
 .PHONY: store-test-results-to-semaphore
 store-test-results-to-semaphore:
@@ -24,13 +24,13 @@ else
 	@echo "Mocha test results not found at $(TEST_RESULT_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_E2E_FILE)),)
-	test-results publish $(TEST_RESULT_E2E_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: E2E ($$(uname -s | tr '[:upper:]' '[:lower:]') $$(uname -m))" --force
+	test-results publish $(TEST_RESULT_E2E_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: E2E ($(os_name_and_arch))" --force
 	@echo "Published E2E test results from $(TEST_RESULT_E2E_FILE)"
 else
 	@echo "E2E test results not found at $(TEST_RESULT_E2E_FILE)"
 endif
 ifneq ($(wildcard $(TEST_RESULT_WEBVIEW_FILE)),)
-	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: Webview ($$(uname -s | tr '[:upper:]' '[:lower:]') $$(uname -m))" --force
+	test-results publish $(TEST_RESULT_WEBVIEW_FILE) --name "VS Code ($${VSCODE_VERSION:-stable}) Extension Tests: Webview ($(os_name_and_arch))" --force
 	@echo "Published Webview test results from $(TEST_RESULT_WEBVIEW_FILE)"
 else
 	@echo "Webview test results not found at $(TEST_RESULT_WEBVIEW_FILE)"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,24 @@ import { configDotenv } from "dotenv";
 
 configDotenv();
 
+const reporters: any[] = [
+  ["list"],
+  ["rollwright/coverage-reporter", { name: "text" }],
+  ["rollwright/coverage-reporter", { name: "lcovonly", options: { file: "lcov-functional.info" } }],
+];
+
+if (process.env.CI) {
+  const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
+  reporters.push([
+    "junit",
+    {
+      outputFile: "TEST-result-webview.xml",
+      includeProjectInTestName: true,
+      suiteName: `VS Code (${vscodeVersion}) Extension Tests: Webview (${process.platform} ${process.arch})`,
+    },
+  ]);
+}
+
 export default defineConfig({
   use: {
     headless: true,
@@ -10,12 +28,5 @@ export default defineConfig({
   },
   workers: 1,
   testMatch: "src/**/*.spec.ts",
-  reporter: [
-    ["list"],
-    ["rollwright/coverage-reporter", { name: "text" }],
-    [
-      "rollwright/coverage-reporter",
-      { name: "lcovonly", options: { file: "lcov-functional.info" } },
-    ],
-  ],
+  reporter: reporters,
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,6 +97,8 @@ const logger = new Logger("extension");
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<vscode.ExtensionContext | undefined> {
+  throw new Error("NOPE");
+
   const extVersion = context.extension.packageJSON.version;
   observabilityContext.extensionVersion = extVersion;
   observabilityContext.extensionActivated = false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -401,7 +401,6 @@ async function setupContextValues() {
     resourcesWithURIs,
     diffableResources,
   ]);
-  throw new Error("NOPE");
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,8 +97,6 @@ const logger = new Logger("extension");
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<vscode.ExtensionContext | undefined> {
-  throw new Error("NOPE");
-
   const extVersion = context.extension.packageJSON.version;
   observabilityContext.extensionVersion = extVersion;
   observabilityContext.extensionActivated = false;
@@ -403,6 +401,7 @@ async function setupContextValues() {
     resourcesWithURIs,
     diffableResources,
   ]);
+  throw new Error("NOPE");
 }
 
 /**

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -84,8 +84,6 @@ export const test = testBase.extend<VSCodeFixture>({
         `--user-data-dir=${tempDir}`,
         `--extensionDevelopmentPath=${outPath}`,
         "--new-window",
-        // run headless in CI environments
-        ...(process.env.CI ? ["--headless"] : []),
       ],
     });
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -82,7 +82,7 @@ export const test = testBase.extend<VSCodeFixture>({
         "--disable-extensions",
         // additional args needed for the Electron launch:
         `--user-data-dir=${tempDir}`,
-        `--extensionDevelopmentPath=${outPath}`,
+        `--extensionDevelopmentPath=${extensionPath}`,
         "--new-window",
       ],
     });

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -105,9 +105,21 @@ export const test = testBase.extend<VSCodeFixture>({
     await use(electronApp);
 
     try {
-      await electronApp.close();
+      // shorten grace period for shutdown to avoid hanging the entire test run
+      await Promise.race([
+        electronApp.close(),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("electronApp.close() timeout after 10s")), 10000),
+        ),
+      ]);
     } catch (error) {
       console.warn("Error closing electron app:", error);
+      // force-kill if needed
+      try {
+        await electronApp.context().close();
+      } catch (contextError) {
+        console.warn("Error closing electron context:", contextError);
+      }
     }
   },
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -84,6 +84,8 @@ export const test = testBase.extend<VSCodeFixture>({
         `--user-data-dir=${tempDir}`,
         `--extensionDevelopmentPath=${outPath}`,
         "--new-window",
+        // run headless in CI environments
+        ...(process.env.CI ? ["--headless"] : []),
       ],
     });
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -82,7 +82,7 @@ export const test = testBase.extend<VSCodeFixture>({
         "--disable-extensions",
         // additional args needed for the Electron launch:
         `--user-data-dir=${tempDir}`,
-        `--extensionDevelopmentPath=${extensionPath}`,
+        `--extensionDevelopmentPath=${outPath}`,
         "--new-window",
       ],
     });

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
       ]
     : "html",
   use: {
-    headless: process.env.CI ? true : false,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   },
   reporter: "html",
   use: {
-    // headless: process.env.CI ? true : false,
+    headless: process.env.CI ? true : false,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -15,7 +15,7 @@ const vscodeVersion = process.env.VSCODE_VERSION || "stable";
 export default defineConfig({
   testDir: path.join(__dirname, "specs"),
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   timeout: 120000,
   workers: 1,
   expect: {

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -21,7 +21,19 @@ export default defineConfig({
   expect: {
     timeout: 10000,
   },
-  reporter: "html",
+  reporter: process.env.CI
+    ? [
+        ["html"],
+        [
+          "junit",
+          {
+            outputFile: path.join(__dirname, "..", "..", "TEST-result-e2e.xml"),
+            includeProjectInTestName: true,
+            suiteName: `VS Code (${vscodeVersion}) Extension Tests: E2E (${process.platform} ${process.arch})`,
+          },
+        ],
+      ]
+    : "html",
   use: {
     headless: process.env.CI ? true : false,
     trace: "retain-on-failure",

--- a/tests/e2e/specs/confluent.spec.ts
+++ b/tests/e2e/specs/confluent.spec.ts
@@ -1,10 +1,11 @@
 import { test } from "../baseTest";
+import { Tag } from "../tags";
 
 import { openConfluentExtension } from "./utils/confluent";
 import { login } from "./utils/confluentCloud";
 
 test.describe(() => {
-  test("should load the extension properly", async ({ page }) => {
+  test("should load the extension properly", { tag: [Tag.Smoke] }, async ({ page }) => {
     await openConfluentExtension(page);
   });
 

--- a/tests/e2e/specs/confluent.spec.ts
+++ b/tests/e2e/specs/confluent.spec.ts
@@ -1,13 +1,18 @@
+import { stubAllDialogs } from "electron-playwright-helpers";
 import { test } from "../baseTest";
 import { Tag } from "../tags";
-
 import { openConfluentExtension } from "./utils/confluent";
 import { login } from "./utils/confluentCloud";
 
 test.describe(() => {
-  test("should load the extension properly", { tag: [Tag.Smoke] }, async ({ page }) => {
-    await openConfluentExtension(page);
-  });
+  test(
+    "should load the extension properly",
+    { tag: [Tag.Smoke] },
+    async ({ page, electronApp }) => {
+      await stubAllDialogs(electronApp);
+      await openConfluentExtension(page);
+    },
+  );
 
   test("sign in to confluent cloud", async ({ page, electronApp }) => {
     await openConfluentExtension(page);

--- a/tests/e2e/tags.ts
+++ b/tests/e2e/tags.ts
@@ -1,0 +1,5 @@
+/** {@see https://playwright.dev/docs/test-annotations#tag-tests} */
+export enum Tag {
+  Smoke = "@smoke",
+  CriticalUserJourney = "@critical-user-journey",
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Basic setup for [test tags](https://playwright.dev/docs/test-annotations#tag-tests)
- Standalone CI step to run on linux amd64/arm64 agents for the `@smoke`-tagged "activate the extension" E2E test

<img width="983" alt="image" src="https://github.com/user-attachments/assets/8e48e53f-f6d8-49cf-b0c9-7744f01c289a" />

Sample failure on activation where the "Confluent Cloud" item (in the Resources view) never appeared:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/9b158b67-1b5d-42f2-919d-9a078b47343b" />

This also sets up the make target and some basic structure to help with running more E2E tests in CI (see https://github.com/confluentinc/vscode/pull/2163).


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- I realized our test-publishing in Semaphore only applied to the Mocha tests, so this branch adds pushing test results from the `functional` and `e2e` tests as well
<img width="214" alt="image" src="https://github.com/user-attachments/assets/7e2aace5-f05f-464b-b1ce-62785cc6dece" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
