### PR TITLE
Bring PR-2344 forward from v1.5.x branch into main.

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -993,7 +993,9 @@ describe("FlinkLanguageClientManager", () => {
   });
 });
 
-/** Class holding stubs impersonating enough of DiagnosticsCollection methods to be useful.  */
+/**
+ * Class stubbing enough of DiagnosticsCollection methods to be useful.
+ **/
 class FakeDiagnosticsCollection {
   public readonly get: sinon.SinonStub;
   public readonly set: sinon.SinonStub;

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -803,17 +803,14 @@ describe("FlinkLanguageClientManager", () => {
     });
 
     describe("onDidChangeTextDocumentHandler", () => {
-      let fakeDiagnosticsCollection: { get: sinon.SinonStub; set: sinon.SinonStub };
+      let fakeDiagnosticsCollection: FakeDiagnosticsCollection;
+
       beforeEach(() => {
         // wire a mock LanguageClient to the flinkManager
         const fakeLanguageClient = sandbox.createStubInstance(LanguageClient);
 
-        fakeDiagnosticsCollection = {
-          get: sandbox.stub(),
-          set: sandbox.stub(),
-        };
-
-        // Override the read-only diagnostics property for testing
+        // Reassign the read-only `diagnostics` property of the language client
+        fakeDiagnosticsCollection = new FakeDiagnosticsCollection(sandbox);
         Object.defineProperty(fakeLanguageClient, "diagnostics", {
           value: fakeDiagnosticsCollection,
           configurable: true,
@@ -884,6 +881,8 @@ describe("FlinkLanguageClientManager", () => {
         // Should not have called diagnostics collection methods
         sinon.assert.notCalled(fakeDiagnosticsCollection.set);
         sinon.assert.notCalled(fakeDiagnosticsCollection.get);
+        sinon.assert.notCalled(fakeDiagnosticsCollection.delete);
+        sinon.assert.notCalled(fakeDiagnosticsCollection.has);
       });
 
       it("should clear diagnostics for flinksql documents on text change if had prior diagnostics", () => {
@@ -897,7 +896,7 @@ describe("FlinkLanguageClientManager", () => {
         flinkManager.trackDocument(fakeUri);
 
         // And make as if this document had diagnostics set
-        fakeDiagnosticsCollection.get.withArgs(fakeUri).returns(true);
+        fakeDiagnosticsCollection.has.withArgs(fakeUri).returns(true);
 
         // Simulate a text document change event
         const fakeEvent: vscode.TextDocumentChangeEvent = {
@@ -908,9 +907,12 @@ describe("FlinkLanguageClientManager", () => {
 
         flinkManager.onDidChangeTextDocumentHandler(fakeEvent);
 
-        // Should have cleared diagnostics for this document
-        sinon.assert.calledOnce(fakeDiagnosticsCollection.set);
-        sinon.assert.calledWith(fakeDiagnosticsCollection.set, fakeUri, []);
+        // Should have detected then cleared diagnostics for this document
+        sinon.assert.calledTwice(fakeDiagnosticsCollection.has);
+        sinon.assert.calledWith(fakeDiagnosticsCollection.has, fakeUri);
+
+        sinon.assert.calledOnce(fakeDiagnosticsCollection.delete);
+        sinon.assert.calledWith(fakeDiagnosticsCollection.delete, fakeUri);
       });
     });
 
@@ -990,3 +992,18 @@ describe("FlinkLanguageClientManager", () => {
     });
   });
 });
+
+/** Class holding stubs impersonating enough of DiagnosticsCollection methods to be useful.  */
+class FakeDiagnosticsCollection {
+  public readonly get: sinon.SinonStub;
+  public readonly set: sinon.SinonStub;
+  public readonly has: sinon.SinonStub;
+  public readonly delete: sinon.SinonStub;
+
+  constructor(sandbox: sinon.SinonSandbox) {
+    this.get = sandbox.stub();
+    this.set = sandbox.stub();
+    this.has = sandbox.stub();
+    this.delete = sandbox.stub();
+  }
+}

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -307,10 +307,10 @@ export class FlinkLanguageClientManager extends DisposableCollection {
 
     if (
       this.openFlinkSqlDocuments.has(uriString) &&
-      this.languageClient?.diagnostics?.get(event.document.uri)
+      this.languageClient?.diagnostics?.has(event.document.uri)
     ) {
       logger.trace(`Clearing diagnostics for document: ${uriString}`);
-      this.languageClient.diagnostics.set(event.document.uri, []);
+      this.clearDiagnostics(event.document.uri);
     }
   }
 
@@ -400,6 +400,18 @@ export class FlinkLanguageClientManager extends DisposableCollection {
     } catch (error) {
       logger.error("Error checking Flink resources availability", error);
       return false;
+    }
+  }
+  /**
+   * Clear diagnostics for a specific document URI
+   * This is used to clear diagnostics when the document is closed or when the language client is reinitialized
+   * It prevents stale diagnostics from being shown in the editor
+   * @param documentUri The URI of the document to clear diagnostics for
+   */
+  private clearDiagnostics(documentUri: Uri): void {
+    if (this.languageClient?.diagnostics?.has(documentUri)) {
+      logger.trace(`Clearing diagnostics for document: ${documentUri.toString()}`);
+      this.languageClient.diagnostics.delete(documentUri);
     }
   }
 
@@ -550,6 +562,12 @@ export class FlinkLanguageClientManager extends DisposableCollection {
 
         // Reset reconnect counter on new initialization
         this.reconnectCounter = 0;
+
+        // Clear any diagnostics for the previous document.
+        if (this.lastDocUri) {
+          this.clearDiagnostics(this.lastDocUri);
+        }
+
         logger.debug(`Starting language client with URL: ${url} for document ${uriStr}`);
         this.languageClient = await this.initializeLanguageClient(url);
 


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Bring https://github.com/confluentinc/vscode/pull/2344 forward from v1.5.x branch into main.
- Revise the existing test coverage over `onDidChangeTextDocumentHandler` making the call into clearDiagnostics() via `clearDiagnostics`'s side effects., generalizing the FakeDiagnosticsCollection concept in the process for future reuse in future tests.
- There's no test coverage (yet) over `maybeStartLanguageClient()` (and therefore also its new call into `clearDiagnostics()`). That's a big enough effort to warrant its own issue, and not this merge forward into main.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2338 in main.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
