### PR TITLE
[v1.5.x] Don't clear diagnostics when saving documents

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -248,7 +248,11 @@ export class FlinkLanguageClientManager implements Disposable {
         }
         if (
           this.openFlinkSqlDocuments.has(uriString) &&
-          this.languageClient?.diagnostics?.has(event.document.uri)
+          this.languageClient?.diagnostics?.has(event.document.uri) &&
+          // Make sure the change updated the content of the document. Otherwise, clearing diagnostics
+          // won't make sense. We'll, for instance, see document change events without content changes
+          // when saving the document.
+          event.contentChanges.length > 0
         ) {
           this.clearDiagnostics(event.document.uri);
         } else {


### PR DESCRIPTION
## Summary of Changes

We clear diagnostics in the [handler for document change events](https://github.com/confluentinc/vscode/blob/v1.5.x/src/flinkSql/flinkLanguageClientManager.ts#L243-L258). Prior to this change, we cleared diagnostics upon saving documents because saving a document generates a document change event.

This change updates the event handler, so that we clear diagnostics only if a document change event updated the content of the document, which is not the case when saving it.

Fixes #2350

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

Tests will follow when bringing this change over to main.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
