### PR TITLE
chore: add Semaphore task for uploading pre-release .vsix files to GitHub

### DIFF
--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -4,13 +4,17 @@ agent:
   machine:
     type: s1-prod-ubuntu24-04-amd64-1
 
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+
 blocks:
   - name: "Package VSIX Files"
     dependencies: []
     task:
       prologue:
         commands:
-          - checkout
           - git fetch --all
           - git checkout $COMMIT_SHA
           - . vault-setup

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -13,7 +13,6 @@ blocks:
           - checkout
           - git fetch --all
           - git checkout $COMMIT_SHA
-          - make ci-bin-sem-cache-restore
           - . vault-setup
           - make install-dependencies
       jobs:

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -18,9 +18,6 @@ blocks:
           - make install-dependencies
       jobs:
         - name: "Package VSIX Files"
-          agent:
-            machine:
-              type: s1-prod-macos-13-5-amd64
           matrix:
             - env_var: TARGET
               values:

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -1,0 +1,60 @@
+version: v1.0
+name: prerelease-multi-arch-packaging
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+blocks:
+  - name: "Package VSIX Files"
+    dependencies: ["Checkout and Prepare"]
+    task:
+      prologue:
+        commands:
+          - checkout
+          - git fetch --all
+          - git checkout $COMMIT_SHA
+          - make ci-bin-sem-cache-restore
+          - . vault-setup
+          - make install-dependencies
+      jobs:
+        - name: "Package VSIX Files"
+          agent:
+            machine:
+              type: s1-prod-macos-13-5-amd64
+          matrix:
+            - env_var: TARGET
+              values:
+                - darwin-x64
+                - darwin-arm64
+                - linux-x64
+                - linux-arm64
+                - win32-x64
+          commands:
+            - |
+              case "$TARGET" in
+                darwin-x64)  export SIDECAR_OS_ARCH=macos-amd64 ;;
+                darwin-arm64) export SIDECAR_OS_ARCH=macos-arm64 ;;
+                linux-x64)   export SIDECAR_OS_ARCH=linux-amd64 ;;
+                linux-arm64) export SIDECAR_OS_ARCH=linux-arm64 ;;
+                win32-x64)   export SIDECAR_OS_ARCH=windows-amd64 ;;
+                *) echo "Unknown TARGET: $TARGET" && exit 1 ;;
+            - make download-sidecar-executable
+            - make download-third-party-notices-sidecar || true
+            - npx gulp bundle
+            - VSIX_FILE=$(find out/ -name "*.vsix")
+            - artifact push workflow ${VSIX_FILE} --destination packaged-vsix-files/$(basename ${VSIX_FILE})
+
+  - name: "Upload Prerelease VSIX Files to GitHub"
+    dependencies:
+      - "Package VSIX Files"
+    task:
+      jobs:
+        - name: "Upload Prerelease VSIX Files"
+          commands:
+            - artifact pull workflow packaged-vsix-files/
+            - |
+              VERSION=$(cat .versions/next.txt)
+              PRERELEASE_TAG="v${VERSION}-pre"
+              for vsix in packaged-vsix-files/*.vsix; do
+                gh release upload "$PRERELEASE_TAG" "$vsix" --clobber
+              done

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -6,6 +6,7 @@ agent:
 
 blocks:
   - name: "Package VSIX Files"
+    dependencies: []
     task:
       prologue:
         commands:

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -33,7 +33,7 @@ blocks:
                 darwin-arm64) export SIDECAR_OS_ARCH=macos-arm64 ;;
                 linux-x64)   export SIDECAR_OS_ARCH=linux-amd64 ;;
                 linux-arm64) export SIDECAR_OS_ARCH=linux-arm64 ;;
-                win32-x64)   export SIDECAR_OS_ARCH=windows-amd64 ;;
+                win32-x64)   export SIDECAR_OS_ARCH=windows-x64 ;;
                 *) echo "Unknown TARGET: $TARGET" && exit 1 ;;
               esac
             - make download-sidecar-executable

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -35,6 +35,7 @@ blocks:
                 linux-arm64) export SIDECAR_OS_ARCH=linux-arm64 ;;
                 win32-x64)   export SIDECAR_OS_ARCH=windows-amd64 ;;
                 *) echo "Unknown TARGET: $TARGET" && exit 1 ;;
+              esac
             - make download-sidecar-executable
             - make download-third-party-notices-sidecar || true
             - npx gulp bundle

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -6,7 +6,6 @@ agent:
 
 blocks:
   - name: "Package VSIX Files"
-    dependencies: ["Checkout and Prepare"]
     task:
       prologue:
         commands:

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -17,7 +17,7 @@ import libReport from "istanbul-lib-report";
 import libSourceMaps from "istanbul-lib-source-maps";
 import reports from "istanbul-reports";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { appendFile, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
@@ -402,6 +402,14 @@ function sidecar() {
   // we may be building for Windows from a non-Windows machine, in which case we'll have the .exe
   if (IS_WINDOWS || process.env.TARGET === "win32-x64") {
     sidecarFilename = `${sidecarFilename}.exe`;
+  }
+  console.log(`Copying sidecar executable ${sidecarFilename} to ${DESTINATION}/bin/`, {
+    is_windows: IS_WINDOWS,
+    target: process.env.TARGET,
+  });
+  const sidecarPath = join("bin", sidecarFilename);
+  if (!existsSync(sidecarPath)) {
+    throw new Error(`Sidecar executable ${sidecarFilename} not found in bin/ directory.`);
   }
 
   return [

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -397,7 +397,12 @@ function pkgjson() {
  */
 function sidecar() {
   const sidecarVersion = readFileSync(".versions/ide-sidecar.txt", "utf-8").replace(/[v\n\s]/g, "");
-  const sidecarFilename = `ide-sidecar-${sidecarVersion}-runner${IS_WINDOWS ? ".exe" : ""}`;
+
+  let sidecarFilename = `ide-sidecar-${sidecarVersion}-runner`;
+  // we may be building for Windows from a non-Windows machine, in which case we'll have the .exe
+  if (IS_WINDOWS || process.env.TARGET === "win32-x64") {
+    sidecarFilename = `${sidecarFilename}.exe`;
+  }
 
   return [
     virtual({

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ ifeq ($(SKIP_DOWNLOAD_EXECUTABLE),true)
 	@echo "Skipping download of sidecar executable since it already exists at $(EXECUTABLE_DOWNLOAD_PATH)"
 else
 	mkdir -p bin && \
+	echo "$(SIDECAR_OS_ARCH): $(IS_WINDOWS)" && \
 	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION): $(EXECUTABLE_DOWNLOAD_PATH)"; \
 	curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
 	chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ ifeq ($(SKIP_DOWNLOAD_EXECUTABLE),true)
 	@echo "Skipping download of sidecar executable since it already exists at $(EXECUTABLE_DOWNLOAD_PATH)"
 else
 	mkdir -p bin && \
-	echo "$(SIDECAR_OS_ARCH): $(IS_WINDOWS)" && \
 	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION): $(EXECUTABLE_DOWNLOAD_PATH)"; \
 	curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
 	chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ ifeq ($(IS_WINDOWS),true)
 else
 	EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
 	export EXECUTABLE_PATH := ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH)
+endif
 
 # Skip download if the executable already exists and is executable
 SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)

