### PR TITLE
add CCloud private network settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
-- Only send the rarer / harder to explain sidecar startup errors to Sentry, so as to lower oncall
-  spiking. Log any startup reason to Segment for tracking, however.
+### Added
+
+- New "Set Private Network Endpoint(s)" command for configuring private network endpoints for a
+  specific CCloud environment.
+
+### Changed
+
+- Telemetry updates to only send less common sidecar startup errors to Sentry.
 
 ## 1.5.0
 

--- a/package.json
+++ b/package.json
@@ -782,6 +782,14 @@
             "default": false,
             "markdownDescription": "Disable SSL/TLS server certificate verification when making requests to Confluent/Kafka connections or resources.\n\n---\n\n⚠️ **WARNING**: This setting may allow a Man-in-the-Middle attack on the network connection between the Confluent extension and Confluent Cloud, which can lead to loss of sensitive data like credentials and PII. **_This should only be used for debugging purposes in non-production environments._**"
           },
+          "confluent.cloud.privateNetworkEndpoints": {
+            "type": "object",
+            "default": {},
+            "description": "Configure private network endpoints for specific Confluent Cloud environments. Each entry maps an environment ID to its corresponding private endpoints.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "confluent.ssl.pemPaths": {
             "type": "array",
             "items": {

--- a/package.json
+++ b/package.json
@@ -412,6 +412,12 @@
         "category": "Confluent: Resources"
       },
       {
+        "command": "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
+        "title": "Set Private Network Endpoint(s)",
+        "icon": "$(confluent-environment)",
+        "category": "Confluent: Resources"
+      },
+      {
         "command": "confluent.resources.flink-compute-pool.select",
         "icon": "$(confluent-flink-compute-pool)",
         "title": "Select Flink Compute Pool",
@@ -1317,6 +1323,10 @@
         {
           "command": "confluent.flink.statements.search.clear",
           "when": "confluent.flinkStatementsSearchApplied"
+        },
+        {
+          "command": "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
+          "when": "false"
         }
       ],
       "editor/title": [
@@ -1690,6 +1700,11 @@
         {
           "command": "confluent.topics.query",
           "when": "view == confluent-topics && viewItem =~ /ccloud-kafka-topic.*-flinkable.*/",
+          "group": "z_openInCloud"
+        },
+        {
+          "command": "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
+          "when": "view == confluent-resources && viewItem =~ /.*ccloud-environment/",
           "group": "z_openInCloud"
         },
         {

--- a/src/commands/environments.test.ts
+++ b/src/commands/environments.test.ts
@@ -1,0 +1,216 @@
+import * as sinon from "sinon";
+import { commands, window } from "vscode";
+import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
+import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
+import { currentFlinkStatementsResourceChanged } from "../emitters";
+import { CCLOUD_PRIVATE_NETWORK_ENDPOINTS } from "../extensionSettings/constants";
+import * as notifications from "../notifications";
+import * as envQuickpicks from "../quickpicks/environments";
+import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
+import * as envCommands from "./environments";
+
+describe("commands/environments.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("setFlinkStatementsEnvironmentCommand()", () => {
+    let flinkStatementsViewProvider: sinon.SinonStubbedInstance<FlinkStatementsViewProvider>;
+    let flinkCcloudEnvironmentQuickPickStub: sinon.SinonStub;
+    let currentFlinkStatementsResourceChangedStub: sinon.SinonStub;
+    let executeCommandStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      flinkStatementsViewProvider = sandbox.createStubInstance(FlinkStatementsViewProvider);
+      flinkStatementsViewProvider.withProgress.callsFake(async (options, task) => await task());
+      sandbox.stub(FlinkStatementsViewProvider, "getInstance").returns(flinkStatementsViewProvider);
+
+      flinkCcloudEnvironmentQuickPickStub = sandbox
+        .stub(envQuickpicks, "flinkCcloudEnvironmentQuickPick")
+        .resolves();
+
+      currentFlinkStatementsResourceChangedStub = sandbox.stub(
+        currentFlinkStatementsResourceChanged,
+        "fire",
+      );
+
+      executeCommandStub = sandbox.stub(commands, "executeCommand").resolves();
+    });
+
+    afterEach(() => {
+      flinkStatementsViewProvider.dispose();
+      sandbox.restore();
+    });
+
+    it("should show a (Flink) CCloud environment quickpick if no env is provided", async () => {
+      // user chooses an environment from the quickpick
+      flinkCcloudEnvironmentQuickPickStub.resolves(TEST_CCLOUD_ENVIRONMENT);
+
+      await envCommands.setFlinkStatementsEnvironmentCommand();
+
+      sinon.assert.calledOnce(flinkStatementsViewProvider.withProgress);
+      sinon.assert.calledWith(
+        flinkStatementsViewProvider.withProgress,
+        "Select Environment",
+        sinon.match.func,
+      );
+
+      sinon.assert.calledOnce(flinkCcloudEnvironmentQuickPickStub);
+      sinon.assert.calledOnce(currentFlinkStatementsResourceChangedStub);
+      sinon.assert.calledWith(currentFlinkStatementsResourceChangedStub, TEST_CCLOUD_ENVIRONMENT);
+      sinon.assert.calledOnce(executeCommandStub);
+      sinon.assert.calledWith(executeCommandStub, "confluent-flink-statements.focus");
+    });
+
+    it("should exit early if no environment is selected from the quickpick", async () => {
+      // user cancels the quickpick
+      flinkCcloudEnvironmentQuickPickStub.resolves(undefined);
+
+      await envCommands.setFlinkStatementsEnvironmentCommand();
+
+      sinon.assert.calledOnce(flinkStatementsViewProvider.withProgress);
+      sinon.assert.calledWith(
+        flinkStatementsViewProvider.withProgress,
+        "Select Environment",
+        sinon.match.func,
+      );
+      sinon.assert.calledOnce(flinkCcloudEnvironmentQuickPickStub);
+      sinon.assert.notCalled(currentFlinkStatementsResourceChangedStub);
+      sinon.assert.notCalled(executeCommandStub);
+    });
+
+    it("should skip the quickpick if a CCloud environment is passed", async () => {
+      await envCommands.setFlinkStatementsEnvironmentCommand(TEST_CCLOUD_ENVIRONMENT);
+
+      sinon.assert.notCalled(flinkStatementsViewProvider.withProgress);
+      sinon.assert.notCalled(flinkCcloudEnvironmentQuickPickStub);
+      sinon.assert.calledOnce(currentFlinkStatementsResourceChangedStub);
+      sinon.assert.calledWith(currentFlinkStatementsResourceChangedStub, TEST_CCLOUD_ENVIRONMENT);
+      sinon.assert.calledOnce(executeCommandStub);
+      sinon.assert.calledWith(executeCommandStub, "confluent-flink-statements.focus");
+    });
+  });
+
+  describe("setPrivateNetworkEndpointCommand()", () => {
+    let ccloudEnvironmentQuickPickStub: sinon.SinonStub;
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
+    let showInputBoxStub: sinon.SinonStub;
+    let showInfoNotificationWithButtonsStub: sinon.SinonStub;
+
+    const fakeEndpoints = "private.network.endpoint1,private.network.endpoint2";
+
+    beforeEach(() => {
+      ccloudEnvironmentQuickPickStub = sandbox
+        .stub(envQuickpicks, "ccloudEnvironmentQuickPick")
+        .resolves(TEST_CCLOUD_ENVIRONMENT);
+
+      // no private network endpoints set by default
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
+      stubbedConfigs.stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, {});
+
+      showInputBoxStub = sandbox.stub(window, "showInputBox").resolves(fakeEndpoints);
+
+      showInfoNotificationWithButtonsStub = sandbox.stub(
+        notifications,
+        "showInfoNotificationWithButtons",
+      );
+    });
+
+    it("should show a CCloud environment quickpick if no argument is provided", async () => {
+      await envCommands.setPrivateNetworkEndpointCommand();
+
+      sinon.assert.calledOnce(ccloudEnvironmentQuickPickStub);
+    });
+
+    it("should exit early if no environment is selected from the quickpick", async () => {
+      ccloudEnvironmentQuickPickStub.resolves(undefined);
+
+      await envCommands.setPrivateNetworkEndpointCommand();
+
+      sinon.assert.calledOnce(ccloudEnvironmentQuickPickStub);
+      sinon.assert.notCalled(showInputBoxStub);
+      sinon.assert.notCalled(stubbedConfigs.update);
+      sinon.assert.notCalled(showInfoNotificationWithButtonsStub);
+    });
+
+    it("should skip the quickpick if a CCloud environment is provided", async () => {
+      await envCommands.setPrivateNetworkEndpointCommand(TEST_CCLOUD_ENVIRONMENT);
+
+      sinon.assert.notCalled(ccloudEnvironmentQuickPickStub);
+    });
+
+    it("should show an input box to set private network endpoints", async () => {
+      await envCommands.setPrivateNetworkEndpointCommand(TEST_CCLOUD_ENVIRONMENT);
+
+      sinon.assert.calledOnce(showInputBoxStub);
+      sinon.assert.calledOnceWithExactly(showInputBoxStub, {
+        title: "Set Private Network Endpoint(s)",
+        prompt: `Enter private network endpoint(s) for environment "${TEST_CCLOUD_ENVIRONMENT.name}" (${TEST_CCLOUD_ENVIRONMENT.id}), separated by commas.`,
+        placeHolder: "endpoint1,endpoint2",
+        value: sinon.match.string,
+        ignoreFocusOut: true,
+      });
+    });
+
+    it("should exit early if the user cancels the input box", async () => {
+      // user cancels the input box
+      showInputBoxStub.resolves(undefined);
+
+      await envCommands.setPrivateNetworkEndpointCommand(TEST_CCLOUD_ENVIRONMENT);
+
+      sinon.assert.calledOnce(showInputBoxStub);
+      sinon.assert.notCalled(stubbedConfigs.update);
+      sinon.assert.notCalled(showInfoNotificationWithButtonsStub);
+    });
+
+    it(`should update the "${CCLOUD_PRIVATE_NETWORK_ENDPOINTS.id}" setting and show a notification`, async () => {
+      await envCommands.setPrivateNetworkEndpointCommand(TEST_CCLOUD_ENVIRONMENT);
+
+      sinon.assert.calledOnce(stubbedConfigs.update);
+      sinon.assert.calledWith(
+        stubbedConfigs.update,
+        CCLOUD_PRIVATE_NETWORK_ENDPOINTS.id,
+        {
+          [TEST_CCLOUD_ENVIRONMENT.id]: fakeEndpoints,
+        },
+        true,
+      );
+
+      sinon.assert.calledOnce(showInfoNotificationWithButtonsStub);
+      sinon.assert.calledOnceWithMatch(
+        showInfoNotificationWithButtonsStub,
+        `Private network endpoint(s) for environment "${TEST_CCLOUD_ENVIRONMENT.name}" (${TEST_CCLOUD_ENVIRONMENT.id}) set to "${fakeEndpoints}"`,
+        {
+          ["Change For Environment"]: sinon.match.func,
+          ["View Settings"]: sinon.match.func,
+        },
+      );
+    });
+
+    it(`should not replace existing endpoints for other environments when updating "${CCLOUD_PRIVATE_NETWORK_ENDPOINTS.id}"`, async () => {
+      const existingEndpoints = {
+        env1: "existing.endpoint1,existing.endpoint2",
+      };
+      stubbedConfigs.stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, existingEndpoints);
+
+      await envCommands.setPrivateNetworkEndpointCommand(TEST_CCLOUD_ENVIRONMENT);
+
+      sinon.assert.calledOnce(stubbedConfigs.update);
+      sinon.assert.calledWith(
+        stubbedConfigs.update,
+        CCLOUD_PRIVATE_NETWORK_ENDPOINTS.id,
+        {
+          ...existingEndpoints,
+          [TEST_CCLOUD_ENVIRONMENT.id]: fakeEndpoints,
+        },
+        true,
+      );
+    });
+  });
+});

