### PR TITLE
Refactor CCloudResourceLoader event handler registration; increase test coverage.

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import * as sinon from "sinon";
 
 import { loadFixtureFromFile } from "../../tests/fixtures/utils";
+import { StubbedEventEmitters, eventEmitterStubs } from "../../tests/stubs/emitters";
 import { getSidecarStub } from "../../tests/stubs/sidecar";
 import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
@@ -42,6 +43,7 @@ import * as graphqlOrgs from "../graphql/organizations";
 import { restFlinkStatementToModel } from "../models/flinkStatement";
 import * as sidecar from "../sidecar";
 import { ResourceManager } from "../storage/resourceManager";
+import { CachingResourceLoader } from "./cachingResourceLoader";
 import { CCloudResourceLoader, loadProviderRegions } from "./ccloudResourceLoader";
 
 describe("CCloudResourceLoader", () => {
@@ -62,6 +64,211 @@ describe("CCloudResourceLoader", () => {
     loader.dispose();
     CCloudResourceLoader["instance"] = null; // Reset singleton instance
     sandbox.restore();
+  });
+
+  describe("constructor", () => {
+    it("should register at least one event handler disposable after construction", () => {
+      const eventHandlers = loader["disposables"];
+      assert(eventHandlers.length > 0, "Expected at least one event handler to be registered");
+    });
+  });
+
+  describe("setEventListeners", () => {
+    let emitterStubs: StubbedEventEmitters;
+
+    beforeEach(() => {
+      // Stub all event emitters in the emitters module
+      emitterStubs = eventEmitterStubs(sandbox);
+    });
+
+    // Expected pairs of emitter and handler method names
+    const handlerEmitterPairs: Array<[keyof typeof emitterStubs, keyof CCloudResourceLoader]> = [
+      ["ccloudConnected", "ccloudConnectedHandler"],
+    ];
+
+    it("setEventListeners()should return the expected number of listeners", () => {
+      // @ts-expect-error protected method
+      const listeners = loader.setEventListeners();
+      assert.strictEqual(listeners.length, handlerEmitterPairs.length);
+    });
+
+    handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
+      it(`should register ${handlerMethodName} with ${emitterName} emitter`, () => {
+        // Create stub for the handler method
+        const handlerStub = sandbox.stub(loader, handlerMethodName);
+
+        // Re-invoke setEventListeners() to capture emitter .event() stub calls, protected method.
+        loader["setEventListeners"]();
+
+        const emitterStub = emitterStubs[emitterName]!;
+
+        // Verify the emitter's event method was called
+        sinon.assert.calledOnce(emitterStub.event);
+
+        // Capture the handler function that was registered
+        const registeredHandler = emitterStub.event.firstCall.args[0];
+
+        // Call the registered handler
+        registeredHandler();
+
+        // Verify the expected method stub was called,
+        // proving that the expected handler was registered
+        // to the expected emitter.
+        sinon.assert.calledOnce(handlerStub);
+      });
+    });
+  });
+
+  describe("ccloudConnectedHandler", () => {
+    let resetStub: sinon.SinonStub;
+    let ensureCoarseResourcesLoadedStub: sinon.SinonStub;
+    beforeEach(() => {
+      resetStub = sandbox.stub(loader, "reset").resolves();
+      ensureCoarseResourcesLoadedStub = sandbox
+        .stub(loader as any, "ensureCoarseResourcesLoaded")
+        .resolves();
+    });
+
+    for (const connected of [true, false]) {
+      it(`should reset the loader state when connected is ${connected}`, async () => {
+        await loader.ccloudConnectedHandler(connected);
+        sinon.assert.calledOnce(resetStub);
+        if (!connected) {
+          sinon.assert.notCalled(ensureCoarseResourcesLoadedStub);
+        }
+      });
+    }
+
+    it("should call ensureCoarseResourcesLoaded when connected is true", async () => {
+      await loader.ccloudConnectedHandler(true);
+      sinon.assert.calledOnce(ensureCoarseResourcesLoadedStub);
+    });
+  });
+
+  describe("reset", () => {
+    it("should reset the organization to null", async () => {
+      loader["organization"] = TEST_CCLOUD_ORGANIZATION;
+      await loader.reset();
+      assert.strictEqual(loader["organization"], null);
+    });
+
+    it("should call super.reset()", async () => {
+      const superResetStub = sandbox.stub(CachingResourceLoader.prototype, "reset").resolves();
+      await loader.reset();
+      sinon.assert.calledOnce(superResetStub);
+    });
+  });
+
+  describe("getOrganization", () => {
+    let getCurrentOrganizationStub: sinon.SinonStub;
+    beforeEach(() => {
+      getCurrentOrganizationStub = sandbox.stub(graphqlOrgs, "getCurrentOrganization");
+    });
+
+    it("should return the cached current organization", async () => {
+      loader["organization"] = TEST_CCLOUD_ORGANIZATION;
+      const org = await loader.getOrganization();
+      assert.strictEqual(org, TEST_CCLOUD_ORGANIZATION);
+      sinon.assert.notCalled(getCurrentOrganizationStub);
+    });
+
+    it("should fetch the current organization if not cached", async () => {
+      getCurrentOrganizationStub.resolves(TEST_CCLOUD_ORGANIZATION);
+      const org = await loader.getOrganization();
+      assert.strictEqual(org, TEST_CCLOUD_ORGANIZATION);
+      sinon.assert.calledOnce(getCurrentOrganizationStub);
+    });
+
+    it("should return undefined if no organization is available", async () => {
+      getCurrentOrganizationStub.resolves(undefined);
+      const org = await loader.getOrganization();
+      assert.strictEqual(org, undefined);
+      sinon.assert.calledOnce(getCurrentOrganizationStub);
+    });
+  });
+
+  describe("determineFlinkQueryables", () => {
+    let getOrganizationStub: sinon.SinonStub;
+    beforeEach(() => {
+      getOrganizationStub = sandbox
+        .stub(loader, "getOrganization")
+        .resolves(TEST_CCLOUD_ORGANIZATION);
+    });
+
+    it("should return empty array if no organization is available", async () => {
+      getOrganizationStub.resolves(undefined);
+      const queryables = await loader.determineFlinkQueryables(TEST_CCLOUD_ENVIRONMENT);
+      assert.deepStrictEqual(queryables, []);
+      sinon.assert.calledOnce(getOrganizationStub);
+    });
+
+    it("should return facts from provided compute pool", async () => {
+      const queryables = await loader.determineFlinkQueryables(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+      assert.strictEqual(queryables.length, 1);
+      assert.strictEqual(queryables[0].organizationId, TEST_CCLOUD_ORGANIZATION.id);
+      assert.strictEqual(queryables[0].environmentId, TEST_CCLOUD_FLINK_COMPUTE_POOL.environmentId);
+      assert.strictEqual(queryables[0].computePoolId, TEST_CCLOUD_FLINK_COMPUTE_POOL.id);
+      assert.strictEqual(queryables[0].provider, TEST_CCLOUD_FLINK_COMPUTE_POOL.provider);
+      assert.strictEqual(queryables[0].region, TEST_CCLOUD_FLINK_COMPUTE_POOL.region);
+      sinon.assert.calledOnce(getOrganizationStub);
+    });
+
+    it("should reduce all of the compute pools in an environment to a reduced set of queryables", async () => {
+      const computePool1 = {
+        ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
+        id: "lfcp-1m68g66",
+        provider: "aws",
+        region: "us-west-2",
+      };
+      const computePool2 = {
+        ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
+        id: "lfcp-2m68g66",
+        provider: "aws",
+        region: "us-east-1", // different region
+      };
+      const computePool3 = {
+        ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
+        id: "lfcp-3m68g66",
+        provider: "gcp", // different cloud provider from computePool1 and computePool2
+        region: "us-west-2",
+      };
+
+      const computePool4 = {
+        ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
+        id: "lfcp-4m68g66",
+        provider: "aws",
+        region: "us-west-2", // same as computePool1
+      };
+
+      const environmentWithPools = {
+        ...TEST_CCLOUD_ENVIRONMENT,
+        flinkComputePools: [computePool1, computePool2, computePool3, computePool4],
+      };
+
+      const queryables = await loader.determineFlinkQueryables(environmentWithPools);
+      // computePool4 is same provider/region as computePool1, so should not be included.
+      assert.strictEqual(queryables.length, 3);
+
+      // All should have same organizationId and environmentId
+      queryables.forEach((q) => {
+        assert.strictEqual(q.organizationId, TEST_CCLOUD_ORGANIZATION.id);
+        assert.strictEqual(q.environmentId, environmentWithPools.id);
+      });
+
+      // set of `${queryable.provider}-${queryable.region}` should include
+      // all unique provider-region combinations.
+      const uniqueProviderRegions = new Set(queryables.map((q) => `${q.provider}-${q.region}`));
+      assert.strictEqual(uniqueProviderRegions.size, 3);
+      assert(uniqueProviderRegions.has("aws-us-west-2"));
+      assert(uniqueProviderRegions.has("aws-us-east-1"));
+      assert(uniqueProviderRegions.has("gcp-us-west-2"));
+
+      // Should NOT have computePoolId specified, since any query using
+      // any of these should not be limited to a specific compute pool.
+      queryables.forEach((q) => {
+        assert.strictEqual(q.computePoolId, undefined);
+      });
+    });
   });
 
   describe("getFlinkStatements", () => {


### PR DESCRIPTION
…

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Refactor CCloudResourceLoader `ccloudConnected` event handler to be toplevel function using established patterns.
- Tests over refactored constructor registering event handler, `setEventListeners` behavior, and `ccloudConnectedHandler` member function.
- New tests over preexisting untested methods `reset()`, `getOrganization()`, `determineFlinkQueryables()` to push test coverage for all methods and over 90% of statements.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
