### PR TITLE
fix: check for open flink docs in ccloud connected event

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -221,7 +221,7 @@ describe("FlinkLanguageClientManager", () => {
         .resolves();
 
       // Re-initialize the singleton so the constructor runs
-      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager["instance"] = null;
       FlinkLanguageClientManager.getInstance();
 
       sinon.assert.calledOnce(maybeStartStub);
@@ -250,7 +250,7 @@ describe("FlinkLanguageClientManager", () => {
         .resolves();
 
       // Re-initialize the singleton so the constructor runs
-      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager["instance"] = null;
       FlinkLanguageClientManager.getInstance();
 
       sinon.assert.calledOnce(maybeStartStub);
@@ -276,7 +276,7 @@ describe("FlinkLanguageClientManager", () => {
         .resolves();
 
       // Re-initialize the singleton so the constructor runs
-      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager["instance"] = null;
       FlinkLanguageClientManager.getInstance();
 
       sinon.assert.notCalled(maybeStartStub);
@@ -295,7 +295,7 @@ describe("FlinkLanguageClientManager", () => {
         .resolves();
 
       // Re-initialize the singleton so the constructor runs
-      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager["instance"] = null;
       FlinkLanguageClientManager.getInstance();
 
       sinon.assert.notCalled(maybeStartStub);
@@ -309,11 +309,11 @@ describe("FlinkLanguageClientManager", () => {
       sandbox.stub(vscode.workspace, "textDocuments").value([fakeDocument]);
 
       // Re-initialize the singleton so the constructor runs
-      (FlinkLanguageClientManager as any).instance = null;
+      FlinkLanguageClientManager["instance"] = null;
       flinkManager = FlinkLanguageClientManager.getInstance();
 
-      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 1);
-      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()), true);
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].size, 1);
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].has(fakeUri.toString()), true);
     });
 
     it("should track documents when opened", () => {
@@ -323,8 +323,8 @@ describe("FlinkLanguageClientManager", () => {
 
       flinkManager.trackDocument(fakeUri);
 
-      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 1);
-      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()), true);
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].size, 1);
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].has(fakeUri.toString()), true);
     });
 
     it("should untrack documents when closed", () => {
@@ -332,11 +332,8 @@ describe("FlinkLanguageClientManager", () => {
       flinkManager.trackDocument(fakeUri);
       flinkManager.untrackDocument(fakeUri);
 
-      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 0);
-      assert.strictEqual(
-        (flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()),
-        false,
-      );
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].size, 0);
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].has(fakeUri.toString()), false);
     });
 
     it("should not track readonly statements", () => {
@@ -349,11 +346,8 @@ describe("FlinkLanguageClientManager", () => {
 
       flinkManager.trackDocument(fakeUri);
 
-      assert.strictEqual((flinkManager as any).openFlinkSqlDocuments.size, 0);
-      assert.strictEqual(
-        (flinkManager as any).openFlinkSqlDocuments.has(fakeUri.toString()),
-        false,
-      );
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].size, 0);
+      assert.strictEqual(flinkManager["openFlinkSqlDocuments"].has(fakeUri.toString()), false);
     });
   });
 });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fixes an issue found during bug bash - if a flinksql doc is already opened when you sign in to CCloud, the language server does not start automatically. 
- Builds on previous branch which added document tracking

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing (minor updates based on prev. PR comment)
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
