### PR TITLE
fix(CI): add `TARGET_BRANCH` param to prerelease task

### DIFF
--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -8,6 +8,17 @@ global_job_config:
   prologue:
     commands:
       - checkout
+      - |
+          if [ -n "$TARGET_BRANCH" ]; then
+            git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH"
+          else
+            git fetch --all
+          fi
+          if [ -z "$COMMIT_SHA" ]; then
+            COMMIT_SHA=$(git rev-parse HEAD)
+          fi
+          git checkout "$COMMIT_SHA"
+      - . vault-setup
 
 blocks:
   - name: "Package VSIX Files"
@@ -15,17 +26,6 @@ blocks:
     task:
       prologue:
         commands:
-          - |
-              if [ -n "$TARGET_BRANCH" ]; then
-                git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH"
-              else
-                git fetch --all
-              fi
-              if [ -z "$COMMIT_SHA" ]; then
-                COMMIT_SHA=$(git rev-parse HEAD)
-              fi
-              git checkout "$COMMIT_SHA"
-          - . vault-setup
           - make install-dependencies
       jobs:
         - name: "Package VSIX Files"

--- a/.semaphore/prerelease-multi-arch-packaging.yml
+++ b/.semaphore/prerelease-multi-arch-packaging.yml
@@ -15,8 +15,12 @@ blocks:
     task:
       prologue:
         commands:
-          - git fetch --all
           - |
+              if [ -n "$TARGET_BRANCH" ]; then
+                git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH"
+              else
+                git fetch --all
+              fi
               if [ -z "$COMMIT_SHA" ]; then
                 COMMIT_SHA=$(git rev-parse HEAD)
               fi

--- a/service.yml
+++ b/service.yml
@@ -30,10 +30,14 @@ semaphore:
       branch: main
       pipeline_file: ".semaphore/prerelease-multi-arch-packaging.yml"
       parameters:
+        - name: TARGET_BRANCH
+          required: true
+          default_value: "main"
+          description: The target branch to create the release from, must be a valid branch.
         - name: COMMIT_SHA
           required: true
           description: |
-            The commit SHA to create the release and tag from, must be a valid SHA/tag/branch.
+            The commit SHA to create the release and tag from.
     - name: scheduled-prerelease-multi-arch-packaging
       branch: main
       pipeline_file: ".semaphore/prerelease-multi-arch-packaging.yml"


### PR DESCRIPTION
Necessary for building prerelease .vsix files for a non-`main` branch.

Sample workflow: https://semaphore.ci.confluent.io/workflows/b1df16dd-23a6-4e9e-a1b8-89e52371d5d1?pipeline_id=39ce1b40-120d-4651-8ed9-a0074d02d9ff

Sample prerelease: https://github.com/confluentinc/vscode/releases/tag/v1.5.1-pre