--- a/src/commands/environments.ts
+++ b/src/commands/environments.ts
@@ -1,7 +1,9 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { currentFlinkStatementsResourceChanged } from "../emitters";
+import { CCLOUD_PRIVATE_NETWORK_ENDPOINTS } from "../extensionSettings/constants";
 import { CCloudEnvironment } from "../models/environment";
+import { showInfoNotificationWithButtons } from "../notifications";
 import { flinkCcloudEnvironmentQuickPick } from "../quickpicks/environments";
 import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 
@@ -26,11 +28,48 @@ async function setFlinkStatementsEnvironmentCommand(item?: CCloudEnvironment): P
   await vscode.commands.executeCommand("confluent-flink-statements.focus");
 }
 
+/** Sets the private network endpoint(s) for a specific Confluent Cloud environment. */
+export async function setPrivateNetworkEndpointCommand(item: CCloudEnvironment): Promise<void> {
+  if (!(item instanceof CCloudEnvironment)) {
+    return;
+  }
+  const existingPrivateEndpoints: Record<string, string> = CCLOUD_PRIVATE_NETWORK_ENDPOINTS.value;
+  const newEndpointsValue: string | undefined = await vscode.window.showInputBox({
+    title: "Set Private Network Endpoint(s)",
+    prompt: `Enter private network endpoint(s) for environment "${item.name}" (${item.id}), separated by commas.`,
+    placeHolder: "endpoint1,endpoint2",
+    value: existingPrivateEndpoints[item.id] || "",
+    ignoreFocusOut: true,
+  });
+  if (newEndpointsValue === undefined) {
+    return;
+  }
+  existingPrivateEndpoints[item.id] = newEndpointsValue.trim();
+  await CCLOUD_PRIVATE_NETWORK_ENDPOINTS.update(existingPrivateEndpoints, true);
+
+  void showInfoNotificationWithButtons(
+    `Private network endpoint(s) for environment "${item.name}" (${item.id}) set to "${newEndpointsValue}"`,
+    {
+      ["Change For Environment"]: async () => await setPrivateNetworkEndpointCommand(item),
+      ["View Settings"]: async () => {
+        await vscode.commands.executeCommand(
+          "workbench.action.openSettings",
+          `@id:${CCLOUD_PRIVATE_NETWORK_ENDPOINTS.id}`,
+        );
+      },
+    },
+  );
+}
+
 export function registerEnvironmentCommands(): vscode.Disposable[] {
   return [
     registerCommandWithLogging(
       "confluent.resources.ccloudenvironment.viewflinkstatements",
       setFlinkStatementsEnvironmentCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
+      setPrivateNetworkEndpointCommand,
     ),
   ];
 }