--- a/Makefile
+++ b/Makefile
@@ -115,13 +115,23 @@ endif
 
 IDE_SIDECAR_VERSION = $(shell cat .versions/ide-sidecar.txt)
 IDE_SIDECAR_VERSION_NO_V := $(call version_no_v,$(IDE_SIDECAR_VERSION))
-EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
-
-# Skip download if the executable already exists and is executable
-SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)
 
 # Get the OS and architecture combination for the sidecar executable
 SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')" )
+
+# Check if we're targeting the Windows sidecar executable from a non-Windows agent
+# (currently only done in `.semaphore/prerelease-multi-arch-packaging.yml` since the pipeline at
+# `.semaphore/multi-arch-packaging.yml` uses `scripts/windows/download-sidecar-executable.ps1`)
+IS_WINDOWS = $(shell echo "$(SIDECAR_OS_ARCH)" | grep -q 'win32' && echo true || echo false)
+ifeq ($(IS_WINDOWS),true)
+	EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner.exe
+	export EXECUTABLE_PATH := ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH).exe
+else
+	EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
+	export EXECUTABLE_PATH := ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH)
+
+# Skip download if the executable already exists and is executable
+SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)
 
 IDE_SIDECAR_REPO := confluentinc/ide-sidecar
 
@@ -134,16 +144,15 @@ ifeq ($(SKIP_DOWNLOAD_EXECUTABLE),true)
 else
 	mkdir -p bin && \
 	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION)"; \
-	export EXECUTABLE_PATH=ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH) && \
-		curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
-		chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
-		if [ $$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) -lt 1048576 ]; then \
-				echo "Error: Downloaded sidecar executable is too small (< 1MB), likely corrupted or failed download" >&2; \
-				cat $(EXECUTABLE_DOWNLOAD_PATH) | head -20 >&2; \
-				rm -f $(EXECUTABLE_DOWNLOAD_PATH); \
-				exit 1; \
-		fi && \
-		echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH) ($$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) bytes)";
+	curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
+	chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
+	if [ $$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) -lt 1048576 ]; then \
+			echo "Error: Downloaded sidecar executable is too small (< 1MB), likely corrupted or failed download" >&2; \
+			cat $(EXECUTABLE_DOWNLOAD_PATH) | head -20 >&2; \
+			rm -f $(EXECUTABLE_DOWNLOAD_PATH); \
+			exit 1; \
+	fi && \
+	echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH) ($$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) bytes)";
 endif
 
 # Downloads the THIRD_PARTY_NOTICES.txt file from the latest release of ide-sidecar as THIRD_PARTY_NOTICES_IDE_SIDECAR.txt

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 
 # Check if we're targeting the Windows sidecar executable from a non-Windows agent
 # (currently only done in `.semaphore/prerelease-multi-arch-packaging.yml` since the pipeline at
 # `.semaphore/multi-arch-packaging.yml` uses `scripts/windows/download-sidecar-executable.ps1`)
