### PR TITLE
Bring `BaseViewProvider` and `ParentedBaseViewProvider` event handling wiring up to standards

### DIFF
--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -408,7 +408,7 @@ describe("FlinkStatementsViewProvider", () => {
     });
   });
 
-  describe("setCustomEventListeners() wires the proper handler methods to the proper event emitters", () => {
+  describe("setEventListeners() and setCustomEventListeners() wire the proper handler methods to the proper event emitters", () => {
     let emitterStubs: StubbedEventEmitters;
 
     beforeEach(() => {
@@ -421,8 +421,14 @@ describe("FlinkStatementsViewProvider", () => {
     const handlerEmitterPairs: Array<
       [keyof typeof emitterStubs, keyof FlinkStatementsViewProvider]
     > = [
+      // Wired directly by FlinkStatementsViewProvider::setCustomEventListeners()
       ["flinkStatementUpdated", "flinkStatementUpdatedHandler"],
       ["flinkStatementDeleted", "flinkStatementDeletedHandler"],
+      // Wired by ParentedBaseViewProvider::setEventListeners()
+      ["ccloudConnected", "ccloudConnectedHandler"],
+      ["currentFlinkStatementsResourceChanged", "parentResourceChangedHandler"],
+      // Wired by BaseViewProvider::setEventListeners() because FlinkStatementsViewProvider assigns searchChangedEmitter
+      ["flinkStatementSearchSet", "setSearch"],
     ];
 
     handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
@@ -430,9 +436,9 @@ describe("FlinkStatementsViewProvider", () => {
         // Create stub for the handler method
         const handlerStub = sandbox.stub(viewProvider, handlerMethodName);
 
-        // Re-invoke setCustomEventListeners() to capture emitter .event() stub calls
+        // Re-invoke setEventListeners() to capture emitter .event() stub calls
         // @ts-expect-error protected method
-        viewProvider.setCustomEventListeners();
+        viewProvider.setEventListeners();
 
         const emitterStub = emitterStubs[emitterName]!;
 


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Only wire up explicit named methods as event handlers within `BaseViewProvider` and `ParentedBaseViewProvider` as is our new standard. The wiring is made a little more complicated due to needing to do so conditionally. 
- Test overall `setEventListers()` behavior across `BaseViewProvider` and `ParentedBaseViewProvider` from perspective of `FlinkStatementsViewProvider`, which passes both the has-parent-changed-event-emitter condition and also the has-search-term-changed-event-emitter condition checks.
- DRAFT waiting on pr refactoring to then be able to test from NewResourceViewProvider perspective, then missing the parent-changed aspect.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
