### PR TITLE
feat: add multi-mode view for Flink Artifacts/UDFs

### DIFF
--- a/package.json
+++ b/package.json
@@ -759,6 +759,18 @@
         "command": "confluent.flink.statements.search.clear",
         "title": "Clear Search",
         "category": "Confluent: Flink Statements View"
+      },
+      {
+        "command": "confluent.flink.setUDFsViewMode",
+        "title": "Switch to Flink UDFs",
+        "icon": "$(code)",
+        "category": "Confluent: Flink Artifacts/UDFs View"
+      },
+      {
+        "command": "confluent.flink.setArtifactsViewMode",
+        "title": "Switch to Flink Artifacts",
+        "icon": "$(folder-library)",
+        "category": "Confluent: Flink Artifacts/UDFs View"
       }
     ],
     "configuration": [
@@ -1345,6 +1357,14 @@
         {
           "command": "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
           "when": "false"
+        },
+        {
+          "command": "confluent.flink.setArtifactsViewMode",
+          "when": "confluent.flinkArtifactsUDFsViewMode == 'UDFs'"
+        },
+        {
+          "command": "confluent.flink.setUDFsViewMode",
+          "when": "confluent.flinkArtifactsUDFsViewMode == 'artifacts'"
         }
       ],
       "editor/title": [
@@ -1518,6 +1538,16 @@
           "command": "confluent.artifacts.flink-compute-pool.select",
           "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@1"
+        },
+        {
+          "command": "confluent.flink.setArtifactsViewMode",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsPoolSelected && confluent.flinkArtifactsUDFsViewMode == 'UDFs'",
+          "group": "navigation@2"
+        },
+        {
+          "command": "confluent.flink.setUDFsViewMode",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsPoolSelected && confluent.flinkArtifactsUDFsViewMode == 'artifacts'",
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -2,7 +2,7 @@ import { Disposable } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
 import { flinkArtifactUDFViewMode } from "../emitters";
-import { FlinkArtifactsViewProviderMode } from "../viewProviders/flinkArtifacts";
+import { FlinkArtifactsViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 
 export async function setFlinkArtifactsViewModeCommand() {
   flinkArtifactUDFViewMode.fire(FlinkArtifactsViewProviderMode.Artifacts);

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -1,0 +1,22 @@
+import { Disposable } from "vscode";
+import { registerCommandWithLogging } from ".";
+import { ContextValues, setContextValue } from "../context/values";
+import { flinkArtifactUDFViewMode } from "../emitters";
+import { FlinkArtifactsViewProviderMode } from "../viewProviders/flinkArtifacts";
+
+export async function setFlinkArtifactsViewModeCommand() {
+  flinkArtifactUDFViewMode.fire(FlinkArtifactsViewProviderMode.Artifacts);
+  await setContextValue(
+    ContextValues.flinkArtifactsUDFsViewMode,
+    FlinkArtifactsViewProviderMode.Artifacts,
+  );
+}
+
+export function registerFlinkArtifactCommands(): Disposable[] {
+  return [
+    registerCommandWithLogging(
+      "confluent.flink.setArtifactsViewMode",
+      setFlinkArtifactsViewModeCommand,
+    ),
+  ];
+}

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -1,0 +1,19 @@
+import { Disposable } from "vscode";
+import { registerCommandWithLogging } from ".";
+import { ContextValues, setContextValue } from "../context/values";
+import { flinkArtifactUDFViewMode } from "../emitters";
+import { FlinkArtifactsViewProviderMode } from "../viewProviders/flinkArtifacts";
+
+export async function setFlinkUDFViewModeCommand() {
+  flinkArtifactUDFViewMode.fire(FlinkArtifactsViewProviderMode.UDFs);
+  await setContextValue(
+    ContextValues.flinkArtifactsUDFsViewMode,
+    FlinkArtifactsViewProviderMode.UDFs,
+  );
+}
+
+export function registerFlinkUDFCommands(): Disposable[] {
+  return [
+    registerCommandWithLogging("confluent.flink.setUDFsViewMode", setFlinkUDFViewModeCommand),
+  ];
+}

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -2,7 +2,7 @@ import { Disposable } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
 import { flinkArtifactUDFViewMode } from "../emitters";
-import { FlinkArtifactsViewProviderMode } from "../viewProviders/flinkArtifacts";
+import { FlinkArtifactsViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 
 export async function setFlinkUDFViewModeCommand() {
   flinkArtifactUDFViewMode.fire(FlinkArtifactsViewProviderMode.UDFs);

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -54,16 +54,19 @@ export enum ContextValues {
   directKafkaClusterAvailable = "confluent.directKafkaClusterAvailable",
   /** A direct connection has been made and a Schema Registry is available for selecting in the Schemas view. */
   directSchemaRegistryAvailable = "confluent.directSchemaRegistryAvailable",
+
   /** A resource has been selected for comparison. */
   resourceSelectedForCompare = "confluent.resourceSelectedForCompare",
-  /** The user clicked a Kafka cluster tree item. */
+
+  /** The user focused a Kafka cluster for the Topics view. */
   kafkaClusterSelected = "confluent.kafkaClusterSelected",
-  /** The user clicked a Schema Registry tree item. */
+  /** The user focused a Schema Registry for the Schemas view. */
   schemaRegistrySelected = "confluent.schemaRegistrySelected",
   /** The user focused a Flink compute pool for the Flink Statements view. */
   flinkStatementsPoolSelected = "confluent.flinkStatementsPoolSelected",
   /** The user focused a Flink compute pool for the Flink Artifacts view. */
   flinkArtifactsPoolSelected = "confluent.flinkArtifactsPoolSelected",
+
   /** The user applied a search string to the Resources view. */
   resourceSearchApplied = "confluent.resourceSearchApplied",
   /** The user applied a search string to the Topics view. */
@@ -74,6 +77,10 @@ export enum ContextValues {
   flinkStatementsSearchApplied = "confluent.flinkStatementsSearchApplied",
   /** The user applied a search string to the Flink Artifacts view. */
   flinkArtifactsSearchApplied = "confluent.flinkArtifactsSearchApplied",
+
+  /** The user changed the mode of the Flink Artifacts/UDFs view. */
+  flinkArtifactsUDFsViewMode = "confluent.flinkArtifactsUDFsViewMode",
+
   /**
    * EXPERIMENTAL: Is the chat participant enabled?
    * (This should go away once the `confluent.experimental.enableChatParticipant` setting is removed.)

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -6,6 +6,7 @@ import { KafkaCluster } from "./models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "./models/resource";
 import { Subject, SubjectWithSchemas } from "./models/schema";
 import { SchemaRegistry } from "./models/schemaRegistry";
+import { FlinkArtifactsViewProviderMode } from "./viewProviders/flinkArtifacts";
 
 // NOTE: these are kept at the global level to allow for easy access from any file and track where
 // we .fire() events and where we react to them via .event()
@@ -136,3 +137,6 @@ export const projectScaffoldUri = new vscode.EventEmitter<vscode.Uri>();
 
 /** Metadata for a given {@link vscode.Uri} has been updated. */
 export const uriMetadataSet = new vscode.EventEmitter<vscode.Uri>();
+
+/** Event emitter for switching Flink artifact/UDF view modes. */
+export const flinkArtifactUDFViewMode = new vscode.EventEmitter<FlinkArtifactsViewProviderMode>();

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -6,7 +6,7 @@ import { KafkaCluster } from "./models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "./models/resource";
 import { Subject, SubjectWithSchemas } from "./models/schema";
 import { SchemaRegistry } from "./models/schemaRegistry";
-import { FlinkArtifactsViewProviderMode } from "./viewProviders/flinkArtifacts";
+import { FlinkArtifactsViewProviderMode } from "./viewProviders/multiViewDelegates/constants";
 
 // NOTE: these are kept at the global level to allow for easy access from any file and track where
 // we .fire() events and where we react to them via .event()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,8 +29,10 @@ import { registerDockerCommands } from "./commands/docker";
 import { registerDocumentCommands } from "./commands/documents";
 import { registerEnvironmentCommands } from "./commands/environments";
 import { registerExtraCommands } from "./commands/extra";
+import { registerFlinkArtifactCommands } from "./commands/flinkArtifacts";
 import { registerFlinkComputePoolCommands } from "./commands/flinkComputePools";
 import { registerFlinkStatementCommands } from "./commands/flinkStatements";
+import { registerFlinkUDFCommands } from "./commands/flinkUDFs";
 import { registerKafkaClusterCommands } from "./commands/kafkaClusters";
 import { registerOrganizationCommands } from "./commands/organizations";
 import { registerNewResourceViewCommands } from "./commands/resources";
@@ -89,7 +91,10 @@ import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { getUriHandler } from "./uriHandler";
 import { WriteableTmpDir } from "./utils/file";
 import { RefreshableTreeViewProvider } from "./viewProviders/baseModels/base";
-import { FlinkArtifactsViewProvider } from "./viewProviders/flinkArtifacts";
+import {
+  FlinkArtifactsUDFsViewProvider,
+  FlinkArtifactsViewProviderMode,
+} from "./viewProviders/flinkArtifacts";
 import { FlinkStatementsViewProvider } from "./viewProviders/flinkStatements";
 import { NewResourceViewProvider } from "./viewProviders/newResources";
 import { ResourceViewProvider } from "./viewProviders/resources";
@@ -215,7 +220,7 @@ async function _activateExtension(
   const topicViewProvider = TopicViewProvider.getInstance();
   const schemasViewProvider = SchemasViewProvider.getInstance();
   const statementsViewProvider = FlinkStatementsViewProvider.getInstance();
-  const artifactsViewProvider = FlinkArtifactsViewProvider.getInstance();
+  const artifactsViewProvider = FlinkArtifactsUDFsViewProvider.getInstance();
   const supportViewProvider = new SupportViewProvider();
   const viewProviderDisposables: vscode.Disposable[] = [
     resourceViewProviderInstance,
@@ -259,8 +264,10 @@ async function _activateExtension(
     ...registerExtraCommands(),
     ...registerDockerCommands(),
     ...registerProjectGenerationCommands(),
+    ...registerFlinkArtifactCommands(),
     ...registerFlinkComputePoolCommands(),
     ...registerFlinkStatementCommands(),
+    ...registerFlinkUDFCommands(),
     ...registerDocumentCommands(),
     ...registerSearchCommands(),
     registerUploadUDFCommand(),
@@ -420,6 +427,11 @@ async function setupContextValues() {
     SCHEMA_URI_SCHEME,
     MESSAGE_URI_SCHEME,
   ]);
+  // set the initial Flink artifacts view mode to "Artifacts" so the UDF mode toggle is visible
+  const flinkViewMode = setContextValue(
+    ContextValues.flinkArtifactsUDFsViewMode,
+    FlinkArtifactsViewProviderMode.Artifacts,
+  );
   await Promise.all([
     chatParticipantEnabled,
     kafkaClusterSelected,
@@ -430,6 +442,7 @@ async function setupContextValues() {
     resourcesWithNames,
     resourcesWithURIs,
     diffableResources,
+    flinkViewMode,
   ]);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,11 +91,9 @@ import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { getUriHandler } from "./uriHandler";
 import { WriteableTmpDir } from "./utils/file";
 import { RefreshableTreeViewProvider } from "./viewProviders/baseModels/base";
-import {
-  FlinkArtifactsUDFsViewProvider,
-  FlinkArtifactsViewProviderMode,
-} from "./viewProviders/flinkArtifacts";
+import { FlinkArtifactsUDFsViewProvider } from "./viewProviders/flinkArtifacts";
 import { FlinkStatementsViewProvider } from "./viewProviders/flinkStatements";
+import { FlinkArtifactsViewProviderMode } from "./viewProviders/multiViewDelegates/constants";
 import { NewResourceViewProvider } from "./viewProviders/newResources";
 import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";

--- a/src/models/flinkUDF.ts
+++ b/src/models/flinkUDF.ts
@@ -38,6 +38,8 @@ export class FlinkUdf implements IResourceBase, IdItem, ISearchable {
     this.id = props.id;
     this.name = props.name;
     this.description = props.description;
+    this.provider = props.provider;
+    this.region = props.region;
   }
 
   searchableText(): string {

--- a/src/models/flinkUDF.ts
+++ b/src/models/flinkUDF.ts
@@ -1,0 +1,61 @@
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ConnectionType } from "../clients/sidecar";
+import { IconNames } from "../constants";
+import { IdItem } from "./main";
+import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+
+export class FlinkUdf implements IResourceBase, IdItem, ISearchable {
+  connectionId!: ConnectionId;
+  connectionType!: ConnectionType;
+  // shoup: update this once https://github.com/confluentinc/vscode/issues/1385 is done
+  iconName: IconNames = "code" as IconNames;
+
+  environmentId!: EnvironmentId;
+
+  id!: string;
+  name!: string;
+  description!: string;
+
+  provider!: string; // cloud
+  region!: string;
+
+  constructor(
+    props: Pick<
+      FlinkUdf,
+      | "connectionId"
+      | "connectionType"
+      | "environmentId"
+      | "id"
+      | "name"
+      | "description"
+      | "provider"
+      | "region"
+    >,
+  ) {
+    this.connectionId = props.connectionId;
+    this.connectionType = props.connectionType;
+    this.environmentId = props.environmentId;
+    this.id = props.id;
+    this.name = props.name;
+    this.description = props.description;
+  }
+
+  searchableText(): string {
+    return `${this.name} ${this.description}`;
+  }
+}
+
+export class FlinkUdfTreeItem extends TreeItem {
+  resource: FlinkUdf;
+
+  constructor(resource: FlinkUdf) {
+    super(resource.name, TreeItemCollapsibleState.None);
+
+    this.id = resource.id;
+    this.resource = resource;
+    this.contextValue = `${resource.connectionType.toLowerCase()}-flink-udf`;
+
+    this.iconPath = new ThemeIcon(resource.iconName);
+    this.description = resource.description;
+  }
+}

--- a/src/viewProviders/baseModels/multiViewBase.test.ts
+++ b/src/viewProviders/baseModels/multiViewBase.test.ts
@@ -1,0 +1,223 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { CancellationToken, EventEmitter, Progress, TreeItem, window } from "vscode";
+import { ConnectionType } from "../../clients/sidecar";
+import { CCLOUD_CONNECTION_ID } from "../../constants";
+import * as contextValues from "../../context/values";
+import { ContextValues } from "../../context/values";
+import { ConnectionId, EnvironmentId } from "../../models/resource";
+import { MultiModeViewProvider, ViewProviderDelegate } from "./multiViewBase";
+
+const TEST_CONTEXT_VALUE: ContextValues = "test-value" as ContextValues;
+
+enum TestMode {
+  Foo = "foo",
+  Bar = "bar",
+}
+
+class TestParentResource {
+  connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
+  connectionType: ConnectionType = ConnectionType.Ccloud;
+  environmentId: EnvironmentId = "test-env-id" as EnvironmentId;
+  id: string = "test-parent";
+
+  searchableText(): string {
+    return `Test Parent ${this.id}`;
+  }
+}
+
+class TestDelegateChild {
+  connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
+  connectionType: ConnectionType = ConnectionType.Ccloud;
+
+  constructor(
+    public id: string,
+    public name: string,
+  ) {}
+
+  searchableText(): string {
+    return `${this.name} ${this.id}`;
+  }
+}
+
+class FooDelegate extends ViewProviderDelegate<TestMode, TestDelegateChild> {
+  readonly mode: TestMode = TestMode.Foo;
+  readonly viewTitle = "Mode Foo";
+  loadingMessage = "Loading Foo items...";
+
+  children: TestDelegateChild[] = [];
+
+  constructor(public parent: TestMultiViewProvider) {
+    super();
+  }
+
+  async fetchChildren(): Promise<TestDelegateChild[]> {
+    return this.children;
+  }
+
+  getTreeItem(element: TestDelegateChild): TreeItem {
+    return new TreeItem(element.name);
+  }
+}
+
+class BarDelegate extends ViewProviderDelegate<TestMode, TestDelegateChild> {
+  readonly mode: TestMode = TestMode.Bar;
+  readonly viewTitle = "Mode Bar";
+  loadingMessage = "Loading Bar items...";
+
+  children: TestDelegateChild[] = [];
+
+  constructor(public parent: TestMultiViewProvider) {
+    super();
+  }
+
+  async fetchChildren(): Promise<TestDelegateChild[]> {
+    return this.children;
+  }
+
+  getTreeItem(element: TestDelegateChild): TreeItem {
+    return new TreeItem(element.name);
+  }
+}
+
+class TestMultiViewProvider extends MultiModeViewProvider<
+  TestMode,
+  TestParentResource,
+  TestDelegateChild
+> {
+  readonly viewId = "test-multiview";
+  readonly loggerName = "test.multiview";
+  readonly kind = "test";
+
+  parentResourceChangedEmitter = new EventEmitter<TestParentResource | null>();
+  parentResourceChangedContextValue = TEST_CONTEXT_VALUE;
+
+  constructor() {
+    super();
+    const fooDelegate = new FooDelegate(this);
+    const barDelegate = new BarDelegate(this);
+
+    this.treeViewDelegates = new Map<TestMode, ViewProviderDelegate<TestMode, TestDelegateChild>>([
+      [TestMode.Foo, fooDelegate],
+      [TestMode.Bar, barDelegate],
+    ]);
+
+    this.defaultDelegate = fooDelegate;
+    this.currentDelegate = this.defaultDelegate;
+    this.delegateContextValue = TEST_CONTEXT_VALUE;
+  }
+}
+
+describe("viewProviders/baseModels/multiViewBase.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let provider: TestMultiViewProvider;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("MultiModeViewProvider", () => {
+    beforeEach(() => {
+      // stub createTreeView to avoid actually creating a VS Code tree view
+      sandbox.stub(window, "createTreeView").callsFake((): any => {
+        return {
+          title: undefined as string | undefined,
+          message: undefined as string | undefined,
+          description: undefined as string | undefined,
+          dispose: () => {},
+        } as any;
+      });
+
+      sandbox.stub(window, "withProgress").callsFake((_, cb) => {
+        const p = {} as Progress<unknown>;
+        const t = {} as CancellationToken;
+        return Promise.resolve(cb(p, t));
+      });
+
+      provider = TestMultiViewProvider["getInstance"]();
+    });
+
+    afterEach(() => {
+      provider.dispose();
+      TestMultiViewProvider["instanceMap"].clear();
+    });
+
+    it("starts with default delegate and delegates children", () => {
+      // no resource -> no children
+      const childrenNone = provider.getChildren();
+      assert.deepStrictEqual(childrenNone, []);
+
+      // with resource -> returns delegate children
+      const fakeChildItem = new TestDelegateChild("id1", "Test Item 1");
+      provider["resource"] = new TestParentResource();
+      const delegate = provider["currentDelegate"];
+      delegate.children = [fakeChildItem];
+      const children = provider.getChildren();
+
+      assert.strictEqual(children.length, 1);
+      assert.strictEqual(children[0].name, fakeChildItem.name);
+    });
+
+    describe("switchMode()", () => {
+      let refreshStub: sinon.SinonStub;
+      let setContextStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        refreshStub = sandbox.stub(provider, "refresh").resolves();
+        setContextStub = sandbox.stub(contextValues, "setContextValue").resolves();
+      });
+
+      it("should update delegate, title, context, and then call refresh()", async () => {
+        await provider.switchMode(TestMode.Bar);
+
+        const delegate = provider["currentDelegate"];
+        assert.strictEqual(delegate.mode, TestMode.Bar);
+        assert.strictEqual(provider["treeView"].title, "Mode Bar");
+        sinon.assert.calledWith(setContextStub, TEST_CONTEXT_VALUE, TestMode.Bar);
+        sinon.assert.calledOnce(refreshStub);
+      });
+
+      it("should just call refresh() when passed the same mode", async () => {
+        await provider.switchMode(TestMode.Foo);
+
+        sinon.assert.calledOnce(refreshStub);
+        sinon.assert.notCalled(setContextStub);
+      });
+
+      it("should not change the delegate when an unknown mode is passed", async () => {
+        const delegate = provider["currentDelegate"];
+
+        await provider.switchMode("ASDF" as TestMode);
+
+        assert.strictEqual(provider["currentDelegate"], delegate);
+        sinon.assert.notCalled(refreshStub);
+        sinon.assert.notCalled(setContextStub);
+      });
+    });
+
+    it("getTreeItem() delegates to the current mode's getTreeItem()", () => {
+      const fakeChildItem = new TestDelegateChild("id1", "Test Item 1");
+      provider["resource"] = new TestParentResource();
+      const delegate = provider["currentDelegate"];
+      delegate.children = [fakeChildItem];
+      const item = provider.getTreeItem(delegate.children[0]);
+
+      assert.strictEqual(item.label, fakeChildItem.name);
+    });
+
+    it("reset() reverts to the default delegate and updates context", async () => {
+      const setContextStub = sandbox.stub(contextValues, "setContextValue").resolves();
+      provider["currentDelegate"] = provider["treeViewDelegates"].get(TestMode.Bar)!;
+
+      await provider.reset();
+
+      const delegate = provider["currentDelegate"];
+      assert.strictEqual(delegate.mode, TestMode.Foo);
+      sinon.assert.calledWith(setContextStub, TEST_CONTEXT_VALUE, TestMode.Foo);
+    });
+  });
+});

--- a/src/viewProviders/baseModels/multiViewBase.test.ts
+++ b/src/viewProviders/baseModels/multiViewBase.test.ts
@@ -40,16 +40,12 @@ class TestDelegateChild {
   }
 }
 
-class FooDelegate extends ViewProviderDelegate<TestMode, TestDelegateChild> {
+class FooDelegate extends ViewProviderDelegate<TestMode, TestParentResource, TestDelegateChild> {
   readonly mode: TestMode = TestMode.Foo;
   readonly viewTitle = "Mode Foo";
   loadingMessage = "Loading Foo items...";
 
   children: TestDelegateChild[] = [];
-
-  constructor(public parent: TestMultiViewProvider) {
-    super();
-  }
 
   async fetchChildren(): Promise<TestDelegateChild[]> {
     return this.children;
@@ -60,16 +56,12 @@ class FooDelegate extends ViewProviderDelegate<TestMode, TestDelegateChild> {
   }
 }
 
-class BarDelegate extends ViewProviderDelegate<TestMode, TestDelegateChild> {
+class BarDelegate extends ViewProviderDelegate<TestMode, TestParentResource, TestDelegateChild> {
   readonly mode: TestMode = TestMode.Bar;
   readonly viewTitle = "Mode Bar";
   loadingMessage = "Loading Bar items...";
 
   children: TestDelegateChild[] = [];
-
-  constructor(public parent: TestMultiViewProvider) {
-    super();
-  }
 
   async fetchChildren(): Promise<TestDelegateChild[]> {
     return this.children;
@@ -94,10 +86,13 @@ class TestMultiViewProvider extends MultiModeViewProvider<
 
   constructor() {
     super();
-    const fooDelegate = new FooDelegate(this);
-    const barDelegate = new BarDelegate(this);
+    const fooDelegate = new FooDelegate();
+    const barDelegate = new BarDelegate();
 
-    this.treeViewDelegates = new Map<TestMode, ViewProviderDelegate<TestMode, TestDelegateChild>>([
+    this.treeViewDelegates = new Map<
+      TestMode,
+      ViewProviderDelegate<TestMode, TestParentResource, TestDelegateChild>
+    >([
       [TestMode.Foo, fooDelegate],
       [TestMode.Bar, barDelegate],
     ]);

--- a/src/viewProviders/baseModels/multiViewBase.ts
+++ b/src/viewProviders/baseModels/multiViewBase.ts
@@ -71,16 +71,10 @@ export abstract class MultiModeViewProvider<
   }
 
   getChildren(element?: T): T[] {
-    if (!this.currentDelegate) {
-      return [];
-    }
     return this.currentDelegate.getChildren(element);
   }
 
   getTreeItem(element: T): TreeItem {
-    if (!this.currentDelegate) {
-      throw new Error("No active mode for getTreeItem");
-    }
     return this.currentDelegate.getTreeItem(element);
   }
 

--- a/src/viewProviders/baseModels/multiViewBase.ts
+++ b/src/viewProviders/baseModels/multiViewBase.ts
@@ -1,0 +1,94 @@
+import { TreeItem } from "vscode";
+import { ContextValues, setContextValue } from "../../context/values";
+import { BaseViewProviderData } from "./base";
+import { EnvironmentedBaseViewProviderData, ParentedBaseViewProvider } from "./parentedBase";
+
+export abstract class ViewProviderDelegate<M extends string, T extends BaseViewProviderData> {
+  abstract readonly mode: M;
+
+  abstract readonly viewTitle: string;
+  abstract loadingMessage: string;
+
+  abstract parent: ParentedBaseViewProvider<EnvironmentedBaseViewProviderData, T>;
+  abstract children: T[];
+
+  abstract fetchChildren(element?: T): Promise<T[]>;
+
+  getChildren(element?: T): T[] {
+    if (!this.parent.resource) {
+      return [];
+    }
+    return this.parent.filterChildren(element, this.children);
+  }
+
+  abstract getTreeItem(element: T): TreeItem;
+}
+
+/**
+ * Abstract base class for multi-mode view providers that can switch between different modes
+ * and delegate tree view operations to mode-specific implementations.
+ */
+export abstract class MultiModeViewProvider<
+  M extends string,
+  P extends EnvironmentedBaseViewProviderData,
+  T extends BaseViewProviderData,
+> extends ParentedBaseViewProvider<P, T> {
+  /** Map of available delegates by their {@linkcode ViewProviderDelegate.mode mode} */
+  protected treeViewDelegates!: Map<M, ViewProviderDelegate<M, T>>;
+
+  protected defaultDelegate!: ViewProviderDelegate<M, T>;
+  protected currentDelegate: ViewProviderDelegate<M, T>;
+
+  /** Optional context value to update when delegate changes */
+  protected delegateContextValue?: ContextValues;
+
+  constructor() {
+    super();
+    this.currentDelegate = this.defaultDelegate;
+  }
+
+  /** Switch to a specific mode by its ID. */
+  async switchMode(mode: M): Promise<void> {
+    const newMode = this.treeViewDelegates.get(mode);
+    if (!newMode) {
+      this.logger.error(`Unknown mode: ${mode}`);
+      return;
+    }
+
+    if (this.currentDelegate === newMode) {
+      // already in this mode, just refresh
+      await this.refresh();
+      return;
+    }
+
+    this.logger.debug(`switching from mode "${this.currentDelegate?.mode}" to "${mode}"`);
+    this.currentDelegate = newMode;
+    if (this.delegateContextValue) {
+      await setContextValue(this.delegateContextValue, mode);
+    }
+    this.treeView.title = this.currentDelegate.viewTitle;
+    await this.refresh();
+  }
+
+  getChildren(element?: T): T[] {
+    if (!this.currentDelegate) {
+      return [];
+    }
+    return this.currentDelegate.getChildren(element);
+  }
+
+  getTreeItem(element: T): TreeItem {
+    if (!this.currentDelegate) {
+      throw new Error("No active mode for getTreeItem");
+    }
+    return this.currentDelegate.getTreeItem(element);
+  }
+
+  override async reset(): Promise<void> {
+    this.currentDelegate = this.defaultDelegate;
+    if (this.delegateContextValue) {
+      await setContextValue(this.delegateContextValue, this.currentDelegate.mode);
+    }
+    await super.reset();
+  }
+}

--- a/src/viewProviders/baseModels/multiViewBase.ts
+++ b/src/viewProviders/baseModels/multiViewBase.ts
@@ -3,7 +3,11 @@ import { ContextValues, setContextValue } from "../../context/values";
 import { BaseViewProviderData } from "./base";
 import { EnvironmentedBaseViewProviderData, ParentedBaseViewProvider } from "./parentedBase";
 
-export abstract class ViewProviderDelegate<M extends string, T extends BaseViewProviderData> {
+export abstract class ViewProviderDelegate<
+  M extends string,
+  P extends EnvironmentedBaseViewProviderData,
+  T extends BaseViewProviderData,
+> {
   abstract readonly mode: M;
 
   abstract readonly viewTitle: string;
@@ -11,7 +15,7 @@ export abstract class ViewProviderDelegate<M extends string, T extends BaseViewP
 
   abstract children: T[];
 
-  abstract fetchChildren(element?: T): Promise<T[]>;
+  abstract fetchChildren(resource: P): Promise<T[]>;
 
   getChildren(): T[] {
     return this.children;
@@ -30,10 +34,10 @@ export abstract class MultiModeViewProvider<
   T extends BaseViewProviderData,
 > extends ParentedBaseViewProvider<P, T> {
   /** Map of available delegates by their {@linkcode ViewProviderDelegate.mode mode} */
-  protected treeViewDelegates!: Map<M, ViewProviderDelegate<M, T>>;
+  protected treeViewDelegates!: Map<M, ViewProviderDelegate<M, P, T>>;
 
-  protected defaultDelegate!: ViewProviderDelegate<M, T>;
-  protected currentDelegate: ViewProviderDelegate<M, T>;
+  protected defaultDelegate!: ViewProviderDelegate<M, P, T>;
+  protected currentDelegate: ViewProviderDelegate<M, P, T>;
 
   /** Optional context value to update when delegate changes */
   protected delegateContextValue?: ContextValues;

--- a/src/viewProviders/baseModels/multiViewBase.ts
+++ b/src/viewProviders/baseModels/multiViewBase.ts
@@ -9,16 +9,12 @@ export abstract class ViewProviderDelegate<M extends string, T extends BaseViewP
   abstract readonly viewTitle: string;
   abstract loadingMessage: string;
 
-  abstract parent: ParentedBaseViewProvider<EnvironmentedBaseViewProviderData, T>;
   abstract children: T[];
 
   abstract fetchChildren(element?: T): Promise<T[]>;
 
-  getChildren(element?: T): T[] {
-    if (!this.parent.resource) {
-      return [];
-    }
-    return this.parent.filterChildren(element, this.children);
+  getChildren(): T[] {
+    return this.children;
   }
 
   abstract getTreeItem(element: T): TreeItem;
@@ -71,7 +67,11 @@ export abstract class MultiModeViewProvider<
   }
 
   getChildren(element?: T): T[] {
-    return this.currentDelegate.getChildren(element);
+    if (!this.resource) {
+      return [];
+    }
+    const children = this.currentDelegate.getChildren();
+    return this.filterChildren(element, children);
   }
 
   getTreeItem(element: T): TreeItem {

--- a/src/viewProviders/flinkArtifacts.test.ts
+++ b/src/viewProviders/flinkArtifacts.test.ts
@@ -1,292 +1,114 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import { CancellationToken, Progress, window } from "vscode";
-import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
-import { createFlinkArtifact } from "../../tests/unit/testResources/flinkArtifact";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
-import { getTestExtensionContext } from "../../tests/unit/testUtils";
-import { ResponseError } from "../clients/flinkArtifacts";
 import * as errors from "../errors";
-import { CCloudResourceLoader } from "../loaders";
 import * as notifications from "../notifications";
-import { FlinkArtifactsViewProvider } from "./flinkArtifacts";
+import { FlinkArtifactsUDFsViewProvider } from "./flinkArtifacts";
 
-describe("FlinkArtifactsViewProvider", () => {
+describe("viewProviders/flinkArtifacts.ts", () => {
   let sandbox: sinon.SinonSandbox;
-  let viewProvider: FlinkArtifactsViewProvider;
-
-  before(async () => {
-    // required for all subclasses of BaseViewProvider since they deal with extension storage
-    await getTestExtensionContext();
-  });
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    viewProvider = FlinkArtifactsViewProvider.getInstance();
   });
 
   afterEach(() => {
-    viewProvider.dispose();
-    // reset singleton instances between tests
-    FlinkArtifactsViewProvider["instanceMap"].clear();
     sandbox.restore();
   });
 
-  describe("refresh()", () => {
-    let changeFireStub: sinon.SinonStub;
-    let logErrorStub: sinon.SinonStub;
-    let showErrorNotificationStub: sinon.SinonStub;
-    let windowWithProgressStub: sinon.SinonStub;
+  describe("FlinkArtifactsUDFsViewProvider", () => {
+    let viewProvider: FlinkArtifactsUDFsViewProvider;
 
     beforeEach(() => {
-      changeFireStub = sandbox.stub(viewProvider["_onDidChangeTreeData"], "fire");
-      logErrorStub = sandbox.stub(errors, "logError");
-      showErrorNotificationStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
-      windowWithProgressStub = sandbox.stub(window, "withProgress").callsFake((_, callback) => {
-        const mockProgress = {} as Progress<unknown>;
-        const mockToken = {} as CancellationToken;
-        return Promise.resolve(callback(mockProgress, mockToken));
-      });
+      viewProvider = FlinkArtifactsUDFsViewProvider.getInstance();
     });
 
-    it("clears when no resource is selected", async () => {
-      // Should clear the artifacts array and fire the change event.
-      await viewProvider.refresh();
-
-      sinon.assert.calledOnce(changeFireStub);
-      assert.deepStrictEqual(viewProvider["_artifacts"], []);
+    afterEach(() => {
+      viewProvider.dispose();
+      // reset singleton instances between tests
+      FlinkArtifactsUDFsViewProvider["instanceMap"].clear();
     });
 
-    it("fetches new artifacts when a resource is selected", async () => {
-      const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-      viewProvider["resource"] = resource;
-
-      const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
-        getStubbedCCloudResourceLoader(sandbox);
-
-      const mockArtifacts = [
-        createFlinkArtifact({
-          id: "artifact1",
-          name: "Test Artifact 1",
-        }),
-        createFlinkArtifact({
-          id: "artifact2",
-          name: "Test Artifact 2",
-        }),
-      ];
-
-      stubbedLoader.getFlinkArtifacts.resolves(mockArtifacts);
-
-      await viewProvider.refresh();
-
-      sinon.assert.calledOnce(windowWithProgressStub);
-      sinon.assert.calledTwice(changeFireStub);
-      sinon.assert.calledOnce(stubbedLoader.getFlinkArtifacts);
-      sinon.assert.calledWith(stubbedLoader.getFlinkArtifacts, resource);
-      assert.deepStrictEqual(viewProvider["_artifacts"], mockArtifacts);
-    });
-
-    it("returns artifacts when compute pool is selected", () => {
-      const mockArtifacts = [
-        createFlinkArtifact({
-          id: "artifact1",
-          name: "Test Artifact 1",
-        }),
-      ];
-
-      viewProvider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-      viewProvider["_artifacts"] = mockArtifacts;
-
-      const children = viewProvider.getChildren();
-      assert.deepStrictEqual(children, mockArtifacts);
-    });
-
-    describe("error handling", () => {
-      let stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+    describe("refresh()", () => {
+      let changeFireStub: sinon.SinonStub;
+      let logErrorStub: sinon.SinonStub;
+      let showErrorNotificationStub: sinon.SinonStub;
+      let windowWithProgressStub: sinon.SinonStub;
+      let delegateFetchStub: sinon.SinonStub;
 
       beforeEach(() => {
-        viewProvider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-        stubbedLoader = getStubbedCCloudResourceLoader(sandbox);
+        changeFireStub = sandbox.stub(viewProvider["_onDidChangeTreeData"], "fire");
+        logErrorStub = sandbox.stub(errors, "logError");
+        showErrorNotificationStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
+        windowWithProgressStub = sandbox.stub(window, "withProgress").callsFake((_, callback) => {
+          const mockProgress = {} as Progress<unknown>;
+          const mockToken = {} as CancellationToken;
+          return Promise.resolve(callback(mockProgress, mockToken));
+        });
+
+        // stub delegate behavior so provider tests don't exercise delegate logic
+        delegateFetchStub = sandbox.stub(viewProvider["currentDelegate"], "fetchChildren");
+        // also add a fake loading message
+        sandbox
+          .stub(viewProvider["currentDelegate"], "loadingMessage")
+          .value("Loading from delegate...");
       });
 
-      it("should handle 4xx HTTP errors with appropriate message", async () => {
-        // Use a 431 status, which is not explicitly handled in the switch statement,
-        // so it should use the default message: "Failed to load Flink artifacts due to an unexpected error."
-        const mockError = new ResponseError(new Response("some other 4xx err", { status: 431 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+      it("should clear when no compute pool is selected", async () => {
+        await viewProvider.refresh();
 
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        sinon.assert.calledOnce(showErrorNotificationStub);
-        sinon.assert.calledWith(
-          showErrorNotificationStub,
-          "Failed to load Flink artifacts due to an unexpected error.",
-        );
-      });
-
-      it("should handle 5xx HTTP errors with appropriate message", async () => {
-        const mockError = new ResponseError(new Response("Service unavailable", { status: 503 }));
-
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
-
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        sinon.assert.calledOnce(showErrorNotificationStub);
-        sinon.assert.calledWith(
-          showErrorNotificationStub,
-          "Failed to load Flink artifacts. The service is temporarily unavailable. Please try again later.",
-        );
-      });
-
-      it("should handle non-HTTP errors with generic message", async () => {
-        const mockError = new Error("Failed to load Flink artifacts");
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
-
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        sinon.assert.calledOnce(showErrorNotificationStub);
-        sinon.assert.calledWith(
-          showErrorNotificationStub,
-          "Failed to load Flink artifacts. Please check your connection and try again.",
-        );
-      });
-
-      it("should not show error notification for HTTP status outside 401-599 range", async () => {
-        const mockError = new ResponseError(new Response("oh no", { status: 300 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
-
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        // Should not show error notification for non-error HTTP status
-        sinon.assert.notCalled(showErrorNotificationStub);
-      });
-
-      it("should clear artifacts and fire change events on error", async () => {
-        const mockError = new ResponseError(new Response("test error", { status: undefined }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
-
-        viewProvider["_artifacts"] = [
-          createFlinkArtifact({
-            id: "artifact1",
-            name: "Initial Artifact",
-          }),
-        ];
-
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        // Artifacts should be cleared at the start of refresh
-        assert.deepStrictEqual(viewProvider["_artifacts"], []);
-
-        // Should fire change event once at start to clear (error prevents final fire call)
         sinon.assert.calledOnce(changeFireStub);
+        sinon.assert.notCalled(windowWithProgressStub);
+        sinon.assert.notCalled(delegateFetchStub);
+        assert.deepStrictEqual(viewProvider["children"], []);
       });
 
-      it("should NOT handle 400 HTTP error with check request message but still log error", async () => {
-        const mockError = new ResponseError(new Response("Bad request", { status: 400 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+      it("should call the current delegate to fetch children when a compute pool is selected", async () => {
+        const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+        viewProvider["resource"] = resource;
 
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
+        const fakeChildren = [{ id: "x" }];
+        delegateFetchStub.resolves(fakeChildren);
 
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
+        await viewProvider.refresh();
 
-        sinon.assert.notCalled(showErrorNotificationStub);
+        sinon.assert.calledOnce(windowWithProgressStub);
+        sinon.assert.calledWithMatch(windowWithProgressStub, sinon.match.any, sinon.match.func);
+        sinon.assert.calledTwice(changeFireStub);
+        sinon.assert.calledOnce(delegateFetchStub);
+        assert.deepStrictEqual(viewProvider["children"], fakeChildren);
       });
 
-      it("should handle 401 HTTP error with authentication message", async () => {
-        const mockError = new ResponseError(new Response("Unauthorized", { status: 401 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+      it("should show an error notification when the delegate's fetchChildren() fails", async () => {
+        viewProvider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+        const fakeError = new Error("uh oh");
+        delegateFetchStub.rejects(fakeError);
 
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
+        await viewProvider.refresh().catch(() => undefined);
 
+        sinon.assert.calledOnce(windowWithProgressStub);
         sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
+        sinon.assert.calledWith(
+          logErrorStub,
+          fakeError,
+          `Failed to load Flink ${viewProvider["currentDelegate"].mode}`,
+        );
         sinon.assert.calledOnce(showErrorNotificationStub);
         sinon.assert.calledWith(
           showErrorNotificationStub,
-          "Authentication required to load Flink artifacts.",
+          `Failed to load Flink ${viewProvider["currentDelegate"].mode}`,
         );
       });
 
-      it("should handle 404 HTTP error with not found message", async () => {
-        const mockError = new ResponseError(new Response("Not found", { status: 404 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+      it("should use the current delegate's loading message in progress indicator", async () => {
+        viewProvider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+        delegateFetchStub.resolves([]);
 
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
+        await viewProvider.refresh();
 
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        sinon.assert.calledOnce(showErrorNotificationStub);
-        sinon.assert.calledWith(
-          showErrorNotificationStub,
-          "Flink artifacts not found for this compute pool.",
-        );
-      });
-
-      it("should handle 429 HTTP error with rate limit message", async () => {
-        const mockError = new ResponseError(new Response("Too many requests", { status: 429 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
-
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        sinon.assert.calledOnce(showErrorNotificationStub);
-        sinon.assert.calledWith(
-          showErrorNotificationStub,
-          "Too many requests. Please try again later.",
-        );
-      });
-
-      it("should handle unknown HTTP error with default message", async () => {
-        const mockError = new ResponseError(new Response("I'm a teapot", { status: 418 }));
-        stubbedLoader.getFlinkArtifacts.rejects(mockError);
-
-        await assert.rejects(async () => {
-          await viewProvider.refresh();
-        }, mockError);
-
-        sinon.assert.calledOnce(logErrorStub);
-        sinon.assert.calledWith(logErrorStub, mockError, "Failed to load Flink artifacts");
-
-        sinon.assert.calledOnce(showErrorNotificationStub);
-        sinon.assert.calledWith(
-          showErrorNotificationStub,
-          "Failed to load Flink artifacts due to an unexpected error.",
-        );
+        const firstArg = windowWithProgressStub.firstCall.args[0];
+        assert.strictEqual(firstArg.title ?? firstArg, "Loading from delegate...");
       });
     });
   });

--- a/src/viewProviders/flinkArtifacts.ts
+++ b/src/viewProviders/flinkArtifacts.ts
@@ -1,63 +1,165 @@
-import { TreeDataProvider, TreeItem } from "vscode";
+import { Disposable, TreeItem } from "vscode";
 import { ContextValues } from "../context/values";
-import { currentFlinkArtifactsPoolChanged } from "../emitters";
+import { currentFlinkArtifactsPoolChanged, flinkArtifactUDFViewMode } from "../emitters";
 import { isResponseError, logError } from "../errors";
 import { CCloudResourceLoader } from "../loaders";
 import { FlinkArtifact, FlinkArtifactTreeItem } from "../models/flinkArtifact";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { FlinkUdf, FlinkUdfTreeItem } from "../models/flinkUDF";
 import { showErrorNotificationWithButtons } from "../notifications";
-import { ParentedBaseViewProvider } from "./baseModels/parentedBase";
+import { MultiModeViewProvider, ViewProviderDelegate } from "./baseModels/multiViewBase";
 
-export class FlinkArtifactsViewProvider
-  extends ParentedBaseViewProvider<CCloudFlinkComputePool, FlinkArtifact>
-  implements TreeDataProvider<FlinkArtifact>
-{
-  readonly kind = "flinkArtifacts";
-  loggerName = "viewProviders.flinkArtifacts";
+export enum FlinkArtifactsViewProviderMode {
+  Artifacts = "artifacts",
+  UDFs = "UDFs",
+}
+
+/** Multi-mode view provider for Flink artifacts and UDFs. */
+export class FlinkArtifactsUDFsViewProvider extends MultiModeViewProvider<
+  FlinkArtifactsViewProviderMode,
+  CCloudFlinkComputePool,
+  FlinkArtifact | FlinkUdf
+> {
   viewId = "confluent-flink-artifacts";
 
   parentResourceChangedEmitter = currentFlinkArtifactsPoolChanged;
   parentResourceChangedContextValue = ContextValues.flinkArtifactsPoolSelected;
-  private _artifacts: FlinkArtifact[] = [];
 
-  getChildren(element?: FlinkArtifact): FlinkArtifact[] {
-    if (!this.computePool) {
-      return [];
-    }
-    return this.filterChildren(element, this._artifacts);
+  children: (FlinkArtifact | FlinkUdf)[] = [];
+
+  constructor() {
+    super();
+    // pass the main provider into each mode so they can call its helpers without needing to extend
+    // the provider itself and causing circular dependencies / stack overflows
+    const artifactsDelegate = new FlinkArtifactsDelegate(this);
+    const udfsDelegate = new FlinkUDFsDelegate(this);
+    this.treeViewDelegates = new Map<
+      FlinkArtifactsViewProviderMode,
+      ViewProviderDelegate<FlinkArtifactsViewProviderMode, FlinkArtifact | FlinkUdf>
+    >([
+      [FlinkArtifactsViewProviderMode.Artifacts, artifactsDelegate],
+      [FlinkArtifactsViewProviderMode.UDFs, udfsDelegate],
+    ]);
+    this.defaultDelegate = artifactsDelegate;
+    this.currentDelegate = this.defaultDelegate;
   }
+
+  setCustomEventListeners(): Disposable[] {
+    return [flinkArtifactUDFViewMode.event(this.switchMode.bind(this))];
+  }
+
   async refresh(): Promise<void> {
-    this._artifacts = [];
+    this.children = [];
 
     if (this.computePool) {
+      // clear out the current delegate's children
       this._onDidChangeTreeData.fire();
 
       await this.withProgress(
-        "Loading Flink artifacts...",
+        this.currentDelegate.loadingMessage,
         async () => {
           try {
-            const loader = CCloudResourceLoader.getInstance();
-            this._artifacts = await loader.getFlinkArtifacts(this.computePool!);
+            this.children = await this.currentDelegate.fetchChildren();
           } catch (error) {
-            const { showNotification, message } = triageGetFlinkArtifactsError(error, this.logger);
-            if (showNotification) {
-              void showErrorNotificationWithButtons(message);
-            }
-            throw error;
+            const msg = `Failed to load Flink ${this.currentDelegate.mode}`;
+            void logError(error, msg);
+            void showErrorNotificationWithButtons(msg);
           }
         },
         false,
       );
     }
 
+    // either show the empty state or the current delegate's children
     this._onDidChangeTreeData.fire();
   }
-  getTreeItem(element: FlinkArtifact): TreeItem {
-    return new FlinkArtifactTreeItem(element);
+
+  get loggerName() {
+    return `viewProviders.flink.${this.currentDelegate?.mode ?? "unknown"}`;
+  }
+
+  get kind() {
+    return this.currentDelegate?.mode ?? "unknown";
   }
 
   get computePool(): CCloudFlinkComputePool | null {
     return this.resource;
+  }
+}
+
+export class FlinkArtifactsDelegate extends ViewProviderDelegate<
+  FlinkArtifactsViewProviderMode,
+  FlinkArtifact
+> {
+  readonly mode = FlinkArtifactsViewProviderMode.Artifacts;
+  readonly viewTitle = "Flink Artifacts (Preview)";
+
+  children: FlinkArtifact[] = [];
+
+  loadingMessage = "Loading Flink artifacts...";
+
+  constructor(readonly parent: FlinkArtifactsUDFsViewProvider) {
+    super();
+  }
+
+  async fetchChildren(): Promise<FlinkArtifact[]> {
+    this.children = [];
+    try {
+      const loader = CCloudResourceLoader.getInstance();
+      this.children = await loader.getFlinkArtifacts(this.parent.computePool!);
+      return this.children;
+    } catch (error) {
+      const { showNotification, message } = triageGetFlinkArtifactsError(error, this.parent.logger);
+      if (showNotification) {
+        void showErrorNotificationWithButtons(message);
+      }
+      throw error;
+    }
+  }
+
+  getTreeItem(element: FlinkArtifact): TreeItem {
+    return new FlinkArtifactTreeItem(element);
+  }
+}
+
+export class FlinkUDFsDelegate extends ViewProviderDelegate<
+  FlinkArtifactsViewProviderMode,
+  FlinkUdf
+> {
+  readonly mode = FlinkArtifactsViewProviderMode.UDFs;
+  readonly viewTitle = "Flink UDFs (Preview)";
+
+  children: FlinkUdf[] = [];
+
+  loadingMessage = "Loading Flink UDFs...";
+
+  constructor(readonly parent: FlinkArtifactsUDFsViewProvider) {
+    super();
+  }
+
+  async fetchChildren(): Promise<FlinkUdf[]> {
+    this.children = [];
+
+    if (this.parent.computePool) {
+      // TODO: replace this when https://github.com/confluentinc/vscode/issues/2310 is done
+      this.children = [
+        new FlinkUdf({
+          connectionId: this.parent.computePool!.connectionId,
+          connectionType: this.parent.computePool!.connectionType,
+          environmentId: this.parent.computePool!.environmentId,
+          id: "example-udf",
+          name: "Example UDF",
+          description: "This is an example UDF for demonstration purposes.",
+          provider: this.parent.computePool!.provider,
+          region: this.parent.computePool!.region,
+        }),
+      ];
+    }
+    return this.children;
+  }
+
+  getTreeItem(element: FlinkUdf): TreeItem {
+    return new FlinkUdfTreeItem(element);
   }
 }
 
@@ -105,11 +207,11 @@ export function triageGetFlinkArtifactsError(
           break;
       }
     }
-    logError(error, "Failed to load Flink artifacts");
+    void logError(error, "Failed to load Flink artifacts");
   } else {
     message = "Failed to load Flink artifacts. Please check your connection and try again.";
     showNotification = true;
-    logError(error, "Failed to load Flink artifacts");
+    void logError(error, "Failed to load Flink artifacts");
   }
 
   return { showNotification, message };

--- a/src/viewProviders/flinkArtifacts.ts
+++ b/src/viewProviders/flinkArtifacts.ts
@@ -34,12 +34,12 @@ export class FlinkArtifactsUDFsViewProvider extends MultiModeViewProvider<
     super();
     // pass the main provider into each mode so they can call its helpers without needing to extend
     // the provider itself and causing circular dependencies / stack overflows
-    const artifactsDelegate = new FlinkArtifactsDelegate(this);
-    const udfsDelegate = new FlinkUDFsDelegate(this);
+    const artifactsDelegate = new FlinkArtifactsDelegate();
+    const udfsDelegate = new FlinkUDFsDelegate();
 
     this.treeViewDelegates = new Map<
       FlinkArtifactsViewProviderMode,
-      ViewProviderDelegate<FlinkArtifactsViewProviderMode, ArtifactOrUdf>
+      ViewProviderDelegate<FlinkArtifactsViewProviderMode, CCloudFlinkComputePool, ArtifactOrUdf>
     >([
       [FlinkArtifactsViewProviderMode.Artifacts, artifactsDelegate],
       [FlinkArtifactsViewProviderMode.UDFs, udfsDelegate],
@@ -64,7 +64,7 @@ export class FlinkArtifactsUDFsViewProvider extends MultiModeViewProvider<
         this.currentDelegate.loadingMessage,
         async () => {
           try {
-            this.children = await this.currentDelegate.fetchChildren();
+            this.children = await this.currentDelegate.fetchChildren(this.computePool!);
           } catch (error) {
             const msg = `Failed to load Flink ${this.currentDelegate.mode}`;
             void logError(error, msg);

--- a/src/viewProviders/flinkArtifacts.ts
+++ b/src/viewProviders/flinkArtifacts.ts
@@ -11,6 +11,8 @@ import { FlinkArtifactsViewProviderMode } from "./multiViewDelegates/constants";
 import { FlinkArtifactsDelegate } from "./multiViewDelegates/flinkArtifactsDelegate";
 import { FlinkUDFsDelegate } from "./multiViewDelegates/flinkUDFsDelegate";
 
+export type ArtifactOrUdf = FlinkArtifact | FlinkUdf;
+
 /**
  * Multi-mode view provider for Flink artifacts and UDFs.
  * - When set to the "artifacts" mode, logic is delegated to the {@link FlinkArtifactsDelegate}.
@@ -19,14 +21,14 @@ import { FlinkUDFsDelegate } from "./multiViewDelegates/flinkUDFsDelegate";
 export class FlinkArtifactsUDFsViewProvider extends MultiModeViewProvider<
   FlinkArtifactsViewProviderMode,
   CCloudFlinkComputePool,
-  FlinkArtifact | FlinkUdf
+  ArtifactOrUdf
 > {
   viewId = "confluent-flink-artifacts";
 
   parentResourceChangedEmitter = currentFlinkArtifactsPoolChanged;
   parentResourceChangedContextValue = ContextValues.flinkArtifactsPoolSelected;
 
-  children: (FlinkArtifact | FlinkUdf)[] = [];
+  children: ArtifactOrUdf[] = [];
 
   constructor() {
     super();
@@ -37,7 +39,7 @@ export class FlinkArtifactsUDFsViewProvider extends MultiModeViewProvider<
 
     this.treeViewDelegates = new Map<
       FlinkArtifactsViewProviderMode,
-      ViewProviderDelegate<FlinkArtifactsViewProviderMode, FlinkArtifact | FlinkUdf>
+      ViewProviderDelegate<FlinkArtifactsViewProviderMode, ArtifactOrUdf>
     >([
       [FlinkArtifactsViewProviderMode.Artifacts, artifactsDelegate],
       [FlinkArtifactsViewProviderMode.UDFs, udfsDelegate],

--- a/src/viewProviders/multiViewDelegates/constants.ts
+++ b/src/viewProviders/multiViewDelegates/constants.ts
@@ -1,0 +1,4 @@
+export enum FlinkArtifactsViewProviderMode {
+  Artifacts = "artifacts",
+  UDFs = "UDFs",
+}

--- a/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.test.ts
+++ b/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.test.ts
@@ -33,7 +33,7 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
     let artifactsDelegate: FlinkArtifactsDelegate;
 
     beforeEach(() => {
-      artifactsDelegate = new FlinkArtifactsDelegate(fakeParent as any);
+      artifactsDelegate = new FlinkArtifactsDelegate();
     });
 
     describe("fetchChildren()", () => {
@@ -56,7 +56,7 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
 
         stubbedLoader.getFlinkArtifacts.resolves(mockArtifacts);
 
-        const children = await artifactsDelegate.fetchChildren();
+        const children = await artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL);
 
         assert.deepStrictEqual(children, mockArtifacts);
         assert.deepStrictEqual(artifactsDelegate["children"], mockArtifacts);
@@ -70,7 +70,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("some other 4xx err", { status: 431 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
 
         assert.deepStrictEqual(artifactsDelegate["children"], []);
         sinon.assert.calledOnce(logErrorStub);
@@ -83,7 +86,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("Service unavailable", { status: 503 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnce(showErrorNotificationStub);
       });
@@ -94,7 +100,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new Error("Failed to load Flink artifacts");
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnce(showErrorNotificationStub);
       });
@@ -105,7 +114,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("oh no", { status: 300 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
 
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.notCalled(showErrorNotificationStub);
@@ -121,7 +133,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
           createFlinkArtifact({ id: "artifact1", name: "Initial Artifact" }),
         ];
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         assert.deepStrictEqual(artifactsDelegate["children"], []);
       });
 
@@ -131,7 +146,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("Bad request", { status: 400 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.notCalled(showErrorNotificationStub);
       });
@@ -142,7 +160,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("Unauthorized", { status: 401 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnce(showErrorNotificationStub);
       });
@@ -153,7 +174,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("Not found", { status: 404 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnce(showErrorNotificationStub);
       });
@@ -164,7 +188,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("Too many requests", { status: 429 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnce(showErrorNotificationStub);
       });
@@ -175,7 +202,10 @@ describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
         const mockError = new ResponseError(new Response("I'm a teapot", { status: 418 }));
         stubbedLoader.getFlinkArtifacts.rejects(mockError);
 
-        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        await assert.rejects(
+          artifactsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL),
+          mockError,
+        );
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnce(showErrorNotificationStub);
       });

--- a/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.test.ts
+++ b/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.test.ts
@@ -1,0 +1,184 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { getStubbedCCloudResourceLoader } from "../../../tests/stubs/resourceLoaders";
+import { createFlinkArtifact } from "../../../tests/unit/testResources/flinkArtifact";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../../tests/unit/testResources/flinkComputePool";
+import { ResponseError } from "../../clients/flinkArtifacts";
+import * as errors from "../../errors";
+import { CCloudResourceLoader } from "../../loaders";
+import * as notifications from "../../notifications";
+import { FlinkArtifactsDelegate } from "./flinkArtifactsDelegate";
+
+describe("multiViewDelegates/flinkArtifactsDelegate.ts (delegate only)", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("FlinkArtifactsDelegate", () => {
+    // Minimal fake parent providing only what's used by the delegate
+    const fakeParent = {
+      computePool: TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      logger: { debug: () => undefined },
+    } as unknown as {
+      computePool: typeof TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      logger: { debug: (m: string, e: unknown) => void };
+    };
+
+    let artifactsDelegate: FlinkArtifactsDelegate;
+
+    beforeEach(() => {
+      artifactsDelegate = new FlinkArtifactsDelegate(fakeParent as any);
+    });
+
+    describe("fetchChildren()", () => {
+      let logErrorStub: sinon.SinonStub;
+      let showErrorNotificationStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        logErrorStub = sandbox.stub(errors, "logError");
+        showErrorNotificationStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
+      });
+
+      it("fetches artifacts from the loader and returns them", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+
+        const mockArtifacts = [
+          createFlinkArtifact({ id: "artifact1", name: "Test Artifact 1" }),
+          createFlinkArtifact({ id: "artifact2", name: "Test Artifact 2" }),
+        ];
+
+        stubbedLoader.getFlinkArtifacts.resolves(mockArtifacts);
+
+        const children = await artifactsDelegate.fetchChildren();
+
+        assert.deepStrictEqual(children, mockArtifacts);
+        assert.deepStrictEqual(artifactsDelegate["children"], mockArtifacts);
+        sinon.assert.calledOnce(stubbedLoader.getFlinkArtifacts);
+        sinon.assert.calledWith(stubbedLoader.getFlinkArtifacts, fakeParent.computePool);
+      });
+
+      it("clears children and rethrows when loader fails (431 -> default message)", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("some other 4xx err", { status: 431 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+
+        assert.deepStrictEqual(artifactsDelegate["children"], []);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+
+      it("handles 503 with service unavailable message", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("Service unavailable", { status: 503 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+
+      it("handles non-HTTP errors with generic message", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new Error("Failed to load Flink artifacts");
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+
+      it("does not show notification for non-error HTTP status (300)", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("oh no", { status: 300 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.notCalled(showErrorNotificationStub);
+      });
+
+      it("clears children at start of fetch when error occurs", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("test error", { status: undefined }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        artifactsDelegate["children"] = [
+          createFlinkArtifact({ id: "artifact1", name: "Initial Artifact" }),
+        ];
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        assert.deepStrictEqual(artifactsDelegate["children"], []);
+      });
+
+      it("does not show notification for 400 but still logs", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("Bad request", { status: 400 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.notCalled(showErrorNotificationStub);
+      });
+
+      it("handles 401 with auth message", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("Unauthorized", { status: 401 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+
+      it("handles 404 with not found message", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("Not found", { status: 404 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+
+      it("handles 429 with rate limit message", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("Too many requests", { status: 429 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+
+      it("handles unknown HTTP error with default message", async () => {
+        const stubbedLoader: sinon.SinonStubbedInstance<CCloudResourceLoader> =
+          getStubbedCCloudResourceLoader(sandbox);
+        const mockError = new ResponseError(new Response("I'm a teapot", { status: 418 }));
+        stubbedLoader.getFlinkArtifacts.rejects(mockError);
+
+        await assert.rejects(() => artifactsDelegate.fetchChildren(), mockError);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnce(showErrorNotificationStub);
+      });
+    });
+  });
+});

--- a/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.ts
+++ b/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.ts
@@ -1,0 +1,97 @@
+import { TreeItem } from "vscode";
+import { isResponseError, logError } from "../../errors";
+import { CCloudResourceLoader } from "../../loaders";
+import { FlinkArtifact, FlinkArtifactTreeItem } from "../../models/flinkArtifact";
+import { showErrorNotificationWithButtons } from "../../notifications";
+import { ViewProviderDelegate } from "../baseModels/multiViewBase";
+import { type FlinkArtifactsUDFsViewProvider } from "../flinkArtifacts";
+import { FlinkArtifactsViewProviderMode } from "./constants";
+
+export class FlinkArtifactsDelegate extends ViewProviderDelegate<
+  FlinkArtifactsViewProviderMode,
+  FlinkArtifact
+> {
+  readonly mode = FlinkArtifactsViewProviderMode.Artifacts;
+  readonly viewTitle = "Flink Artifacts (Preview)";
+
+  children: FlinkArtifact[] = [];
+
+  loadingMessage = "Loading Flink artifacts...";
+
+  constructor(readonly parent: FlinkArtifactsUDFsViewProvider) {
+    super();
+  }
+
+  async fetchChildren(): Promise<FlinkArtifact[]> {
+    this.children = [];
+    try {
+      const loader = CCloudResourceLoader.getInstance();
+      this.children = await loader.getFlinkArtifacts(this.parent.computePool!);
+      return this.children;
+    } catch (error) {
+      const { showNotification, message } = triageGetFlinkArtifactsError(error, this.parent.logger);
+      if (showNotification) {
+        void showErrorNotificationWithButtons(message);
+      }
+      throw error;
+    }
+  }
+
+  getTreeItem(element: FlinkArtifact): TreeItem {
+    return new FlinkArtifactTreeItem(element);
+  }
+}
+
+export function triageGetFlinkArtifactsError(
+  error: unknown,
+  logger: { debug: (msg: string, err: unknown) => void },
+): {
+  showNotification: boolean;
+  message: string;
+} {
+  let showNotification = false;
+  let message = "Failed to load Flink artifacts.";
+
+  if (isResponseError(error)) {
+    const status = error.response.status;
+    error.response
+      .clone()
+      .json()
+      .catch((err) => {
+        logger.debug("Failed to parse error response as JSON", err);
+      });
+    /* Note: This switch statement intentionally excludes 400 errors.
+     Otherwise, they may pop up on loading the compute pool if it is using an unsupported cloud provider. */
+    if (status >= 401 && status < 600) {
+      showNotification = true;
+      switch (status) {
+        case 401:
+          message = "Authentication required to load Flink artifacts.";
+          break;
+        case 403:
+          message = "Failed to load Flink artifacts. Please check your permissions and try again.";
+          break;
+        case 404:
+          message = "Flink artifacts not found for this compute pool.";
+          break;
+        case 429:
+          message = "Too many requests. Please try again later.";
+          break;
+        case 503:
+          message =
+            "Failed to load Flink artifacts. The service is temporarily unavailable. Please try again later.";
+          break;
+        default:
+          message = "Failed to load Flink artifacts due to an unexpected error.";
+          break;
+      }
+    }
+    void logError(error, "Failed to load Flink artifacts");
+  } else {
+    message = "Failed to load Flink artifacts. Please check your connection and try again.";
+    showNotification = true;
+    void logError(error, "Failed to load Flink artifacts");
+  }
+
+  return { showNotification, message };
+}

--- a/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.ts
+++ b/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.ts
@@ -2,13 +2,14 @@ import { TreeItem } from "vscode";
 import { isResponseError, logError } from "../../errors";
 import { CCloudResourceLoader } from "../../loaders";
 import { FlinkArtifact, FlinkArtifactTreeItem } from "../../models/flinkArtifact";
+import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
 import { showErrorNotificationWithButtons } from "../../notifications";
 import { ViewProviderDelegate } from "../baseModels/multiViewBase";
-import { type FlinkArtifactsUDFsViewProvider } from "../flinkArtifacts";
 import { FlinkArtifactsViewProviderMode } from "./constants";
 
 export class FlinkArtifactsDelegate extends ViewProviderDelegate<
   FlinkArtifactsViewProviderMode,
+  CCloudFlinkComputePool,
   FlinkArtifact
 > {
   readonly mode = FlinkArtifactsViewProviderMode.Artifacts;
@@ -18,15 +19,11 @@ export class FlinkArtifactsDelegate extends ViewProviderDelegate<
 
   loadingMessage = "Loading Flink artifacts...";
 
-  constructor(readonly parent: FlinkArtifactsUDFsViewProvider) {
-    super();
-  }
-
-  async fetchChildren(): Promise<FlinkArtifact[]> {
+  async fetchChildren(resource: CCloudFlinkComputePool): Promise<FlinkArtifact[]> {
     this.children = [];
     try {
       const loader = CCloudResourceLoader.getInstance();
-      this.children = await loader.getFlinkArtifacts(this.parent.computePool!);
+      this.children = await loader.getFlinkArtifacts(resource);
       return this.children;
     } catch (error) {
       const { showNotification, message } = triageGetFlinkArtifactsError(error);

--- a/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.ts
+++ b/src/viewProviders/multiViewDelegates/flinkArtifactsDelegate.ts
@@ -29,7 +29,7 @@ export class FlinkArtifactsDelegate extends ViewProviderDelegate<
       this.children = await loader.getFlinkArtifacts(this.parent.computePool!);
       return this.children;
     } catch (error) {
-      const { showNotification, message } = triageGetFlinkArtifactsError(error, this.parent.logger);
+      const { showNotification, message } = triageGetFlinkArtifactsError(error);
       if (showNotification) {
         void showErrorNotificationWithButtons(message);
       }
@@ -42,10 +42,7 @@ export class FlinkArtifactsDelegate extends ViewProviderDelegate<
   }
 }
 
-export function triageGetFlinkArtifactsError(
-  error: unknown,
-  logger: { debug: (msg: string, err: unknown) => void },
-): {
+export function triageGetFlinkArtifactsError(error: unknown): {
   showNotification: boolean;
   message: string;
 } {
@@ -54,12 +51,6 @@ export function triageGetFlinkArtifactsError(
 
   if (isResponseError(error)) {
     const status = error.response.status;
-    error.response
-      .clone()
-      .json()
-      .catch((err) => {
-        logger.debug("Failed to parse error response as JSON", err);
-      });
     /* Note: This switch statement intentionally excludes 400 errors.
      Otherwise, they may pop up on loading the compute pool if it is using an unsupported cloud provider. */
     if (status >= 401 && status < 600) {

--- a/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.test.ts
+++ b/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.test.ts
@@ -22,7 +22,7 @@ describe("viewProviders/multiViewDelegates/flinkUDFsDelegate.ts", () => {
 
     beforeEach(() => {
       provider = FlinkArtifactsUDFsViewProvider.getInstance();
-      udfsDelegate = new FlinkUDFsDelegate(provider);
+      udfsDelegate = new FlinkUDFsDelegate();
     });
 
     afterEach(() => {
@@ -30,19 +30,9 @@ describe("viewProviders/multiViewDelegates/flinkUDFsDelegate.ts", () => {
       FlinkArtifactsUDFsViewProvider["instanceMap"].clear();
     });
 
-    it("should return an empty array when no compute pool is selected", async () => {
-      provider["resource"] = null;
-
-      const items = await udfsDelegate.fetchChildren();
-
-      assert.deepStrictEqual(items, []);
-    });
-
-    it("should return a UDF array when a compute pool is selected", async () => {
+    it(".fetchChildren() should return a FlinkUdf array when a compute pool is provided", async () => {
       // TODO: stub the actual loading here when https://github.com/confluentinc/vscode/issues/2310 is done
-      provider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-
-      const items = await udfsDelegate.fetchChildren();
+      const items = await udfsDelegate.fetchChildren(TEST_CCLOUD_FLINK_COMPUTE_POOL);
 
       assert.ok(items.length > 0);
       assert.ok(items[0] instanceof FlinkUdf);

--- a/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.test.ts
+++ b/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.test.ts
@@ -1,0 +1,51 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../../tests/unit/testResources/flinkComputePool";
+import { FlinkUdf } from "../../models/flinkUDF";
+import { FlinkArtifactsUDFsViewProvider } from "../flinkArtifacts";
+import { FlinkUDFsDelegate } from "./flinkUDFsDelegate";
+
+describe("viewProviders/multiViewDelegates/flinkUDFsDelegate.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("FlinkUDFsDelegate", () => {
+    let provider: FlinkArtifactsUDFsViewProvider;
+    let udfsDelegate: FlinkUDFsDelegate;
+
+    beforeEach(() => {
+      provider = FlinkArtifactsUDFsViewProvider.getInstance();
+      udfsDelegate = new FlinkUDFsDelegate(provider);
+    });
+
+    afterEach(() => {
+      provider.dispose();
+      FlinkArtifactsUDFsViewProvider["instanceMap"].clear();
+    });
+
+    it("should return an empty array when no compute pool is selected", async () => {
+      provider["resource"] = null;
+
+      const items = await udfsDelegate.fetchChildren();
+
+      assert.deepStrictEqual(items, []);
+    });
+
+    it("should return a UDF array when a compute pool is selected", async () => {
+      // TODO: stub the actual loading here when https://github.com/confluentinc/vscode/issues/2310 is done
+      provider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+      const items = await udfsDelegate.fetchChildren();
+
+      assert.ok(items.length > 0);
+      assert.ok(items[0] instanceof FlinkUdf);
+    });
+  });
+});

--- a/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.ts
+++ b/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.ts
@@ -1,0 +1,46 @@
+import { TreeItem } from "vscode";
+import { FlinkUdf, FlinkUdfTreeItem } from "../../models/flinkUDF";
+import { ViewProviderDelegate } from "../baseModels/multiViewBase";
+import { type FlinkArtifactsUDFsViewProvider } from "../flinkArtifacts";
+import { FlinkArtifactsViewProviderMode } from "./constants";
+
+export class FlinkUDFsDelegate extends ViewProviderDelegate<
+  FlinkArtifactsViewProviderMode,
+  FlinkUdf
+> {
+  readonly mode = FlinkArtifactsViewProviderMode.UDFs;
+  readonly viewTitle = "Flink UDFs (Preview)";
+
+  children: FlinkUdf[] = [];
+
+  loadingMessage = "Loading Flink UDFs...";
+
+  constructor(readonly parent: FlinkArtifactsUDFsViewProvider) {
+    super();
+  }
+
+  async fetchChildren(): Promise<FlinkUdf[]> {
+    this.children = [];
+
+    if (this.parent.computePool) {
+      // TODO: replace this when https://github.com/confluentinc/vscode/issues/2310 is done
+      this.children = [
+        new FlinkUdf({
+          connectionId: this.parent.computePool!.connectionId,
+          connectionType: this.parent.computePool!.connectionType,
+          environmentId: this.parent.computePool!.environmentId,
+          id: "example-udf",
+          name: "Example UDF",
+          description: "This is an example UDF for demonstration purposes.",
+          provider: this.parent.computePool!.provider,
+          region: this.parent.computePool!.region,
+        }),
+      ];
+    }
+    return this.children;
+  }
+
+  getTreeItem(element: FlinkUdf): TreeItem {
+    return new FlinkUdfTreeItem(element);
+  }
+}

--- a/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.ts
+++ b/src/viewProviders/multiViewDelegates/flinkUDFsDelegate.ts
@@ -1,11 +1,12 @@
 import { TreeItem } from "vscode";
+import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
 import { FlinkUdf, FlinkUdfTreeItem } from "../../models/flinkUDF";
 import { ViewProviderDelegate } from "../baseModels/multiViewBase";
-import { type FlinkArtifactsUDFsViewProvider } from "../flinkArtifacts";
 import { FlinkArtifactsViewProviderMode } from "./constants";
 
 export class FlinkUDFsDelegate extends ViewProviderDelegate<
   FlinkArtifactsViewProviderMode,
+  CCloudFlinkComputePool,
   FlinkUdf
 > {
   readonly mode = FlinkArtifactsViewProviderMode.UDFs;
@@ -15,28 +16,23 @@ export class FlinkUDFsDelegate extends ViewProviderDelegate<
 
   loadingMessage = "Loading Flink UDFs...";
 
-  constructor(readonly parent: FlinkArtifactsUDFsViewProvider) {
-    super();
-  }
-
-  async fetchChildren(): Promise<FlinkUdf[]> {
+  async fetchChildren(resource: CCloudFlinkComputePool): Promise<FlinkUdf[]> {
     this.children = [];
 
-    if (this.parent.computePool) {
-      // TODO: replace this when https://github.com/confluentinc/vscode/issues/2310 is done
-      this.children = [
-        new FlinkUdf({
-          connectionId: this.parent.computePool!.connectionId,
-          connectionType: this.parent.computePool!.connectionType,
-          environmentId: this.parent.computePool!.environmentId,
-          id: "example-udf",
-          name: "Example UDF",
-          description: "This is an example UDF for demonstration purposes.",
-          provider: this.parent.computePool!.provider,
-          region: this.parent.computePool!.region,
-        }),
-      ];
-    }
+    // TODO: replace this when https://github.com/confluentinc/vscode/issues/2310 is done
+    this.children = [
+      new FlinkUdf({
+        connectionId: resource.connectionId,
+        connectionType: resource.connectionType,
+        environmentId: resource.environmentId,
+        id: "example-udf",
+        name: "Example UDF",
+        description: "This is an example UDF for demonstration purposes.",
+        provider: resource.provider,
+        region: resource.region,
+      }),
+    ];
+
     return this.children;
   }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Continuation of https://github.com/confluentinc/vscode/pull/2243, but with reusable `MultiModeViewProvider` and `ViewProviderDelegate` classes to switch between "Flink Artifacts" and "Flink UDFs" modes in the single `confluent-flink-artifacts` view.


https://github.com/user-attachments/assets/47113860-301a-44d7-a728-c55ace7fe1d5



## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- The current action-toggling behavior works fine for two view modes, but we'll need to explore better UI/UX if a view needs three modes. Cycling through them would be clunky, but a quickpick may feel like overkill.
- I don't like the `FlinkArtifactsUDFs*` naming pattern, but can't come up with anything better at the moment without it being too vague

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [x] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
