### PR TITLE
Prevent empty-string subjects from making us fall over.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+ - Prevent the existence of an empty-string subject from breaking operations ([#2149](https://github.com/confluentinc/vscode/issues/2149)).
+
 ## 1.4.1
 
 ### Changed

--- a/src/loaders/loaderUtils.test.ts
+++ b/src/loaders/loaderUtils.test.ts
@@ -26,7 +26,8 @@ export const topicsResponseData: TopicData[] = [
 describe("loaderUtils correlateTopicsWithSchemaSubjects() test", () => {
   it("should correlate topics with schema subjects as strings", () => {
     // topic 1-3 will be correlated with schema subjects, topic 4 will not.
-    const subjectStrings: string[] = ["topic1-value", "topic2-key", "topic3-Foo"];
+    // (Include empty string subject to further exercise issue #2149.)
+    const subjectStrings: string[] = ["topic1-value", "topic2-key", "topic3-Foo", ""];
     const subjects: Subject[] = subjectStrings.map(
       (name) =>
         new Subject(
@@ -85,6 +86,14 @@ describe("loaderUtils fetchSubjects() and fetchSchemasForSubject() tests", () =>
     // be sure to test against a wholly separate array, 'cause .sort() is in-place.
     // Will do a locale search which is case independent
     assert.deepStrictEqual(subjectStrings, ["subject1", "Subject2", "subject3"]);
+  });
+
+  it("fetchSubjects() should work with empty string subjects", async () => {
+    stubbedSubjectsV1Api.list.resolves(["subject1", "", "subject2"]);
+    const subjects = await loaderUtils.fetchSubjects(TEST_LOCAL_SCHEMA_REGISTRY);
+    const subjectStrings = subjects.map((s) => s.name);
+    // Should include the empty string subject.
+    assert.deepStrictEqual(subjectStrings, ["", "subject1", "subject2"]);
   });
 
   it("fetchSchemasForSubject() should fetch versions of schemas for a given subject", async () => {

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -24,15 +24,20 @@ import {
 
 describe("Subject model methods", () => {
   it("Constructor vs bad subject name", () => {
-    const badSubjects = [undefined, null, ""];
+    const badSubjects = [undefined, null];
     for (const badSubject of badSubjects) {
       assert.throws(
         () => {
-          new Subject(badSubject as string, CCLOUD_CONNECTION_ID, "envId" as EnvironmentId, "srId");
+          new Subject(
+            badSubject as unknown as string,
+            CCLOUD_CONNECTION_ID,
+            "envId" as EnvironmentId,
+            "srId",
+          );
         },
         {
           name: "Error",
-          message: `Subject name cannot be undefined, null, or empty: ${badSubject} from ${CCLOUD_CONNECTION_ID}`,
+          message: `Subject name cannot be undefined or null: ${badSubject} from ${CCLOUD_CONNECTION_ID}`,
         },
       );
     }

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -64,10 +64,8 @@ export class Subject implements IResourceBase, ISearchable, ISchemaRegistryResou
   ) {
     // These may be constructed from either route responses or resource manager cache load,
     // (i.e. outside of typescript's control), so be extra cautious.
-    if (name === undefined || name === null || name === "") {
-      throw new Error(
-        `Subject name cannot be undefined, null, or empty: ${name} from ${connectionId}`,
-      );
+    if (name === undefined || name === null) {
+      throw new Error(`Subject name cannot be undefined or null: ${name} from ${connectionId}`);
     }
 
     this.name = name;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Close #2149 against release/1.4.x by allowing the empty string as a valid subject name, because CCloud SRs do not prevent their creation when done through route calls.
- Alas, CCloud SRs reject requests to _delete_ such beasts, but that's well out of VScode extension's capabilities to fix.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Now instead of an error, we show the empty-subject'd schema in the Schemas view, and do not raise an exception when listing topics and correlating against such schemas.
![image](https://github.com/user-attachments/assets/71d19c87-b302-45b6-a2ed-cfcec48599b7)


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