-IS_WINDOWS = $(shell echo "$(SIDECAR_OS_ARCH)" | grep -q 'win32' && echo true || echo false)
+IS_WINDOWS = $(shell echo "$(SIDECAR_OS_ARCH)" | grep -q 'windows' && echo true || echo false)
 ifeq ($(IS_WINDOWS),true)
 	EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner.exe
 	export EXECUTABLE_PATH := ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH).exe

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ifeq ($(SKIP_DOWNLOAD_EXECUTABLE),true)
 	@echo "Skipping download of sidecar executable since it already exists at $(EXECUTABLE_DOWNLOAD_PATH)"
 else
 	mkdir -p bin && \
-	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION)"; \
+	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION): $(EXECUTABLE_DOWNLOAD_PATH)"; \
 	curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
 	chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
 	if [ $$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) -lt 1048576 ]; then \

--- a/service.yml
+++ b/service.yml
@@ -26,9 +26,9 @@ semaphore:
         - name: TEST_SUITE
           required: false
           description: The test name or tag(s) (pipe-separated, e.g. `@ccloud|@direct`) to run. If not specified, will run all E2E tests.
-    - name: upload-prerelease-vsix-files
+    - name: prerelease-multi-arch-packaging
       branch: main
-      pipeline_file: ".semaphore/multi-arch-packaging.yml"
+      pipeline_file: ".semaphore/prerelease-multi-arch-packaging.yml"
       parameters:
         - name: COMMIT_SHA
           required: true

--- a/service.yml
+++ b/service.yml
@@ -26,6 +26,14 @@ semaphore:
         - name: TEST_SUITE
           required: false
           description: The test name or tag(s) (pipe-separated, e.g. `@ccloud|@direct`) to run. If not specified, will run all E2E tests.
+    - name: upload-prerelease-vsix-files
+      branch: main
+      pipeline_file: ".semaphore/multi-arch-packaging.yml"
+      parameters:
+        - name: COMMIT_SHA
+          required: true
+          description: |
+            The commit SHA to create the release and tag from, must be a valid SHA/tag/branch.
 sonarqube:
   enable: false
 make:


### PR DESCRIPTION
We're adding a (manual, for now) Semaphore task to allow building prerelease .vsix files for our supported `vsce` targets:

<img width="674" height="273" alt="image" src="https://github.com/user-attachments/assets/a9da1a46-ce96-4a8d-9c51-a03cf5187700" />

This requires the [GitHub (pre-release) Release](https://github.com/confluentinc/vscode/releases/tag/v1.6.0-pre) to already be available (done from a separate task) beforehand.
<img width="1201" height="570" alt="image" src="https://github.com/user-attachments/assets/b6e5f103-e662-4eb7-8e75-c1e9d6432e3c" />

For now, each of these steps is manual until we're comfortable enough with the flow to start scheduling them (delete existing prerelease, create new prerelease, build vsix files for prerelease).


Closes #1697