### PR TITLE
chore(CI): set up scheduled prerelease vsixes

### DIFF
--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -16,7 +16,11 @@ blocks:
       prologue:
         commands:
           - git fetch --all
-          - git checkout $COMMIT_SHA
+          - |
+              if [ -z "$COMMIT_SHA" ]; then
+                COMMIT_SHA=$(git rev-parse HEAD)
+              fi
+              git checkout "$COMMIT_SHA"
           - . vault-setup
           - make install-dependencies
       jobs:

--- a/service.yml
+++ b/service.yml
@@ -34,6 +34,11 @@ semaphore:
           required: true
           description: |
             The commit SHA to create the release and tag from, must be a valid SHA/tag/branch.
+    - name: scheduled-prerelease-multi-arch-packaging
+      branch: main
+      pipeline_file: ".semaphore/prerelease-multi-arch-packaging.yml"
+      scheduled: true
+      at: "10 4 * * *" # Every day at 04:10 UTC
 sonarqube:
   enable: false
 make:


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/vscode/pull/2226 where we set up a daily task to package and upload .vsix files based off the latest commit to `main` to a GitHub prerelease matching [`.versions/next.txt`](https://github.com/confluentinc/vscode/blob/main/.versions/next.txt). (GitHub prereleases will be created through a separate process outside of this repository.)

Sample run: https://semaphore.ci.confluent.io/workflows/b883aea6-b920-487c-90c2-5f265b0fb9d3

> [!NOTE]
> We'll still have to use the manual `prerelease-multi-arch-packaging` task for generating prereleases for a release branch.