### PR TITLE
[main] pull in fixes from `v1.5.x`

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -945,7 +945,7 @@ describe("FlinkLanguageClientManager", () => {
 
         flinkManager.onDidChangeTextDocumentHandler(fakeEvent);
 
-        // Should have detected then cleared diagnostics for this document
+        // Should check for diagnostics, but no clearing since there weren't content changes
         sinon.assert.calledOnce(fakeDiagnosticsCollection.has);
         sinon.assert.calledWith(fakeDiagnosticsCollection.has, fakeUri);
 

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -39,6 +39,8 @@ describe("FlinkLanguageClientManager", () => {
   let getCatalogDatabaseFromMetadataStub: sinon.SinonStub;
   let resourceManagerStub: sinon.SinonStubbedInstance<ResourceManager>;
 
+  const TEST_FILE_URI = vscode.Uri.parse("file:///test.flink.sql");
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     FlinkLanguageClientManager["instance"] = null;
@@ -182,13 +184,11 @@ describe("FlinkLanguageClientManager", () => {
   });
 
   describe("getFlinkSqlSettings", () => {
-    const testUri = vscode.Uri.parse("file:///test.flink.sql");
-
     it("should return null for all settings if not configured", async () => {
       stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, "").stubGet(FLINK_CONFIG_DATABASE, "");
       resourceManagerStub.getUriMetadata.resolves(undefined);
 
-      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+      const settings = await flinkManager.getFlinkSqlSettings(TEST_FILE_URI);
 
       assert.deepStrictEqual(settings, {
         computePoolId: null,
@@ -203,7 +203,7 @@ describe("FlinkLanguageClientManager", () => {
         .stubGet(FLINK_CONFIG_DATABASE, "config-db-id");
       resourceManagerStub.getUriMetadata.resolves(undefined);
 
-      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+      const settings = await flinkManager.getFlinkSqlSettings(TEST_FILE_URI);
 
       assert.deepStrictEqual(settings, {
         computePoolId: "config-pool-id",
@@ -225,7 +225,7 @@ describe("FlinkLanguageClientManager", () => {
         database: { name: "test-db-name" },
       });
 
-      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+      const settings = await flinkManager.getFlinkSqlSettings(TEST_FILE_URI);
 
       sinon.assert.calledOnce(getCatalogDatabaseFromMetadataStub);
       assert.deepStrictEqual(settings, {
@@ -249,7 +249,7 @@ describe("FlinkLanguageClientManager", () => {
         database: { name: "metadata-db-name" },
       });
 
-      const settings = await flinkManager.getFlinkSqlSettings(testUri);
+      const settings = await flinkManager.getFlinkSqlSettings(TEST_FILE_URI);
 
       assert.deepStrictEqual(settings, {
         computePoolId: "metadata-pool",
@@ -613,6 +613,273 @@ describe("FlinkLanguageClientManager", () => {
         async () => await flinkManager.simulateDocumentChangeToTriggerDiagnostics(fakeDoc),
         fakeError,
       );
+    });
+  });
+
+  describe("maybeStartLanguageClient", () => {
+    let getFlinkSqlSettingsStub: sinon.SinonStub;
+    let validateFlinkSettingsStub: sinon.SinonStub;
+    let buildFlinkSqlWebSocketUrlStub: sinon.SinonStub;
+    let isLanguageClientConnectedStub: sinon.SinonStub;
+    let cleanupLanguageClientStub: sinon.SinonStub;
+    let clearDiagnosticsStub: sinon.SinonStub;
+    let initializeLanguageClientStub: sinon.SinonStub;
+    let notifyConfigChangedStub: sinon.SinonStub;
+    let simulateDocumentChangeToTriggerDiagnosticsStub: sinon.SinonStub;
+    let workspaceTextDocumentsStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      // simulate authenticated CCloud connection by default
+      hasCCloudAuthSessionStub.returns(true);
+
+      getFlinkSqlSettingsStub = sandbox.stub(flinkManager, "getFlinkSqlSettings");
+      getFlinkSqlSettingsStub.resolves({ computePoolId: TEST_CCLOUD_FLINK_COMPUTE_POOL_ID });
+
+      validateFlinkSettingsStub = sandbox.stub(flinkManager, "validateFlinkSettings");
+      validateFlinkSettingsStub.resolves(true);
+
+      buildFlinkSqlWebSocketUrlStub = sandbox.stub(
+        flinkManager as any,
+        "buildFlinkSqlWebSocketUrl",
+      );
+      buildFlinkSqlWebSocketUrlStub.resolves("ws://localhost:8080/test");
+
+      isLanguageClientConnectedStub = sandbox.stub(
+        flinkManager as any,
+        "isLanguageClientConnected",
+      );
+      isLanguageClientConnectedStub.returns(false);
+
+      cleanupLanguageClientStub = sandbox.stub().resolves();
+      flinkManager["cleanupLanguageClient"] = cleanupLanguageClientStub;
+
+      clearDiagnosticsStub = sandbox.stub().resolves();
+      flinkManager["clearDiagnostics"] = clearDiagnosticsStub;
+
+      const fakeLanguageClient = sandbox.createStubInstance(LanguageClient);
+      initializeLanguageClientStub = sandbox.stub().resolves(fakeLanguageClient);
+      flinkManager["initializeLanguageClient"] = initializeLanguageClientStub;
+
+      notifyConfigChangedStub = sandbox.stub().resolves();
+      flinkManager["notifyConfigChanged"] = notifyConfigChangedStub;
+
+      simulateDocumentChangeToTriggerDiagnosticsStub = sandbox.stub().resolves();
+      flinkManager["simulateDocumentChangeToTriggerDiagnostics"] =
+        simulateDocumentChangeToTriggerDiagnosticsStub;
+
+      workspaceTextDocumentsStub = sandbox.stub(vscode.workspace, "textDocuments").value([]);
+
+      // start with a fresh slate
+      flinkManager["languageClient"] = null;
+      flinkManager["lastDocUri"] = null;
+      flinkManager["lastWebSocketUrl"] = null;
+      flinkManager["reconnectCounter"] = 0;
+    });
+
+    it("should return early if the user doesn't have an authenticated CCloud connection", async () => {
+      hasCCloudAuthSessionStub.returns(false);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.notCalled(getFlinkSqlSettingsStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    it("should return early if no URI is provided", async () => {
+      await flinkManager.maybeStartLanguageClient();
+
+      sinon.assert.notCalled(getFlinkSqlSettingsStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    // the "Language client already exists for this [document] URI" scenario
+    it("should return early if the language client exists for the same URI and restartRunningClient=false", async () => {
+      isLanguageClientConnectedStub.returns(true);
+      flinkManager["lastDocUri"] = TEST_FILE_URI;
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI, false); // no forced restart
+
+      sinon.assert.notCalled(getFlinkSqlSettingsStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    it("should call initializeLanguageClient() if the language client exists for the same document URI and restartRunningClient=true", async () => {
+      isLanguageClientConnectedStub.returns(true);
+      flinkManager["lastDocUri"] = TEST_FILE_URI;
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI, true); // forced restart
+
+      sinon.assert.calledOnce(getFlinkSqlSettingsStub);
+      sinon.assert.calledOnce(cleanupLanguageClientStub);
+      sinon.assert.calledOnce(initializeLanguageClientStub);
+    });
+
+    it("should return early if no compute pool is set", async () => {
+      getFlinkSqlSettingsStub.resolves({ computePoolId: null });
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(getFlinkSqlSettingsStub);
+      sinon.assert.notCalled(validateFlinkSettingsStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    it("should return early if compute pool validation fails", async () => {
+      validateFlinkSettingsStub.resolves(false);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(getFlinkSqlSettingsStub);
+      sinon.assert.calledOnce(validateFlinkSettingsStub);
+      sinon.assert.notCalled(buildFlinkSqlWebSocketUrlStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    it("should return early if WebSocket URL building fails", async () => {
+      buildFlinkSqlWebSocketUrlStub.rejects(new Error("Failed to build URL"));
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(buildFlinkSqlWebSocketUrlStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    it("should return early if WebSocket URL building returns null", async () => {
+      // like if .lookupComputePoolInfo() returns null for various reasons
+      buildFlinkSqlWebSocketUrlStub.resolves(null);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(buildFlinkSqlWebSocketUrlStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    // the "Language client already connected to correct [websocket] url" scenario
+    it("should return early if the language client is already connected to the same WebSocket URL and restartRunningClient=false", async () => {
+      const testUrl = "ws://localhost:8080/test";
+      isLanguageClientConnectedStub.returns(true);
+      flinkManager["lastWebSocketUrl"] = testUrl;
+      buildFlinkSqlWebSocketUrlStub.resolves(testUrl);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI, false); // no forced restart
+
+      sinon.assert.calledOnce(buildFlinkSqlWebSocketUrlStub);
+      sinon.assert.notCalled(cleanupLanguageClientStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+    });
+
+    it("should cleanup and reinitialize if the language client is connected but the WebSocket URL changed", async () => {
+      const oldUrl = "ws://localhost:8080/old";
+      const newUrl = "ws://localhost:8080/new";
+      isLanguageClientConnectedStub.returns(true);
+      flinkManager["lastWebSocketUrl"] = oldUrl;
+      buildFlinkSqlWebSocketUrlStub.resolves(newUrl);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(cleanupLanguageClientStub);
+      sinon.assert.calledOnce(initializeLanguageClientStub);
+      sinon.assert.calledWith(initializeLanguageClientStub, newUrl);
+      // verify that the cleanup happens before reinitialization
+      sinon.assert.callOrder(cleanupLanguageClientStub, initializeLanguageClientStub);
+    });
+
+    it("should successfully initialize the language client with valid settings", async () => {
+      const testUrl = "ws://localhost:8080/test";
+      buildFlinkSqlWebSocketUrlStub.resolves(testUrl);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(getFlinkSqlSettingsStub);
+      sinon.assert.calledOnce(validateFlinkSettingsStub);
+      sinon.assert.calledOnce(buildFlinkSqlWebSocketUrlStub);
+      sinon.assert.calledOnce(initializeLanguageClientStub);
+      sinon.assert.calledWith(initializeLanguageClientStub, testUrl);
+      sinon.assert.calledOnce(notifyConfigChangedStub);
+      // verify internal state is properly set
+      assert.strictEqual(flinkManager["lastDocUri"], TEST_FILE_URI);
+      assert.strictEqual(flinkManager["lastWebSocketUrl"], testUrl);
+      assert.strictEqual(flinkManager["reconnectCounter"], 0);
+    });
+
+    it("should call .clearDiagnostics() for the previous document if it exists", async () => {
+      const previousUri = vscode.Uri.parse("file:///previous.flink.sql");
+      flinkManager["lastDocUri"] = previousUri;
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(clearDiagnosticsStub);
+      sinon.assert.calledWith(clearDiagnosticsStub, previousUri);
+    });
+
+    it("should not call .clearDiagnostics() if no previous document exists", async () => {
+      flinkManager["lastDocUri"] = null;
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.notCalled(clearDiagnosticsStub);
+    });
+
+    it("should call simulateDocumentChangeToTriggerDiagnostics() in finally block when client is created", async () => {
+      const testDocument = {
+        uri: TEST_FILE_URI,
+        languageId: FLINKSQL_LANGUAGE_ID,
+      } as vscode.TextDocument;
+      workspaceTextDocumentsStub.value([testDocument]);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(simulateDocumentChangeToTriggerDiagnosticsStub);
+      sinon.assert.calledWith(simulateDocumentChangeToTriggerDiagnosticsStub, testDocument);
+    });
+
+    it("should not call simulateDocumentChangeToTriggerDiagnostics() if no matching document is found", async () => {
+      const otherDocument = {
+        uri: vscode.Uri.parse("file:///other.flink.sql"),
+        languageId: FLINKSQL_LANGUAGE_ID,
+      } as vscode.TextDocument;
+      workspaceTextDocumentsStub.value([otherDocument]);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.notCalled(simulateDocumentChangeToTriggerDiagnosticsStub);
+    });
+
+    it("should not call simulateDocumentChangeToTriggerDiagnostics() if no language client exists", async () => {
+      initializeLanguageClientStub.resolves(null);
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.notCalled(simulateDocumentChangeToTriggerDiagnosticsStub);
+    });
+
+    it("should handle errors and still call simulateDocumentChangeToTriggerDiagnostics() in the finally block", async () => {
+      flinkManager["languageClient"] = sandbox.createStubInstance(LanguageClient);
+      const testDocument = {
+        uri: TEST_FILE_URI,
+        languageId: FLINKSQL_LANGUAGE_ID,
+      } as vscode.TextDocument;
+      workspaceTextDocumentsStub.value([testDocument]);
+      const testError = new Error("Test error");
+      getFlinkSqlSettingsStub.rejects(testError);
+
+      // error shouldn't propagate, just get logged
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      sinon.assert.calledOnce(getFlinkSqlSettingsStub);
+      sinon.assert.notCalled(initializeLanguageClientStub);
+      sinon.assert.calledOnce(simulateDocumentChangeToTriggerDiagnosticsStub);
+    });
+
+    it("should not add language client to .disposables if initializeLanguageClient() returns null", async () => {
+      initializeLanguageClientStub.resolves(null);
+      const disposablesSizeBefore = flinkManager["disposables"].length;
+
+      await flinkManager.maybeStartLanguageClient(TEST_FILE_URI);
+
+      assert.strictEqual(flinkManager["disposables"].length, disposablesSizeBefore);
+      assert.strictEqual(flinkManager["languageClient"], null);
+      sinon.assert.notCalled(notifyConfigChangedStub);
     });
   });
 

--- a/src/flinkSql/flinkLanguageClientManager.test.ts
+++ b/src/flinkSql/flinkLanguageClientManager.test.ts
@@ -885,7 +885,7 @@ describe("FlinkLanguageClientManager", () => {
         sinon.assert.notCalled(fakeDiagnosticsCollection.has);
       });
 
-      it("should clear diagnostics for flinksql documents on text change if had prior diagnostics", () => {
+      it("should clear diagnostics for flinksql documents on text change if had prior diagnostics and the TextDocumentChangeEvent has contentChanges", () => {
         const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
         const fakeDocument = {
           languageId: FLINKSQL_LANGUAGE_ID,
@@ -901,7 +901,15 @@ describe("FlinkLanguageClientManager", () => {
         // Simulate a text document change event
         const fakeEvent: vscode.TextDocumentChangeEvent = {
           document: fakeDocument,
-          contentChanges: [],
+          contentChanges: [
+            {
+              // the content here doesn't matter, we just want a TextDocumentContentChangeEvent
+              range: new vscode.Range(0, 0, 1, 0),
+              rangeOffset: 0,
+              rangeLength: 1,
+              text: "SELECT * FROM test",
+            },
+          ],
           reason: vscode.TextDocumentChangeReason.Undo,
         };
 
@@ -913,6 +921,35 @@ describe("FlinkLanguageClientManager", () => {
 
         sinon.assert.calledOnce(fakeDiagnosticsCollection.delete);
         sinon.assert.calledWith(fakeDiagnosticsCollection.delete, fakeUri);
+      });
+
+      it("should not clear diagnostics if the TextDocumentChangeEvent does not have any contentChanges", () => {
+        const fakeUri = vscode.Uri.parse("file:///fake/path/test.flinksql");
+        const fakeDocument = {
+          languageId: FLINKSQL_LANGUAGE_ID,
+          uri: fakeUri,
+        } as vscode.TextDocument;
+
+        // stash the document in the openFlinkSqlDocuments set
+        flinkManager.trackDocument(fakeUri);
+
+        // And make as if this document had diagnostics set
+        fakeDiagnosticsCollection.has.withArgs(fakeUri).returns(true);
+
+        // Simulate a text document change event
+        const fakeEvent: vscode.TextDocumentChangeEvent = {
+          document: fakeDocument,
+          contentChanges: [], // no content changes = no clearing diagnostics
+          reason: vscode.TextDocumentChangeReason.Undo,
+        };
+
+        flinkManager.onDidChangeTextDocumentHandler(fakeEvent);
+
+        // Should have detected then cleared diagnostics for this document
+        sinon.assert.calledOnce(fakeDiagnosticsCollection.has);
+        sinon.assert.calledWith(fakeDiagnosticsCollection.has, fakeUri);
+
+        sinon.assert.notCalled(fakeDiagnosticsCollection.delete);
       });
     });
 

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -166,6 +166,30 @@ export class FlinkLanguageClientManager extends DisposableCollection {
     }
   }
 
+  /**
+   * Simulates a document change to trigger diagnostics on the server side. Is needed to get diagnostics
+   * when opening a new document. Can be removed when the CCloud Flink Language Service has been updated.
+   * @param doc The document to simulate changes for.
+   * @returns A promise that resolves when the notification has been sent.
+   */
+  public async simulateDocumentChangeToTriggerDiagnostics(doc: TextDocument): Promise<void> {
+    if (!this.languageClient) {
+      logger.info("Can't simulate document change for non-existing language client.");
+      return;
+    }
+    await this.languageClient.sendNotification("textDocument/didChange", {
+      textDocument: {
+        uri: doc.uri.toString() || "",
+        version: doc.version,
+      },
+      contentChanges: [
+        {
+          text: doc.getText(),
+        },
+      ],
+    });
+  }
+
   // Event Handlers.
 
   /**
@@ -243,6 +267,7 @@ export class FlinkLanguageClientManager extends DisposableCollection {
     if (editor && this.isAppropriateDocument(editor.document)) {
       logger.trace("Active editor changed to Flink SQL file, initializing language client");
       await this.maybeStartLanguageClient(editor.document.uri);
+      await this.simulateDocumentChangeToTriggerDiagnostics(editor.document);
     }
   }
 
@@ -274,6 +299,7 @@ export class FlinkLanguageClientManager extends DisposableCollection {
       } else {
         logger.trace("Initializing language client for changed active Flink SQL document");
         await this.maybeStartLanguageClient(doc.uri);
+        await this.simulateDocumentChangeToTriggerDiagnostics(doc);
       }
     }
   }
@@ -597,7 +623,7 @@ export class FlinkLanguageClientManager extends DisposableCollection {
             action: "client_initialized",
             compute_pool_id: computePoolId,
           });
-          this.notifyConfigChanged();
+          await this.notifyConfigChanged();
         }
       } catch (error) {
         let msg = "Error in maybeStartLanguageClient";

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -307,7 +307,11 @@ export class FlinkLanguageClientManager extends DisposableCollection {
 
     if (
       this.openFlinkSqlDocuments.has(uriString) &&
-      this.languageClient?.diagnostics?.has(event.document.uri)
+      this.languageClient?.diagnostics?.has(event.document.uri) &&
+      // Make sure the change updated the content of the document. Otherwise, clearing diagnostics
+      // won't make sense. We'll, for instance, see document change events without content changes
+      // when saving the document.
+      event.contentChanges.length > 0
     ) {
       logger.trace(`Clearing diagnostics for document: ${uriString}`);
       this.clearDiagnostics(event.document.uri);

--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -267,7 +267,6 @@ export class FlinkLanguageClientManager extends DisposableCollection {
     if (editor && this.isAppropriateDocument(editor.document)) {
       logger.trace("Active editor changed to Flink SQL file, initializing language client");
       await this.maybeStartLanguageClient(editor.document.uri);
-      await this.simulateDocumentChangeToTriggerDiagnostics(editor.document);
     }
   }
 
@@ -299,7 +298,6 @@ export class FlinkLanguageClientManager extends DisposableCollection {
       } else {
         logger.trace("Initializing language client for changed active Flink SQL document");
         await this.maybeStartLanguageClient(doc.uri);
-        await this.simulateDocumentChangeToTriggerDiagnostics(doc);
       }
     }
   }
@@ -634,6 +632,15 @@ export class FlinkLanguageClientManager extends DisposableCollection {
         });
       } finally {
         logger.trace(`Released initialization lock for ${uriStr}`);
+        // Trigger diagnostics for the active document if language client is available
+        if (this.languageClient) {
+          logger.trace(`Simulating change to ${uriStr} to trigger diagnostics`);
+          for (const textDocument of workspace.textDocuments) {
+            if (textDocument.uri.toString() === uriStr) {
+              await this.simulateDocumentChangeToTriggerDiagnostics(textDocument);
+            }
+          }
+        }
       }
     });
   }


### PR DESCRIPTION
- https://github.com/confluentinc/vscode/pull/2354 closes #2350
  - [x] new test added for empty `TextDocumentChangeEvent.contentChanges` array
  - [x] updated test for clearing diagnostics to include one item in `TextDocumentChangeEvent.contentChanges`
- https://github.com/confluentinc/vscode/pull/2348 closes #2343
  - [x] new tests added for `simulateDocumentChangeToTriggerDiagnostics()`
- https://github.com/confluentinc/vscode/pull/2353 closes #2349
  - [x] new tests added for `maybeStartLanguageClient()` to include the addition of the `simulateDocumentChangeToTriggerDiagnostics()` call