### PR TITLE
scaffold: catch pattern mismatches when submitted with keyboard

### DIFF
--- a/src/webview/scaffold-form.ts
+++ b/src/webview/scaffold-form.ts
@@ -93,9 +93,16 @@ class ScaffoldFormViewModel extends ViewModel {
     }
     this.hasValidationErrors(document.querySelectorAll(".input-container.error").length > 0);
   }
+
   async handleSubmit(event: Event) {
     event.preventDefault();
     const form = event.target as HTMLFormElement;
+    // Re-check all inputs to catch errors missed if validateInput doesn't run onBlur (submitted with Enter)
+    const inputs = Array.from(form.querySelectorAll<HTMLInputElement>("input"));
+    for (const input of inputs) {
+      // type casting to unknown! it's ok, the only part of the Event validateInput cares about is target.input
+      this.validateInput({ target: input } as unknown as Event);
+    }
     this.hasValidationErrors(
       document.querySelectorAll(".input-container.error").length > 0 || !form.checkValidity(),
     );


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fixes #2168 
- We found that users could submit invalid (pattern mismatched) values from the project generation form if using the `Enter` key to submit the form. This adds an extra validation check for each input just before submission to prevent that.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- In investigation I asked myself why `form.checkValidity()` wasn't working in this case, and realized it's because the RegEx patterns are _not_ added as input `attr` in the HTML form, instead checked explicitly on blur. 
- Then I had to go back to my notes from January to remember _why_ I did that: Seems that the JS RegEx interprets the unicode sets in [HTML with the `/v` flag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#pattern), which is different than the the backend Scaffold Service's template generation. Adding the patterns from templates to the HTML was giving a SyntaxError in some cases. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
