### PR TITLE
telemetry: add `hasCCloudDomain` to 'Direct Connection Action' events

### DIFF
--- a/src/directConnectManager.ts
+++ b/src/directConnectManager.ts
@@ -10,6 +10,7 @@ import {
 } from "./clients/sidecar";
 import { getExtensionContext } from "./context/extension";
 import { getCredentialsType } from "./directConnections/credentials";
+import { hasCCloudDomain } from "./directConnections/utils";
 import { directConnectionsChanged, environmentChanged } from "./emitters";
 import { ExtensionContextNotSetError } from "./errors";
 import { DirectResourceLoader, ResourceLoader } from "./loaders";
@@ -181,6 +182,7 @@ export class DirectConnectionManager extends DisposableCollection {
       withSchemaRegistry: !!spec.schema_registry,
       kafkaAuthType: getCredentialsType(spec.kafka_cluster?.credentials),
       schemaRegistryAuthType: getCredentialsType(spec.schema_registry?.credentials),
+      hasCCloudDomain: hasCCloudDomain(spec.kafka_cluster) || hasCCloudDomain(spec.schema_registry),
     });
 
     if (connection && !dryRun) {
@@ -227,6 +229,7 @@ export class DirectConnectionManager extends DisposableCollection {
       kafkaSslEnabled: spec.kafka_cluster?.ssl?.enabled,
       schemaRegistryAuthType: getCredentialsType(spec.schema_registry?.credentials),
       schemaRegistrySslEnabled: spec.schema_registry?.ssl?.enabled,
+      hasCCloudDomain: hasCCloudDomain(spec.kafka_cluster) || hasCCloudDomain(spec.schema_registry),
     });
   }
 
@@ -250,6 +253,9 @@ export class DirectConnectionManager extends DisposableCollection {
       kafkaSslEnabled: incomingSpec.kafka_cluster?.ssl?.enabled,
       schemaRegistryAuthType: getCredentialsType(incomingSpec.schema_registry?.credentials),
       schemaRegistrySslEnabled: incomingSpec.schema_registry?.ssl?.enabled,
+      hasCCloudDomain:
+        hasCCloudDomain(incomingSpec.kafka_cluster) ||
+        hasCCloudDomain(incomingSpec.schema_registry),
     });
 
     // update the connection in secret storage (via full replace of the connection by its id)

--- a/src/directConnections/utils.test.ts
+++ b/src/directConnections/utils.test.ts
@@ -1,0 +1,61 @@
+import * as assert from "assert";
+import { TEST_DIRECT_CONNECTION_FORM_SPEC } from "../../tests/unit/testResources/connection";
+import { CCLOUD_DOMAIN_SUBSTRING, hasCCloudDomain } from "./utils";
+
+describe("directConnections/utils.ts", function () {
+  describe("hasCCloudDomain()", function () {
+    it(`should return true when a Kafka config's bootstrap_servers includes "${CCLOUD_DOMAIN_SUBSTRING}"`, function () {
+      const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
+      spec.kafka_cluster = {
+        bootstrap_servers: "pkc-123.region.provider.confluent.cloud:9092",
+      };
+
+      const result = hasCCloudDomain(spec.kafka_cluster);
+
+      assert.strictEqual(result, true);
+    });
+
+    it(`should return false when a Kafka config's bootstrap_servers does not include "${CCLOUD_DOMAIN_SUBSTRING}"`, function () {
+      const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
+      spec.kafka_cluster = {
+        bootstrap_servers: "localhost:9092",
+      };
+
+      const result = hasCCloudDomain(spec.kafka_cluster);
+
+      assert.strictEqual(result, false);
+    });
+
+    it(`should return true when a Schema Registry config's uri includes "${CCLOUD_DOMAIN_SUBSTRING}"`, function () {
+      const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
+      spec.schema_registry = {
+        uri: "https://pkc-123.region.provider.confluent.cloud",
+      };
+
+      const result = hasCCloudDomain(spec.schema_registry);
+
+      assert.strictEqual(result, true);
+    });
+
+    it(`should return false when a Schema Registry config's uri does not include "${CCLOUD_DOMAIN_SUBSTRING}"`, function () {
+      const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
+      spec.schema_registry = {
+        uri: "https://localhost:443",
+      };
+
+      const result = hasCCloudDomain(spec.schema_registry);
+
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false when no config is provided", function () {
+      const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
+
+      const kafkaResult = hasCCloudDomain(spec.kafka_cluster);
+      assert.strictEqual(kafkaResult, false);
+
+      const schemaRegistryResult = hasCCloudDomain(spec.schema_registry);
+      assert.strictEqual(schemaRegistryResult, false);
+    });
+  });
+});

