### PR TITLE
cleanup: add `dispose()` methods and clean up between tests

### DIFF
--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -83,6 +83,7 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
   });
 
   afterEach(() => {
+    authProvider.dispose();
     // reset the singleton instance between tests
     ConfluentCloudAuthProvider["instance"] = null;
     sandbox.restore();
@@ -351,6 +352,20 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
       assert.strictEqual(result.success, success);
     });
   }
+
+  describe("dispose()", function () {
+    it("should dispose of all .disposables", () => {
+      const disposable1 = { dispose: sandbox.stub() };
+      const disposable2 = { dispose: sandbox.stub() };
+      authProvider.disposables.push(disposable1, disposable2);
+
+      authProvider.dispose();
+
+      sinon.assert.calledOnce(disposable1.dispose);
+      sinon.assert.calledOnce(disposable2.dispose);
+      assert.strictEqual(authProvider.disposables.length, 0);
+    });
+  });
 });
 
 describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider URI handling", () => {
@@ -391,6 +406,7 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider URI handling", () =
   });
 
   afterEach(() => {
+    authProvider.dispose();
     // reset the singleton instance between tests
     ConfluentCloudAuthProvider["instance"] = null;
     sandbox.restore();

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -352,20 +352,6 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
       assert.strictEqual(result.success, success);
     });
   }
-
-  describe("dispose()", function () {
-    it("should dispose of all .disposables", () => {
-      const disposable1 = { dispose: sandbox.stub() };
-      const disposable2 = { dispose: sandbox.stub() };
-      authProvider.disposables.push(disposable1, disposable2);
-
-      authProvider.dispose();
-
-      sinon.assert.calledOnce(disposable1.dispose);
-      sinon.assert.calledOnce(disposable2.dispose);
-      assert.strictEqual(authProvider.disposables.length, 0);
-    });
-  });
 });
 
 describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider URI handling", () => {

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -24,7 +24,7 @@ import { getSecretStorage } from "../storage/utils";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
 import { getUriHandler } from "../uriHandler";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
 import { AuthCallbackEvent } from "./types";
 
@@ -64,7 +64,7 @@ const logger = new Logger("authn.ccloudProvider");
  * (with a new `sign_in_uri`), which should only be done by the user signing out.
  */
 export class ConfluentCloudAuthProvider
