### PR TITLE
chore: cleanup udf implementation

### DIFF
--- a/src/commands/uploadUDF.test.ts
+++ b/src/commands/uploadUDF.test.ts
@@ -3,7 +3,7 @@ import * as sinon from "sinon";
 import type { PresignedUploadUrlArtifactV1PresignedUrlRequest } from "../clients/flinkArtifacts";
 import * as errorsModule from "../errors";
 import * as sidecarModule from "../sidecar";
-import { getPresignedUploadUrl } from "./uploadUDF";
+import { getPresignedUploadUrl } from "./utils/uploadUDF";
 
 describe("getPresignedUploadUrl", () => {
   let sandbox: sinon.SinonSandbox;

--- a/src/commands/uploadUDF.ts
+++ b/src/commands/uploadUDF.ts
@@ -1,12 +1,9 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
-import {
-  PresignedUploadUrlArtifactV1PresignedUrl200Response,
-  PresignedUploadUrlArtifactV1PresignedUrlRequest,
-} from "../clients/flinkArtifacts/models";
+import { PresignedUploadUrlArtifactV1PresignedUrlRequest } from "../clients/flinkArtifacts/models";
 import { logError } from "../errors";
-import { EnvironmentId, IEnvProviderRegion } from "../models/resource";
-import { getSidecar } from "../sidecar";
+import { showErrorNotificationWithButtons } from "../notifications";
+import { handlePresignedUrlRequest, promptForUDFUploadParams } from "./utils/uploadUDF";
 
 /**
  * Prompts the user for environment, cloud provider, region, and artifact name.
@@ -19,83 +16,6 @@ export interface UDFUploadParams {
   artifactName: string;
   fileFormat: string;
 }
-
-export async function promptForUDFUploadParams(): Promise<UDFUploadParams | undefined> {
-  const environment = await vscode.window.showInputBox({
-    prompt: "Enter the Environment ID for the UDF upload",
-    ignoreFocusOut: true,
-    validateInput: (value) => (value ? undefined : "Environment ID is required"),
-  });
-  if (!environment) {
-    vscode.window.showWarningMessage("Upload UDF cancelled: Environment ID is required.");
-    return undefined;
-  }
-
-  const cloud = await vscode.window.showQuickPick(["AWS", "Azure"], {
-    placeHolder: "Select the cloud provider for the UDF upload",
-  });
-  if (!cloud) {
-    vscode.window.showWarningMessage("Upload UDF cancelled: Cloud provider is required.");
-    return undefined;
-  }
-  const fileFormat = await vscode.window.showQuickPick(["zip", "jar"], {
-    placeHolder: "Select the file format for the UDF",
-  });
-  if (!fileFormat) {
-    vscode.window.showWarningMessage("Upload UDF cancelled: File format is required.");
-    return undefined;
-  }
-
-  const region = await vscode.window.showInputBox({
-    prompt: "Enter the region for the UDF upload",
-    ignoreFocusOut: true,
-    validateInput: (value) => (value ? undefined : "Region is required"),
-  });
-  if (!region) {
-    vscode.window.showWarningMessage("Upload UDF cancelled: Region is required.");
-    return undefined;
-  }
-
-  const artifactName = await vscode.window.showInputBox({
-    prompt: "Enter the artifact name for the UDF",
-    ignoreFocusOut: true,
-    validateInput: (value) => (value ? undefined : "Artifact name is required"),
-  });
-  if (!artifactName) {
-    vscode.window.showWarningMessage("Upload UDF cancelled: Artifact name is required.");
-    return undefined;
-  }
-
-  return { environment, cloud, region, artifactName, fileFormat };
-}
-
-/**
- * Requests a presigned upload URL for a Flink artifact using the sidecar.
- * @param request PresignedUploadUrlArtifactV1PresignedUrlRequest
- * @returns The presigned URL response object, or undefined if the request fails.
- */
-export async function getPresignedUploadUrl(
-  request: PresignedUploadUrlArtifactV1PresignedUrlRequest,
-): Promise<PresignedUploadUrlArtifactV1PresignedUrl200Response | undefined> {
-  try {
-    const sidecarHandle = await getSidecar();
-    const providerRegion: IEnvProviderRegion = {
-      environmentId: request.environment as EnvironmentId,
-      provider: request.cloud,
-      region: request.region,
-    };
-    const presignedClient = sidecarHandle.getFlinkPresignedUrlsApi(providerRegion);
-
-    // Wrap the request as required by the OpenAPI client
-    const urlResponse = await presignedClient.presignedUploadUrlArtifactV1PresignedUrl({
-      PresignedUploadUrlArtifactV1PresignedUrlRequest: request,
-    });
-    return urlResponse;
-  } catch (err) {
-    logError(err, "Failed to get presigned upload URL");
-    return undefined;
-  }
-}
 export async function uploadUDFCommand(): Promise<void> {
   try {
     const params = await promptForUDFUploadParams();
@@ -103,7 +23,6 @@ export async function uploadUDFCommand(): Promise<void> {
       return;
     }
 
-    // Build the request object
     const request: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
       environment: params.environment,
       cloud: params.cloud,
@@ -112,36 +31,22 @@ export async function uploadUDFCommand(): Promise<void> {
       content_format: params.fileFormat,
     };
 
-    // Call the API
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
         title: "Requesting presigned upload URL...",
         cancellable: false,
       },
-      async () => {
-        const response = await getPresignedUploadUrl(request);
-        if (response && response.upload_url) {
-          vscode.window
-            .showInformationMessage("Presigned upload URL received.", "Copy URL")
-            .then((selection) => {
-              if (selection === "Copy URL") {
-                vscode.env.clipboard.writeText(response.upload_url!);
-                vscode.window.showInformationMessage("Upload URL copied to clipboard.");
-              }
-            });
-        } else {
-          vscode.window.showErrorMessage(
-            "Failed to get presigned upload URL. See logs for details.",
-          );
-        }
-      },
+      () => handlePresignedUrlRequest(request),
     );
   } catch (err) {
     logError(err, "Failed to execute Upload UDF command");
-    vscode.window.showErrorMessage("An error occurred while uploading UDF. See logs for details.");
+    showErrorNotificationWithButtons(
+      "An error occurred while uploading UDF. See logs for details.",
+    );
   }
 }
