### PR TITLE
Sentry client: add rate limiting to prevent single-user spikes

### DIFF
--- a/src/telemetry/sentryClient.ts
+++ b/src/telemetry/sentryClient.ts
@@ -13,7 +13,7 @@ import { checkTelemetrySettings, includeObservabilityContext } from "./eventProc
 const logger = new Logger("sentry");
 let sentryScope: Scope | null = null;
 let sentryClient: NodeClient | null = null;
-const throttledEvents: Record<string, boolean> = {};
+const throttledEvents: Record<string, NodeJS.Timeout> = {};
 
 /**
  * Returns the Sentry Scope singleton, creating it if it doesn't exist
@@ -70,11 +70,8 @@ export function initSentry() {
           logger.debug("Rate limiting activated for", msg);
           return null;
         }
-        throttledEvents[msg] = true;
-        setTimeout(() => {
-          if (msg) {
-            delete throttledEvents[msg];
-          }
+        throttledEvents[msg] = setTimeout(() => {
+          delete throttledEvents[msg];
         }, 60000); // clear after 1 minute
       }
       return event;


### PR DESCRIPTION
## Summary of Changes

- To prevent overwhelming our Sentry account with repetitive errors, add rate limiting for events sent by a single instance. 
- Caps the number of error events with the same message to one per minute by saving the message in `throttledEvents`, with a handler in `beforeSend`
- Still logs that rate limiting has occurred & surfaces errors to output logger
- Closes #1174 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- TIL that [Sentry uses a dynamic algorithm to detect spikes](https://docs.sentry.io/pricing/quotas/spike-protection/#how-sentry-detects-spikes), so the number of errors that will cause a spike aren't set in stone. 
- When a spike happens we get an On Call Slack channel alert, but sometimes there's no action that can be taken (it could be on the user's machine and unrelated to us). We've seen this happen a few times over the past year, most recently by one of our own team members during release testing 😀 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
