### PR TITLE
MINOR: stop sending preferences error 400 responses to sentry

### DIFF
--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -137,7 +137,7 @@ describe("extensionSettings/sidecarSync.ts", function () {
     sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
   });
 
-  it("updatePreferences() should log and not re-throw errors when updating preferences", async function () {
+  it("updatePreferences() should log and not re-throw errors when syncing settings to the sidecar preferences API", async function () {
     const errorMessage = "Failed to update preferences";
     const error = new Error(errorMessage);
     mockClient.gatewayV1PreferencesPut.rejects(error);
@@ -145,15 +145,16 @@ describe("extensionSettings/sidecarSync.ts", function () {
     await updates.updatePreferences();
 
     sinon.assert.calledOnce(mockClient.gatewayV1PreferencesPut);
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      sinon.match.instanceOf(Error).and(sinon.match.has("message", errorMessage)),
-      "updating preferences",
-      { extra: { functionName: "updatePreferences" } },
-    );
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
     const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
     assert.strictEqual(callArgs[0], `Failed to sync settings: ${errorMessage}`);
+    // non-ResponseError should go to Sentry
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      sinon.match.instanceOf(Error).and(sinon.match.has("message", errorMessage)),
+      "syncing settings to sidecar preferences API",
+      { extra: { functionName: "updatePreferences" } },
+    );
   });
 
   it("updatePreferences() should show an error notification when an Error is caught", async function () {
@@ -166,7 +167,7 @@ describe("extensionSettings/sidecarSync.ts", function () {
     sinon.assert.calledWithExactly(
       logErrorStub,
       sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
-      "updating preferences",
+      "syncing settings to sidecar preferences API",
       { extra: { functionName: "updatePreferences" } },
     );
 
@@ -175,7 +176,7 @@ describe("extensionSettings/sidecarSync.ts", function () {
     assert.strictEqual(callArgs[0], `Failed to sync settings: ${error.message}`);
   });
 
-  it("updatePreferences() should show an error notification with a settings button when a ResponseError is caught and valid failure errors are returned", async function () {
+  it("updatePreferences() should show an error notification with a settings button when a ResponseError (status 400) is caught and valid failure errors are returned", async function () {
     const errorResponse = new Response("Bad Request", { status: 400 });
     const fakeFailureError = {
       code: "cert_not_found",
@@ -191,14 +192,53 @@ describe("extensionSettings/sidecarSync.ts", function () {
 
     await updates.updatePreferences();
 
-    // no need to send error 400 responses to Sentry; the notification should tell the user what
-    // needs to be changed
-    sinon.assert.notCalled(logErrorStub);
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
     const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
     assert.strictEqual(callArgs[0], `Failed to sync settings: ${fakeFailureError.detail}`);
     assert.ok(Object.keys(callArgs[1]).includes("Update Settings"));
     assert.ok(Object.keys(callArgs[1]).includes("Open Logs"));
     assert.ok(Object.keys(callArgs[1]).includes("File Issue"));
+    // not sending error 400s to Sentry
+    sinon.assert.calledOnce(logErrorStub);
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      error,
+      "syncing settings to sidecar preferences API",
+      {},
+    );
+  });
+
+  it("updatePreferences() should show an error notification with a settings button when a ResponseError (non-400 status) is caught and valid failure errors are returned", async function () {
+    const errorResponse = new Response("Internal server error", { status: 500 });
+    const fakeFailureError = {
+      code: "cert_not_found",
+      title: "Cert file cannot be found",
+      detail: "The cert file '/foo/bar/baz' cannot be found.",
+      source: "/spec/tls_pem_paths" as JsonNode, // pointer to the specific field, not actual object
+    } satisfies SidecarError;
+    sandbox.stub(errorResponse, "clone").returns(errorResponse);
+    sandbox.stub(errorResponse, "json").resolves({ errors: [fakeFailureError] });
+    const error = new ResponseError(errorResponse);
+
+    mockClient.gatewayV1PreferencesPut.rejects(error);
+
+    await updates.updatePreferences();
+
+    sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
+    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
+    assert.strictEqual(callArgs[0], `Failed to sync settings: ${fakeFailureError.detail}`);
+    assert.ok(Object.keys(callArgs[1]).includes("Update Settings"));
+    assert.ok(Object.keys(callArgs[1]).includes("Open Logs"));
+    assert.ok(Object.keys(callArgs[1]).includes("File Issue"));
+    // not an expected 400 error, so send to Sentry and let the team triage
+    sinon.assert.calledOnce(logErrorStub);
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      error,
+      "syncing settings to sidecar preferences API",
+      {
+        extra: { functionName: "updatePreferences" },
+      },
+    );
   });
 });

--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -193,11 +193,15 @@ describe("extensionSettings/sidecarSync.ts", function () {
     await updates.updatePreferences();
 
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
-    assert.strictEqual(callArgs[0], `Failed to sync settings: ${fakeFailureError.detail}`);
-    assert.ok(Object.keys(callArgs[1]).includes("Update Settings"));
-    assert.ok(Object.keys(callArgs[1]).includes("Open Logs"));
-    assert.ok(Object.keys(callArgs[1]).includes("File Issue"));
+    sinon.assert.calledOnceWithExactly(
+      showErrorNotificationWithButtonsStub,
+      `Failed to sync settings: ${fakeFailureError.detail}`,
+      {
+        "Update Settings": sinon.match.func,
+        "Open Logs": sinon.match.func,
+        "File Issue": sinon.match.func,
+      },
+    );
     // not sending error 400s to Sentry
     sinon.assert.calledOnce(logErrorStub);
     sinon.assert.calledWithExactly(
@@ -225,11 +229,15 @@ describe("extensionSettings/sidecarSync.ts", function () {
     await updates.updatePreferences();
 
     sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
-    assert.strictEqual(callArgs[0], `Failed to sync settings: ${fakeFailureError.detail}`);
-    assert.ok(Object.keys(callArgs[1]).includes("Update Settings"));
-    assert.ok(Object.keys(callArgs[1]).includes("Open Logs"));
-    assert.ok(Object.keys(callArgs[1]).includes("File Issue"));
+    sinon.assert.calledOnceWithExactly(
+      showErrorNotificationWithButtonsStub,
+      `Failed to sync settings: ${fakeFailureError.detail}`,
+      {
+        "Update Settings": sinon.match.func,
+        "Open Logs": sinon.match.func,
+        "File Issue": sinon.match.func,
+      },
+    );
     // not an expected 400 error, so send to Sentry and let the team triage
     sinon.assert.calledOnce(logErrorStub);
     sinon.assert.calledWithExactly(


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We already show error notifications when syncing to the sidecar Preferences API, so there isn't any need to send those same errors to Sentry. We will still send them if:
- we get a non-`ResponseError`
- we get a `ResponseError` with a non-`400` status

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- We don't need `PreferencesFailureError` anymore after the sidecar set up the `SidecarError` model, but its `source` is still referenced as a `JsonNode` despite the fact that we only ever see strings in the response data

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