--- a/src/extensionSettings/constants.ts
+++ b/src/extensionSettings/constants.ts
@@ -48,6 +48,14 @@ export const SSL_VERIFY_SERVER_CERT_DISABLED = new ExtensionSetting<boolean>(
   "confluent.debugging.sslTls.serverCertificateVerificationDisabled",
   SettingsSection.CCLOUD,
 );
+/**
+ * Configure private network endpoints for specific Confluent Cloud environments.
+ * Each entry maps an environment ID to its corresponding private endpoints.
+ */
+export const CCLOUD_PRIVATE_NETWORK_ENDPOINTS = new ExtensionSetting<Record<string, string>>(
+  "confluent.cloud.privateNetworkEndpoints",
+  SettingsSection.CCLOUD,
+);
 /** Array of string paths pointing to .pem files in the current environment for SSL/TLS. */
 export const SSL_PEM_PATHS = new ExtensionSetting<string[]>(
   "confluent.ssl.pemPaths",

--- a/src/extensionSettings/listener.ts
+++ b/src/extensionSettings/listener.ts
@@ -14,7 +14,7 @@ import {
 } from "./constants";
 import { updatePreferences } from "./sidecarSync";
 
-const logger = new Logger("preferences.listener");
+const logger = new Logger("extensionSettings.listener");
 
 /** Any settings that require syncing with the sidecar's preferences API. */
 export const PREFERENCES_SYNC_SETTINGS = [

--- a/src/extensionSettings/listener.ts
+++ b/src/extensionSettings/listener.ts
@@ -4,6 +4,7 @@ import { FlinkLanguageClientManager } from "../flinkSql/flinkLanguageClientManag
 import { Logger } from "../logging";
 import { logUsage, UserEvent } from "../telemetry/events";
 import {
+  CCLOUD_PRIVATE_NETWORK_ENDPOINTS,
   ENABLE_CHAT_PARTICIPANT,
   ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER,
   KRB5_CONFIG_PATH,
@@ -15,35 +16,34 @@ import { updatePreferences } from "./sidecarSync";
 
 const logger = new Logger("preferences.listener");
 
+/** Any settings that require syncing with the sidecar's preferences API. */
+export const PREFERENCES_SYNC_SETTINGS = [
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+  KRB5_CONFIG_PATH,
+  CCLOUD_PRIVATE_NETWORK_ENDPOINTS,
+];
+
 /** Main listener for any changes to workspace settings. */
 export function createConfigChangeListener(): Disposable {
   // NOTE: this fires from any VS Code configuration, not just configs from our extension
   const disposable: Disposable = workspace.onDidChangeConfiguration(
     async (event: ConfigurationChangeEvent) => {
-      if (event.affectsConfiguration(SSL_PEM_PATHS.id)) {
-        // inform the sidecar that the SSL/TLS .pem paths have changed
-        logger.debug(`"${SSL_PEM_PATHS.id}" config changed`);
-        await updatePreferences();
-        return;
-      }
-
-      if (event.affectsConfiguration(SSL_VERIFY_SERVER_CERT_DISABLED.id)) {
-        // inform the sidecar that the server cert verification has changed
-        logger.debug(`"${SSL_VERIFY_SERVER_CERT_DISABLED.id}" config changed`);
+      const changedId = PREFERENCES_SYNC_SETTINGS.find((setting) =>
+        event.affectsConfiguration(setting.id),
+      );
+      if (changedId) {
+        logger.debug(`"${changedId.id}" setting changed`);
         await updatePreferences();
         return;
       }
 
       if (event.affectsConfiguration(LOCAL_DOCKER_SOCKET_PATH.id)) {
         // just log it so we don't have to log every time we use it
-        logger.debug(`"${LOCAL_DOCKER_SOCKET_PATH.id}" changed:`, LOCAL_DOCKER_SOCKET_PATH.value);
-        return;
-      }
-
-      if (event.affectsConfiguration(KRB5_CONFIG_PATH.id)) {
-        // inform the sidecar that the krb5 config path has changed
-        logger.debug(`"${KRB5_CONFIG_PATH.id}" config changed`);
-        await updatePreferences();
+        logger.debug(
+          `"${LOCAL_DOCKER_SOCKET_PATH.id}" setting changed:`,
+          LOCAL_DOCKER_SOCKET_PATH.value,
+        );
         return;
       }
 
@@ -53,7 +53,7 @@ export function createConfigChangeListener(): Disposable {
       if (event.affectsConfiguration(ENABLE_CHAT_PARTICIPANT.id)) {
         // user toggled the "Enable Chat Participant" experimental setting
         const enabled: boolean = ENABLE_CHAT_PARTICIPANT.value;
-        logger.debug(`"${ENABLE_CHAT_PARTICIPANT.id}" config changed`, { enabled });
+        logger.debug(`"${ENABLE_CHAT_PARTICIPANT.id}" setting changed`, { enabled });
         setContextValue(ContextValues.chatParticipantEnabled, enabled);
         // telemetry for how often users opt in or out of the chat participant feature
         logUsage(UserEvent.ExtensionSettingsChange, {
@@ -67,7 +67,7 @@ export function createConfigChangeListener(): Disposable {
         // user toggled the "Enable Flink CCloud Language Server" preview setting
         // TODO when we remove this flag and settings listener, remove the undefined uri option in `maybeStartLanguageClient`
         const enabled: boolean = ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER.value;
-        logger.debug(`"${ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER.id}" config changed`, { enabled });
+        logger.debug(`"${ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER.id}" setting changed`, { enabled });
 
         const manager = FlinkLanguageClientManager.getInstance();
         if (enabled) {

--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -161,7 +161,7 @@ describe("extensionSettings/sidecarSync.ts", function () {
           tls_pem_paths: tlsPemPaths,
           trust_all_certificates: trustAllCerts,
           flink_private_endpoints: updates.splitPrivateNetworkEndpoints(privateNetworkEndpoints),
-        } as any,
+        },
       };
       stubbedPreferencesResourceApi.gatewayV1PreferencesPut.resolves(fakePreferences);
 

--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -12,7 +12,12 @@ import {
 import * as errors from "../errors";
 import * as notifications from "../notifications";
 import * as sidecar from "../sidecar";
-import { KRB5_CONFIG_PATH, SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
+import {
+  CCLOUD_PRIVATE_NETWORK_ENDPOINTS,
+  KRB5_CONFIG_PATH,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 import * as updates from "./sidecarSync";
 import { loadPreferencesFromWorkspaceConfig } from "./sidecarSync";
 
@@ -54,7 +59,8 @@ describe("extensionSettings/sidecarSync.ts", function () {
     stubbedConfigs
       .stubGet(SSL_PEM_PATHS, SSL_PEM_PATHS.defaultValue)
       .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, SSL_VERIFY_SERVER_CERT_DISABLED.defaultValue)
-      .stubGet(KRB5_CONFIG_PATH, KRB5_CONFIG_PATH.defaultValue);
+      .stubGet(KRB5_CONFIG_PATH, KRB5_CONFIG_PATH.defaultValue)
+      .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, CCLOUD_PRIVATE_NETWORK_ENDPOINTS.defaultValue);
 
     const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
 
@@ -62,6 +68,7 @@ describe("extensionSettings/sidecarSync.ts", function () {
       tls_pem_paths: SSL_PEM_PATHS.defaultValue,
       trust_all_certificates: SSL_VERIFY_SERVER_CERT_DISABLED.defaultValue,
       kerberos_config_file_path: KRB5_CONFIG_PATH.defaultValue,
+      private_network_endpoints: CCLOUD_PRIVATE_NETWORK_ENDPOINTS.defaultValue,
     });
   });
 
@@ -70,10 +77,15 @@ describe("extensionSettings/sidecarSync.ts", function () {
     const tlsPemPaths: string[] = ["path/to/custom.pem"];
     const trustAllCerts = true;
     const krb5Config = "path/to/custom/krb5.conf";
+    const privateNetworkEndpoints: Record<string, string> = {
+      env1: "endpoint1",
+      env2: "endpoint2",
+    };
     stubbedConfigs
       .stubGet(SSL_PEM_PATHS, tlsPemPaths)
       .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, trustAllCerts)
-      .stubGet(KRB5_CONFIG_PATH, krb5Config);
+      .stubGet(KRB5_CONFIG_PATH, krb5Config)
+      .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, privateNetworkEndpoints);
 
     const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
 
@@ -81,6 +93,7 @@ describe("extensionSettings/sidecarSync.ts", function () {
       kerberos_config_file_path: krb5Config,
       tls_pem_paths: tlsPemPaths,
       trust_all_certificates: trustAllCerts,
+      private_network_endpoints: privateNetworkEndpoints,
     });
   });
 
@@ -89,10 +102,15 @@ describe("extensionSettings/sidecarSync.ts", function () {
     const tlsPemPaths: string[] = ["path/to/custom.pem"];
     const trustAllCerts = true;
     const krb5Config = "path/to/custom/krb5.conf";
+    const privateNetworkEndpoints: Record<string, string> = {
+      env1: "endpoint1",
+      env2: "endpoint2",
+    };
     stubbedConfigs
       .stubGet(SSL_PEM_PATHS, tlsPemPaths)
       .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, trustAllCerts)
-      .stubGet(KRB5_CONFIG_PATH, krb5Config);
+      .stubGet(KRB5_CONFIG_PATH, krb5Config)
+      .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, privateNetworkEndpoints);
 
     const fakePreferences: Preferences = {
       api_version: "gateway/v1",
@@ -101,7 +119,8 @@ describe("extensionSettings/sidecarSync.ts", function () {
         kerberos_config_file_path: krb5Config,
         tls_pem_paths: tlsPemPaths,
         trust_all_certificates: trustAllCerts,
-      },
+        private_network_endpoints: privateNetworkEndpoints,
+      } as any,
     };
     mockClient.gatewayV1PreferencesPut.resolves(fakePreferences);
 

--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -22,7 +22,7 @@ import {
 import * as updates from "./sidecarSync";
 import { loadPreferencesFromWorkspaceConfig } from "./sidecarSync";
 
-describe.only("extensionSettings/sidecarSync.ts", function () {
+describe("extensionSettings/sidecarSync.ts", function () {
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(function () {

--- a/src/extensionSettings/sidecarSync.test.ts
+++ b/src/extensionSettings/sidecarSync.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
+import { getSidecarStub } from "../../tests/stubs/sidecar";
 import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
 import {
   JsonNode,
@@ -21,228 +22,269 @@ import {
 import * as updates from "./sidecarSync";
 import { loadPreferencesFromWorkspaceConfig } from "./sidecarSync";
 
-describe("extensionSettings/sidecarSync.ts", function () {
+describe.only("extensionSettings/sidecarSync.ts", function () {
   let sandbox: sinon.SinonSandbox;
-  let mockClient: sinon.SinonStubbedInstance<PreferencesResourceApi>;
-  let stubbedConfigs: StubbedWorkspaceConfiguration;
-  let logErrorStub: sinon.SinonStub;
-  let showErrorNotificationWithButtonsStub: sinon.SinonStub;
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-
-    logErrorStub = sandbox.stub(errors, "logError");
-
-    // create the stubs for the sidecar + service client
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
-    mockClient = sandbox.createStubInstance(PreferencesResourceApi);
-    mockSidecarHandle.getPreferencesApi.returns(mockClient);
-    // stub the getSidecar function to return the mock sidecar handle
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
-
-    stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
-
-    // stub the notifications
-    showErrorNotificationWithButtonsStub = sandbox.stub(
-      notifications,
-      "showErrorNotificationWithButtons",
-    );
   });
 
   afterEach(function () {
     sandbox.restore();
   });
 
-  it("loadDefaultPreferences() should load default preferences from the workspace configuration", async function () {
-    // default values, no user changes
-    stubbedConfigs
-      .stubGet(SSL_PEM_PATHS, SSL_PEM_PATHS.defaultValue)
-      .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, SSL_VERIFY_SERVER_CERT_DISABLED.defaultValue)
-      .stubGet(KRB5_CONFIG_PATH, KRB5_CONFIG_PATH.defaultValue)
-      .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, CCLOUD_PRIVATE_NETWORK_ENDPOINTS.defaultValue);
+  describe("loadDefaultPreferences()", function () {
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
 
-    const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
-
-    assert.deepStrictEqual(result, {
-      tls_pem_paths: SSL_PEM_PATHS.defaultValue,
-      trust_all_certificates: SSL_VERIFY_SERVER_CERT_DISABLED.defaultValue,
-      kerberos_config_file_path: KRB5_CONFIG_PATH.defaultValue,
-      private_network_endpoints: CCLOUD_PRIVATE_NETWORK_ENDPOINTS.defaultValue,
+    beforeEach(function () {
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
     });
-  });
 
-  it("loadDefaultPreferences() should load preferences with custom values", async function () {
-    // simulate user changing from the default values
-    const tlsPemPaths: string[] = ["path/to/custom.pem"];
-    const trustAllCerts = true;
-    const krb5Config = "path/to/custom/krb5.conf";
-    const privateNetworkEndpoints: Record<string, string> = {
-      env1: "endpoint1",
-      env2: "endpoint2",
-    };
-    stubbedConfigs
-      .stubGet(SSL_PEM_PATHS, tlsPemPaths)
-      .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, trustAllCerts)
-      .stubGet(KRB5_CONFIG_PATH, krb5Config)
-      .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, privateNetworkEndpoints);
+    it("should load default preferences from the workspace configuration", async function () {
+      // default values, no user changes
+      stubbedConfigs
+        .stubGet(SSL_PEM_PATHS, SSL_PEM_PATHS.defaultValue)
+        .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, SSL_VERIFY_SERVER_CERT_DISABLED.defaultValue)
+        .stubGet(KRB5_CONFIG_PATH, KRB5_CONFIG_PATH.defaultValue)
+        .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, CCLOUD_PRIVATE_NETWORK_ENDPOINTS.defaultValue);
 
-    const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
+      const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
 
-    assert.deepStrictEqual(result, {
-      kerberos_config_file_path: krb5Config,
-      tls_pem_paths: tlsPemPaths,
-      trust_all_certificates: trustAllCerts,
-      private_network_endpoints: privateNetworkEndpoints,
+      assert.deepStrictEqual(result, {
+        tls_pem_paths: SSL_PEM_PATHS.defaultValue,
+        trust_all_certificates: SSL_VERIFY_SERVER_CERT_DISABLED.defaultValue,
+        kerberos_config_file_path: KRB5_CONFIG_PATH.defaultValue,
+        flink_private_endpoints: CCLOUD_PRIVATE_NETWORK_ENDPOINTS.defaultValue,
+      });
     });
-  });
 
-  it("updatePreferences() should update preferences successfully based on workspace configs", async function () {
-    // simulate user changing from the default values
-    const tlsPemPaths: string[] = ["path/to/custom.pem"];
-    const trustAllCerts = true;
-    const krb5Config = "path/to/custom/krb5.conf";
-    const privateNetworkEndpoints: Record<string, string> = {
-      env1: "endpoint1",
-      env2: "endpoint2",
-    };
-    stubbedConfigs
-      .stubGet(SSL_PEM_PATHS, tlsPemPaths)
-      .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, trustAllCerts)
-      .stubGet(KRB5_CONFIG_PATH, krb5Config)
-      .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, privateNetworkEndpoints);
+    it("should load preferences with custom values", async function () {
+      // simulate user changing from the default values
+      const tlsPemPaths: string[] = ["path/to/custom.pem"];
+      const trustAllCerts = true;
+      const krb5Config = "path/to/custom/krb5.conf";
+      const endpoints: string[] = ["endpoint1a,endpoint1b ", "endpoint2"];
+      const privateNetworkEndpoints: Record<string, string> = {
+        env1: endpoints[0],
+        env2: endpoints[1],
+      };
+      stubbedConfigs
+        .stubGet(SSL_PEM_PATHS, tlsPemPaths)
+        .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, trustAllCerts)
+        .stubGet(KRB5_CONFIG_PATH, krb5Config)
+        .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, privateNetworkEndpoints);
 
-    const fakePreferences: Preferences = {
-      api_version: "gateway/v1",
-      kind: "Preferences",
-      spec: {
+      const result: PreferencesSpec = loadPreferencesFromWorkspaceConfig();
+
+      assert.deepStrictEqual(result, {
         kerberos_config_file_path: krb5Config,
         tls_pem_paths: tlsPemPaths,
         trust_all_certificates: trustAllCerts,
-        private_network_endpoints: privateNetworkEndpoints,
-      } as any,
-    };
-    mockClient.gatewayV1PreferencesPut.resolves(fakePreferences);
-
-    await updates.updatePreferences();
-
-    sinon.assert.calledWithExactly(mockClient.gatewayV1PreferencesPut, {
-      Preferences: fakePreferences,
+        flink_private_endpoints: {
+          env1: ["endpoint1a", "endpoint1b"], // comma-split and whitespace-trimmed
+          env2: ["endpoint2"],
+        },
+      });
     });
-    sinon.assert.notCalled(logErrorStub);
-    sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
   });
 
-  it("updatePreferences() should log and not re-throw errors when syncing settings to the sidecar preferences API", async function () {
-    const errorMessage = "Failed to update preferences";
-    const error = new Error(errorMessage);
-    mockClient.gatewayV1PreferencesPut.rejects(error);
+  describe("splitPrivateNetworkEndpoints()", function () {
+    it("should split private network endpoints into a Record of string arrays", function () {
+      const rawEndpoints: Record<string, string> = {
+        env1: "endpoint1a, endpoint1b",
+        env2: "endpoint2",
+      };
+      const result = updates.splitPrivateNetworkEndpoints(rawEndpoints);
 
-    await updates.updatePreferences();
+      assert.deepStrictEqual(result, {
+        env1: ["endpoint1a", "endpoint1b"],
+        env2: ["endpoint2"],
+      });
+    });
 
-    sinon.assert.calledOnce(mockClient.gatewayV1PreferencesPut);
-    sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
-    assert.strictEqual(callArgs[0], `Failed to sync settings: ${errorMessage}`);
-    // non-ResponseError should go to Sentry
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      sinon.match.instanceOf(Error).and(sinon.match.has("message", errorMessage)),
-      "syncing settings to sidecar preferences API",
-      { extra: { functionName: "updatePreferences" } },
-    );
+    it("should handle empty values and whitespace", function () {
+      const rawEndpoints: Record<string, string> = {
+        env1: "  , endpoint1b,  ",
+        env2: "endpoint2,  ",
+      };
+      const result = updates.splitPrivateNetworkEndpoints(rawEndpoints);
+
+      assert.deepStrictEqual(result, {
+        env1: ["endpoint1b"],
+        env2: ["endpoint2"],
+      });
+    });
   });
 
-  it("updatePreferences() should show an error notification when an Error is caught", async function () {
-    const error = new Error("uh oh");
-    mockClient.gatewayV1PreferencesPut.rejects(error);
+  describe("updatePreferences()", function () {
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
+    let logErrorStub: sinon.SinonStub;
+    let showErrorNotificationWithButtonsStub: sinon.SinonStub;
+    let stubbedSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle>;
+    let stubbedPreferencesResourceApi: sinon.SinonStubbedInstance<PreferencesResourceApi>;
 
-    await updates.updatePreferences();
+    beforeEach(function () {
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
 
-    sinon.assert.calledOnce(logErrorStub);
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
-      "syncing settings to sidecar preferences API",
-      { extra: { functionName: "updatePreferences" } },
-    );
+      logErrorStub = sandbox.stub(errors, "logError");
 
-    sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
-    assert.strictEqual(callArgs[0], `Failed to sync settings: ${error.message}`);
-  });
+      showErrorNotificationWithButtonsStub = sandbox.stub(
+        notifications,
+        "showErrorNotificationWithButtons",
+      );
 
-  it("updatePreferences() should show an error notification with a settings button when a ResponseError (status 400) is caught and valid failure errors are returned", async function () {
-    const errorResponse = new Response("Bad Request", { status: 400 });
-    const fakeFailureError = {
-      code: "cert_not_found",
-      title: "Cert file cannot be found",
-      detail: "The cert file '/foo/bar/baz' cannot be found.",
-      source: "/spec/tls_pem_paths" as JsonNode, // pointer to the specific field, not actual object
-    } satisfies SidecarError;
-    sandbox.stub(errorResponse, "clone").returns(errorResponse);
-    sandbox.stub(errorResponse, "json").resolves({ errors: [fakeFailureError] });
-    const error = new ResponseError(errorResponse);
+      stubbedPreferencesResourceApi = sandbox.createStubInstance(PreferencesResourceApi);
+      stubbedSidecarHandle = getSidecarStub(sandbox);
+      stubbedSidecarHandle.getPreferencesApi.returns(stubbedPreferencesResourceApi);
+    });
 
-    mockClient.gatewayV1PreferencesPut.rejects(error);
+    it("should update preferences successfully based on workspace configs", async function () {
+      // simulate user changing from the default values
+      const tlsPemPaths: string[] = ["path/to/custom.pem"];
+      const trustAllCerts = true;
+      const krb5Config = "path/to/custom/krb5.conf";
+      const privateNetworkEndpoints: Record<string, string> = {
+        env1: "endpoint1",
+        env2: "endpoint2",
+      };
+      stubbedConfigs
+        .stubGet(SSL_PEM_PATHS, tlsPemPaths)
+        .stubGet(SSL_VERIFY_SERVER_CERT_DISABLED, trustAllCerts)
+        .stubGet(KRB5_CONFIG_PATH, krb5Config)
+        .stubGet(CCLOUD_PRIVATE_NETWORK_ENDPOINTS, privateNetworkEndpoints);
 
-    await updates.updatePreferences();
+      const fakePreferences: Preferences = {
+        api_version: "gateway/v1",
+        kind: "Preferences",
+        spec: {
+          kerberos_config_file_path: krb5Config,
+          tls_pem_paths: tlsPemPaths,
+          trust_all_certificates: trustAllCerts,
+          flink_private_endpoints: updates.splitPrivateNetworkEndpoints(privateNetworkEndpoints),
+        } as any,
+      };
+      stubbedPreferencesResourceApi.gatewayV1PreferencesPut.resolves(fakePreferences);
 
-    sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    sinon.assert.calledOnceWithExactly(
-      showErrorNotificationWithButtonsStub,
-      `Failed to sync settings: ${fakeFailureError.detail}`,
-      {
-        "Update Settings": sinon.match.func,
-        "Open Logs": sinon.match.func,
-        "File Issue": sinon.match.func,
-      },
-    );
-    // not sending error 400s to Sentry
-    sinon.assert.calledOnce(logErrorStub);
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      error,
-      "syncing settings to sidecar preferences API",
-      {},
-    );
-  });
+      await updates.updatePreferences();
 
-  it("updatePreferences() should show an error notification with a settings button when a ResponseError (non-400 status) is caught and valid failure errors are returned", async function () {
-    const errorResponse = new Response("Internal server error", { status: 500 });
-    const fakeFailureError = {
-      code: "cert_not_found",
-      title: "Cert file cannot be found",
-      detail: "The cert file '/foo/bar/baz' cannot be found.",
-      source: "/spec/tls_pem_paths" as JsonNode, // pointer to the specific field, not actual object
-    } satisfies SidecarError;
-    sandbox.stub(errorResponse, "clone").returns(errorResponse);
-    sandbox.stub(errorResponse, "json").resolves({ errors: [fakeFailureError] });
-    const error = new ResponseError(errorResponse);
+      sinon.assert.calledWithExactly(stubbedPreferencesResourceApi.gatewayV1PreferencesPut, {
+        Preferences: fakePreferences,
+      });
+      sinon.assert.notCalled(logErrorStub);
+      sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
+    });
 
-    mockClient.gatewayV1PreferencesPut.rejects(error);
+    it("should log and not re-throw errors when syncing settings to the sidecar preferences API", async function () {
+      const errorMessage = "Failed to update preferences";
+      const error = new Error(errorMessage);
+      stubbedPreferencesResourceApi.gatewayV1PreferencesPut.rejects(error);
 
-    await updates.updatePreferences();
+      await updates.updatePreferences();
 
-    sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
-    sinon.assert.calledOnceWithExactly(
-      showErrorNotificationWithButtonsStub,
-      `Failed to sync settings: ${fakeFailureError.detail}`,
-      {
-        "Update Settings": sinon.match.func,
-        "Open Logs": sinon.match.func,
-        "File Issue": sinon.match.func,
-      },
-    );
-    // not an expected 400 error, so send to Sentry and let the team triage
-    sinon.assert.calledOnce(logErrorStub);
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      error,
-      "syncing settings to sidecar preferences API",
-      {
-        extra: { functionName: "updatePreferences" },
-      },
-    );
+      sinon.assert.calledOnce(stubbedPreferencesResourceApi.gatewayV1PreferencesPut);
+      sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
+      const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
+      assert.strictEqual(callArgs[0], `Failed to sync settings: ${errorMessage}`);
+      // non-ResponseError should go to Sentry
+      sinon.assert.calledWithExactly(
+        logErrorStub,
+        sinon.match.instanceOf(Error).and(sinon.match.has("message", errorMessage)),
+        "syncing settings to sidecar preferences API",
+        { extra: { functionName: "updatePreferences" } },
+      );
+    });
+
+    it("should show an error notification when an Error is caught", async function () {
+      const error = new Error("uh oh");
+      stubbedPreferencesResourceApi.gatewayV1PreferencesPut.rejects(error);
+
+      await updates.updatePreferences();
+
+      sinon.assert.calledOnce(logErrorStub);
+      sinon.assert.calledWithExactly(
+        logErrorStub,
+        sinon.match.instanceOf(Error).and(sinon.match.has("message", error.message)),
+        "syncing settings to sidecar preferences API",
+        { extra: { functionName: "updatePreferences" } },
+      );
+
+      sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
+      const callArgs = showErrorNotificationWithButtonsStub.getCall(0).args;
+      assert.strictEqual(callArgs[0], `Failed to sync settings: ${error.message}`);
+    });
+
+    it("should show an error notification with a settings button when a ResponseError (status 400) is caught and valid failure errors are returned", async function () {
+      const errorResponse = new Response("Bad Request", { status: 400 });
+      const fakeFailureError = {
+        code: "cert_not_found",
+        title: "Cert file cannot be found",
+        detail: "The cert file '/foo/bar/baz' cannot be found.",
+        source: "/spec/tls_pem_paths" as JsonNode, // pointer to the specific field, not actual object
+      } satisfies SidecarError;
+      sandbox.stub(errorResponse, "clone").returns(errorResponse);
+      sandbox.stub(errorResponse, "json").resolves({ errors: [fakeFailureError] });
+      const error = new ResponseError(errorResponse);
+
+      stubbedPreferencesResourceApi.gatewayV1PreferencesPut.rejects(error);
+
+      await updates.updatePreferences();
+
+      sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
+      sinon.assert.calledOnceWithExactly(
+        showErrorNotificationWithButtonsStub,
+        `Failed to sync settings: ${fakeFailureError.detail}`,
+        {
+          "Update Settings": sinon.match.func,
+          "Open Logs": sinon.match.func,
+          "File Issue": sinon.match.func,
+        },
+      );
+      // not sending error 400s to Sentry
+      sinon.assert.calledOnce(logErrorStub);
+      sinon.assert.calledWithExactly(
+        logErrorStub,
+        error,
+        "syncing settings to sidecar preferences API",
+        {},
+      );
+    });
+
+    it("should show an error notification with a settings button when a ResponseError (non-400 status) is caught and valid failure errors are returned", async function () {
+      const errorResponse = new Response("Internal server error", { status: 500 });
+      const fakeFailureError = {
+        code: "cert_not_found",
+        title: "Cert file cannot be found",
+        detail: "The cert file '/foo/bar/baz' cannot be found.",
+        source: "/spec/tls_pem_paths" as JsonNode, // pointer to the specific field, not actual object
+      } satisfies SidecarError;
+      sandbox.stub(errorResponse, "clone").returns(errorResponse);
+      sandbox.stub(errorResponse, "json").resolves({ errors: [fakeFailureError] });
+      const error = new ResponseError(errorResponse);
+
+      stubbedPreferencesResourceApi.gatewayV1PreferencesPut.rejects(error);
+
+      await updates.updatePreferences();
+
+      sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
+      sinon.assert.calledOnceWithExactly(
+        showErrorNotificationWithButtonsStub,
+        `Failed to sync settings: ${fakeFailureError.detail}`,
+        {
+          "Update Settings": sinon.match.func,
+          "Open Logs": sinon.match.func,
+          "File Issue": sinon.match.func,
+        },
+      );
+      // not an expected 400 error, so send to Sentry and let the team triage
+      sinon.assert.calledOnce(logErrorStub);
+      sinon.assert.calledWithExactly(
+        logErrorStub,
+        error,
+        "syncing settings to sidecar preferences API",
+        {
+          extra: { functionName: "updatePreferences" },
+        },
+      );
+    });
   });
 });

--- a/src/extensionSettings/sidecarSync.ts
+++ b/src/extensionSettings/sidecarSync.ts
@@ -30,13 +30,35 @@ export function loadPreferencesFromWorkspaceConfig(): PreferencesSpec {
   const pemPaths: string[] = SSL_PEM_PATHS.value;
   const trustAllCerts: boolean = SSL_VERIFY_SERVER_CERT_DISABLED.value;
   const krb5ConfigPath: string = KRB5_CONFIG_PATH.value;
-  const privateNetworkEndpoints: Record<string, string> = CCLOUD_PRIVATE_NETWORK_ENDPOINTS.value;
+  const privateNetworkEndpoints: Record<string, string[]> = splitPrivateNetworkEndpoints(
+    CCLOUD_PRIVATE_NETWORK_ENDPOINTS.value,
+  );
   return {
     tls_pem_paths: pemPaths,
     trust_all_certificates: trustAllCerts,
     kerberos_config_file_path: krb5ConfigPath,
-    private_network_endpoints: privateNetworkEndpoints,
+    flink_private_endpoints: privateNetworkEndpoints,
   } as any;
+}
+
+// shoup: we should move this somewhere else if we have to handle a similar conversion elsewhere
+/**
+ * Convert a private network endpoints `Record<string, string>` into a `Record<string, string[]>`
+ * by splitting the values on commas and trimming whitespace.
+ */
+export function splitPrivateNetworkEndpoints(
+  privateNetworkEndpointsRaw: Record<string, string>,
+): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const key in privateNetworkEndpointsRaw) {
+    const value = privateNetworkEndpointsRaw[key];
+    // separate by commas, trim whitespace, and filter out empty strings
+    result[key] = value
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return result;
 }
 
 /** Update the sidecar's preferences API with the current user settings. */

--- a/src/extensionSettings/sidecarSync.ts
+++ b/src/extensionSettings/sidecarSync.ts
@@ -20,7 +20,7 @@ import {
   SSL_VERIFY_SERVER_CERT_DISABLED,
 } from "./constants";
 
-const logger = new Logger("preferences.sidecarSync");
+const logger = new Logger("extensionSettings.sidecarSync");
 
 /**
  * Load the current preferences API related values from the workspace configuration / user settings.

--- a/src/extensionSettings/sidecarSync.ts
+++ b/src/extensionSettings/sidecarSync.ts
@@ -13,7 +13,12 @@ import {
   showErrorNotificationWithButtons,
 } from "../notifications";
 import { getSidecar } from "../sidecar";
-import { KRB5_CONFIG_PATH, SSL_PEM_PATHS, SSL_VERIFY_SERVER_CERT_DISABLED } from "./constants";
+import {
+  CCLOUD_PRIVATE_NETWORK_ENDPOINTS,
+  KRB5_CONFIG_PATH,
+  SSL_PEM_PATHS,
+  SSL_VERIFY_SERVER_CERT_DISABLED,
+} from "./constants";
 
 const logger = new Logger("preferences.sidecarSync");
 
@@ -25,11 +30,13 @@ export function loadPreferencesFromWorkspaceConfig(): PreferencesSpec {
   const pemPaths: string[] = SSL_PEM_PATHS.value;
   const trustAllCerts: boolean = SSL_VERIFY_SERVER_CERT_DISABLED.value;
   const krb5ConfigPath: string = KRB5_CONFIG_PATH.value;
+  const privateNetworkEndpoints: Record<string, string> = CCLOUD_PRIVATE_NETWORK_ENDPOINTS.value;
   return {
     tls_pem_paths: pemPaths,
     trust_all_certificates: trustAllCerts,
     kerberos_config_file_path: krb5ConfigPath,
-  };
+    private_network_endpoints: privateNetworkEndpoints,
+  } as any;
 }
 
 /** Update the sidecar's preferences API with the current user settings. */

--- a/src/extensionSettings/sidecarSync.ts
+++ b/src/extensionSettings/sidecarSync.ts
@@ -38,7 +38,7 @@ export function loadPreferencesFromWorkspaceConfig(): PreferencesSpec {
     trust_all_certificates: trustAllCerts,
     kerberos_config_file_path: krb5ConfigPath,
     flink_private_endpoints: privateNetworkEndpoints,
-  } as any;
+  };
 }
 
 // shoup: we should move this somewhere else if we have to handle a similar conversion elsewhere

--- a/src/sidecar/constants.ts
+++ b/src/sidecar/constants.ts
@@ -11,6 +11,9 @@ export const SIDECAR_CONNECTION_ID_HEADER: string = "x-connection-id";
 /** Header used to specify a given (Kafka, Schema Registry, etc) cluster ID, if applicable */
 export const CLUSTER_ID_HEADER: string = "x-cluster-id";
 
+/** Header used to specify the Confluent Cloud environment, if applicable */
+export const CCLOUD_ENV_ID_HEADER: string = "x-ccloud-env-id";
+
 /** Header used to specify which cloud provider */
 export const CCLOUD_PROVIDER_HEADER: string = "x-ccloud-provider";
 

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -51,6 +51,7 @@ import { Logger } from "../logging";
 import { ConnectionId, IEnvProviderRegion } from "../models/resource";
 import { Message, MessageType } from "../ws/messageTypes";
 import {
+  CCLOUD_ENV_ID_HEADER,
   CCLOUD_PROVIDER_HEADER,
   CCLOUD_REGION_HEADER,
   CLUSTER_ID_HEADER,
@@ -397,6 +398,7 @@ export class SidecarHandle {
   public constructFlinkDataPlaneClientHeaders(providerRegion: IEnvProviderRegion): HTTPHeaders {
     return {
       ...this.defaultClientConfigParams.headers,
+      [CCLOUD_ENV_ID_HEADER]: providerRegion.environmentId,
       [CCLOUD_PROVIDER_HEADER]: providerRegion.provider,
       [CCLOUD_REGION_HEADER]: providerRegion.region,
       [SIDECAR_CONNECTION_ID_HEADER]: CCLOUD_CONNECTION_ID,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Added:
- New command to set private network endpoint(s) for a CCloud environment
    <img width="481" height="215" alt="image" src="https://github.com/user-attachments/assets/3b7ea5a9-4b8a-4629-81f3-e69e75c633b0" />
- ...which updates a (new) setting `confluent.cloud.privateNetworkEndpoints`
    <img width="622" height="205" alt="image" src="https://github.com/user-attachments/assets/bebfbd24-7cf8-46d5-a5eb-1358709180b9" />

This configuration is sent to the sidecar to update the preferences API changes introduced in https://github.com/confluentinc/ide-sidecar/pull/472.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Added tests over `setFlinkStatementsEnvironmentCommand()` as well to get >90% coverage on `commands/environments.ts`

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
