### PR TITLE
chore: fix `sonar-project.properties` exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,7 @@
+sonar.projectKey=vscode
+sonar.language=javascript,typescript
+sonar.sources=src
+sonar.javascript.lcov.reportPaths=coverage/lcov-functional.info,coverage/lcov.info
 sonar.coverage.exclusions=src/testing.ts,src/**/*.test.ts,src/clients/**/*,src/**/*.spec.ts
 sonar.cpd.exclusions=src/testing.ts,src/**/*.test.ts,src/clients/**/*,src/**/*.spec.ts
 sonar.exclusions=src/testing.ts,src/**/*.test.ts,src/clients/**/*,src/**/*.spec.ts
-sonar.javascript.lcov.reportPaths=coverage/lcov-functional.info,coverage/lcov.info
-sonar.language=javascript,typescript
-sonar.projectKey=vscode
-sonar.sources=src
-sonar.typescript.coverage.reportPaths=coverage/lcov-functional.info,coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
-sonar.coverage.exclusions=src/**/*.test.ts,src/clients/**/*,node_modules/**/*
-sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
-sonar.exclusions=.vscode-test/**/*,Gulpfile.mjs,bin/**/*,mk-files/**/*,node_modules/**/*,playwright.config.ts,src/**/*.spec.ts,src/**/*.test.ts,src/clients/**/*,src/testing.ts,tests/**/*,userdata/**/*
+sonar.coverage.exclusions=src/testing.ts,src/**/*.test.ts,src/clients/**/*,src/**/*.spec.ts
+sonar.cpd.exclusions=src/testing.ts,src/**/*.test.ts,src/clients/**/*,src/**/*.spec.ts
+sonar.exclusions=src/testing.ts,src/**/*.test.ts,src/clients/**/*,src/**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov-functional.info,coverage/lcov.info
 sonar.language=javascript,typescript
 sonar.projectKey=vscode

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.exclusions=src/**/*.test.ts,src/clients/**/*,node_modules/**/*
 sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.exclusions=.vscode-test/**/*,Gulpfile.mjs,bin/**/*,mk-files/**/*,node_modules/**/*,playwright.config.ts,src/**/*.spec.ts,src/**/*.test.ts,src/clients/**/*,src/testing.ts,tests/**/*,userdata/**/*
 sonar.javascript.lcov.reportPaths=coverage/lcov-functional.info,coverage/lcov.info


### PR DESCRIPTION
Mainly to match the same behavior we see via `gulp test --coverage`: 
https://github.com/confluentinc/vscode/blob/8468f8419d03699bb3b1e9bd7a630d2e29588800/Gulpfile.js#L632-L636

With some extras since sonarqube is looking at all of `src/` instead of just the files that are part of our Gulp (test)build processes:
- we didn't need to exclude anything that wasn't under `src/` since we set `sonar.sources=src`, which removes the need to exclude things like `node_modules/` and `tests/`
- `sonar.typescript.coverage.reportPaths` wasn't valid and didn't actually do anything, and [`sonar.javascript.lcov.reportPaths`](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/test-coverage/test-coverage-parameters/#javaScript-typeScript) handles what we need
