### PR TITLE
[v1.5.x] update Gulpfile/Makefile for prerelease builds

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -17,7 +17,7 @@ import libReport from "istanbul-lib-report";
 import libSourceMaps from "istanbul-lib-source-maps";
 import reports from "istanbul-reports";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { appendFile, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
@@ -397,7 +397,20 @@ function pkgjson() {
  */
 function sidecar() {
   const sidecarVersion = readFileSync(".versions/ide-sidecar.txt", "utf-8").replace(/[v\n\s]/g, "");
-  const sidecarFilename = `ide-sidecar-${sidecarVersion}-runner${IS_WINDOWS ? ".exe" : ""}`;
+
+  let sidecarFilename = `ide-sidecar-${sidecarVersion}-runner`;
+  // we may be building for Windows from a non-Windows machine, in which case we'll have the .exe
+  if (IS_WINDOWS || process.env.TARGET === "win32-x64") {
+    sidecarFilename = `${sidecarFilename}.exe`;
+  }
+  console.log(`Copying sidecar executable ${sidecarFilename} to ${DESTINATION}/bin/`, {
+    is_windows: IS_WINDOWS,
+    target: process.env.TARGET,
+  });
+  const sidecarPath = join("bin", sidecarFilename);
+  if (!existsSync(sidecarPath)) {
+    throw new Error(`Sidecar executable ${sidecarFilename} not found in bin/ directory.`);
+  }
 
   return [
     virtual({

--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,24 @@ endif
 
 IDE_SIDECAR_VERSION = $(shell cat .versions/ide-sidecar.txt)
 IDE_SIDECAR_VERSION_NO_V := $(call version_no_v,$(IDE_SIDECAR_VERSION))
-EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
-
-# Skip download if the executable already exists and is executable
-SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)
 
 # Get the OS and architecture combination for the sidecar executable
 SIDECAR_OS_ARCH ?= $(shell echo "$$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')" )
+
+# Check if we're targeting the Windows sidecar executable from a non-Windows agent
+# (currently only done in `.semaphore/prerelease-multi-arch-packaging.yml` since the pipeline at
+# `.semaphore/multi-arch-packaging.yml` uses `scripts/windows/download-sidecar-executable.ps1`)
+IS_WINDOWS = $(shell echo "$(SIDECAR_OS_ARCH)" | grep -q 'windows' && echo true || echo false)
+ifeq ($(IS_WINDOWS),true)
+	EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner.exe
+	export EXECUTABLE_PATH := ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH).exe
+else
+	EXECUTABLE_DOWNLOAD_PATH := bin/ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner
+	export EXECUTABLE_PATH := ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH)
+endif
+
+# Skip download if the executable already exists and is executable
+SKIP_DOWNLOAD_EXECUTABLE := $(shell [ -x $(EXECUTABLE_DOWNLOAD_PATH) ] && echo true || echo false)
 
 IDE_SIDECAR_REPO := confluentinc/ide-sidecar
 
@@ -116,17 +127,16 @@ ifeq ($(SKIP_DOWNLOAD_EXECUTABLE),true)
 	@echo "Skipping download of sidecar executable since it already exists at $(EXECUTABLE_DOWNLOAD_PATH)"
 else
 	mkdir -p bin && \
-	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION)"; \
-	export EXECUTABLE_PATH=ide-sidecar-$(IDE_SIDECAR_VERSION_NO_V)-runner-$(SIDECAR_OS_ARCH) && \
-		curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
-		chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
-		if [ $$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) -lt 1048576 ]; then \
-				echo "Error: Downloaded sidecar executable is too small (< 1MB), likely corrupted or failed download" >&2; \
-				cat $(EXECUTABLE_DOWNLOAD_PATH) | head -20 >&2; \
-				rm -f $(EXECUTABLE_DOWNLOAD_PATH); \
-				exit 1; \
-		fi && \
-		echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH) ($$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) bytes)";
+	echo "Using curl to download sidecar executable from GitHub release $(IDE_SIDECAR_VERSION): $(EXECUTABLE_DOWNLOAD_PATH)"; \
+	curl --fail -L -o $(EXECUTABLE_DOWNLOAD_PATH) "https://github.com/$(IDE_SIDECAR_REPO)/releases/download/$(IDE_SIDECAR_VERSION)/$${EXECUTABLE_PATH}" && \
+	chmod +x $(EXECUTABLE_DOWNLOAD_PATH) && \
+	if [ $$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) -lt 1048576 ]; then \
+			echo "Error: Downloaded sidecar executable is too small (< 1MB), likely corrupted or failed download" >&2; \
+			cat $(EXECUTABLE_DOWNLOAD_PATH) | head -20 >&2; \
+			rm -f $(EXECUTABLE_DOWNLOAD_PATH); \
+			exit 1; \
+	fi && \
+	echo "Downloaded sidecar executable to $(EXECUTABLE_DOWNLOAD_PATH) ($$(stat -f%z $(EXECUTABLE_DOWNLOAD_PATH) 2>/dev/null || stat -c%s $(EXECUTABLE_DOWNLOAD_PATH)) bytes)";
 endif
 
 # Downloads the THIRD_PARTY_NOTICES.txt file from the latest release of ide-sidecar as THIRD_PARTY_NOTICES_IDE_SIDECAR.txt


### PR DESCRIPTION
Pulls in Gulpfile/Makefile changes from #2226, which are needed if we want to create prerelease .vsix files (mainly for Windows builds) from the existing Semaphore task(s) on `main`.

We don't need the pipeline file or the service.yml task configs from that PR since we aren't kicking off any builds from this branch, and any future builds will include it from `main` by default.