### PR TITLE
Fix for edit/delete/export direct connection command wiring for new resources provider when connection is 'not connected'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1576,17 +1576,17 @@
         },
         {
           "command": "confluent.connections.direct.delete",
-          "when": "viewItem == direct-environment || viewItem =~ /.*resources-direct-container-.*/",
+          "when": "viewItem == direct-environment || viewItem =~ /resources-direct-container.*/",
           "group": "inline@3"
         },
         {
           "command": "confluent.connections.direct.edit",
-          "when": "viewItem == direct-environment || viewItem =~ /.*resources-direct-container-.*/",
+          "when": "viewItem == direct-environment || viewItem =~ /resources-direct-container.*/",
           "group": "inline@2"
         },
         {
           "command": "confluent.connections.direct.export",
-          "when": "viewItem == direct-environment || viewItem =~ /.*resources-direct-container-.*/",
+          "when": "viewItem == direct-environment || viewItem =~ /resources-direct-container.*/",
           "group": "inline@1"
         },
         {

--- a/src/viewProviders/newResources.test.ts
+++ b/src/viewProviders/newResources.test.ts
@@ -87,6 +87,10 @@ describe("viewProviders/newResources.ts", () => {
       schemaRegistry: TEST_DIRECT_SCHEMA_REGISTRY,
     });
 
+    const TEST_DIRECT_ENVIRONMENT_NO_CLUSTERS = new DirectEnvironment({
+      ...TEST_DIRECT_ENVIRONMENT,
+    });
+
     beforeEach(() => {
       directLoader = new DirectResourceLoader("test-direct-connection-id" as ConnectionId);
       directConnectionRow = new DirectConnectionRow(directLoader);
@@ -111,6 +115,25 @@ describe("viewProviders/newResources.ts", () => {
 
       beforeEach(() => {
         getEnvironmentsStub = sandbox.stub(directLoader, "getEnvironments").resolves([]);
+      });
+
+      describe("getTreeItem", () => {
+        it("when connected", () => {
+          directConnectionRow.environments.push(TEST_DIRECT_ENVIRONMENT_WITH_KAFKA_AND_SR);
+          const treeItem = directConnectionRow.getTreeItem();
+          assert.strictEqual(treeItem.collapsibleState, TreeItemCollapsibleState.Expanded);
+          assert.strictEqual(treeItem.contextValue, "resources-direct-container-connected");
+          assert.strictEqual(treeItem.id, `${directConnectionRow.connectionId}-connected`);
+        });
+
+        it("when not connected, empty environment", () => {
+          directConnectionRow.environments.push(TEST_DIRECT_ENVIRONMENT_NO_CLUSTERS);
+          const treeItem = directConnectionRow.getTreeItem();
+          assert.strictEqual(treeItem.collapsibleState, TreeItemCollapsibleState.None);
+          // No "-connected" suffix when not connected.
+          assert.strictEqual(treeItem.contextValue, "resources-direct-container");
+          assert.strictEqual(treeItem.id, `${directConnectionRow.connectionId}`);
+        });
       });
 
       it("searchableText() returns the connection name after refresh completes", async () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix for the command invocation wiring for currently-disconnected direct connection rows in the Resources view when populated by the new resources provider.
- Command wiring fix was that the regular expression was expecting a trailing '-' in the row's context value when not connected, but there won't be one. So, simplify the regular expression and remove the trailing dash.
- Write some additional tests over `DirectConnection` row vs `getTreeItem()` for clarity for the future.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2289
- Without this fix, the commands would be invokable from currently-connected status DirectConnection rows, just not the currently-disconnected ones.
- Now both show the expected edit/export/delete command icons (The "a-main-test-kafka-cluster shadow" connection is in disconnected state right now, whereas "local shadow" is connected. Now they both offer the same commands):

![fix-command-wiring](https://github.com/user-attachments/assets/0c3e1e4b-3670-4387-ad94-e4eca230a0f8)




## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