-  extends BaseDisposableManager
+  extends DisposableCollection
   implements vscode.AuthenticationProvider
 {
   // tells VS Code which sessions have been added, removed, or changed for this extension instance

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -24,6 +24,7 @@ import { getSecretStorage } from "../storage/utils";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
 import { getUriHandler } from "../uriHandler";
+import { BaseDisposableManager } from "../utils/disposables";
 import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
 import { AuthCallbackEvent } from "./types";
 
@@ -62,11 +63,10 @@ const logger = new Logger("authn.ccloudProvider");
  * only way we get back to `NONE` is by deleting the connection entirely and recreating a new one
  * (with a new `sign_in_uri`), which should only be done by the user signing out.
  */
-export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider {
-  /** Disposables belonging to this provider to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: vscode.Disposable[] = [];
-
+export class ConfluentCloudAuthProvider
+  extends BaseDisposableManager
+  implements vscode.AuthenticationProvider
+{
   // tells VS Code which sessions have been added, removed, or changed for this extension instance
   // NOTE: does not trigger cross-workspace events
   private _onDidChangeSessions =
@@ -84,6 +84,7 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
   private static instance: ConfluentCloudAuthProvider | null = null;
   // private to enforce singleton pattern and avoid attempting to re-register the auth provider
   private constructor() {
+    super();
     const context: vscode.ExtensionContext = getExtensionContext();
     if (!context) {
       // extension context required for keeping up with secrets changes
@@ -100,11 +101,6 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
       ConfluentCloudAuthProvider.instance = new ConfluentCloudAuthProvider();
     }
     return ConfluentCloudAuthProvider.instance;
-  }
-
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   /**

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -102,6 +102,11 @@ export class ConfluentCloudAuthProvider implements vscode.AuthenticationProvider
     return ConfluentCloudAuthProvider.instance;
   }
 
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+
   /**
    * Create a CCloud connection with the sidecar if one doesn't already exist, then start the
    * browser-based authentication flow.

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -71,12 +71,6 @@ describe("codelens/flinkSqlProvider.ts FlinkSqlCodelensProvider", () => {
     }
   });
 
-  it("should register event listeners to .disposables", () => {
-    // Need to figure out why stubbing the event emitters' .event methods doesn't work here
-    // when checking call counts after the provider is created
-    assert.strictEqual(provider.disposables.length, 2);
-  });
-
   it("should create codelenses at the top of the document", async () => {
     const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
 

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -52,6 +52,11 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
     return FlinkSqlCodelensProvider.instance;
   }
 
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
     const codeLenses: CodeLens[] = [];
 

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -20,17 +20,17 @@ import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import { UriMetadata } from "../storage/types";
+import { BaseDisposableManager } from "../utils/disposables";
 
 const logger = new Logger("codelens.flinkSqlProvider");
 
-export class FlinkSqlCodelensProvider implements CodeLensProvider {
-  disposables: Disposable[] = [];
-
+export class FlinkSqlCodelensProvider extends BaseDisposableManager implements CodeLensProvider {
   // controls refreshing the available codelenses
   private _onDidChangeCodeLenses: EventEmitter<void> = new EventEmitter<void>();
   readonly onDidChangeCodeLenses: Event<void> = this._onDidChangeCodeLenses.event;
 
   private constructor() {
+    super();
     // refresh/update all codelenses for documents visible in the workspace when any of these fire
     const ccloudConnectedSub: Disposable = ccloudConnected.event((connected: boolean) => {
       logger.debug("ccloudConnected event fired, updating codelenses", { connected });
@@ -50,11 +50,6 @@ export class FlinkSqlCodelensProvider implements CodeLensProvider {
       FlinkSqlCodelensProvider.instance = new FlinkSqlCodelensProvider();
     }
     return FlinkSqlCodelensProvider.instance;
-  }
-
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -20,11 +20,11 @@ import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import { UriMetadata } from "../storage/types";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 
 const logger = new Logger("codelens.flinkSqlProvider");
 
-export class FlinkSqlCodelensProvider extends BaseDisposableManager implements CodeLensProvider {
+export class FlinkSqlCodelensProvider extends DisposableCollection implements CodeLensProvider {
   // controls refreshing the available codelenses
   private _onDidChangeCodeLenses: EventEmitter<void> = new EventEmitter<void>();
   readonly onDidChangeCodeLenses: Event<void> = this._onDidChangeCodeLenses.event;

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -325,18 +325,4 @@ describe("DirectConnectionManager behavior", () => {
       sinon.assert.calledWith(deregisterInstanceStub, TEST_DIRECT_CONNECTION_ID);
     });
   });
-
-  describe("dispose()", function () {
-    it("should dispose of all .disposables", () => {
-      const disposable1 = { dispose: sandbox.stub() };
-      const disposable2 = { dispose: sandbox.stub() };
-      manager.disposables.push(disposable1, disposable2);
-
-      manager.dispose();
-
-      sinon.assert.calledOnce(disposable1.dispose);
-      sinon.assert.calledOnce(disposable2.dispose);
-      assert.strictEqual(manager.disposables.length, 0);
-    });
-  });
 });

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -30,7 +30,7 @@ import {
 } from "./storage/resourceManager";
 import { getSecretStorage } from "./storage/utils";
 import { logUsage, UserEvent } from "./telemetry/events";
-import { BaseDisposableManager } from "./utils/disposables";
+import { DisposableCollection } from "./utils/disposables";
 import { getSchemasViewProvider } from "./viewProviders/schemas";
 import { getTopicViewProvider } from "./viewProviders/topics";
 
@@ -44,7 +44,7 @@ const logger = new Logger("directConnectManager");
  * - deleting connections through actions on the Resources view
  * - firing events when the connection list changes or a specific connection is updated/deleted
  */
-export class DirectConnectionManager extends BaseDisposableManager {
+export class DirectConnectionManager extends DisposableCollection {
   // singleton instance to prevent multiple listeners and single source of connection management
   private static instance: DirectConnectionManager | null = null;
   private constructor() {

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -60,6 +60,11 @@ export class DirectConnectionManager {
     this.disposables.push(...listeners);
   }
 
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+
   static getInstance(): DirectConnectionManager {
     if (!DirectConnectionManager.instance) {
       DirectConnectionManager.instance = new DirectConnectionManager();

--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -30,6 +30,7 @@ import {
 } from "./storage/resourceManager";
 import { getSecretStorage } from "./storage/utils";
 import { logUsage, UserEvent } from "./telemetry/events";
+import { BaseDisposableManager } from "./utils/disposables";
 import { getSchemasViewProvider } from "./viewProviders/schemas";
 import { getTopicViewProvider } from "./viewProviders/topics";
 
@@ -43,14 +44,11 @@ const logger = new Logger("directConnectManager");
  * - deleting connections through actions on the Resources view
  * - firing events when the connection list changes or a specific connection is updated/deleted
  */
-export class DirectConnectionManager {
-  /** Disposables belonging to this class to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: Disposable[] = [];
-
+export class DirectConnectionManager extends BaseDisposableManager {
   // singleton instance to prevent multiple listeners and single source of connection management
   private static instance: DirectConnectionManager | null = null;
   private constructor() {
+    super();
     const context = getExtensionContext();
     if (!context) {
       // need access to SecretStorage to manage connection secrets
@@ -58,11 +56,6 @@ export class DirectConnectionManager {
     }
     const listeners = this.setEventListeners();
     this.disposables.push(...listeners);
-  }
-
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   static getInstance(): DirectConnectionManager {

--- a/src/documentMetadataManager.ts
+++ b/src/documentMetadataManager.ts
@@ -26,6 +26,11 @@ export class DocumentMetadataManager {
     return DocumentMetadataManager.instance;
   }
 
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+
   private registerEventListeners() {
     this.disposables.push(
       workspace.onDidOpenTextDocument(this.handleDocumentOpen, this),

--- a/src/documentMetadataManager.ts
+++ b/src/documentMetadataManager.ts
@@ -3,7 +3,7 @@ import { FLINKSTATEMENT_URI_SCHEME } from "./documentProviders/flinkStatement";
 import { Logger } from "./logging";
 import { getResourceManager } from "./storage/resourceManager";
 import { UriMetadataMap } from "./storage/types";
-import { BaseDisposableManager } from "./utils/disposables";
+import { DisposableCollection } from "./utils/disposables";
 
 const logger = new Logger("documentMetadataManager");
 
@@ -11,7 +11,7 @@ const logger = new Logger("documentMetadataManager");
 const SUPPORTED_URI_SCHEMES = ["file", "untitled", FLINKSTATEMENT_URI_SCHEME];
 
 /** Manager for VS Code {@link TextDocument}s that tracks metadata across document lifecycle events */
-export class DocumentMetadataManager extends BaseDisposableManager {
+export class DocumentMetadataManager extends DisposableCollection {
   private resourceManager = getResourceManager();
 
   private constructor() {

--- a/src/documentMetadataManager.ts
+++ b/src/documentMetadataManager.ts
@@ -1,8 +1,9 @@
-import { Disposable, TextDocument, Uri, workspace } from "vscode";
+import { TextDocument, Uri, workspace } from "vscode";
 import { FLINKSTATEMENT_URI_SCHEME } from "./documentProviders/flinkStatement";
 import { Logger } from "./logging";
 import { getResourceManager } from "./storage/resourceManager";
 import { UriMetadataMap } from "./storage/types";
+import { BaseDisposableManager } from "./utils/disposables";
 
 const logger = new Logger("documentMetadataManager");
 
@@ -10,11 +11,11 @@ const logger = new Logger("documentMetadataManager");
 const SUPPORTED_URI_SCHEMES = ["file", "untitled", FLINKSTATEMENT_URI_SCHEME];
 
 /** Manager for VS Code {@link TextDocument}s that tracks metadata across document lifecycle events */
-export class DocumentMetadataManager {
+export class DocumentMetadataManager extends BaseDisposableManager {
   private resourceManager = getResourceManager();
-  disposables: Disposable[] = [];
 
   private constructor() {
+    super();
     this.registerEventListeners();
   }
 
@@ -24,11 +25,6 @@ export class DocumentMetadataManager {
       DocumentMetadataManager.instance = new DocumentMetadataManager();
     }
     return DocumentMetadataManager.instance;
-  }
-
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   private registerEventListeners() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,12 +192,12 @@ async function _activateExtension(
   const artifactsViewProvider = FlinkArtifactsViewProvider.getInstance();
   const supportViewProvider = new SupportViewProvider();
   const viewProviderDisposables: vscode.Disposable[] = [
-    ...resourceViewProvider.disposables,
-    ...topicViewProvider.disposables,
-    ...schemasViewProvider.disposables,
-    ...supportViewProvider.disposables,
-    ...statementsViewProvider.disposables,
-    ...artifactsViewProvider.disposables,
+    resourceViewProvider,
+    topicViewProvider,
+    schemasViewProvider,
+    supportViewProvider,
+    statementsViewProvider,
+    artifactsViewProvider,
   ];
   logger.info("View providers initialized");
   // explicitly "reset" the Topics & Schemas views so no resources linger during reactivation/update
@@ -279,7 +279,7 @@ async function _activateExtension(
   ConnectionStateWatcher.getInstance();
 
   const directConnectionManager = DirectConnectionManager.getInstance();
-  context.subscriptions.push(...directConnectionManager.disposables);
+  context.subscriptions.push(directConnectionManager);
 
   // ensure our diagnostic collection(s) are cleared when the extension is deactivated
   context.subscriptions.push(JSON_DIAGNOSTIC_COLLECTION);
@@ -301,12 +301,12 @@ async function _activateExtension(
   context.subscriptions.push(getCCloudStatusBarItem());
 
   const docManager = DocumentMetadataManager.getInstance();
-  context.subscriptions.push(...docManager.disposables);
+  context.subscriptions.push(docManager);
 
   const provider = FlinkSqlCodelensProvider.getInstance();
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider("flinksql", provider),
-    ...provider.disposables,
+    provider,
   );
 
   // one-time cleanup of old log files from before the rotating log file stream was implemented
@@ -507,7 +507,7 @@ async function setupAuthProvider(): Promise<vscode.Disposable[]> {
   }
 
   logger.info("Confluent Cloud auth provider registered");
-  return [providerDisposable, ...provider.disposables];
+  return [providerDisposable, provider];
 }
 
 /** Set up the document providers for custom URI schemes. */

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -59,8 +59,9 @@ describe("FlinkLanguageClientManager", () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
+    flinkManager.dispose();
     FlinkLanguageClientManager["instance"] = null;
+    sandbox.restore();
   });
 
   describe("validateFlinkSettings", () => {

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -24,7 +24,7 @@ import { SIDECAR_PORT } from "../sidecar/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import { UriMetadata } from "../storage/types";
 import { logUsage, UserEvent } from "../telemetry/events";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { initializeLanguageClient } from "./languageClient";
 import {
   clearFlinkSQLLanguageServerOutputChannel,
@@ -45,7 +45,7 @@ export interface FlinkSqlSettings {
  * - Fetches and manages information about the active Editor's Flink compute pool resources
  * - Manages Flink SQL Language Client lifecycle & related settings
  */
-export class FlinkLanguageClientManager extends BaseDisposableManager {
+export class FlinkLanguageClientManager extends DisposableCollection {
   private static instance: FlinkLanguageClientManager | null = null;
   private languageClient: LanguageClient | null = null;
   private lastWebSocketUrl: string | null = null;

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -646,8 +646,7 @@ export class FlinkLanguageClientManager extends BaseDisposableManager {
 
   public async dispose(): Promise<void> {
     await this.cleanupLanguageClient();
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
+    super.dispose();
     this.openFlinkSqlDocuments.clear();
     FlinkLanguageClientManager.instance = null; // reset singleton instance to clear state
     clearFlinkSQLLanguageServerOutputChannel();

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -24,6 +24,7 @@ import { SIDECAR_PORT } from "../sidecar/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import { UriMetadata } from "../storage/types";
 import { logUsage, UserEvent } from "../telemetry/events";
+import { BaseDisposableManager } from "../utils/disposables";
 import { initializeLanguageClient } from "./languageClient";
 import {
   clearFlinkSQLLanguageServerOutputChannel,
@@ -44,9 +45,8 @@ export interface FlinkSqlSettings {
  * - Fetches and manages information about the active Editor's Flink compute pool resources
  * - Manages Flink SQL Language Client lifecycle & related settings
  */
-export class FlinkLanguageClientManager implements Disposable {
+export class FlinkLanguageClientManager extends BaseDisposableManager {
   private static instance: FlinkLanguageClientManager | null = null;
-  private disposables: Disposable[] = [];
   private languageClient: LanguageClient | null = null;
   private lastWebSocketUrl: string | null = null;
   private lastDocUri: Uri | null = null;
@@ -65,6 +65,7 @@ export class FlinkLanguageClientManager implements Disposable {
   }
 
   private constructor() {
+    super();
     // make sure we dispose the output channel when the manager is disposed
     const outputChannel: LogOutputChannel = getFlinkSQLLanguageServerOutputChannel();
     this.disposables.push(outputChannel);

--- a/src/flinkSql/flinkStatementManager.test.ts
+++ b/src/flinkSql/flinkStatementManager.test.ts
@@ -96,8 +96,9 @@ describe("flinkStatementManager.ts", () => {
     });
 
     afterEach(() => {
-      sandbox.restore();
+      instance.dispose();
       FlinkStatementManager["instance"] = undefined;
+      sandbox.restore();
     });
 
     describe("getConfiguration()", () => {

--- a/src/flinkSql/flinkStatementManager.ts
+++ b/src/flinkSql/flinkStatementManager.ts
@@ -8,7 +8,7 @@ import {
 import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { FlinkStatement, FlinkStatementId } from "../models/flinkStatement";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { IntervalPoller } from "../utils/timing";
 import { executeInWorkerPool, extract } from "../utils/workerPool";
 
@@ -37,7 +37,7 @@ export type FlinkStatementManagerConfiguration = {
  * Emits an event onto `flinkStatementUpdated` whenever a nonterminal statement is updated, and
  * an event onto `flinkStatementDeleted` whenever a nonterminal statement is deleted.
  * */
-export class FlinkStatementManager extends BaseDisposableManager {
+export class FlinkStatementManager extends DisposableCollection {
   private static instance: FlinkStatementManager | undefined = undefined;
 
   static getInstance(): FlinkStatementManager {

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -49,7 +49,7 @@ describe("CCloudResourceLoader", () => {
   });
 
   afterEach(() => {
-    CCloudResourceLoader.dispose();
+    loader.dispose();
     CCloudResourceLoader["instance"] = null; // Reset singleton instance
     sandbox.restore();
   });

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -49,8 +49,9 @@ describe("CCloudResourceLoader", () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
+    CCloudResourceLoader.dispose();
     CCloudResourceLoader["instance"] = null; // Reset singleton instance
+    sandbox.restore();
   });
 
   describe("getFlinkStatements", () => {

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -21,7 +21,6 @@ import { getSidecar, SidecarHandle } from "../sidecar";
 import { ObjectSet } from "../utils/objectset";
 import { executeInWorkerPool, ExecutionResult, extract } from "../utils/workerPool";
 import { CachingResourceLoader } from "./cachingResourceLoader";
-import { ResourceLoader } from "./resourceLoader";
 
 const logger = new Logger("storage.ccloudResourceLoader");
 
@@ -78,7 +77,7 @@ export class CCloudResourceLoader extends CachingResourceLoader<
       }
     });
 
-    ResourceLoader.disposables.push(ccloudConnectedSub);
+    this.disposables.push(ccloudConnectedSub);
   }
 
   /** Fulfill ResourceLoader::getEnvironmentsFromGraphQL */

--- a/src/loaders/localResourceLoader.test.ts
+++ b/src/loaders/localResourceLoader.test.ts
@@ -10,7 +10,7 @@ describe("LocalResourceLoader", () => {
   });
 
   afterEach(() => {
-    LocalResourceLoader.dispose();
+    loader.dispose();
     LocalResourceLoader["instance"] = null; // Reset singleton instance
   });
 

--- a/src/loaders/localResourceLoader.test.ts
+++ b/src/loaders/localResourceLoader.test.ts
@@ -10,6 +10,7 @@ describe("LocalResourceLoader", () => {
   });
 
   afterEach(() => {
+    LocalResourceLoader.dispose();
     LocalResourceLoader["instance"] = null; // Reset singleton instance
   });
 

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -15,6 +15,7 @@ import {
   TEST_LOCAL_SCHEMA_REGISTRY,
   TEST_LOCAL_SUBJECT_WITH_SCHEMAS,
 } from "../../tests/unit/testResources";
+import { TEST_DIRECT_CONNECTION_ID } from "../../tests/unit/testResources/connection";
 import {
   createTestSubject,
   createTestTopicData,
@@ -803,17 +804,31 @@ describe("ResourceLoader::dispose()", function () {
     sandbox.restore();
   });
 
-  for (const loader of [CCloudResourceLoader, DirectResourceLoader, LocalResourceLoader]) {
+  for (const loader of [CCloudResourceLoader, LocalResourceLoader]) {
     it(`should dispose of all ${loader.name}.disposables`, () => {
       const disposable1 = { dispose: sandbox.stub() };
       const disposable2 = { dispose: sandbox.stub() };
 
-      loader.getDisposables().push(disposable1, disposable2);
-      loader.dispose();
+      const loaderInstance = loader.getInstance();
+      loaderInstance.disposables.push(disposable1, disposable2);
+      loaderInstance.dispose();
 
       sinon.assert.calledOnce(disposable1.dispose);
       sinon.assert.calledOnce(disposable2.dispose);
-      assert.strictEqual(loader.getDisposables().length, 0);
+      assert.strictEqual(loaderInstance.disposables.length, 0);
     });
   }
+
+  it("should dispose of all DirectResourceLoader.disposables", () => {
+    const disposable1 = { dispose: sandbox.stub() };
+    const disposable2 = { dispose: sandbox.stub() };
+
+    const directLoader = new DirectResourceLoader(TEST_DIRECT_CONNECTION_ID);
+    directLoader.disposables.push(disposable1, disposable2);
+    directLoader.dispose();
+
+    sinon.assert.calledOnce(disposable1.dispose);
+    sinon.assert.calledOnce(disposable2.dispose);
+    assert.strictEqual(directLoader.disposables.length, 0);
+  });
 });

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -15,7 +15,6 @@ import {
   TEST_LOCAL_SCHEMA_REGISTRY,
   TEST_LOCAL_SUBJECT_WITH_SCHEMAS,
 } from "../../tests/unit/testResources";
-import { TEST_DIRECT_CONNECTION_ID } from "../../tests/unit/testResources/connection";
 import {
   createTestSubject,
   createTestTopicData,
@@ -790,45 +789,5 @@ describe("ResourceLoader::getInstance()", () => {
         return (err as Error).message.startsWith("Unknown connectionId");
       },
     );
-  });
-});
-
-describe("ResourceLoader::dispose()", function () {
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(function () {
-    sandbox = sinon.createSandbox();
-  });
-
-  afterEach(function () {
-    sandbox.restore();
-  });
-
-  for (const loader of [CCloudResourceLoader, LocalResourceLoader]) {
-    it(`should dispose of all ${loader.name}.disposables`, () => {
-      const disposable1 = { dispose: sandbox.stub() };
-      const disposable2 = { dispose: sandbox.stub() };
-
-      const loaderInstance = loader.getInstance();
-      loaderInstance.disposables.push(disposable1, disposable2);
-      loaderInstance.dispose();
-
-      sinon.assert.calledOnce(disposable1.dispose);
-      sinon.assert.calledOnce(disposable2.dispose);
-      assert.strictEqual(loaderInstance.disposables.length, 0);
-    });
-  }
-
-  it("should dispose of all DirectResourceLoader.disposables", () => {
-    const disposable1 = { dispose: sandbox.stub() };
-    const disposable2 = { dispose: sandbox.stub() };
-
-    const directLoader = new DirectResourceLoader(TEST_DIRECT_CONNECTION_ID);
-    directLoader.disposables.push(disposable1, disposable2);
-    directLoader.dispose();
-
-    sinon.assert.calledOnce(disposable1.dispose);
-    sinon.assert.calledOnce(disposable2.dispose);
-    assert.strictEqual(directLoader.disposables.length, 0);
   });
 });

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -791,3 +791,29 @@ describe("ResourceLoader::getInstance()", () => {
     );
   });
 });
+
+describe("ResourceLoader::dispose()", function () {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  for (const loader of [CCloudResourceLoader, DirectResourceLoader, LocalResourceLoader]) {
+    it(`should dispose of all ${loader.name}.disposables`, () => {
+      const disposable1 = { dispose: sandbox.stub() };
+      const disposable2 = { dispose: sandbox.stub() };
+
+      loader.getDisposables().push(disposable1, disposable2);
+      loader.dispose();
+
+      sinon.assert.calledOnce(disposable1.dispose);
+      sinon.assert.calledOnce(disposable2.dispose);
+      assert.strictEqual(loader.getDisposables().length, 0);
+    });
+  }
+});

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -1,4 +1,3 @@
-import { Disposable } from "vscode";
 import { DeleteSchemaVersionRequest, DeleteSubjectRequest } from "../clients/schemaRegistryRest";
 import { ConnectionType } from "../clients/sidecar";
 import { isResponseError, logError } from "../errors";
@@ -12,6 +11,7 @@ import { KafkaTopic } from "../models/topic";
 import { showWarningNotificationWithButtons } from "../notifications";
 import { getSidecar } from "../sidecar";
 import { getResourceManager } from "../storage/resourceManager";
+import { BaseDisposableManager } from "../utils/disposables";
 import { DirectResourceLoader } from "./directResourceLoader";
 import { fetchSchemasForSubject, fetchSubjects } from "./loaderUtils";
 
@@ -26,26 +26,11 @@ const logger = new Logger("resourceLoader");
  *
  * Generic class over the concrete {@link EnvironmentType}
  */
-export abstract class ResourceLoader implements IResourceBase {
+export abstract class ResourceLoader extends BaseDisposableManager implements IResourceBase {
   /** The connectionId for this resource loader. */
   public abstract connectionId: ConnectionId;
   /** The parent connectionType for this resource loader. */
   public abstract connectionType: ConnectionType;
-
-  /** Disposables belonging to all instances of ResourceLoader to be added to the extension
-   * context during activation, cleaned up on extension deactivation.
-   */
-  protected static disposables: Disposable[] = [];
-
-  /**  Return all known long lived disposables for extension cleanup. */
-  public static getDisposables(): Disposable[] {
-    return ResourceLoader.disposables;
-  }
-
-  static dispose() {
-    ResourceLoader.disposables.forEach((d) => d.dispose());
-    ResourceLoader.disposables = [];
-  }
 
   // Map of connectionId to ResourceLoader instance.
   private static registry: Map<ConnectionId, ResourceLoader> = new Map();

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -42,6 +42,11 @@ export abstract class ResourceLoader implements IResourceBase {
     return ResourceLoader.disposables;
   }
 
+  static dispose() {
+    ResourceLoader.disposables.forEach((d) => d.dispose());
+    ResourceLoader.disposables = [];
+  }
+
   // Map of connectionId to ResourceLoader instance.
   private static registry: Map<ConnectionId, ResourceLoader> = new Map();
 

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -11,7 +11,7 @@ import { KafkaTopic } from "../models/topic";
 import { showWarningNotificationWithButtons } from "../notifications";
 import { getSidecar } from "../sidecar";
 import { getResourceManager } from "../storage/resourceManager";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { DirectResourceLoader } from "./directResourceLoader";
 import { fetchSchemasForSubject, fetchSubjects } from "./loaderUtils";
 
@@ -26,7 +26,7 @@ const logger = new Logger("resourceLoader");
  *
  * Generic class over the concrete {@link EnvironmentType}
  */
-export abstract class ResourceLoader extends BaseDisposableManager implements IResourceBase {
+export abstract class ResourceLoader extends DisposableCollection implements IResourceBase {
   /** The connectionId for this resource loader. */
   public abstract connectionId: ConnectionId;
   /** The parent connectionType for this resource loader. */

--- a/src/loaders/resourceLoaderInitialization.ts
+++ b/src/loaders/resourceLoaderInitialization.ts
@@ -13,5 +13,5 @@ export function constructResourceLoaderSingletons(): Disposable[] {
   const localLoader = LocalResourceLoader.getInstance();
   ResourceLoader.registerInstance(LOCAL_CONNECTION_ID, localLoader);
 
-  return [...ccloudLoader.disposables, ...localLoader.disposables];
+  return [ccloudLoader, localLoader];
 }

--- a/src/loaders/resourceLoaderInitialization.ts
+++ b/src/loaders/resourceLoaderInitialization.ts
@@ -7,8 +7,11 @@ import { LocalResourceLoader } from "./localResourceLoader";
 /** Construct and register the singleton resource loaders so they may register their event listeners and
  * so that ResourceLoader.getInstance() will find them. */
 export function constructResourceLoaderSingletons(): Disposable[] {
-  ResourceLoader.registerInstance(CCLOUD_CONNECTION_ID, CCloudResourceLoader.getInstance());
-  ResourceLoader.registerInstance(LOCAL_CONNECTION_ID, LocalResourceLoader.getInstance());
+  const ccloudLoader = CCloudResourceLoader.getInstance();
+  ResourceLoader.registerInstance(CCLOUD_CONNECTION_ID, ccloudLoader);
 
-  return ResourceLoader.getDisposables();
+  const localLoader = LocalResourceLoader.getInstance();
+  ResourceLoader.registerInstance(LOCAL_CONNECTION_ID, localLoader);
+
+  return [...ccloudLoader.disposables, ...localLoader.disposables];
 }

--- a/src/quickpicks/schemaRegistries.test.ts
+++ b/src/quickpicks/schemaRegistries.test.ts
@@ -68,6 +68,7 @@ describe("quickpicks/schemaRegistries.ts schemaRegistryQuickPick()", function ()
   });
 
   afterEach(function () {
+    schemasViewProvider.dispose();
     SchemasViewProvider["instance"] = null;
     sandbox.restore();
   });

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -4,7 +4,7 @@ import { EventEmitter as NodeEventEmitter } from "node:events";
 import WebSocket from "ws";
 import { logError } from "../errors";
 import { Logger } from "../logging";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { Message, MessageBodyDecoders, MessageType, validateMessageBody } from "../ws/messageTypes";
 
 const logger = new Logger("websocketManager");
@@ -12,7 +12,7 @@ const logger = new Logger("websocketManager");
 /** Type describing message handler callbacks to whom received messages are routed. */
 export type MessageCallback<T extends MessageType> = (message: Message<T>) => Promise<void>;
 
-export class WebsocketManager extends BaseDisposableManager {
+export class WebsocketManager extends DisposableCollection {
   static instance: WebsocketManager | null = null;
 
   static getInstance(): WebsocketManager {

--- a/src/utils/disposables.test.ts
+++ b/src/utils/disposables.test.ts
@@ -1,0 +1,24 @@
+import * as sinon from "sinon";
+import { BaseDisposableManager } from "./disposables";
+
+class TestDisposableManager extends BaseDisposableManager {
+  dispose(): void {
+    super.dispose();
+  }
+}
+
+describe("utils/disposables.ts BaseDisposableManager", function () {
+  it("should dispose all registered disposables", function () {
+    const manager = new TestDisposableManager();
+
+    const disposable1 = { dispose: sinon.spy() };
+    const disposable2 = { dispose: sinon.spy() };
+    manager.disposables.push(disposable1);
+    manager.disposables.push(disposable2);
+
+    manager.dispose();
+
+    sinon.assert.calledOnce(disposable1.dispose);
+    sinon.assert.calledOnce(disposable2.dispose);
+  });
+});

--- a/src/utils/disposables.test.ts
+++ b/src/utils/disposables.test.ts
@@ -13,8 +13,8 @@ describe("utils/disposables.ts BaseDisposableManager", function () {
 
     const disposable1 = { dispose: sinon.spy() };
     const disposable2 = { dispose: sinon.spy() };
-    manager.disposables.push(disposable1);
-    manager.disposables.push(disposable2);
+    manager["disposables"].push(disposable1);
+    manager["disposables"].push(disposable2);
 
     manager.dispose();
 

--- a/src/utils/disposables.test.ts
+++ b/src/utils/disposables.test.ts
@@ -1,15 +1,15 @@
 import * as sinon from "sinon";
-import { BaseDisposableManager } from "./disposables";
+import { DisposableCollection } from "./disposables";
 
-class TestDisposableManager extends BaseDisposableManager {
+class TestDisposableCollection extends DisposableCollection {
   dispose(): void {
     super.dispose();
   }
 }
 
-describe("utils/disposables.ts BaseDisposableManager", function () {
+describe("utils/disposables.ts DisposableCollection", function () {
   it("should dispose all registered disposables", function () {
-    const manager = new TestDisposableManager();
+    const manager = new TestDisposableCollection();
 
     const disposable1 = { dispose: sinon.spy() };
     const disposable2 = { dispose: sinon.spy() };

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -1,10 +1,6 @@
 import { Disposable } from "vscode";
 
-/**
- * A base class for managing a collection of {@link Disposable disposables}.
- * This class implements the `dispose` method to clean up all registered disposables.
- */
-export abstract class BaseDisposableManager implements Disposable {
+export abstract class DisposableCollection implements Disposable {
   protected disposables: Disposable[] = [];
 
   dispose(): void {

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -1,0 +1,14 @@
+import { Disposable } from "vscode";
+
+/**
+ * A base class for managing a collection of {@link Disposable disposables}.
+ * This class implements the `dispose` method to clean up all registered disposables.
+ */
+export abstract class BaseDisposableManager implements Disposable {
+  disposables: Disposable[] = [];
+
+  dispose(): void {
+    this.disposables.forEach((disposable) => disposable.dispose());
+    this.disposables = [];
+  }
+}

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -5,7 +5,7 @@ import { Disposable } from "vscode";
  * This class implements the `dispose` method to clean up all registered disposables.
  */
 export abstract class BaseDisposableManager implements Disposable {
-  disposables: Disposable[] = [];
+  protected disposables: Disposable[] = [];
 
   dispose(): void {
     this.disposables.forEach((disposable) => disposable.dispose());

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -114,7 +114,7 @@ describe("viewProviders/base.ts BaseViewProvider", () => {
     it("should include custom event listeners in disposables", () => {
       // one for the custom event listener, and any implemented in the base class as part of the
       // private `setEventListeners` method
-      assert.ok(provider.disposables.length > 1);
+      assert.ok(provider["disposables"].length > 1);
       assert.ok(provider.setCustomEventListenersCalled);
     });
 

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -332,20 +332,6 @@ describe("viewProviders/base.ts BaseViewProvider", () => {
       });
     });
   });
-
-  describe("dispose()", function () {
-    it("should dispose of all .disposables", () => {
-      const disposable1 = { dispose: sandbox.stub() };
-      const disposable2 = { dispose: sandbox.stub() };
-      provider.disposables.push(disposable1, disposable2);
-
-      provider.dispose();
-
-      sinon.assert.calledOnce(disposable1.dispose);
-      sinon.assert.calledOnce(disposable2.dispose);
-      assert.strictEqual(provider.disposables.length, 0);
-    });
-  });
 });
 
 /** Sample view provider subclass for testing {@link ParentedBaseViewProvider}. */

--- a/src/viewProviders/base.test.ts
+++ b/src/viewProviders/base.test.ts
@@ -78,9 +78,10 @@ describe("viewProviders/base.ts BaseViewProvider", () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
+    provider.dispose();
     // reset singleton instances between tests
     BaseViewProvider["instanceMap"].clear();
+    sandbox.restore();
   });
 
   describe("getInstance()", () => {
@@ -329,6 +330,20 @@ describe("viewProviders/base.ts BaseViewProvider", () => {
         title: "Test Progress",
         cancellable: false,
       });
+    });
+  });
+
+  describe("dispose()", function () {
+    it("should dispose of all .disposables", () => {
+      const disposable1 = { dispose: sandbox.stub() };
+      const disposable2 = { dispose: sandbox.stub() };
+      provider.disposables.push(disposable1, disposable2);
+
+      provider.dispose();
+
+      sinon.assert.calledOnce(disposable1.dispose);
+      sinon.assert.calledOnce(disposable2.dispose);
+      assert.strictEqual(provider.disposables.length, 0);
     });
   });
 });

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -115,6 +115,12 @@ export abstract class BaseViewProvider<T extends BaseViewProviderData>
     return BaseViewProvider.instanceMap.get(className) as U;
   }
 
+  /** Dispose of this view provider and its tracked {@linkcode disposables}. Mainly used in tests. */
+  dispose(): void {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+
   /** Set up event listeners for this view provider. */
   protected setEventListeners(): Disposable[] {
     const disposables: Disposable[] = [];

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -19,7 +19,7 @@ import { IdItem } from "../models/main";
 import { EnvironmentId, IResourceBase, isCCloud, ISearchable } from "../models/resource";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { titleCase } from "../utils";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { filterItems, itemMatchesSearch } from "./search";
 
 /** View providers offering our common refresh() pattern. */
@@ -36,7 +36,7 @@ type BaseViewProviderData = IResourceBase & IdItem & ISearchable & { environment
  * @template T The primary resource(s) that will be shown in the view.
  */
 export abstract class BaseViewProvider<T extends BaseViewProviderData>
-  extends BaseDisposableManager
+  extends DisposableCollection
   implements TreeDataProvider<T>, RefreshableTreeViewProvider
 {
   abstract loggerName: string;

--- a/src/viewProviders/base.ts
+++ b/src/viewProviders/base.ts
@@ -19,6 +19,7 @@ import { IdItem } from "../models/main";
 import { EnvironmentId, IResourceBase, isCCloud, ISearchable } from "../models/resource";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { titleCase } from "../utils";
+import { BaseDisposableManager } from "../utils/disposables";
 import { filterItems, itemMatchesSearch } from "./search";
 
 /** View providers offering our common refresh() pattern. */
@@ -35,15 +36,12 @@ type BaseViewProviderData = IResourceBase & IdItem & ISearchable & { environment
  * @template T The primary resource(s) that will be shown in the view.
  */
 export abstract class BaseViewProvider<T extends BaseViewProviderData>
+  extends BaseDisposableManager
   implements TreeDataProvider<T>, RefreshableTreeViewProvider
 {
   abstract loggerName: string;
   abstract readonly kind: string;
   logger!: Logger;
-
-  /** Disposables belonging to this provider to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: Disposable[] = [];
 
   protected _onDidChangeTreeData: EventEmitter<T | undefined | void> = new EventEmitter<
     T | undefined | void
@@ -83,6 +81,7 @@ export abstract class BaseViewProvider<T extends BaseViewProviderData>
   // NOTE: this is usually private/protected with a singleton pattern, but needs to be public for
   // the subclasses to be called with .getInstance() properly
   public constructor() {
+    super();
     if (!getExtensionContext()) {
       // getChildren() will fail without the extension context
       throw new ExtensionContextNotSetError(this.constructor.name);
@@ -113,12 +112,6 @@ export abstract class BaseViewProvider<T extends BaseViewProviderData>
       BaseViewProvider.instanceMap.set(className, instance);
     }
     return BaseViewProvider.instanceMap.get(className) as U;
-  }
-
-  /** Dispose of this view provider and its tracked {@linkcode disposables}. Mainly used in tests. */
-  dispose(): void {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   /** Set up event listeners for this view provider. */

--- a/src/viewProviders/flinkArtifacts.test.ts
+++ b/src/viewProviders/flinkArtifacts.test.ts
@@ -25,9 +25,10 @@ describe("FlinkArtifactsViewProvider", () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
+    viewProvider.dispose();
     // reset singleton instances between tests
     FlinkArtifactsViewProvider["instanceMap"].clear();
+    sandbox.restore();
   });
 
   describe("refresh()", () => {

--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -36,9 +36,10 @@ describe("FlinkStatementsViewProvider", () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
+    viewProvider.dispose();
     // reset singleton instances between tests
     FlinkStatementsViewProvider["instanceMap"].clear();
+    sandbox.restore();
   });
 
   describe("refresh()", () => {

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -66,8 +66,9 @@ describe("ResourceViewProvider methods", () => {
   });
 
   afterEach(() => {
+    provider.dispose(); // clean up provider disposables
+    ResourceViewProvider["instance"] = null; // reset singleton instance
     sandbox.restore();
-    ResourceViewProvider["instance"] = null;
   });
 
   for (const resource of [
@@ -128,6 +129,20 @@ describe("ResourceViewProvider methods", () => {
 
     assert.strictEqual(provider.environmentsMap.size, 1);
     assert.ok(provider.environmentsMap.has(TEST_DIRECT_ENVIRONMENT.id));
+  });
+
+  describe("dispose()", function () {
+    it("should dispose of all .disposables", () => {
+      const disposable1 = { dispose: sandbox.stub() };
+      const disposable2 = { dispose: sandbox.stub() };
+      provider.disposables.push(disposable1, disposable2);
+
+      provider.dispose();
+
+      sinon.assert.calledOnce(disposable1.dispose);
+      sinon.assert.calledOnce(disposable2.dispose);
+      assert.strictEqual(provider.disposables.length, 0);
+    });
   });
 });
 

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -130,20 +130,6 @@ describe("ResourceViewProvider methods", () => {
     assert.strictEqual(provider.environmentsMap.size, 1);
     assert.ok(provider.environmentsMap.has(TEST_DIRECT_ENVIRONMENT.id));
   });
-
-  describe("dispose()", function () {
-    it("should dispose of all .disposables", () => {
-      const disposable1 = { dispose: sandbox.stub() };
-      const disposable2 = { dispose: sandbox.stub() };
-      provider.disposables.push(disposable1, disposable2);
-
-      provider.dispose();
-
-      sinon.assert.calledOnce(disposable1.dispose);
-      sinon.assert.calledOnce(disposable2.dispose);
-      assert.strictEqual(provider.disposables.length, 0);
-    });
-  });
 });
 
 describe("ResourceViewProvider loading functions", () => {

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -316,8 +316,9 @@ describe("ResourceViewProvider context value updates", () => {
   });
 
   afterEach(() => {
-    sandbox.restore();
+    provider.dispose();
     ResourceViewProvider["instance"] = null;
+    sandbox.restore();
   });
 
   it("getTreeItem() should update context values correctly when a direct environment has no resources", async () => {
@@ -490,7 +491,10 @@ describe("ResourceViewProvider search behavior", () => {
   });
 
   afterEach(() => {
+    provider.dispose();
     ResourceViewProvider["instance"] = null;
+
+    CCloudResourceLoader.dispose();
     CCloudResourceLoader["instance"] = null;
 
     sandbox.restore();

--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -480,7 +480,7 @@ describe("ResourceViewProvider search behavior", () => {
     provider.dispose();
     ResourceViewProvider["instance"] = null;
 
-    CCloudResourceLoader.dispose();
+    ccloudLoader.dispose();
     CCloudResourceLoader["instance"] = null;
 
     sandbox.restore();

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -59,7 +59,7 @@ import { updateLocalConnection } from "../sidecar/connections/local";
 import { ConnectionStateWatcher } from "../sidecar/connections/watcher";
 import { DirectConnectionsById, getResourceManager } from "../storage/resourceManager";
 import { logUsage, UserEvent } from "../telemetry/events";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { RefreshableTreeViewProvider } from "./base";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -86,7 +86,7 @@ type ResourceViewProviderData =
   | DirectResources;
 
 export class ResourceViewProvider
-  extends BaseDisposableManager
+  extends DisposableCollection
   implements vscode.TreeDataProvider<ResourceViewProviderData>, RefreshableTreeViewProvider
 {
   readonly kind: string = "resources";

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -59,6 +59,7 @@ import { updateLocalConnection } from "../sidecar/connections/local";
 import { ConnectionStateWatcher } from "../sidecar/connections/watcher";
 import { DirectConnectionsById, getResourceManager } from "../storage/resourceManager";
 import { logUsage, UserEvent } from "../telemetry/events";
+import { BaseDisposableManager } from "../utils/disposables";
 import { RefreshableTreeViewProvider } from "./base";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -85,12 +86,10 @@ type ResourceViewProviderData =
   | DirectResources;
 
 export class ResourceViewProvider
+  extends BaseDisposableManager
   implements vscode.TreeDataProvider<ResourceViewProviderData>, RefreshableTreeViewProvider
 {
   readonly kind: string = "resources";
-  /** Disposables belonging to this provider to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: vscode.Disposable[] = [];
 
   private _onDidChangeTreeData = new vscode.EventEmitter<
     ResourceViewProviderData | undefined | void
@@ -136,6 +135,7 @@ export class ResourceViewProvider
   private static instance: ResourceViewProvider | null = null;
 
   private constructor() {
+    super();
     if (!getExtensionContext()) {
       // getChildren() will fail without the extension context
       throw new ExtensionContextNotSetError("ResourceViewProvider");
@@ -156,11 +156,6 @@ export class ResourceViewProvider
       ResourceViewProvider.instance = new ResourceViewProvider();
     }
     return ResourceViewProvider.instance;
-  }
-
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   async getTreeItem(element: ResourceViewProviderData): Promise<vscode.TreeItem> {

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -158,6 +158,11 @@ export class ResourceViewProvider
     return ResourceViewProvider.instance;
   }
 
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+
   async getTreeItem(element: ResourceViewProviderData): Promise<vscode.TreeItem> {
     let treeItem: vscode.TreeItem;
     if (element instanceof Environment) {

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -144,6 +144,7 @@ describe("SchemasViewProvider search behavior", () => {
   });
 
   afterEach(() => {
+    provider.dispose();
     SchemasViewProvider["instance"] = null;
   });
 

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -21,6 +21,7 @@ import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { logUsage, UserEvent } from "../telemetry/events";
+import { BaseDisposableManager } from "../utils/disposables";
 import { RefreshableTreeViewProvider } from "./base";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -34,12 +35,10 @@ const logger = new Logger("viewProviders.schemas");
 type SchemasViewProviderData = Subject | Schema;
 
 export class SchemasViewProvider
+  extends BaseDisposableManager
   implements vscode.TreeDataProvider<SchemasViewProviderData>, RefreshableTreeViewProvider
 {
   readonly kind = "schemas";
-  /** Disposables belonging to this provider to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: vscode.Disposable[] = [];
 
   private _onDidChangeTreeData: vscode.EventEmitter<SchemasViewProviderData | undefined | void> =
     new vscode.EventEmitter<SchemasViewProviderData | undefined | void>();
@@ -146,6 +145,7 @@ export class SchemasViewProvider
   private static instance: SchemasViewProvider | null = null;
 
   private constructor() {
+    super();
     if (!getExtensionContext()) {
       // getChildren() will fail without the extension context
       throw new ExtensionContextNotSetError("SchemasViewProvider");
@@ -163,12 +163,6 @@ export class SchemasViewProvider
       SchemasViewProvider.instance = new SchemasViewProvider();
     }
     return SchemasViewProvider.instance;
-  }
-
-  /** Deregister event listeners, etc. */
-  dispose(): void {
-    this.disposables.forEach((d) => d.dispose());
-    this.disposables = [];
   }
 
   /** Convenience method to revert this view to its original state. */

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -21,7 +21,7 @@ import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { logUsage, UserEvent } from "../telemetry/events";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { RefreshableTreeViewProvider } from "./base";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -35,7 +35,7 @@ const logger = new Logger("viewProviders.schemas");
 type SchemasViewProviderData = Subject | Schema;
 
 export class SchemasViewProvider
-  extends BaseDisposableManager
+  extends DisposableCollection
   implements vscode.TreeDataProvider<SchemasViewProviderData>, RefreshableTreeViewProvider
 {
   readonly kind = "schemas";

--- a/src/viewProviders/support.ts
+++ b/src/viewProviders/support.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 
 export class SupportViewProvider
-  extends BaseDisposableManager
+  extends DisposableCollection
   implements vscode.TreeDataProvider<vscode.TreeItem>
 {
   constructor() {

--- a/src/viewProviders/support.ts
+++ b/src/viewProviders/support.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
+import { BaseDisposableManager } from "../utils/disposables";
 
-export class SupportViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
-  /** Disposables belonging to this provider to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: vscode.Disposable[] = [];
-
+export class SupportViewProvider
+  extends BaseDisposableManager
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
   constructor() {
+    super();
     // register to the Support view
     const provider: vscode.Disposable = vscode.window.registerTreeDataProvider(
       "confluent-support",

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -23,6 +23,7 @@ import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
 import { logUsage, UserEvent } from "../telemetry/events";
+import { BaseDisposableManager } from "../utils/disposables";
 import { RefreshableTreeViewProvider } from "./base";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -36,12 +37,10 @@ const logger = new Logger("viewProviders.topics");
 type TopicViewProviderData = KafkaTopic | Subject | Schema;
 
 export class TopicViewProvider
+  extends BaseDisposableManager
   implements vscode.TreeDataProvider<TopicViewProviderData>, RefreshableTreeViewProvider
 {
   readonly kind = "topics";
-  /** Disposables belonging to this provider to be added to the extension context during activation,
-   * cleaned up on extension deactivation. */
-  disposables: vscode.Disposable[] = [];
 
   private _onDidChangeTreeData: vscode.EventEmitter<TopicViewProviderData | undefined | void> =
     new vscode.EventEmitter<TopicViewProviderData | undefined | void>();
@@ -82,6 +81,7 @@ export class TopicViewProvider
 
   private static instance: TopicViewProvider | null = null;
   private constructor() {
+    super();
     if (!getExtensionContext()) {
       // getChildren() will fail without the extension context
       throw new ExtensionContextNotSetError("TopicViewProvider");

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -23,7 +23,7 @@ import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
 import { logUsage, UserEvent } from "../telemetry/events";
-import { BaseDisposableManager } from "../utils/disposables";
+import { DisposableCollection } from "../utils/disposables";
 import { RefreshableTreeViewProvider } from "./base";
 import { updateCollapsibleStateFromSearch } from "./collapsing";
 import { filterItems, itemMatchesSearch, SEARCH_DECORATION_URI_SCHEME } from "./search";
@@ -37,7 +37,7 @@ const logger = new Logger("viewProviders.topics");
 type TopicViewProviderData = KafkaTopic | Subject | Schema;
 
 export class TopicViewProvider
-  extends BaseDisposableManager
+  extends DisposableCollection
   implements vscode.TreeDataProvider<TopicViewProviderData>, RefreshableTreeViewProvider
 {
   readonly kind = "topics";


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

In an effort to clean up potential test flakes and global test state bleedover, this PR adds some dedicated `dispose()` methods to our classes that keep track of their own `.disposables`. 

This is done by adding a base `DisposableCollection` class that keeps track of a `disposables` array (like may existing classes do) and implements a simple `dispose()` method to clean up whatever disposables are created (by subclasses).

> [!NOTE]
> This isn't a big deal for actual extension code since they should all be registering to the `ExtensionContext.subscriptions` at extension activation time (which then get disposed at deactivation time).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
