### PR TITLE
Enforce sha 512 for warpstream scram connections

### DIFF
--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -1,8 +1,8 @@
 import { ObservableScope } from "inertial";
 import {
-  type KerberosCredentials,
   type ApiKeyAndSecret,
   type BasicCredentials,
+  type KerberosCredentials,
   type OAuthCredentials,
   type ScramCredentials,
 } from "../clients/sidecar";
@@ -54,6 +54,13 @@ export class AuthCredentials extends HTMLElement {
 
   getInputId(name: string) {
     return this.identifier() + ".credentials." + name;
+  }
+  getHashAlgorithm() {
+    // Default to SCRAM_SHA_256 unless WarpStream, which uses SCRAM_SHA_512
+    // @ts-expect-error the creds could be of any Credentials type
+    return this.creds()?.hash_algorithm ?? this.connectionType() === "WarpStream"
+      ? "SCRAM_SHA_512"
+      : "SCRAM_SHA_256";
   }
 
   // Add all initial form values to the form data, including defaults
@@ -228,8 +235,9 @@ export class AuthCredentials extends HTMLElement {
               required
               data-attr-id="this.getInputId('hash_algorithm')"
               data-attr-name="this.getInputId('hash_algorithm')"
-              data-value="this.creds()?.hash_algorithm ?? 'SCRAM_SHA_256'"
               data-on-input="this.updateValue(event)"
+              data-value="this.creds()?.hash_algorithm ?? this.getHashAlgorithm()"
+              data-attr-disabled="this.connectionType() === 'WarpStream'"
             >
               <option value="SCRAM_SHA_256">SCRAM_SHA_256</option>
               <option value="SCRAM_SHA_512">SCRAM_SHA_512</option>

--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -57,10 +57,10 @@ export class AuthCredentials extends HTMLElement {
   }
   getHashAlgorithm() {
     // Default to SCRAM_SHA_256 unless WarpStream, which uses SCRAM_SHA_512
-    // @ts-expect-error the creds could be of any Credentials type
-    return this.creds()?.hash_algorithm ?? this.connectionType() === "WarpStream"
+    return this.connectionType() === "WarpStream"
       ? "SCRAM_SHA_512"
-      : "SCRAM_SHA_256";
+      : // @ts-expect-error the creds could be of any Credentials type
+        this.creds()?.hash_algorithm ?? "SCRAM_SHA_256";
   }
 
   // Add all initial form values to the form data, including defaults
@@ -236,7 +236,7 @@ export class AuthCredentials extends HTMLElement {
               data-attr-id="this.getInputId('hash_algorithm')"
               data-attr-name="this.getInputId('hash_algorithm')"
               data-on-input="this.updateValue(event)"
-              data-value="this.creds()?.hash_algorithm ?? this.getHashAlgorithm()"
+              data-value="this.getHashAlgorithm()"
               data-attr-disabled="this.connectionType() === 'WarpStream'"
             >
               <option value="SCRAM_SHA_256">SCRAM_SHA_256</option>

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -121,12 +121,9 @@
               data-value="this.kafkaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <option value="None" selected>None</option>
-              <option value="Basic">Username & Password (SASL/PLAIN)</option>
-              <option value="API">API Credentials (SASL/PLAIN)</option>
-              <option value="SCRAM">SASL/SCRAM</option>
-              <option value="OAuth">SASL/OAUTHBEARER</option>
-              <option value="Kerberos">Kerberos (SASL/GSSAPI)</option>
+              <template data-for="auth of this.getValidAuthTypes()">
+                <option data-attr-value="this.auth().value" data-text="this.auth().label"></option>
+              </template>
             </select>
           </div>
           <div class="content-wrapper">

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -209,13 +209,15 @@
               id="schema_registry.auth_type"
               name="schema_registry.auth_type"
               data-on-input="this.updateValue(event)"
-              data-value="this.schemaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <option value="None" selected>None</option>
-              <option value="Basic">Username & Password</option>
-              <option value="API">API Credentials</option>
-              <option value="OAuth">OAuth</option>
+              <template data-for="auth of this.getValidAuthTypes()">
+                <option
+                  data-attr-value="this.auth().value"
+                  data-text="this.auth().label"
+                  data-attr-selected="this.auth().value === this.schemaAuthType()"
+                ></option>
+              </template>
             </select>
           </div>
           <div class="content-wrapper">

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -118,11 +118,14 @@
               id="kafka_cluster.auth_type"
               name="kafka_cluster.auth_type"
               data-on-input="this.updateValue(event)"
-              data-value="this.kafkaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
               <template data-for="auth of this.getValidAuthTypes()">
-                <option data-attr-value="this.auth().value" data-text="this.auth().label"></option>
+                <option
+                  data-attr-value="this.auth().value"
+                  data-text="this.auth().label"
+                  data-attr-selected="this.auth().value === this.kafkaAuthType()"
+                ></option>
               </template>
             </select>
           </div>

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -120,7 +120,7 @@
               data-on-input="this.updateValue(event)"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <template data-for="auth of this.getValidAuthTypes()">
+              <template data-for="auth of this.getValidKafkaAuthTypes()">
                 <option
                   data-attr-value="this.auth().value"
                   data-text="this.auth().label"
@@ -209,15 +209,13 @@
               id="schema_registry.auth_type"
               name="schema_registry.auth_type"
               data-on-input="this.updateValue(event)"
+              data-value="this.schemaAuthType()"
               data-attr-disabled="this.editing() ? true : false"
             >
-              <template data-for="auth of this.getValidAuthTypes()">
-                <option
-                  data-attr-value="this.auth().value"
-                  data-text="this.auth().label"
-                  data-attr-selected="this.auth().value === this.schemaAuthType()"
-                ></option>
-              </template>
+              <option value="None" selected>None</option>
+              <option value="Basic">Username & Password</option>
+              <option value="API">API Credentials</option>
+              <option value="OAuth">OAuth</option>
             </select>
           </div>
           <div class="content-wrapper">

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -92,8 +92,6 @@ test("renders form html correctly", async ({ page }) => {
 
   const authKafka = page.locator("select[name='kafka_cluster.auth_type']");
   await expect(authKafka).toBeVisible();
-  // Don't check for options count - these are populated dynamically by JavaScript
-  // which isn't executed in this static HTML test
 
   const schemaUrlInput = page.locator("input[name='schema_registry.uri']");
   await expect(schemaUrlInput).toBeVisible();
@@ -105,8 +103,6 @@ test("renders form html correctly", async ({ page }) => {
 
   const authSchema = page.locator("select[name='schema_registry.auth_type']");
   await expect(authSchema).not.toBe(null);
-  const authSchemaOptions = await authSchema.locator("option").all();
-  await expect(authSchemaOptions.length).toBe(4); // None, Basic, API, OAuth
 });
 test("renders form with existing connection spec values (for edit/import)", async ({
   execute,

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -103,6 +103,8 @@ test("renders form html correctly", async ({ page }) => {
 
   const authSchema = page.locator("select[name='schema_registry.auth_type']");
   await expect(authSchema).not.toBe(null);
+  const authSchemaOptions = await authSchema.locator("option").all();
+  await expect(authSchemaOptions.length).toBe(4); // None, Basic, API, OAuth
 });
 test("renders form with existing connection spec values (for edit/import)", async ({
   execute,

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -12,9 +12,9 @@ import {
   ConnectionSpec,
   ConnectionType,
   HashAlgorithm,
+  KerberosCredentials,
   OAuthCredentials,
   ScramCredentials,
-  KerberosCredentials,
 } from "../clients/sidecar";
 
 const template = readFileSync(new URL("direct-connect-form.html", import.meta.url), "utf8");
@@ -91,9 +91,9 @@ test("renders form html correctly", async ({ page }) => {
   await expect(sslCheckbox).toBeVisible();
 
   const authKafka = page.locator("select[name='kafka_cluster.auth_type']");
-  await expect(authKafka).not.toBe(null);
-  const authKafkaOptions = await authKafka.locator("option").all();
-  await expect(authKafkaOptions.length).toBe(6);
+  await expect(authKafka).toBeVisible();
+  // Don't check for options count - these are populated dynamically by JavaScript
+  // which isn't executed in this static HTML test
 
   const schemaUrlInput = page.locator("input[name='schema_registry.uri']");
   await expect(schemaUrlInput).toBeVisible();

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -199,8 +199,6 @@ class DirectConnectFormViewModel extends ViewModel {
         if (input.value === "Confluent Cloud") {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
-          this.kafkaAuthType("API");
-          // this.schemaAuthType("API");
         }
         if (input.value === "WarpStream") {
           this.kafkaAuthType("Basic");

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -200,10 +200,6 @@ class DirectConnectFormViewModel extends ViewModel {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
         }
-        if (input.value === "WarpStream") {
-          this.kafkaAuthType("Basic");
-          // this.schemaAuthType("Basic");
-        }
         break;
       case "kafka_cluster.auth_type":
         this.kafkaAuthType(input.value as SupportedAuthTypes);

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -19,7 +19,14 @@ addEventListener("DOMContentLoaded", () => {
   applyBindings(ui, os, vm);
   vm.setupEnterKeyHandler();
 });
-
+const allAuthOptions: Array<{ label: string; value: SupportedAuthTypes }> = [
+  { label: "None", value: "None" },
+  { label: "Username & Password (SASL/PLAIN)", value: "Basic" },
+  { label: "API Credentials (SASL/PLAIN)", value: "API" },
+  { label: "SASL/SCRAM", value: "SCRAM" },
+  { label: "SASL/OAUTHBEARER", value: "OAuth" },
+  { label: "Kerberos (SASL/GSSAPI)", value: "Kerberos" },
+];
 class DirectConnectFormViewModel extends ViewModel {
   /** Load connection spec if it exists (for Edit) */
   spec = this.resolve(async () => {
@@ -106,6 +113,19 @@ class DirectConnectFormViewModel extends ViewModel {
   schemaSslConfig = this.derive(() => {
     return this.spec()?.schema_registry?.ssl || {};
   });
+
+  /** Get valid auth types based on form connection type */
+  getValidAuthTypes = this.derive(() => {
+    switch (this.platformType()) {
+      case "Confluent Cloud":
+        return allAuthOptions.filter((auth) => ["API", "SCRAM", "OAuth"].includes(auth.value));
+      case "WarpStream":
+        return allAuthOptions.filter((auth) => ["Basic", "SCRAM"].includes(auth.value));
+      default:
+        return allAuthOptions;
+    }
+  });
+
   /** Form State */
   message = this.signal("");
   success = this.signal(false);
@@ -179,6 +199,12 @@ class DirectConnectFormViewModel extends ViewModel {
         if (input.value === "Confluent Cloud") {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
+          this.kafkaAuthType("API");
+          // this.schemaAuthType("API");
+        }
+        if (input.value === "WarpStream") {
+          this.kafkaAuthType("Basic");
+          // this.schemaAuthType("Basic");
         }
         break;
       case "kafka_cluster.auth_type":

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -275,6 +275,14 @@ class DirectConnectFormViewModel extends ViewModel {
       return;
     }
 
+    if (
+      data["formconnectiontype"] === "WarpStream" &&
+      data["kafka_cluster.auth_type"] === "SCRAM"
+    ) {
+      // Enforce SCRAM_SHA_512 for WarpStream in the data; that's all WarpStream supports
+      data["kafka_cluster.credentials.hash_algorithm"] = "SCRAM_SHA_512";
+    }
+
     if (data["formconnectiontype"] === "Confluent Cloud") {
       // these fields are disabled when CCloud selected; add them back in form data
       data["kafka_cluster.ssl.enabled"] = "true";

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -115,7 +115,7 @@ class DirectConnectFormViewModel extends ViewModel {
   });
 
   /** Get valid auth types based on form connection type */
-  getValidAuthTypes = this.derive(() => {
+  getValidKafkaAuthTypes = this.derive(() => {
     switch (this.platformType()) {
       case "Confluent Cloud":
         return allAuthOptions.filter((auth) => ["API", "SCRAM", "OAuth"].includes(auth.value));


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes https://github.com/confluentinc/vscode/issues/1255. 
- Built on https://github.com/confluentinc/vscode/pull/1413 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

| WarpStream SCRAM only allows SHA 512 |
| -- |
| <img width="317" height="347" alt="Screenshot 2025-07-22 at 8 24 05 AM" src="https://github.com/user-attachments/assets/d2f11fdf-826a-4c4b-aa8d-c0e2c8637008" /> |

- ⚠️ Caveat: with this change, users with existing warpstream connections that have set sha 256 will be forced to update the sha type if they edit. This is a good thing. And hopefully this is extremely rare as that combo was never supported and won't work anyways. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
