### PR TITLE
fix: Do not skip reconnection attempts when unauthenticated

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -675,10 +675,11 @@ export class FlinkLanguageClientManager implements Disposable {
    * Handle WebSocket disconnection events and attempt reconnection
    */
   private handleWebSocketDisconnect(): void {
-    // Skip reconnection attempts if we're not authenticated
+    // We don't need to skip reconnection attempts if we're not authenticated since we only know about
+    // the user's control plane token while the sidecar uses the longer-lived data plane token for
+    // authenticating with the Confluent Cloud language service.
     if (!hasCCloudAuthSession()) {
-      logger.warn("Not attempting reconnection: User not authenticated with CCloud");
-      return;
+      logger.warn("Attempting to reconnect websocket despite user having an expired control plane token");
     }
 
     // If we've reached max attempts, stop trying to reconnect

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -679,7 +679,9 @@ export class FlinkLanguageClientManager implements Disposable {
     // the user's control plane token while the sidecar uses the longer-lived data plane token for
     // authenticating with the Confluent Cloud language service.
     if (!hasCCloudAuthSession()) {
-      logger.warn("Attempting to reconnect websocket despite user having an expired control plane token");
+      logger.warn(
+        "Attempting to reconnect websocket despite user having an expired control plane token",
+      );
     }
 
     // If we've reached max attempts, stop trying to reconnect


### PR DESCRIPTION
## Summary of Changes

This change should harden the language client's reconnect logic by making sure we don't skip reconnection attempts if we're not authenticated since we only know about the user's control plane token while the sidecar uses the longer-lived data plane token for authenticating with the Confluent Cloud language service.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
