### PR TITLE
fix: connections form not closing after save + falsely reporting "disconnected"

### DIFF
--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -73,7 +73,7 @@ export function openDirectConnectionForm(connection: CustomConnectionSpec | null
   // Listen to changes in connections and close the form if the connection no longer exists
   // Only needed for edit/update forms, not for new connections
   let connectionChangesListener: Disposable | null = null;
-  if (action && connection) {
+  if (action === "update" && connection) {
     connectionChangesListener = directConnectionsChanged.event(async () => {
       await handleConnectionChange(connection, directConnectForm);
     });

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -18,12 +18,12 @@ import { SupportedAuthTypes } from "./directConnections/types";
 import { directConnectionsChanged } from "./emitters";
 import { DEFAULT_KRB5_CONFIG_PATH, KRB5_CONFIG_PATH } from "./extensionSettings/constants";
 import { ConnectionId } from "./models/resource";
+import { showInfoNotificationWithButtons } from "./notifications";
 import { CustomConnectionSpec, getResourceManager } from "./storage/resourceManager";
 import { WebviewPanelCache } from "./webview-cache";
 import { handleWebviewMessage } from "./webview/comms/comms";
 import { PostResponse, TestResponse, post } from "./webview/direct-connect-form";
 import connectionFormTemplate from "./webview/direct-connect-form.html";
-import { showInfoNotificationWithButtons } from "./notifications";
 
 type MessageSender = OverloadUnion<typeof post>;
 type MessageResponse<MessageType extends string> = Awaited<

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -109,12 +109,12 @@ export function openDirectConnectionForm(connection: CustomConnectionSpec | null
     } else {
       result.success = true;
       // save and close the form
+      directConnectForm.dispose();
       await showInfoNotificationWithButtons(`New Connection Created`, {
         "Edit Connection": () => {
           commands.executeCommand("confluent.connections.direct.edit", newConnection.id);
         },
       });
-      directConnectForm.dispose();
     }
     return result;
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2189 which exposed two issues:
1. With the dispose call happening _after_ the `await window.showInfoNotificationWithButtons...`, the form wouldn't close after saving unless/until the user responded to the window notification. **Solution**: Move dispose call ahead of the line. 
2. The handler/listener for closing the form when a connection is deleted should not be invoked for New connections, including the Imported ones. **Solution**: Check for "update" action before creating `connectionChangesListener`

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