+
 /**
  * Registers the "confluent.uploadUDF" command with logging.
  * Note: this is a placeholder, the final command will register and upload the UDF in a clean sweep.

--- a/src/commands/utils/uploadUDF.test.ts
+++ b/src/commands/utils/uploadUDF.test.ts
@@ -1,0 +1,142 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import {
+  PresignedUploadUrlArtifactV1PresignedUrl200Response,
+  PresignedUploadUrlArtifactV1PresignedUrl200ResponseApiVersionEnum,
+  PresignedUploadUrlArtifactV1PresignedUrl200ResponseKindEnum,
+  PresignedUploadUrlArtifactV1PresignedUrlRequest,
+} from "../../clients/flinkArtifacts";
+import * as errors from "../../errors";
+import * as notifications from "../../notifications";
+import * as sidecar from "../../sidecar";
+import { getPresignedUploadUrl, handlePresignedUrlRequest } from "./uploadUDF";
+
+describe("uploadUDF utils", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("getPresignedUploadUrl", () => {
+    it("should return presigned URL response when request succeeds", async () => {
+      const mockRequest: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
+        environment: "env-123",
+        cloud: "AWS",
+        region: "us-west-2",
+        id: "test-artifact",
+        content_format: "jar",
+      };
+
+      const mockResponse: PresignedUploadUrlArtifactV1PresignedUrl200Response = {
+        api_version: "v1" as any,
+        kind: "PresignedUploadUrl" as any,
+        upload_url: "https://example.com/upload",
+      };
+
+      const mockPresignedClient = {
+        presignedUploadUrlArtifactV1PresignedUrl: sandbox.stub().resolves(mockResponse),
+      };
+
+      const mockSidecarHandle = {
+        getFlinkPresignedUrlsApi: sandbox.stub().returns(mockPresignedClient),
+      };
+
+      sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle as any);
+
+      const result = await getPresignedUploadUrl(mockRequest);
+
+      assert.deepStrictEqual(result, mockResponse);
+      sinon.assert.calledOnce(sidecar.getSidecar as sinon.SinonStub);
+      sinon.assert.calledOnceWithExactly(mockSidecarHandle.getFlinkPresignedUrlsApi, {
+        environmentId: "env-123",
+        provider: "AWS",
+        region: "us-west-2",
+      });
+      sinon.assert.calledOnceWithExactly(
+        mockPresignedClient.presignedUploadUrlArtifactV1PresignedUrl,
+        {
+          PresignedUploadUrlArtifactV1PresignedUrlRequest: mockRequest,
+        },
+      );
+    });
+
+    it("should return undefined and log error when request fails", async () => {
+      const mockRequest: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
+        environment: "env-123",
+        cloud: "AWS",
+        region: "us-west-2",
+        id: "test-artifact",
+        content_format: "jar",
+      };
+
+      const mockError = new Error("API request failed");
+      sandbox.stub(sidecar, "getSidecar").rejects(mockError);
+      const logErrorStub = sandbox.stub(errors, "logError");
+
+      const result = await getPresignedUploadUrl(mockRequest);
+
+      assert.strictEqual(result, undefined);
+      sinon.assert.calledOnceWithExactly(
+        logErrorStub,
+        mockError,
+        "Failed to get presigned upload URL",
+      );
+    });
+  });
+
+  it("should show error notification when response is undefined", async () => {
+    const mockRequest: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
+      environment: "env-123",
+      cloud: "AWS",
+      region: "us-west-2",
+      id: "test-artifact",
+      content_format: "jar",
+    };
+
+    sandbox.stub(sidecar, "getSidecar").rejects(new Error("Failed"));
+    sandbox.stub(errors, "logError");
+    const showErrorStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
+
+    await handlePresignedUrlRequest(mockRequest);
+
+    sinon.assert.calledOnceWithExactly(
+      showErrorStub,
+      "Failed to get presigned upload URL. See logs for details.",
+    );
+  });
+
+  it("should show error notification when response has no upload_url", async () => {
+    const mockRequest: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
+      environment: "env-123",
+      cloud: "AWS",
+      region: "us-west-2",
+      id: "test-artifact",
+      content_format: "jar",
+    };
+
+    const mockResponse: PresignedUploadUrlArtifactV1PresignedUrl200Response = {
+      api_version: PresignedUploadUrlArtifactV1PresignedUrl200ResponseApiVersionEnum.ArtifactV1,
+      kind: PresignedUploadUrlArtifactV1PresignedUrl200ResponseKindEnum.PresignedUrl,
+    };
+
+    sandbox.stub(sidecar, "getSidecar").resolves({
+      getFlinkPresignedUrlsApi: () => ({
+        presignedUploadUrlArtifactV1PresignedUrl: sandbox.stub().resolves(mockResponse),
+      }),
+    } as any);
+
+    const showErrorStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
+
+    await handlePresignedUrlRequest(mockRequest);
+
+    sinon.assert.calledOnceWithExactly(
+      showErrorStub,
+      "Failed to get presigned upload URL. See logs for details.",
+    );
+  });
+});

--- a/src/commands/utils/uploadUDF.ts
+++ b/src/commands/utils/uploadUDF.ts
@@ -1,0 +1,123 @@
+import * as vscode from "vscode";
+import {
+  PresignedUploadUrlArtifactV1PresignedUrl200Response,
+  PresignedUploadUrlArtifactV1PresignedUrlRequest,
+} from "../../clients/flinkArtifacts";
+import { logError } from "../../errors";
+import { EnvironmentId, IEnvProviderRegion } from "../../models/resource";
+import {
+  showErrorNotificationWithButtons,
+  showInfoNotificationWithButtons,
+  showWarningNotificationWithButtons,
+} from "../../notifications";
+import { getSidecar } from "../../sidecar";
+
+/**
+ * Prompts the user for environment, cloud provider, region, and artifact name.
+ * Returns an object with these values, or undefined if the user cancels.
+ */
+export interface UDFUploadParams {
+  environment: string;
+  cloud: string;
+  region: string;
+  artifactName: string;
+  fileFormat: string;
+}
+
+/**
+ * Requests a presigned upload URL for a Flink artifact using the sidecar.
+ * @param request PresignedUploadUrlArtifactV1PresignedUrlRequest
+ * @returns The presigned URL response object, or undefined if the request fails.
+ */
+export async function getPresignedUploadUrl(
+  request: PresignedUploadUrlArtifactV1PresignedUrlRequest,
+): Promise<PresignedUploadUrlArtifactV1PresignedUrl200Response | undefined> {
+  try {
+    const sidecarHandle = await getSidecar();
+    const providerRegion: IEnvProviderRegion = {
+      environmentId: request.environment as EnvironmentId,
+      provider: request.cloud,
+      region: request.region,
+    };
+    const presignedClient = sidecarHandle.getFlinkPresignedUrlsApi(providerRegion);
+
+    // Wrap the request as required by the OpenAPI client
+    const urlResponse = await presignedClient.presignedUploadUrlArtifactV1PresignedUrl({
+      PresignedUploadUrlArtifactV1PresignedUrlRequest: request,
+    });
+    return urlResponse;
+  } catch (err) {
+    logError(err, "Failed to get presigned upload URL");
+    return undefined;
+  }
+}
+
+/**
+ * Handles the presigned URL request and shows appropriate notifications.
+ * @param request The presigned upload URL request
+ */
+export async function handlePresignedUrlRequest(
+  request: PresignedUploadUrlArtifactV1PresignedUrlRequest,
+): Promise<void> {
+  const response = await getPresignedUploadUrl(request);
+  if (response && response.upload_url) {
+    showInfoNotificationWithButtons("Presigned upload URL received.", {
+      "Copy URL": () => {
+        vscode.env.clipboard.writeText(response.upload_url!);
+        vscode.window.showInformationMessage("Upload URL copied to clipboard.");
+      },
+    });
+  } else {
+    showErrorNotificationWithButtons("Failed to get presigned upload URL. See logs for details.");
+  }
+}
+export async function promptForUDFUploadParams(): Promise<UDFUploadParams | undefined> {
+  const environment = await vscode.window.showInputBox({
+    prompt: "Enter the Environment ID for the UDF upload",
+    ignoreFocusOut: true,
+    validateInput: (value) => (value ? undefined : "Environment ID is required"),
+  });
+  if (!environment) {
+    showErrorNotificationWithButtons("Upload UDF cancelled: Environment ID is required.");
+    return undefined;
+  }
+  const cloud = await vscode.window.showQuickPick(["AWS", "Azure"], {
+    placeHolder: "Select the cloud provider for the UDF upload",
+  });
+  if (!cloud) {
+    showErrorNotificationWithButtons("Upload UDF cancelled: Cloud provider is required.");
+    return undefined;
+  }
+  const fileFormat = await vscode.window.showQuickPick(["zip", "jar"], {
+    placeHolder: "Select the file format for the UDF",
+  });
+
+  if (!fileFormat) {
+    showWarningNotificationWithButtons("Upload UDF cancelled: File format is required.");
+    return undefined;
+  }
+
+  const region = await vscode.window.showInputBox({
+    prompt: "Enter the region for the UDF upload",
+    ignoreFocusOut: true,
+    validateInput: (value) => (value ? undefined : "Region is required"),
+  });
+
+  if (!region) {
+    showWarningNotificationWithButtons("Upload UDF cancelled: Region is required.");
+    return undefined;
+  }
+
+  const artifactName = await vscode.window.showInputBox({
+    prompt: "Enter the artifact name for the UDF",
+    ignoreFocusOut: true,
+    validateInput: (value) => (value ? undefined : "Artifact name is required"),
+  });
+
+  if (!artifactName) {
+    showWarningNotificationWithButtons("Upload UDF cancelled: Artifact name is required.");
+    return undefined;
+  }
+
+  return { environment, cloud, region, artifactName, fileFormat };
+}


### PR DESCRIPTION
## Summary of Changes

Cleaning up UDF implementation before adding upload functionality to what's already there (fetching presigned URL).

These functions: 
- `promptForUDFUploadParams`
- `getPresignedUploadUrl` 

Got moved out to a utility file (subfolder perhaps to come) 

In addition 
- `handlePresignedUrlRequest`

was moved from a mid-function async call to its own spot in the utility file. 

Added some unit tests but kept them away from certain pieces of functionality that might changes, like the `promptForUDFUploadParams` function. 

Lastly, this PR replaces some of the lower level `window.vscode` calls with some of the wrappers available from [notifications.ts](https://github.com/confluentinc/vscode/blob/9d9b34c056f2053ae80a7f841db13083acc83612/src/notifications.ts#L4)

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
