### PR TITLE
bugfix(pt 2): make it so clicking on compute pool without artifacts doesn't trigger attempt to get artifacts

### DIFF
--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -13,106 +13,122 @@ import * as quickpicks from "../quickpicks/flinkComputePools";
 import * as kafkaQuickpicks from "../quickpicks/kafkaClusters";
 import * as commandsModule from "./flinkComputePools";
 
-describe("configureFlinkDefaults command", () => {
+describe("flinkComputePools.ts", () => {
   let sandbox: sinon.SinonSandbox;
-  let flinkComputePoolQuickPickStub: sinon.SinonStub;
-  let flinkDatabaseQuickpickStub: sinon.SinonStub;
-  let stubbedConfigs: StubbedWorkspaceConfiguration;
-  let showInformationMessageStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    flinkComputePoolQuickPickStub = sandbox.stub(quickpicks, "flinkComputePoolQuickPick");
-    flinkDatabaseQuickpickStub = sandbox.stub(kafkaQuickpicks, "flinkDatabaseQuickpick");
-    stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
-    showInformationMessageStub = sandbox
-      .stub(vscode.window, "showInformationMessage")
-      .resolves(undefined);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  it("should return early if no compute pool is selected", async () => {
-    flinkComputePoolQuickPickStub.resolves(undefined);
+  describe("configureFlinkDefaults command", () => {
+    let flinkComputePoolQuickPickStub: sinon.SinonStub;
+    let flinkDatabaseQuickpickStub: sinon.SinonStub;
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
+    let showInformationMessageStub: sinon.SinonStub;
 
-    await commandsModule.configureFlinkDefaults();
+    beforeEach(() => {
+      flinkComputePoolQuickPickStub = sandbox.stub(quickpicks, "flinkComputePoolQuickPick");
+      flinkDatabaseQuickpickStub = sandbox.stub(kafkaQuickpicks, "flinkDatabaseQuickpick");
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
+      showInformationMessageStub = sandbox
+        .stub(vscode.window, "showInformationMessage")
+        .resolves(undefined);
+    });
 
-    assert.ok(stubbedConfigs.update.notCalled);
-    assert.ok(flinkDatabaseQuickpickStub.notCalled);
+    it("should return early if no compute pool is selected", async () => {
+      flinkComputePoolQuickPickStub.resolves(undefined);
+
+      await commandsModule.configureFlinkDefaults();
+
+      assert.ok(stubbedConfigs.update.notCalled);
+      assert.ok(flinkDatabaseQuickpickStub.notCalled);
+    });
+
+    it("should update config and show info message after pool and database are selected", async () => {
+      flinkComputePoolQuickPickStub.resolves(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+      flinkDatabaseQuickpickStub.resolves(TEST_CCLOUD_KAFKA_CLUSTER);
+
+      await commandsModule.configureFlinkDefaults();
+
+      sinon.assert.calledWithExactly(
+        stubbedConfigs.update,
+        FLINK_CONFIG_COMPUTE_POOL.id,
+        TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
+        true,
+      );
+      sinon.assert.calledWithExactly(
+        stubbedConfigs.update,
+        FLINK_CONFIG_DATABASE.id,
+        TEST_CCLOUD_KAFKA_CLUSTER.id,
+        true,
+      );
+      sinon.assert.calledOnce(showInformationMessageStub);
+    });
+
+    it("should open settings if user selects 'View' in info message", async () => {
+      const pool = { id: "pool1" };
+      const cluster = { name: "db1" };
+      flinkComputePoolQuickPickStub.resolves(pool);
+      flinkDatabaseQuickpickStub.resolves(cluster);
+      showInformationMessageStub.resolves("View");
+      const executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
+
+      await commandsModule.configureFlinkDefaults();
+
+      assert.ok(
+        executeCommandStub.calledWith(
+          "workbench.action.openSettings",
+          "@ext:confluentinc.vscode-confluent flink",
+        ),
+      );
+    });
   });
 
-  it("should update config and show info message after pool and database are selected", async () => {
-    flinkComputePoolQuickPickStub.resolves(TEST_CCLOUD_FLINK_COMPUTE_POOL);
-    flinkDatabaseQuickpickStub.resolves(TEST_CCLOUD_KAFKA_CLUSTER);
+  describe("selectPoolFromResourcesViewCommand", () => {
+    let executeCommandStub: sinon.SinonStub;
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
 
-    await commandsModule.configureFlinkDefaults();
+    beforeEach(() => {
+      executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
+    });
 
-    sinon.assert.calledWithExactly(
-      stubbedConfigs.update,
-      FLINK_CONFIG_COMPUTE_POOL.id,
-      TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
-      true,
-    );
-    sinon.assert.calledWithExactly(
-      stubbedConfigs.update,
-      FLINK_CONFIG_DATABASE.id,
-      TEST_CCLOUD_KAFKA_CLUSTER.id,
-      true,
-    );
-    sinon.assert.calledOnce(showInformationMessageStub);
-  });
+    it("should invoke both statements and artifacts pool selection commands when Flink Artifacts is enabled", async () => {
+      stubbedConfigs.stubGet(ENABLE_FLINK_ARTIFACTS, true);
 
-  it("should open settings if user selects 'View' in info message", async () => {
-    const pool = { id: "pool1" };
-    const cluster = { name: "db1" };
-    flinkComputePoolQuickPickStub.resolves(pool);
-    flinkDatabaseQuickpickStub.resolves(cluster);
-    showInformationMessageStub.resolves("View");
-    const executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
+      await commandsModule.selectPoolFromResourcesViewCommand(TEST_CCLOUD_FLINK_COMPUTE_POOL);
 
-    await commandsModule.configureFlinkDefaults();
+      sinon.assert.calledWith(
+        executeCommandStub,
+        "confluent.statements.flink-compute-pool.select",
+        TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      );
+      sinon.assert.calledWith(
+        executeCommandStub,
+        "confluent.artifacts.flink-compute-pool.select",
+        TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      );
+    });
 
-    assert.ok(
-      executeCommandStub.calledWith(
-        "workbench.action.openSettings",
-        "@ext:confluentinc.vscode-confluent flink",
-      ),
-    );
-  });
-});
+    it("should only invoke statements pool selection command when Flink Artifacts is disabled", async () => {
+      stubbedConfigs.stubGet(ENABLE_FLINK_ARTIFACTS, false);
 
-describe("selectPoolFromResourcesViewCommand", () => {
-  let sandbox: sinon.SinonSandbox;
-  let executeCommandStub: sinon.SinonStub;
-  let stubbedConfigs: StubbedWorkspaceConfiguration;
+      await commandsModule.selectPoolFromResourcesViewCommand(TEST_CCLOUD_FLINK_COMPUTE_POOL);
 
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
-    stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
-  it("should call both statements and artifacts pool selection commands when Flink Artifacts is enabled", async () => {
-    stubbedConfigs.stubGet(ENABLE_FLINK_ARTIFACTS, true);
-
-    await commandsModule.selectPoolFromResourcesViewCommand(TEST_CCLOUD_FLINK_COMPUTE_POOL);
-
-    sinon.assert.calledWith(executeCommandStub, "confluent-flink-statements.focus");
-    sinon.assert.calledWith(executeCommandStub, "confluent-flink-artifacts.focus");
-  });
-
-  it("should only call statements pool selection command when Flink Artifacts is disabled", async () => {
-    stubbedConfigs.stubGet(ENABLE_FLINK_ARTIFACTS, false);
-
-    await commandsModule.selectPoolFromResourcesViewCommand(TEST_CCLOUD_FLINK_COMPUTE_POOL);
-
-    sinon.assert.calledWith(executeCommandStub, "confluent-flink-statements.focus");
-    sinon.assert.neverCalledWith(executeCommandStub, "confluent-flink-artifacts.focus");
+      sinon.assert.calledWith(
+        executeCommandStub,
+        "confluent.statements.flink-compute-pool.select",
+        TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      );
+      sinon.assert.neverCalledWith(
+        executeCommandStub,
+        "confluent.artifacts.flink-compute-pool.select",
+        TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      );
+    });
   });
 });

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -38,13 +38,23 @@ export async function selectPoolFromResourcesViewCommand(item?: CCloudFlinkCompu
 
   // need to pass a new argument to prevent the views from being focused,
   // see https://github.com/confluentinc/vscode/issues/1967
-  const promises: Promise<void>[] = [selectPoolForStatementsViewCommand(pool)];
+
+  // Indirectly invoke selectPoolForStatementsViewCommand() and perhaps
+  // selectPoolForArtifactsViewCommand() to update the views with the selected pool.
+  // (The indirection is done for test mocking purposes -- cannot stub
+  // functions within the same module, but can always stub commands.executeCommand().)
+
+  const thenables: Thenable<void>[] = [
+    // Will invoke selectPoolForStatementsViewCommand().
+    commands.executeCommand("confluent.statements.flink-compute-pool.select", pool),
+  ];
 
   // Only include artifacts view selection if Flink Artifacts feature is enabled
   if (ENABLE_FLINK_ARTIFACTS.value) {
-    promises.push(selectPoolForArtifactsViewCommand(pool));
+    // Will invoke selectPoolForArtifactsViewCommand().
+    thenables.push(commands.executeCommand("confluent.artifacts.flink-compute-pool.select", pool));
   }
-  await Promise.all(promises);
+  await Promise.all(thenables);
 }
 
 /**


### PR DESCRIPTION
## Summary of Changes

resolves #2266 

## Any additional details or context that should be provided?



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
