### PR TITLE
[main] clear CCloud connected state from sign-out command to prevent incorrect CCloud expiration notification

### DIFF
--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -11,17 +11,19 @@ import { DirectEnvironment } from "../models/environment";
 import { ConnectionId } from "../models/resource";
 import { showErrorNotificationWithButtons } from "../notifications";
 import { deleteCCloudConnection } from "../sidecar/connections/ccloud";
+import { SecretStorageKeys } from "../storage/constants";
 import {
   CustomConnectionSpec,
   CustomConnectionSpecFromJSON,
   getResourceManager,
 } from "../storage/resourceManager";
+import { getSecretStorage } from "../storage/utils";
 import { ResourceViewProvider } from "../viewProviders/resources";
 
 const logger = new Logger("commands.connections");
 
 /** Allow CCloud sign-in via the auth provider outside of the Accounts section of the VS Code UI. */
-async function ccloudSignIn() {
+export async function ccloudSignIn() {
   try {
     await getCCloudAuthSession(true);
   } catch (error) {
@@ -45,7 +47,7 @@ async function ccloudSignIn() {
   }
 }
 
-async function ccloudSignOut() {
+export async function ccloudSignOut() {
   const authSession = await getCCloudAuthSession();
   if (!authSession) {
     return;
@@ -69,8 +71,16 @@ Sign out from this extension?`,
   if (confirmation !== yesButton) {
     return;
   }
-  // sign out by clearing the stored auth session
-  await deleteCCloudConnection();
+
+  // sign out by clearing the stored auth session, and also clear any previous connected state
+  // so ccloudStateHandling doesn't see old state and incorrectly show an expiration notification
+  await Promise.all([
+    deleteCCloudConnection(),
+    getSecretStorage().delete(SecretStorageKeys.CCLOUD_STATE),
+  ]);
+
+  // this will trigger the auth provider's `.handleSessionRemoved(true)` and fire the
+  // ccloudConnected event, which covers the rest of the `.removeSession()` logic
   ccloudAuthSessionInvalidated.fire();
 }
 


### PR DESCRIPTION
https://github.com/confluentinc/vscode/pull/2166 to main