### PR TITLE
[v1.5.x] clear CCloud connected state from sign-out command to prevent incorrect CCloud expiration notification

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -23,7 +23,7 @@ import { ResourceViewProvider } from "../viewProviders/resources";
 const logger = new Logger("commands.connections");
 
 /** Allow CCloud sign-in via the auth provider outside of the Accounts section of the VS Code UI. */
-async function ccloudSignIn() {
+export async function ccloudSignIn() {
   try {
     await getCCloudAuthSession(true);
   } catch (error) {
@@ -47,7 +47,7 @@ async function ccloudSignIn() {
   }
 }
 
-async function ccloudSignOut() {
+export async function ccloudSignOut() {
   const authSession = await getCCloudAuthSession();
   if (!authSession) {
     return;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This was really a one-line change, where our `ccloudSignOut` command (from the Resources view > "Confluent Cloud" item):
https://github.com/confluentinc/vscode/blob/7a140245adfca83865f7e128f9258577d9f33fa5/src/commands/connections.ts#L72-L73

...needed to behave the same as the auth provider (signing out from the Accounts menu):
https://github.com/confluentinc/vscode/blob/7a140245adfca83865f7e128f9258577d9f33fa5/src/authn/ccloudProvider.ts#L345-L350

This wasn't a problem before https://github.com/confluentinc/vscode/pull/2127 since we didn't depend as much on connected state transitions from `SUCCESS` to `NONE`, which was the cause of the (incorrect) expiration notification.

Closes #2165.

## For Reviewers:

To click-test, compare notifications that appear when signing in and out multiple times between `main` and this branch, via:
- the Accounts menu
- the Confluent Cloud item in the Resources view

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Most other line changes here are adding test coverage for the `ccloudSignIn` and `ccloudSignOut` commands, bumping our coverage in `src/commands/connections.ts` slightly (from ~19% to ~32%)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
