### PR TITLE
[v1.5.x] Always trigger diagnostics after attempting language client start

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -581,11 +581,13 @@ export class FlinkLanguageClientManager implements Disposable {
         });
       } finally {
         logger.trace(`Released initialization lock for ${uriStr}`);
-        // Trigger diagnostics for the active document
-        logger.trace(`Simulating change to ${uriStr} to trigger diagnostics`);
-        for (const textDocument of workspace.textDocuments) {
-          if (textDocument.uri.toString() === uriStr) {
-            await this.simulateDocumentChangeToTriggerDiagnostics(textDocument);
+        // Trigger diagnostics for the active document if language client is available
+        if (this.languageClient) {
+          logger.trace(`Simulating change to ${uriStr} to trigger diagnostics`);
+          for (const textDocument of workspace.textDocuments) {
+            if (textDocument.uri.toString() === uriStr) {
+              await this.simulateDocumentChangeToTriggerDiagnostics(textDocument);
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary of Changes

This change makes sure we always trigger diagnostics by simulating a change to the active document after attempting a language client start. Technically, it's done by simulating the change in the `finally { }` block inside the `maybeStartLanguageClient()` function.

Fixes #2349 and should address my feedback on https://github.com/confluentinc/vscode/pull/2351.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Tests will follow in a separate PR against main.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
