### PR TITLE
More test coverage for untitled scheme documents vs starting up flink language client

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -663,20 +663,22 @@ describe("FlinkLanguageClientManager", () => {
     });
 
     describe("onDidChangeActiveTextEditorHandler", () => {
-      it("should call maybeStartLanguageClient when active editor changes to flinksql", () => {
-        const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
-        const fakeDocument = {
-          languageId: FLINKSQL_LANGUAGE_ID,
-          uri: fakeUri,
-        } as vscode.TextDocument;
-        const fakeEditor = { document: fakeDocument } as vscode.TextEditor;
+      for (const goodScheme of ["file", "untitled"]) {
+        it(`should call maybeStartLanguageClient for flinksql document in ${goodScheme} scheme`, () => {
+          const fakeUri = vscode.Uri.parse(`${goodScheme}:///fake/path/test.flinksql`);
+          const fakeDocument = {
+            languageId: FLINKSQL_LANGUAGE_ID,
+            uri: fakeUri,
+          } as vscode.TextDocument;
+          const fakeEditor = { document: fakeDocument } as vscode.TextEditor;
 
-        // Simulate active editor change
-        flinkManager.onDidChangeActiveTextEditorHandler(fakeEditor);
+          // Simulate active editor change
+          flinkManager.onDidChangeActiveTextEditorHandler(fakeEditor);
 
-        sinon.assert.calledOnce(maybeStartLanguageClientStub);
-        sinon.assert.calledWith(maybeStartLanguageClientStub, fakeUri);
-      });
+          sinon.assert.calledOnce(maybeStartLanguageClientStub);
+          sinon.assert.calledWith(maybeStartLanguageClientStub, fakeUri);
+        });
+      }
 
       it("should not call maybeStartLanguageClient when active editor is not flinksql", () => {
         const fakeUri = vscode.Uri.parse("file:///fake/path/test.txt");
@@ -754,48 +756,50 @@ describe("FlinkLanguageClientManager", () => {
         sinon.assert.calledWith(trackDocumentStub, fakeUri);
       });
 
-      it(`should call maybeStartLanguageClient when a flinksql document is opened when no active editor at all`, async () => {
-        const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
-        const fakeDocument = {
-          languageId: FLINKSQL_LANGUAGE_ID,
-          uri: fakeUri,
-        } as vscode.TextDocument;
-
-        // set window.activeTextEditor getter to return undefined
-        returnedActiveTextEditor = undefined;
-
-        await flinkManager.onDidOpenTextDocumentHandler(fakeDocument);
-
-        sinon.assert.calledOnce(maybeStartLanguageClientStub);
-        sinon.assert.calledWith(maybeStartLanguageClientStub, fakeUri);
-
-        // should have tracked the document
-        sinon.assert.calledOnce(trackDocumentStub);
-        sinon.assert.calledWith(trackDocumentStub, fakeUri);
-      });
-
-      it(`should call maybeStartLanguageClient when open document changes language id`, async () => {
-        const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
-        const fakeDocument = {
-          languageId: FLINKSQL_LANGUAGE_ID,
-          uri: fakeUri,
-        } as vscode.TextDocument;
-
-        // set window.activeTextEditor getter to return same document, but
-        // with a different language id, as if this event is announcing
-        // the language id change per onDidOpenTextDocument documentation.
-        returnedActiveTextEditor = {
-          document: {
-            languageId: "plaintext",
+      for (const goodScheme of ["file", "untitled"]) {
+        it(`should call maybeStartLanguageClient when a flinksql document is opened when no active editor at all: scheme ${goodScheme}`, async () => {
+          const fakeUri = vscode.Uri.parse(`${goodScheme}:///fake/path/test.flinksql`);
+          const fakeDocument = {
+            languageId: FLINKSQL_LANGUAGE_ID,
             uri: fakeUri,
-          },
-        } as vscode.TextEditor;
+          } as vscode.TextDocument;
 
-        await flinkManager.onDidOpenTextDocumentHandler(fakeDocument);
+          // set window.activeTextEditor getter to return undefined
+          returnedActiveTextEditor = undefined;
 
-        sinon.assert.calledOnce(maybeStartLanguageClientStub);
-        sinon.assert.calledWith(maybeStartLanguageClientStub, fakeUri);
-      });
+          await flinkManager.onDidOpenTextDocumentHandler(fakeDocument);
+
+          sinon.assert.calledOnce(maybeStartLanguageClientStub);
+          sinon.assert.calledWith(maybeStartLanguageClientStub, fakeUri);
+
+          // should have tracked the document
+          sinon.assert.calledOnce(trackDocumentStub);
+          sinon.assert.calledWith(trackDocumentStub, fakeUri);
+        });
+
+        it(`should call maybeStartLanguageClient when open document changes language id: scheme ${goodScheme}`, async () => {
+          const fakeUri = vscode.Uri.parse(`${goodScheme}:///fake/path/test.flinksql`);
+          const fakeDocument = {
+            languageId: FLINKSQL_LANGUAGE_ID,
+            uri: fakeUri,
+          } as vscode.TextDocument;
+
+          // set window.activeTextEditor getter to return same document, but
+          // with a different language id, as if this event is announcing
+          // the language id change per onDidOpenTextDocument documentation.
+          returnedActiveTextEditor = {
+            document: {
+              languageId: "plaintext",
+              uri: fakeUri,
+            },
+          } as vscode.TextEditor;
+
+          await flinkManager.onDidOpenTextDocumentHandler(fakeDocument);
+
+          sinon.assert.calledOnce(maybeStartLanguageClientStub);
+          sinon.assert.calledWith(maybeStartLanguageClientStub, fakeUri);
+        });
+      }
     });
 
     describe("onDidChangeTextDocumentHandler", () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- More test coverage for untitled scheme documents vs starting up flink language client, followup item from #2315 review comments. 
- Adds positive test case coverage for untitled:// (unsaved file) scheme over `onDidChangeActiveTextEditorHandler` and `onDidOpenTextDocumentHandler`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
