### PR TITLE
🍒 1.5.x -> main: Force reinitialization of language client after WebSocket reconnect

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -477,8 +477,10 @@ export class FlinkLanguageClientManager extends DisposableCollection {
    * - User is authenticated with CCloud
    * - User has designated a compute pool to use (language server route is region+provider specific)
    * - User has opened a Flink SQL file
+   * @param uri The URI of the document to initialize the client for
+   * @param restartRunningClient Whether to force reinitialization of the language client even if it's already running
    */
-  public async maybeStartLanguageClient(uri?: Uri): Promise<void> {
+  public async maybeStartLanguageClient(uri?: Uri, restartRunningClient = false): Promise<void> {
     const uriStr = uri?.toString() || "undefined";
     logger.trace(`Requesting language client initialization for ${uriStr}`);
     // We use runExclusive to ensure only one initialization attempt at a time
@@ -502,8 +504,14 @@ export class FlinkLanguageClientManager extends DisposableCollection {
           this.lastDocUri &&
           uri.toString() === this.lastDocUri.toString()
         ) {
-          logger.trace("Language client already exists for this URI, skipping initialization");
-          return;
+          if (!restartRunningClient) {
+            logger.trace("Language client already exists for this URI, skipping initialization");
+            return;
+          } else {
+            logger.trace(
+              "Language client is already running for this URI, but forcing reinitialization",
+            );
+          }
         }
 
         const { computePoolId } = await this.getFlinkSqlSettings(uri);
@@ -535,7 +543,11 @@ export class FlinkLanguageClientManager extends DisposableCollection {
           return;
         }
 
-        if (this.isLanguageClientConnected() && url === this.lastWebSocketUrl) {
+        if (
+          this.isLanguageClientConnected() &&
+          url === this.lastWebSocketUrl &&
+          !restartRunningClient
+        ) {
           // If we already have a client, it's alive, the compute pool matches, so we're good
           logger.trace("Language client already connected to correct url, no need to reinitialize");
           return;
@@ -752,7 +764,8 @@ export class FlinkLanguageClientManager extends DisposableCollection {
   private async restartLanguageClient(): Promise<void> {
     if (!this.lastDocUri) return; // We should never get here
     try {
-      await this.maybeStartLanguageClient(this.lastDocUri);
+      // Enforce restart of language client
+      await this.maybeStartLanguageClient(this.lastDocUri, true);
       // Reset counter on successful reconnection
       this.reconnectCounter = 0;
     } catch (e) {


### PR DESCRIPTION
## Summary of Changes

🍒 https://github.com/confluentinc/vscode/pull/2341 from `1.5.x` branch

This change makes sure we always reinitialize the language client after a reconnect to the remote language server. It should fix cases where an idle disconnect does not lead to timely reconnects.

Fixes #2273

## Any additional details or context that should be provided?

We'll implement unit tests in a follow-up PR; captured in https://github.com/confluentinc/vscode/issues/2346.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
