### PR TITLE
Only send the rarer / harder to explain sidecar startup errors to Sentry ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Changed (post-1.5 cut)
+
+- Only send the rarer / harder to explain sidecar startup errors to Sentry, so as
+to lower oncall spiking. Log any startup reason to Segment for tracking, however.
+
+## (pre-1.5 cut)
+
 ### Added
 
 - On Confluent Cloud topics, context menu now offers the option to "Query with Flink SQL"

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -37,8 +37,8 @@ import {
   killSidecar,
   normalizedSidecarPath,
   pause,
-  showSidecarStartupErrorMessage,
   spawn,
+  triageSidecarStartupError,
   wasConnRefused,
 } from "./utils";
 
@@ -192,23 +192,7 @@ export class SidecarManager {
       );
     } catch (e) {
       // This is the only place we show sidecar startup issues to the user.
-
-      // Ensure the error was logged to the error logger and Sentry.
-      if (e instanceof SidecarFatalError) {
-        logError(e, "Sidecar startup SidecarFatalError", {
-          extra: {
-            reason: e.reason,
-          },
-        });
-      } else {
-        logError(e, "Sidecar startup error", {
-          extra: {
-            reason: "Unknown",
-          },
-        });
-      }
-
-      void showSidecarStartupErrorMessage(e);
+      void triageSidecarStartupError(e);
 
       throw e;
     } finally {

--- a/src/telemetry/events.ts
+++ b/src/telemetry/events.ts
@@ -23,6 +23,7 @@ export enum UserEvent {
   FlinkStatementViewStatistics = "Flink Statement View Statistics",
   CopilotInteraction = "Copilot Interaction",
   FlinkSqlClientInteraction = "Flink SQL Language Client Interaction",
+  SidecarStartupFailure = "Sidecar Startup Failure",
   /**
    * Used for basic settings changes like enabling/disabling a feature or changing enum/numeric
    * values.


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Only send the rarer / harder to explain sidecar startup errors to Sentry, so as to lower oncall spiking. Log any startup reason to Segment for tracking, however.
- Closes #2206

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This moves the logError call from `startSidecar()` into the now `triageSidecarStartupError()`, which conditionalizes adding in the sentry payload based on the failure reason.
- Adds in unconditoinally logging the failure reason into a new Segment event.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
