### PR TITLE
fix: Force reinitialization of language client after WebSocket reconnect

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -432,9 +432,9 @@ export class FlinkLanguageClientManager implements Disposable {
    * - User has designated a compute pool to use (language server route is region+provider specific)
    * - User has opened a Flink SQL file
    * @param uri The URI of the document to initialize the client for
-   * @param forceRestart Whether to force reinitialization of the language client even if it's already running
+   * @param restartRunningClient Whether to force reinitialization of the language client even if it's already running
    */
-  public async maybeStartLanguageClient(uri?: Uri, forceRestart = false): Promise<void> {
+  public async maybeStartLanguageClient(uri?: Uri, restartRunningClient = false): Promise<void> {
     const uriStr = uri?.toString() || "undefined";
     logger.trace(`Requesting language client initialization for ${uriStr}`);
     // We use runExclusive to ensure only one initialization attempt at a time
@@ -458,12 +458,12 @@ export class FlinkLanguageClientManager implements Disposable {
           this.lastDocUri &&
           uri.toString() === this.lastDocUri.toString()
         ) {
-          if (!forceRestart) {
+          if (!restartRunningClient) {
             logger.trace("Language client already exists for this URI, skipping initialization");
             return;
           } else {
             logger.trace(
-              "Language client already exists for this URI, but forcing reinitialization of language client",
+              "Language client is already running for this URI, but forcing reinitialization",
             );
           }
         }

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -497,7 +497,11 @@ export class FlinkLanguageClientManager implements Disposable {
           return;
         }
 
-        if (this.isLanguageClientConnected() && url === this.lastWebSocketUrl) {
+        if (
+          this.isLanguageClientConnected() &&
+          url === this.lastWebSocketUrl &&
+          !restartRunningClient
+        ) {
           // If we already have a client, it's alive, the compute pool matches, so we're good
           logger.trace("Language client already connected to correct url, no need to reinitialize");
           return;


### PR DESCRIPTION
## Summary of Changes

This change makes sure we always reinitialize the language client after a reconnect to the remote language server. It should fix cases where an idle disconnect does not lead to timely reconnects.

## Any additional details or context that should be provided?

Fixes #2273 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
