### PR TITLE
Revert "Jlr/reinstate preview declaration (#2302)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -822,10 +822,7 @@
           "confluent.flink.enableConfluentCloudLanguageServer": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents. (Requires [signing in to Confluent Cloud](command:confluent.connections.ccloud.signIn).)",
-            "tags": [
-              "preview"
-            ]
+            "markdownDescription": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents. (Requires [signing in to Confluent Cloud](command:confluent.connections.ccloud.signIn).)"
           },
           "confluent.flink.computePoolId": {
             "type": "string",
@@ -997,7 +994,7 @@
         },
         {
           "id": "confluent-flink-statements",
-          "name": "Flink Statements (Preview)",
+          "name": "Flink Statements",
           "visibility": "collapsed",
           "icon": "$(confluent-logo)"
         },


### PR DESCRIPTION
## Summary of Changes

This reverts commit 3ce9cf8f282342418762ca27bc6565cabd409daf to remove the preview label/flag from the Flink features in the upcoming 1.5.2 patch release.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
