### PR TITLE
direct connections form: check connection urls for ssl enabled

### DIFF
--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -198,7 +198,7 @@ test("submits the form with defaults & dummy data", async ({ execute, page }) =>
   // Fill out the form with dummy data & submit
   await page.fill("input[name=name]", "Test Connection");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
-  await page.fill("input[name='schema_registry.uri']", "http://fakehost:8081");
+  await page.fill("input[name='schema_registry.uri']", "https://fakehost:8081");
   await page.click("input[type=submit][value='Save']");
 
   // Check if the form submission was successful
@@ -218,7 +218,7 @@ test("submits the form with defaults & dummy data", async ({ execute, page }) =>
     formconnectiontype: "Apache Kafka",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
-    "schema_registry.uri": "http://fakehost:8081",
+    "schema_registry.uri": "https://fakehost:8081",
   });
 });
 test("changes the checkbox for ssl to false if localhost", async ({ execute, page }) => {
@@ -344,7 +344,7 @@ test("submits the form with empty trust/key stores as defaults when ssl enabled"
   // Fill out the form with dummy data
   await page.fill("input[name=name]", "Test Connection");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
-  await page.fill("input[name='schema_registry.uri']", "http://fakehost:8081");
+  await page.fill("input[name='schema_registry.uri']", "https://fakehost:8081");
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
 
   // Submit and check the form data
@@ -365,7 +365,7 @@ test("submits the form with empty trust/key stores as defaults when ssl enabled"
     formconnectiontype: "Apache Kafka",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
-    "schema_registry.uri": "http://fakehost:8081",
+    "schema_registry.uri": "https://fakehost:8081",
   });
 });
 test("submits the form with namespaced TLS config fields when filled", async ({
@@ -696,7 +696,7 @@ test("submits values for SASL/OAUTHBEARER auth type when filled in", async ({ ex
   await page.fill("input[name='kafka_cluster.credentials.ccloud_identity_pool_id']", "pool-xyz789");
   await page.check("input[type=checkbox][name='kafka_cluster.ssl.enabled']");
   await page.check("input[type=checkbox][name='schema_registry.ssl.enabled']");
-  await page.fill("input[name='schema_registry.uri']", "http://fakehost:8081");
+  await page.fill("input[name='schema_registry.uri']", "https://fakehost:8081");
   await page.selectOption("select[name='schema_registry.auth_type']", "OAuth");
   await page.fill(
     "input[name='schema_registry.credentials.tokens_url']",
@@ -737,7 +737,7 @@ test("submits values for SASL/OAUTHBEARER auth type when filled in", async ({ ex
     "kafka_cluster.credentials.scope": "kafka-cluster",
     "kafka_cluster.credentials.tokens_url": "https://auth-provider.example/oauth2/token",
     "kafka_cluster.ssl.enabled": "true",
-    "schema_registry.uri": "http://fakehost:8081",
+    "schema_registry.uri": "https://fakehost:8081",
     "schema_registry.auth_type": "OAuth",
     "schema_registry.ssl.enabled": "true",
     "schema_registry.credentials.scope": "kafka-cluster",
@@ -970,7 +970,7 @@ test("submits ssl verify_hostname as false when unchecked", async ({ execute, pa
 
   await page.fill("input[name=name]", "SSL Verify Test");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
-  await page.fill("input[name='schema_registry.uri']", "http://fakehost:8081");
+  await page.fill("input[name='schema_registry.uri']", "https://fakehost:8081");
 
   await page.click("p:has-text('TLS Configuration')");
   await page.uncheck("input[name='kafka_cluster.ssl.verify_hostname']");
@@ -1007,7 +1007,7 @@ test("submits ssl.enabled as false when unchecked", async ({ execute, page }) =>
   // Fill in basic form data
   await page.fill("input[name=name]", "SSL Disabled Test");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
-  await page.fill("input[name='schema_registry.uri']", "http://fakehost:8081");
+  await page.fill("input[name='schema_registry.uri']", "https://fakehost:8081");
 
   // Ensure SSL is unchecked for both Kafka and Schema Registry
   await page.uncheck("input[name='kafka_cluster.ssl.enabled']");
@@ -1044,7 +1044,7 @@ test("submits default types for keystore and truststore", async ({ execute, page
   // Fill in basic form data
   await page.fill("input[name=name]", "SSL Disabled Test");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
-  await page.fill("input[name='schema_registry.uri']", "http://fakehost:8081");
+  await page.fill("input[name='schema_registry.uri']", "https://fakehost:8081");
   await page.click("p:has-text('TLS Configuration')");
   await page.fill("input[name='kafka_cluster.ssl.keystore.path']", "/path/to/keystore");
   await page.fill("input[name='kafka_cluster.ssl.truststore.path']", "/path/to/truststore");
@@ -1135,7 +1135,7 @@ const SPEC_SAMPLE = {
     },
   },
   schema_registry: {
-    uri: "http://fakehost:8081",
+    uri: "https://fakehost:8081",
     ssl: {
       enabled: true,
     },

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -274,6 +274,52 @@ test("changes the checkbox for ssl to false if localhost", async ({ execute, pag
     "schema_registry.uri": "http://localhost:8081",
   });
 });
+test("changes schema registry ssl checkbox based on uri scheme", async ({ execute, page }) => {
+  const sendWebviewMessage = await execute(async () => {
+    const { sendWebviewMessage } = await import("./comms/comms");
+    return sendWebviewMessage as SinonStub;
+  });
+
+  await execute(async (stub) => {
+    stub.withArgs("Submit").resolves(null);
+  }, sendWebviewMessage);
+
+  await execute(async () => {
+    await import("./main");
+    await import("./direct-connect-form");
+    // redispatching because the page already exists for some time
+    // before we actually import the view model application
+    window.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  // Fill out basic form data
+  await page.fill("input[name=name]", "Test Connection");
+  await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
+
+  // Test http:// URL - should disable SSL
+  await page.fill("input[name='schema_registry.uri']", "http://example.com:8081");
+  // Click to make sure URI blurs
+  await page.click("p:has-text('TLS Configuration')");
+
+  let schemaSslCheckbox = page.locator("input[type=checkbox][name='schema_registry.ssl.enabled']");
+  await expect(schemaSslCheckbox).not.toBeChecked();
+
+  // Test https:// URL - should enable SSL
+  await page.fill("input[name='schema_registry.uri']", "https://example.com:8081");
+  // Click to make sure URI blurs
+  await page.click("p:has-text('TLS Configuration')");
+
+  schemaSslCheckbox = page.locator("input[type=checkbox][name='schema_registry.ssl.enabled']");
+  await expect(schemaSslCheckbox).toBeChecked();
+
+  // Test localhost URL - should disable SSL
+  await page.fill("input[name='schema_registry.uri']", "http://localhost:8081");
+  // Click to make sure URI blurs
+  await page.click("p:has-text('TLS Configuration')");
+
+  schemaSslCheckbox = page.locator("input[type=checkbox][name='schema_registry.ssl.enabled']");
+  await expect(schemaSslCheckbox).not.toBeChecked();
+});
 test("submits the form with empty trust/key stores as defaults when ssl enabled", async ({
   execute,
   page,

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -216,13 +216,13 @@ class DirectConnectFormViewModel extends ViewModel {
       case "kafka_cluster.bootstrap_servers":
         this.kafkaBootstrapServers(input.value);
         // if localhost, uncheck SSL
-        if (input.value.includes("localhost")) {
+        if (input.value.includes("localhost") || input.value.startsWith("http:")) {
           this.kafkaSslEnabled(false);
           await post("UpdateSpecValue", {
             inputName: "kafka_cluster.ssl.enabled",
             inputValue: false,
           });
-        } else if (input.value.includes("https")) {
+        } else if (input.value.startsWith("https:")) {
           this.kafkaSslEnabled(true);
           await post("UpdateSpecValue", {
             inputName: "kafka_cluster.ssl.enabled",
@@ -233,13 +233,13 @@ class DirectConnectFormViewModel extends ViewModel {
       case "schema_registry.uri":
         this.schemaUri(input.value);
         // if localhost, uncheck SSL
-        if (input.value.includes("localhost")) {
+        if (input.value.includes("localhost") || input.value.startsWith("http:")) {
           this.schemaSslEnabled(false);
           await post("UpdateSpecValue", {
             inputName: "schema_registry.ssl.enabled",
             inputValue: false,
           });
-        } else if (input.value.includes("https")) {
+        } else if (input.value.startsWith("https:")) {
           this.schemaSslEnabled(true);
           await post("UpdateSpecValue", {
             inputName: "schema_registry.ssl.enabled",

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -216,17 +216,11 @@ class DirectConnectFormViewModel extends ViewModel {
       case "kafka_cluster.bootstrap_servers":
         this.kafkaBootstrapServers(input.value);
         // if localhost, uncheck SSL
-        if (input.value.includes("localhost") || input.value.startsWith("http:")) {
+        if (input.value.includes("localhost")) {
           this.kafkaSslEnabled(false);
           await post("UpdateSpecValue", {
             inputName: "kafka_cluster.ssl.enabled",
             inputValue: false,
-          });
-        } else if (input.value.startsWith("https:")) {
-          this.kafkaSslEnabled(true);
-          await post("UpdateSpecValue", {
-            inputName: "kafka_cluster.ssl.enabled",
-            inputValue: true,
           });
         }
         break;

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -222,6 +222,12 @@ class DirectConnectFormViewModel extends ViewModel {
             inputName: "kafka_cluster.ssl.enabled",
             inputValue: false,
           });
+        } else if (input.value.includes("https")) {
+          this.kafkaSslEnabled(true);
+          await post("UpdateSpecValue", {
+            inputName: "kafka_cluster.ssl.enabled",
+            inputValue: true,
+          });
         }
         break;
       case "schema_registry.uri":
@@ -232,6 +238,12 @@ class DirectConnectFormViewModel extends ViewModel {
           await post("UpdateSpecValue", {
             inputName: "schema_registry.ssl.enabled",
             inputValue: false,
+          });
+        } else if (input.value.includes("https")) {
+          this.schemaSslEnabled(true);
+          await post("UpdateSpecValue", {
+            inputName: "schema_registry.ssl.enabled",
+            inputValue: true,
           });
         }
         break;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #1415 
- If the user types in `http:` we know the are not using ssl, and if they type `https:` we know they are, so we can be smart about checking the box to enable or not. 
- Doesn't prevent users from clicking the box again to revert our helpful change. But they shouldn't do that. Bad user. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Built on https://github.com/confluentinc/vscode/pull/2217 must merge that first

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
