### PR TITLE
[v1.5.x] send CCloud auth failed events to Sentry

### DIFF
--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -12,9 +12,12 @@ import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { ConnectedState, Connection } from "../clients/sidecar";
 import { CCLOUD_AUTH_CALLBACK_URI, CCLOUD_CONNECTION_ID } from "../constants";
 import { ccloudAuthSessionInvalidated } from "../emitters";
+import * as errors from "../errors";
 import { getSidecar } from "../sidecar";
 import * as ccloud from "../sidecar/connections/ccloud";
 import * as watcher from "../sidecar/connections/watcher";
+import * as sidecarLogging from "../sidecar/logging";
+import { SidecarOutputs } from "../sidecar/types";
 import { SecretStorageKeys } from "../storage/constants";
 import { getResourceManager, ResourceManager } from "../storage/resourceManager";
 import { clearWorkspaceState } from "../storage/utils";
@@ -35,6 +38,8 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
   let getCCloudConnectionStub: sinon.SinonStub;
   let createCCloudConnectionStub: sinon.SinonStub;
   let deleteConnectionStub: sinon.SinonStub;
+  let logErrorStub: sinon.SinonStub;
+  let gatherSidecarOutputsStub: sinon.SinonStub;
   // auth provider stubs
   let browserAuthFlowStub: sinon.SinonStub;
   let stubOnDidChangeSessions: sinon.SinonStubbedInstance<
@@ -68,6 +73,13 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
 
     showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage").resolves();
     showInfoMessageStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
+
+    logErrorStub = sandbox.stub(errors, "logError").resolves();
+    gatherSidecarOutputsStub = sandbox.stub(sidecarLogging, "gatherSidecarOutputs").resolves({
+      logLines: [],
+      parsedLogLines: [],
+      stderrLines: [],
+    } satisfies SidecarOutputs);
   });
 
   afterEach(() => {
@@ -117,10 +129,17 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
     );
   });
 
-  it("createSession() should handle authentication failure", async () => {
+  it("createSession() should handle authentication failure and send sidecar logs to Sentry", async () => {
     getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
     // authentication fails
     browserAuthFlowStub.resolves({ success: false, resetPassword: false });
+    // stub the sidecar logs so we don't pull in the real logs and blow up test output
+    const fakeSidecarLogs = {
+      logLines: ["oh no", "something went wrong"],
+      parsedLogLines: [],
+      stderrLines: [],
+    } satisfies SidecarOutputs;
+    gatherSidecarOutputsStub.resolves(fakeSidecarLogs);
 
     const authFailedMsg = "Confluent Cloud authentication failed. See browser for details.";
     await assert.rejects(authProvider.createSession(), {
@@ -128,6 +147,13 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
     });
 
     sinon.assert.calledWith(showErrorMessageStub, authFailedMsg);
+    sinon.assert.calledOnce(gatherSidecarOutputsStub);
+    sinon.assert.calledWithExactly(
+      logErrorStub,
+      sinon.match.instanceOf(Error),
+      "CCloud authentication failed",
+      { extra: { sidecarLogs: fakeSidecarLogs.logLines.join("\n") } },
+    );
   });
 
   it("createSession() should handle password reset scenario", async () => {
@@ -144,6 +170,8 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
       "Your password has been reset. Please sign in again to Confluent Cloud.",
       sinon.match(CCLOUD_SIGN_IN_BUTTON_LABEL),
     );
+    sinon.assert.notCalled(gatherSidecarOutputsStub);
+    sinon.assert.notCalled(logErrorStub);
   });
 
   it("createSession() should handle user cancellation", async () => {
@@ -158,6 +186,8 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
     sinon.assert.notCalled(deleteConnectionStub);
     sinon.assert.notCalled(showInfoMessageStub);
     sinon.assert.notCalled(showErrorMessageStub);
+    sinon.assert.notCalled(gatherSidecarOutputsStub);
+    sinon.assert.notCalled(logErrorStub);
   });
 
   it(`getSessions() should treat connections with a ${ConnectedState.None}/${ConnectedState.Failed} state as nonexistent`, async () => {

--- a/src/sidecar/logging.ts
+++ b/src/sidecar/logging.ts
@@ -303,8 +303,11 @@ export async function gatherSidecarOutputs(
     const parsed: SidecarLogFormat | null = parseSidecarLogLine(rawLogLine);
     if (parsed && parsed.timestamp) {
       parsedLines.push(parsed);
-
-      const formatted = `\t> ${parsed.timestamp} ${parsed.level} [${parsed.loggerName}] ${parsed.message}`;
+      const formatted: string = formatSidecarLogLine(parsed, {
+        withTimestamp: true,
+        withLevel: true,
+        withMdc: true,
+      });
       reformattedLogLines.push(formatted);
     } else {
       // JSON parsing failed or the line is missing required fields. Only append the raw line if nonempty.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We want to get more real-time alerting when multiple users experience failures when authenticating to CCloud via the browser-based auth flow in the extension, so this PR sets up an additional event to send to Sentry when we get the `success=false` URI callback (when users see "Confluent Cloud authentication failed. See browser for details."). This will allow our team to quickly focus on triaging to see if there was a regression or external change that we need to address. 

Sample Sentry event data:
<img width="978" height="522" alt="image" src="https://github.com/user-attachments/assets/9e9d2599-c191-424f-8673-081174fa4f4c" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
