### PR TITLE
Bring new view controller event handler tests up to speed; write one more event handler-related test across the view controller family.

### DIFF
--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -425,6 +425,12 @@ describe("FlinkStatementsViewProvider", () => {
       ["flinkStatementDeleted", "flinkStatementDeletedHandler"],
     ];
 
+    it("setCustomEventListeners should return the expected number of listeners", () => {
+      // @ts-expect-error protected method
+      const listeners = viewProvider.setCustomEventListeners();
+      assert.strictEqual(listeners.length, handlerEmitterPairs.length);
+    });
+
     handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
       it(`should register ${handlerMethodName} with ${emitterName} emitter`, () => {
         // Create stub for the handler method

--- a/src/viewProviders/newResources.test.ts
+++ b/src/viewProviders/newResources.test.ts
@@ -641,6 +641,12 @@ describe("viewProviders/newResources.ts", () => {
           ["connectionDisconnected", "refreshConnection"],
         ];
 
+      it("setCustomEventListeners should return the expected number of listeners", () => {
+        // @ts-expect-error protected method
+        const listeners = provider.setCustomEventListeners();
+        assert.strictEqual(listeners.length, handlerEmitterPairs.length);
+      });
+
       handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
         it(`should register ${handlerMethodName} with ${emitterName} emitter`, () => {
           // Create stub for the handler method

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -575,6 +575,11 @@ describe("SchemasViewProvider", () => {
       ["schemaVersionsChanged", "schemaVersionsChangedHandler"],
     ];
 
+    it("setEventListeners should return the expected number of listeners", () => {
+      const listeners = provider.setEventListeners();
+      assert.strictEqual(listeners.length, handlerEmitterPairs.length);
+    });
+
     handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
       it(`should register ${handlerMethodName} with ${emitterName} emitter`, () => {
         // Create stub for the handler method

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -521,6 +521,11 @@ describe("TopicViewProvider", () => {
       ["schemaVersionsChanged", "subjectChangeHandler"],
     ];
 
+    it("setEventListeners should return the expected number of listeners", () => {
+      const listeners = provider.setEventListeners();
+      assert.strictEqual(listeners.length, handlerEmitterPairs.length);
+    });
+
     handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
       it(`should register ${handlerMethodName} with ${emitterName} emitter`, () => {
         // Create stub for the handler method


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Bring NewResourceViewProvider event handler registration tests up to speed with technology created in #2254.
- While here, also prove that the event registration method returns the tested-number of event handlers, otherwise when we go and add more event handlers into these, their wiring may go untested. This change will now force a test fail in that case.


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
