### PR TITLE
[1.5.x] Clear document prior diagnostics earlier

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -572,10 +572,10 @@ export class FlinkLanguageClientManager implements Disposable {
           });
 
           // Clear any previous diagnostics for the document *before*
-          // reinitializing the language client (which ends
-          // up reassigning `this.lastDocUri` to null momentarily before
-          // we reassign it after successful language client initialization
-          // in a few lines from now).
+          // reinitializing the language client. (cleanupLanguageClient()
+          // will set this.lastDocUri to null, which will then prevent
+          // the attempt to clear diagnostics before the call to
+          // initializeLanguageClient().)
           if (this.lastDocUri) {
             this.clearDiagnostics(this.lastDocUri);
           }


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-  Clear document prior diagnostics earlier when restarting language client, otherwise this.lastDocUri will be null when we consider clearing and it the clearing will be skipped (`this.cleanupLanguageClient()` sets `this.lastDocUri` to `null`, so if we try this check after that call, we'll always skip the clear diagnostics call).
- Closes #2365 against v1.5.3.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