--- a/src/directConnections/utils.test.ts
+++ b/src/directConnections/utils.test.ts
@@ -49,14 +49,9 @@ describe("directConnections/utils.ts", function () {
     });
 
     it("should return false when no config is provided", function () {
-      // no Kafka/SR configs by default
-      const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
+      const result = hasCCloudDomain(undefined);
 
-      const kafkaResult = hasCCloudDomain(spec.kafka_cluster);
-      assert.strictEqual(kafkaResult, false);
-
-      const schemaRegistryResult = hasCCloudDomain(spec.schema_registry);
-      assert.strictEqual(schemaRegistryResult, false);
+      assert.strictEqual(result, false);
     });
   });
 });

--- a/src/directConnections/utils.test.ts
+++ b/src/directConnections/utils.test.ts
@@ -49,6 +49,7 @@ describe("directConnections/utils.ts", function () {
     });
 
     it("should return false when no config is provided", function () {
+      // no Kafka/SR configs by default
       const spec = TEST_DIRECT_CONNECTION_FORM_SPEC;
 
       const kafkaResult = hasCCloudDomain(spec.kafka_cluster);

--- a/src/directConnections/utils.ts
+++ b/src/directConnections/utils.ts
@@ -18,11 +18,11 @@ export function hasCCloudDomain(
     return false;
   }
 
-  let isCCloud = false;
+  let hasCCloud = false;
   if (instanceOfKafkaClusterConfig(config)) {
-    isCCloud = config.bootstrap_servers.includes(CCLOUD_DOMAIN_SUBSTRING);
+    hasCCloud = config.bootstrap_servers.includes(CCLOUD_DOMAIN_SUBSTRING);
   } else if (instanceOfSchemaRegistryConfig(config)) {
-    isCCloud = config.uri.includes(CCLOUD_DOMAIN_SUBSTRING);
+    hasCCloud = config.uri.includes(CCLOUD_DOMAIN_SUBSTRING);
   }
-  return isCCloud;
+  return hasCCloud;
 }

--- a/src/directConnections/utils.ts
+++ b/src/directConnections/utils.ts
@@ -1,0 +1,28 @@
+import {
+  instanceOfKafkaClusterConfig,
+  instanceOfSchemaRegistryConfig,
+  KafkaClusterConfig,
+  SchemaRegistryConfig,
+} from "../clients/sidecar";
+
+export const CCLOUD_DOMAIN_SUBSTRING = ".confluent.cloud";
+
+/**
+ * Checks if the given Kafka or Schema Registry configuration is a Confluent Cloud domain.
+ * @param config - The {@link KafkaClusterConfig} or {@link SchemaRegistryConfig} to check, if available.
+ */
+export function hasCCloudDomain(
+  config: KafkaClusterConfig | SchemaRegistryConfig | undefined,
+): boolean {
+  if (!config) {
+    return false;
+  }
+
+  let isCCloud = false;
+  if (instanceOfKafkaClusterConfig(config)) {
+    isCCloud = config.bootstrap_servers.includes(CCLOUD_DOMAIN_SUBSTRING);
+  } else if (instanceOfSchemaRegistryConfig(config)) {
+    isCCloud = config.uri.includes(CCLOUD_DOMAIN_SUBSTRING);
+  }
+  return isCCloud;
+}

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -1,6 +1,7 @@
 import { graphql } from "gql.tada";
 import { commands } from "vscode";
 import { ConnectedState, Connection, ConnectionStatus, ConnectionType } from "../clients/sidecar";
+import { hasCCloudDomain } from "../directConnections/utils";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import { DirectEnvironment } from "../models/environment";
@@ -96,6 +97,8 @@ export async function getDirectResources(
         withKafka: !!spec?.kafka_cluster,
         withSchemaRegistry: !!spec?.schema_registry,
         failedReason: "connection still in ATTEMPTING state",
+        hasCCloudDomain:
+          hasCCloudDomain(spec?.kafka_cluster) || hasCCloudDomain(spec?.schema_registry),
       });
     }
   }

--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -746,4 +746,44 @@ describe("sidecar/connections/watcher.ts getConnectionSummaries()", () => {
     assert.strictEqual(summaries.length, 1);
     assert.strictEqual(summaries[0].failedReason, srFailedMessage);
   });
+
+  it("should include hasCCloudDomain for DIRECT connection summaries", async () => {
+    const connection: Connection = {
+      ...TEST_DIRECT_CONNECTION,
+      status: {
+        kafka_cluster: { state: ConnectedState.Success },
+        schema_registry: { state: ConnectedState.Success },
+      },
+    };
+
+    const summaries: ConnectionSummary[] = await getConnectionSummaries(
+      connection,
+      ConnectedState.Success,
+    );
+
+    assert.strictEqual(summaries.length, 2);
+    for (const summary of summaries) {
+      // We aren't setting Kafka/SR configs here, so this will always be false.
+      // We also don't need to test the hasCCloudDomain() values here, just that it exists;
+      // see `src/directConnections/utils.test.ts` for hasCCloudDomain() tests.
+      assert.strictEqual(summary.hasCCloudDomain, false);
+    }
+  });
+
+  it("should not include hasCCloudDomain for CCLOUD connection summaries", async () => {
+    const connection: Connection = {
+      ...TEST_CCLOUD_CONNECTION,
+      status: {
+        ccloud: { state: ConnectedState.Success },
+      },
+    };
+
+    const summaries: ConnectionSummary[] = await getConnectionSummaries(
+      connection,
+      ConnectedState.Success,
+    );
+
+    assert.strictEqual(summaries.length, 1);
+    assert.strictEqual(summaries[0].hasCCloudDomain, undefined);
+  });
 });

