### PR TITLE
Stop exporting logger and stubbing it in a test.

### DIFF
--- a/src/quickpicks/kafkaClusters.test.ts
+++ b/src/quickpicks/kafkaClusters.test.ts
@@ -13,7 +13,7 @@ import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { ResourceLoader } from "../loaders";
 import { CCloudKafkaCluster, KafkaCluster, LocalKafkaCluster } from "../models/kafkaCluster";
 import * as topicsViewProviders from "../viewProviders/topics";
-import { flinkDatabaseQuickpick, kafkaClusterQuickPick, logger as qpLogger } from "./kafkaClusters";
+import { flinkDatabaseQuickpick, kafkaClusterQuickPick } from "./kafkaClusters";
 import { QuickPickItemWithValue } from "./types";
 
 describe("kafkaClusterQuickPick", () => {
@@ -65,16 +65,8 @@ describe("kafkaClusterQuickPick", () => {
     // should have included clusters referencing TEST_LOCAL_ENVIRONMENT, so will make code hit error.
     mockLoaders[0].getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
 
-    // mock out the logger's warning method so we can prove going down into this unexpected codepath
-    const loggerWarnStub = sandbox.stub(qpLogger, "warn");
-
     const result = await kafkaClusterQuickPick();
     assert.strictEqual(result, undefined);
-    assert.strictEqual(loggerWarnStub.callCount, 1);
-    assert.strictEqual(
-      loggerWarnStub.getCall(0).args[0],
-      `No environment found for Kafka cluster ${TEST_CCLOUD_KAFKA_CLUSTER.name}`,
-    );
   });
 
   it("Offers all Kafka clusters if driven w/o a filter lambda", async () => {

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -11,8 +11,7 @@ import { getConnectionLabel, isCCloud, isDirect, isLocal } from "../models/resou
 import { getTopicViewProvider } from "../viewProviders/topics";
 import { QuickPickItemWithValue } from "./types";
 
-// Exported only for testsuite purposes.
-export const logger = new Logger("quickpicks.kafkaClusters");
+const logger = new Logger("quickpicks.kafkaClusters");
 
 /** Wrapper for the Kafka Cluster quickpick to accomodate data-fetching time and display a progress indicator on the Topics view. */
 export async function kafkaClusterQuickPickWithViewProgress(): Promise<KafkaCluster | undefined> {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Stop exporting the Kafka cluster quickpick logger on behalf of a single test, it becomes catnip for auto-importing when making first logger call in a module which doesn't have a logger defined yet, ensuing hilarity.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
