### PR TITLE
[v1.5.x] Add Flink language server logs to support zip (#2352)

### DIFF
--- a/src/commands/support.ts
+++ b/src/commands/support.ts
@@ -5,6 +5,7 @@ import { commands, Disposable, env, Uri, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { EXTENSION_ID } from "../constants";
 import { observabilityContext } from "../context/observability";
+import { getFlinkLSLogFileUris } from "../flinkSql/logging";
 import { CURRENT_LOGFILE_NAME, getLogFileDir, Logger, ROTATED_LOGFILE_NAMES } from "../logging";
 import { SIDECAR_LOGFILE_NAME } from "../sidecar/constants";
 import { getSidecarFormattedLogfilePath, getSidecarLogfilePath } from "../sidecar/logging";
@@ -233,6 +234,14 @@ async function saveSupportZip() {
     sourceUri: uri,
     zipPath: `${uri.path.split("/").pop() || "vscode-confluent.log"}`,
   }));
+
+  // add flink language server log files
+  fileEntries.push(
+    ...getFlinkLSLogFileUris().map((uri) => ({
+      sourceUri: uri,
+      zipPath: `${uri.path.split("/").pop() || "vscode-confluent-flink-language-server.log"}`,
+    })),
+  );
 
   // add the raw JSON log file first
   fileEntries.push({

--- a/src/flinkSql/logging.ts
+++ b/src/flinkSql/logging.ts
@@ -1,18 +1,22 @@
-import { LogOutputChannel, window } from "vscode";
+import { LogOutputChannel, Uri } from "vscode";
+import { RotatingLogOutputChannel } from "../logging";
 
-let languageServerOutputChannel: LogOutputChannel | undefined;
+let languageServerOutputChannel: RotatingLogOutputChannel | undefined;
 
 /** Get the {@link LogOutputChannel} for the Flink SQL language server, creating it if it doesn't already exist. */
 export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
   if (!languageServerOutputChannel) {
-    languageServerOutputChannel = window.createOutputChannel(
+    languageServerOutputChannel = new RotatingLogOutputChannel(
       "Confluent Flink SQL Language Server",
-      {
-        log: true,
-      },
+      `flink-language-server-${process.pid}`,
     );
   }
   return languageServerOutputChannel;
+}
+
+/** Gets the file URIs for the Flink SQL language server log file. */
+export function getFlinkLSLogFileUris(): Uri[] {
+  return languageServerOutputChannel?.getFileUris() ?? [];
 }
 
 /**
@@ -21,5 +25,6 @@ export function getFlinkSQLLanguageServerOutputChannel(): LogOutputChannel {
  * created when the language client is restarted.
  */
 export function clearFlinkSQLLanguageServerOutputChannel(): void {
+  languageServerOutputChannel?.dispose();
   languageServerOutputChannel = undefined;
 }

--- a/src/utils/fsWrappers.ts
+++ b/src/utils/fsWrappers.ts
@@ -70,3 +70,11 @@ export function openSync(path: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode |
 export function closeSync(fd: number): void {
   fs.closeSync(fd);
 }
+
+/**
+ * Wrapper for fs.existsSync()
+ * Return true if the file is stat-able, if not false.
+ * */
+export function existsSync(uri: vscode.Uri): boolean {
+  return fs.existsSync(uri.fsPath);
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes #2334

* Add Flink language server logs to support zip
* Introduce new rotating log output channel and file manager classes to instantiate log writing pattern
* Add wrapper class for fs.existsSync

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
