### PR TITLE
chore: updates for test coverage and using Extension Test Runner

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -5,6 +5,18 @@ export default defineConfig([
     files: "out/**/*.test.js",
     mocha: {
       ui: "bdd",
+      color: true,
+      timeout: 10_000,
     },
+    launchArgs: [
+      "--no-sandbox",
+      "--profile-temp",
+      "--skip-release-notes",
+      "--skip-welcome",
+      "--disable-gpu",
+      "--disable-updates",
+      "--disable-workspace-trust",
+      "--disable-extensions",
+    ],
   },
 ]);

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -43,7 +43,6 @@ export async function run() {
   // mocha.suite.beforeEach("Global individual setup", globalBeforeEach);
 
   const failures = await new Promise<number>((resolve) => mocha.run(resolve));
-  if (failures > 0) throw new Error(`${failures} tests failed.`);
   // @ts-expect-error __coverage__ is what istanbul uses for storing coverage data
   const coverageData = global.__coverage__ ?? null;
   if (coverageData != null) {
@@ -51,6 +50,7 @@ export async function run() {
     const coverageFilePath = join(projectRoot, "coverage.json");
     await writeFile(coverageFilePath, JSON.stringify(coverageData));
   }
+  if (failures > 0) throw new Error(`${failures} tests failed.`);
 }
 
 async function globalBeforeAll() {


### PR DESCRIPTION
- updates our `.vscode-test.js` to use Mocha configs similar to [testing.ts](https://github.com/confluentinc/vscode/blob/3e75e714b820d110b957835c919a37897f91254b/src/testing.ts#L15-L19) (but no CI timeout since we can only run it locally) and [Gulpfile.ts](https://github.com/confluentinc/vscode/blob/3e75e714b820d110b957835c919a37897f91254b/Gulpfile.js#L679-L688)
- adjusts our test reporting so we always create a coverage report (and show it) even if tests fail