--- a/src/sidecar/connections/watcher.ts
+++ b/src/sidecar/connections/watcher.ts
@@ -12,6 +12,7 @@ import {
 } from "../../clients/sidecar";
 import { getCredentialsType } from "../../directConnections/credentials";
 import { FormConnectionType, SupportedAuthTypes } from "../../directConnections/types";
+import { hasCCloudDomain } from "../../directConnections/utils";
 import { connectionStable, environmentChanged } from "../../emitters";
 import { Logger } from "../../logging";
 import { ConnectionId, connectionIdToType, EnvironmentId } from "../../models/resource";
@@ -136,6 +137,7 @@ export async function reportUsableState(connection: Connection) {
         // kafkaConfigSslEnabled or schemaRegistryConfigSslEnabled
         [`${configPrefix}SslEnabled`]: summary.sslEnabled,
         failedReason: summary.failedReason,
+        hasCCloudDomain: summary.hasCCloudDomain,
       });
     });
     successfulConnectionSummaries.forEach((summary) => {
@@ -152,6 +154,7 @@ export async function reportUsableState(connection: Connection) {
         // kafkaConfigSslEnabled or schemaRegistryConfigSslEnabled
         [`${configPrefix}SslEnabled`]: summary.sslEnabled,
         failedReason: summary.failedReason,
+        hasCCloudDomain: summary.hasCCloudDomain,
       });
     });
   }
@@ -176,6 +179,7 @@ export interface ConnectionSummary {
   authType?: SupportedAuthTypes | "Browser";
   sslEnabled?: boolean;
   failedReason?: string; // only for `FAILED` states
+  hasCCloudDomain?: boolean; // only for `DIRECT` connections
 }
 
 /**
@@ -209,6 +213,7 @@ export async function getConnectionSummaries(
             sslEnabled: kafkaConfig?.ssl?.enabled ?? false,
             connectedState: state,
             failedReason: kafkaClusterStatus.errors?.sign_in?.message,
+            hasCCloudDomain: hasCCloudDomain(kafkaConfig),
           });
         }
 
@@ -226,6 +231,7 @@ export async function getConnectionSummaries(
             sslEnabled: schemaRegistryConfig?.ssl?.enabled ?? false,
             connectedState: state,
             failedReason: schemaRegistryState.errors?.sign_in?.message,
+            hasCCloudDomain: hasCCloudDomain(schemaRegistryConfig),
           });
         }
       }

--- a/tests/unit/testResources/connection.ts
+++ b/tests/unit/testResources/connection.ts
@@ -3,6 +3,7 @@ import {
   ConnectedState,
   Connection,
   ConnectionFromJSON,
+  ConnectionSpec,
   ConnectionSpecFromJSON,
   ConnectionType,
   UserInfo,
@@ -91,11 +92,16 @@ export const TEST_DIRECT_CONNECTION: Connection = ConnectionFromJSON({
     id: TEST_DIRECT_CONNECTION_ID,
     name: "New Connection",
     type: ConnectionType.Direct,
-  },
+  } satisfies ConnectionSpec,
   status: {},
 } satisfies Connection);
 
-/** Fake spec augmented with `formConnectionType` for test purposes. */
+/**
+ * Fake spec augmented with `formConnectionType` for test purposes.
+ *
+ * **NOTE**: This does not include a {@link ConnectionSpec.kafka_cluster Kafka config} or a
+ * {@link ConnectionSpec.schema_registry Schema Registry config} by default.
+ */
 export const TEST_DIRECT_CONNECTION_FORM_SPEC: CustomConnectionSpec = {
   ...ConnectionSpecFromJSON(TEST_DIRECT_CONNECTION.spec),
   id: TEST_DIRECT_CONNECTION_ID, // enforced ConnectionId type


### PR DESCRIPTION
## Summary of Changes

New helper function [`hasCCloudDomain()`](https://github.com/confluentinc/vscode/blob/b9d2f6de7033ff08497d9f962f4faf9ea9859742/src/directConnections/utils.ts#L10-L14) to check a Kafka cluster config's `bootstrap_servers` or a Schema Registry config's `uri` to see if they contain the `.confluent.cloud` substring. If so, we'll add a new boolean value to associated direct connection telemetry events:
<img width="1005" height="357" alt="image" src="https://github.com/user-attachments/assets/7f8dac7a-2d9d-40dc-8698-b3374d209b15" />

Closes #2280. (I opted for a more generic `hasCCloudDomain` to capture "Kafka OR Schema Registry" instead of a definitive `isCCloud` which may only apply to half of the connection configs if a user is pointing at CCloud Kafka and some other SR, or vice versa.)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
