### PR TITLE
Udf auth ccloud

### DIFF
--- a/src/viewProviders/flinkArtifacts.test.ts
+++ b/src/viewProviders/flinkArtifacts.test.ts
@@ -2,12 +2,12 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { CancellationToken, Progress, window } from "vscode";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
+import { createFlinkArtifact } from "../../tests/unit/testResources/flinkArtifact";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import { createResponseError, getTestExtensionContext } from "../../tests/unit/testUtils";
 import { ConnectionType } from "../clients/sidecar/models/ConnectionType";
 import { ccloudAuthSessionInvalidated } from "../emitters";
 import { CCloudResourceLoader } from "../loaders";
-import { FlinkArtifact } from "../models/flinkArtifact";
 import { FlinkArtifactsViewProvider } from "./flinkArtifacts";
 
 describe("FlinkArtifactsViewProvider", () => {
@@ -62,25 +62,21 @@ describe("FlinkArtifactsViewProvider", () => {
         getStubbedCCloudResourceLoader(sandbox);
 
       const mockArtifacts = [
-        new FlinkArtifact({
+        createFlinkArtifact({
           connectionId: resource.connectionId,
           connectionType: resource.connectionType,
           environmentId: resource.environmentId,
           id: "artifact1",
           name: "Test Artifact 1",
           description: "Test artifact description",
-          provider: "aws",
-          region: "us-east-1",
         }),
-        new FlinkArtifact({
+        createFlinkArtifact({
           connectionId: resource.connectionId,
           connectionType: resource.connectionType,
           environmentId: resource.environmentId,
           id: "artifact2",
           name: "Test Artifact 2",
           description: "Another test artifact",
-          provider: "aws",
-          region: "us-east-1",
         }),
       ];
 
@@ -158,15 +154,13 @@ describe("FlinkArtifactsViewProvider", () => {
 
   it("returns artifacts when compute pool is selected", () => {
     const mockArtifacts = [
-      new FlinkArtifact({
+      createFlinkArtifact({
         connectionId: TEST_CCLOUD_FLINK_COMPUTE_POOL.connectionId,
         connectionType: ConnectionType.Ccloud,
         environmentId: TEST_CCLOUD_FLINK_COMPUTE_POOL.environmentId,
         id: "artifact1",
         name: "Test Artifact 1",
         description: "Test artifact description",
-        provider: "aws",
-        region: "us-east-1",
       }),
     ];
 

--- a/tests/unit/testResources/flinkArtifact.ts
+++ b/tests/unit/testResources/flinkArtifact.ts
@@ -1,0 +1,31 @@
+import { ConnectionType } from "../../../src/clients/sidecar";
+import { CCLOUD_CONNECTION_ID } from "../../../src/constants";
+import { FlinkArtifact } from "../../../src/models/flinkArtifact";
+import { ConnectionId, EnvironmentId } from "../../../src/models/resource";
+import { TEST_CCLOUD_ENVIRONMENT_ID } from "./environments";
+
+export const TEST_CCLOUD_FLINK_ARTIFACT = createFlinkArtifact();
+
+export interface CreateFlinkArtifactArgs {
+  connectionId?: ConnectionId;
+  connectionType?: ConnectionType;
+  environmentId?: EnvironmentId;
+  id?: string;
+  name?: string;
+  description?: string;
+  provider?: string;
+  region?: string;
+}
+
+export function createFlinkArtifact(overrides: CreateFlinkArtifactArgs = {}): FlinkArtifact {
+  return new FlinkArtifact({
+    connectionId: overrides.connectionId || CCLOUD_CONNECTION_ID,
+    connectionType: overrides.connectionType || ConnectionType.Ccloud,
+    environmentId: overrides.environmentId || TEST_CCLOUD_ENVIRONMENT_ID,
+    id: overrides.id || "artifact-123",
+    name: overrides.name || "Test Artifact",
+    description: overrides.description || "Test artifact description",
+    provider: overrides.provider || "aws",
+    region: overrides.region || "us-east-1",
+  });
+}

--- a/tests/unit/testResources/index.ts
+++ b/tests/unit/testResources/index.ts
@@ -1,4 +1,5 @@
 export * from "./environments";
+export * from "./flinkArtifact";
 export * from "./kafkaCluster";
 export * from "./schema";
 export * from "./schemaRegistry";


### PR DESCRIPTION
## Summary of Changes

> [!WARNING]
> Requires https://github.com/confluentinc/vscode/pull/2238 to be merged first, then this branch will add user feedback on 400-599 code errs, network errs.

- main
    - [add a base artifact for testing](https://github.com/confluentinc/vscode/pull/2238)
        - [add user feedback](https://github.com/confluentinc/vscode/compare/main...udf-auth-ccloud?expand=1)

This branch also addresses #2235 and removes firing auth events from the `FlinkArtifacts` logic, making it rely on the middleware instead.

## Any additional details or context that should be provided?

Users will now see a notification on failure to load:

<img width="1632" height="502" alt="Screenshot 2025-07-24 at 7 56 13 AM" src="https://github.com/user-attachments/assets/89accfb7-fadf-4c80-99b2-59357d47f230" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
