### PR TITLE
Add test coverage for new classes that save output logs

### DIFF
--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -139,22 +139,22 @@ describe("logging.ts", () => {
   const TEST_BASEPATH = "test-base-path";
 
   describe("RotatingLogManager", () => {
-    let instanceOfRotatingLogManager: RotatingLogManager;
+    let instance: RotatingLogManager;
 
     beforeEach(() => {
       // create new RotatingLogManager instance for each test
-      instanceOfRotatingLogManager = new RotatingLogManager(TEST_BASEPATH);
+      instance = new RotatingLogManager(TEST_BASEPATH);
     });
 
     afterEach(() => {
-      instanceOfRotatingLogManager.dispose();
+      instance.dispose();
     });
 
     describe("rotatingFilenameGenerator", () => {
       it("should instantiate with empty _rotatedFileNames", function () {
-        const fileName = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 0);
-        const currentFileName = instanceOfRotatingLogManager["_currentFileName"];
-        const rotatedFileNames = instanceOfRotatingLogManager["_rotatedFileNames"];
+        const fileName = instance.rotatingFilenameGenerator(new Date(), 0);
+        const currentFileName = instance["_currentFileName"];
+        const rotatedFileNames = instance["_rotatedFileNames"];
 
         assert.strictEqual(fileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
         // no rotations yet
@@ -163,16 +163,16 @@ describe("logging.ts", () => {
       });
 
       it("should generate filename without index", function () {
-        const filename = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date());
+        const filename = instance.rotatingFilenameGenerator(new Date());
 
         assert.strictEqual(filename, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
       });
 
       it("should generate a new filename with a higher index", function () {
-        const fileName1 = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
-        const fileName2 = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 2);
-        const currentFileName = instanceOfRotatingLogManager["_currentFileName"];
-        const rotatedFileNames = instanceOfRotatingLogManager["_rotatedFileNames"];
+        const fileName1 = instance.rotatingFilenameGenerator(new Date(), 1);
+        const fileName2 = instance.rotatingFilenameGenerator(new Date(), 2);
+        const currentFileName = instance["_currentFileName"];
+        const rotatedFileNames = instance["_rotatedFileNames"];
 
         assert.strictEqual(fileName1, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
         assert.strictEqual(fileName2, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
@@ -184,9 +184,9 @@ describe("logging.ts", () => {
       });
 
       it("should limit rotated file names to MAX_LOGFILES", function () {
-        const rotatedFileNames = instanceOfRotatingLogManager["_rotatedFileNames"];
+        const rotatedFileNames = instance["_rotatedFileNames"];
         for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
-          instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), i);
+          instance.rotatingFilenameGenerator(new Date(), i);
         }
 
         assert.strictEqual(rotatedFileNames.length, MAX_LOGFILES);
@@ -196,21 +196,21 @@ describe("logging.ts", () => {
     describe("getStream()", () => {
       it("should create a new stream if one doesn't exist", function () {
         // ensure we start with no existing stream
-        assert.strictEqual(instanceOfRotatingLogManager["stream"], undefined);
+        assert.strictEqual(instance["stream"], undefined);
 
-        const stream = instanceOfRotatingLogManager.getStream();
+        const stream = instance.getStream();
 
         // check that stream is created and has expected properties
         assert.ok(stream, "Stream should be created");
         // check that the stream is stored internally
-        assert.strictEqual(instanceOfRotatingLogManager["stream"], stream);
+        assert.strictEqual(instance["stream"], stream);
         // check that stream is not closed initially
         assert.strictEqual(stream.closed, false, "New stream should not be closed");
       });
 
       it("should return existing stream on subsequent calls", function () {
-        const stream1 = instanceOfRotatingLogManager.getStream();
-        const stream2 = instanceOfRotatingLogManager.getStream();
+        const stream1 = instance.getStream();
+        const stream2 = instance.getStream();
 
         assert.strictEqual(stream1, stream2);
       });
@@ -235,7 +235,7 @@ describe("logging.ts", () => {
           return uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
         });
 
-        const fileUris = instanceOfRotatingLogManager.getFileUris();
+        const fileUris = instance.getFileUris();
 
         assert.strictEqual(fileUris.length, 1);
         assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
@@ -244,13 +244,13 @@ describe("logging.ts", () => {
 
       it("should return current and rotated file URIs when rotated files exist", () => {
         // generate some rotated files by calling the filename generator
-        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
-        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 2);
+        instance.rotatingFilenameGenerator(new Date(), 1);
+        instance.rotatingFilenameGenerator(new Date(), 2);
 
         // mock that all files exist
         existsSyncStub.returns(true);
 
-        const fileUris = instanceOfRotatingLogManager.getFileUris();
+        const fileUris = instance.getFileUris();
 
         assert.strictEqual(fileUris.length, 3);
 
@@ -272,15 +272,15 @@ describe("logging.ts", () => {
 
       it("should filter out non-existent files", () => {
         // generate some rotated files
-        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
-        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 2);
+        instance.rotatingFilenameGenerator(new Date(), 1);
+        instance.rotatingFilenameGenerator(new Date(), 2);
 
         // mock that only current file and first rotated file exist
         existsSyncStub.callsFake((uri: Uri) => {
           return !uri.fsPath.includes(".2.log");
         });
 
-        const fileUris = instanceOfRotatingLogManager.getFileUris();
+        const fileUris = instance.getFileUris();
 
         assert.strictEqual(fileUris.length, 2);
 
@@ -293,7 +293,7 @@ describe("logging.ts", () => {
         // mock that no files exist
         existsSyncStub.returns(false);
 
-        const fileUris = instanceOfRotatingLogManager.getFileUris();
+        const fileUris = instance.getFileUris();
 
         assert.strictEqual(fileUris.length, 0);
       });
@@ -301,12 +301,12 @@ describe("logging.ts", () => {
       it("should return current file + MAX_LOGFILES rotated files", () => {
         // generate maximum number of rotated files
         for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
-          instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), i);
+          instance.rotatingFilenameGenerator(new Date(), i);
         }
 
         existsSyncStub.returns(true);
 
-        const fileUris = instanceOfRotatingLogManager.getFileUris();
+        const fileUris = instance.getFileUris();
 
         // should have current file + MAX_LOGFILES rotated files
         assert.strictEqual(fileUris.length, MAX_LOGFILES + 1);

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -344,11 +344,7 @@ describe("logging.ts", () => {
 
     beforeEach(() => {
       // create new rotating log output channel instance for each test
-      instance = new RotatingLogOutputChannel(
-        TEST_CHANNELNAME,
-        TEST_BASEPATH,
-        TEST_CONSOLENAME,
-      );
+      instance = new RotatingLogOutputChannel(TEST_CHANNELNAME, TEST_BASEPATH, TEST_CONSOLENAME);
 
       // stub rotating log output channel methods
       outputChannelStub = instance["outputChannel"];
@@ -360,7 +356,8 @@ describe("logging.ts", () => {
       errorStub = sandbox.stub(outputChannelStub, "error");
       appendStub = sandbox.stub(outputChannelStub, "append");
       appendLineStub = sandbox.stub(outputChannelStub, "appendLine");
-      replaceStub = sandbox.stub(outputChannelStub, "replace");      clearStub = sandbox.stub(outputChannelStub, "clear");
+      replaceStub = sandbox.stub(outputChannelStub, "replace");
+      clearStub = sandbox.stub(outputChannelStub, "clear");
       hideStub = sandbox.stub(outputChannelStub, "hide");
       showStub = sandbox.stub(outputChannelStub, "show");
 
@@ -380,7 +377,7 @@ describe("logging.ts", () => {
       assert.strictEqual(instance.name, outputChannelStub.name);
     });
 
-    it('should get logLevel from member outputChannel', () => {
+    it("should get logLevel from member outputChannel", () => {
       assert.strictEqual(instance.logLevel, outputChannelStub.logLevel);
     });
 

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -1,5 +1,8 @@
 import * as assert from "assert";
 import sinon from "sinon";
+import * as fsWrappers from "./utils/fsWrappers";
+import { WriteableTmpDir } from "./utils/file";
+import { Uri } from "vscode";
 import {
   BASEFILE_PREFIX,
   CURRENT_LOGFILE_NAME,
@@ -126,33 +129,178 @@ describe("logging.ts rotatingFilenameGenerator", function () {
   });
 });
 
-describe("logging.ts RotatingLogManager", () => {
+// constants for testing RotatingLogManager and RotatingLogOutputChannel
+const TEST_BASEPATH = "test-base-path";
+const TEST_CHANNELNAME = "test-channel-name";
+const TEST_CONSOLENAME = "test-console-name";
+
+describe("logging.ts RotatingLogManager", function () {
   let sandbox: sinon.SinonSandbox;
   let logManager: RotatingLogManager;
-  // let writeableTmpDirStub: sinon.SinonStub;
 
-  beforeEach(() => {
+  let existsSyncStub: sinon.SinonStub;
+  let writeableTmpDirStub: sinon.SinonStub;
+
+  beforeEach(function () {
     sandbox = sinon.createSandbox();
 
-    // create stub to check correct directory
-    // writeableTmpDirStub = sandbox.stub(WriteableTmpDir.getInstance(), "get").returns("/temptest/");
-
     // create new RotatingLogManager instance for each test
-    logManager = new RotatingLogManager("test");
+    logManager = new RotatingLogManager(TEST_BASEPATH);
   });
 
   afterEach(function () {
+    logManager.dispose();
     sandbox.restore();
+  });
+
+  it("should instantiate with empty _rotatedFileNames", function () {
+    const fileName = logManager.rotatingFilenameGenerator(new Date(), 0);
+    const currentFileName = (logManager as any)._currentFileName;
+    const rotatedFileNames = (logManager as any)._rotatedFileNames;
+
+    assert.strictEqual(fileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+    // no rotations yet
+    assert.strictEqual(rotatedFileNames.length, 0);
+    assert.strictEqual(currentFileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
   });
 
   it("should generate filename without index", function () {
     const filename = logManager.rotatingFilenameGenerator(new Date());
 
-    assert.strictEqual(filename, `${BASEFILE_PREFIX}-test-base.log`);
+    assert.strictEqual(filename, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+  });
+
+  it("should generate a new filename with a higher index", function () {
+    const fileName1 = logManager.rotatingFilenameGenerator(new Date(), 1);
+    const fileName2 = logManager.rotatingFilenameGenerator(new Date(), 2);
+    const currentFileName = (logManager as any)._currentFileName;
+    const rotatedFileNames = (logManager as any)._rotatedFileNames;
+
+    assert.strictEqual(fileName1, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
+    assert.strictEqual(fileName2, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
+    // one rotated file, current left alone
+    assert.strictEqual(rotatedFileNames.length, 2);
+    assert.strictEqual(rotatedFileNames[0], `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
+    assert.strictEqual(rotatedFileNames[1], `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
+    assert.strictEqual(currentFileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+  });
+
+  it("should limit rotated file names to MAX_LOGFILES", function () {
+    const rotatedFileNames = (logManager as any)._rotatedFileNames;
+    for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
+      logManager.rotatingFilenameGenerator(new Date(), i);
+    }
+
+    assert.strictEqual(rotatedFileNames.length, MAX_LOGFILES);
+  });
+
+  it("should return existing stream on subsequent calls", function () {
+    const stream1 = logManager.getStream();
+    const stream2 = logManager.getStream();
+
+    assert.strictEqual(stream1, stream2);
+  });
+
+  describe("getFileUris", function () {
+    it("should return only current file URI when no rotated files exist", function () {
+      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
+      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+      writeableTmpDirStub = sandbox.stub(WriteableTmpDir.getInstance(), "get").returns("/test/dir");
+      // mock that only the current file exists
+      existsSyncStub.callsFake((uri: Uri) => {
+        return uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+      });
+
+      const fileUris = logManager.getFileUris();
+
+      assert.strictEqual(fileUris.length, 1);
+      assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
+      assert.strictEqual(writeableTmpDirStub.calledOnce, true);
+    });
+
+    it("should return current and rotated file URIs when rotated files exist", function () {
+      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
+      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+      // generate some rotated files by calling the filename generator
+      logManager.rotatingFilenameGenerator(new Date(), 1);
+      logManager.rotatingFilenameGenerator(new Date(), 2);
+
+      // mock that all files exist
+      existsSyncStub.returns(true);
+
+      const fileUris = logManager.getFileUris();
+
+      assert.strictEqual(fileUris.length, 3);
+
+      // check current file is included
+      const currentFileUri = fileUris.find(
+        (uri) =>
+          uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`) &&
+          !uri.fsPath.includes(".1.") &&
+          !uri.fsPath.includes(".2."),
+      );
+      assert.ok(currentFileUri, "Current file URI should be included");
+
+      // check rotated files are included
+      const rotatedFile1Uri = fileUris.find((uri) => uri.fsPath.includes(".1.log"));
+      const rotatedFile2Uri = fileUris.find((uri) => uri.fsPath.includes(".2.log"));
+      assert.ok(rotatedFile1Uri, "Rotated file 1 URI should be included");
+      assert.ok(rotatedFile2Uri, "Rotated file 2 URI should be included");
+    });
+
+    it("should filter out non-existent files", function () {
+      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
+      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+
+      // generate some rotated files
+      logManager.rotatingFilenameGenerator(new Date(), 1);
+      logManager.rotatingFilenameGenerator(new Date(), 2);
+
+      // mock that only current file and first rotated file exist
+      existsSyncStub.callsFake((uri: Uri) => {
+        return !uri.fsPath.includes(".2.log");
+      });
+
+      const fileUris = logManager.getFileUris();
+
+      assert.strictEqual(fileUris.length, 2);
+
+      // check that .2.log file is not included
+      const missingFile = fileUris.find((uri) => uri.fsPath.includes(".2.log"));
+      assert.strictEqual(missingFile, undefined, "Non-existent file should not be included");
+    });
+
+    it("should return empty array when no files exist", function () {
+      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
+      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+
+      // mock that no files exist
+      existsSyncStub.returns(false);
+
+      const fileUris = logManager.getFileUris();
+
+      assert.strictEqual(fileUris.length, 0);
+    });
+
+    it("should handle maximum number of rotated files", function () {
+      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
+      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+      // generate maximum number of rotated files
+      for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
+        logManager.rotatingFilenameGenerator(new Date(), i);
+      }
+
+      existsSyncStub.returns(true);
+
+      const fileUris = logManager.getFileUris();
+
+      // should have current file + MAX_LOGFILES rotated files
+      assert.strictEqual(fileUris.length, MAX_LOGFILES + 1);
+    });
   });
 });
 
-describe("logging.ts RotatingLogOutputChannel", () => {
+describe("logging.ts RotatingLogOutputChannel", function () {
   let sandbox: sinon.SinonSandbox;
 
   let traceStub: sinon.SinonStub;
@@ -160,22 +308,39 @@ describe("logging.ts RotatingLogOutputChannel", () => {
   let infoStub: sinon.SinonStub;
   let warnStub: sinon.SinonStub;
   let errorStub: sinon.SinonStub;
+  let appendStub: sinon.SinonStub;
+  let appendLineStub: sinon.SinonStub;
+  let replaceStub: sinon.SinonStub;
+  let existsSyncStub: sinon.SinonStub;
+  let writeableTmpDirStub: sinon.SinonStub;
 
   let logOutputChannel: RotatingLogOutputChannel;
 
-  beforeEach(() => {
+  beforeEach(function () {
     sandbox = sinon.createSandbox();
 
-    logOutputChannel = new RotatingLogOutputChannel("test-channel-name", "test-basepath");
+    // create new rotating log output channel instance for each test
+    logOutputChannel = new RotatingLogOutputChannel(
+      TEST_CHANNELNAME,
+      TEST_BASEPATH,
+      TEST_CONSOLENAME,
+    );
 
-    traceStub = sandbox.stub(logOutputChannel, "trace");
-    debugStub = sandbox.stub(logOutputChannel, "debug");
-    infoStub = sandbox.stub(logOutputChannel, "info");
-    warnStub = sandbox.stub(logOutputChannel, "warn");
-    errorStub = sandbox.stub(logOutputChannel, "error");
+    // stub rotating log output channel methods
+    const outputChannel = (logOutputChannel as any).outputChannel;
+
+    traceStub = sandbox.stub(outputChannel, "trace");
+    debugStub = sandbox.stub(outputChannel, "debug");
+    infoStub = sandbox.stub(outputChannel, "info");
+    warnStub = sandbox.stub(outputChannel, "warn");
+    errorStub = sandbox.stub(outputChannel, "error");
+    appendStub = sandbox.stub(outputChannel, "append");
+    appendLineStub = sandbox.stub(outputChannel, "appendLine");
+    replaceStub = sandbox.stub(outputChannel, "replace");
   });
 
   afterEach(function () {
+    logOutputChannel.dispose();
     sandbox.restore();
   });
 
@@ -183,34 +348,75 @@ describe("logging.ts RotatingLogOutputChannel", () => {
     logOutputChannel.trace("test message");
 
     assert.strictEqual(traceStub.calledOnce, true);
-    assert.strictEqual(traceStub.firstCall.args[0], "test message");
+    assert.strictEqual(traceStub.firstCall.args[0], `test message`);
   });
 
   it("should handle info method", function () {
     logOutputChannel.info("info message");
 
     assert.strictEqual(infoStub.calledOnce, true);
-    assert.strictEqual(infoStub.firstCall.args[0], "info message");
+    console.log(infoStub.firstCall.args[0]);
+    assert.strictEqual(infoStub.firstCall.args[0], `info message`);
   });
 
   it("should handle error method", function () {
     logOutputChannel.error("error message");
 
     assert.strictEqual(errorStub.calledOnce, true);
-    assert.strictEqual(errorStub.firstCall.args[0], "error message");
+    assert.strictEqual(errorStub.firstCall.args[0], `error message`);
   });
 
   it("should handle warn method", function () {
-    logOutputChannel.error("warn message");
+    logOutputChannel.warn("warn message");
 
     assert.strictEqual(warnStub.calledOnce, true);
-    assert.strictEqual(warnStub.firstCall.args[0], "warn message");
+    assert.strictEqual(warnStub.firstCall.args[0], `warn message`);
   });
 
   it("should handle debug method", function () {
     logOutputChannel.debug("debug message");
 
     assert.strictEqual(debugStub.calledOnce, true);
-    assert.strictEqual(debugStub.firstCall.args[0], "debug message");
+    assert.strictEqual(debugStub.firstCall.args[0], `debug message`);
+  });
+
+  it("should handle append method", function () {
+    logOutputChannel.append("append message");
+
+    assert.strictEqual(appendStub.calledOnce, true);
+    assert.strictEqual(appendStub.firstCall.args[0], "append message");
+  });
+
+  it("should handle appendLine method", function () {
+    logOutputChannel.appendLine("appendLine message");
+
+    assert.strictEqual(appendLineStub.calledOnce, true);
+    assert.strictEqual(appendLineStub.firstCall.args[0], "appendLine message");
+  });
+
+  it("should handle replace method", function () {
+    logOutputChannel.replace("replace message");
+
+    assert.strictEqual(replaceStub.calledOnce, true);
+    assert.strictEqual(replaceStub.firstCall.args[0], "replace message");
+  });
+
+  it("should delegate getFileUris() method", function () {
+    existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+    writeableTmpDirStub = sandbox.stub(WriteableTmpDir.getInstance(), "get").returns("/test/dir");
+    // generate some rotated files to have URIs to return
+    const rotatingLogManager = (logOutputChannel as any).rotatingLogManager;
+    rotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
+
+    existsSyncStub.returns(true);
+
+    const fileUris = logOutputChannel.getFileUris();
+
+    assert.strictEqual(existsSyncStub.called, true);
+    assert.strictEqual(writeableTmpDirStub.called, true);
+    assert.ok(Array.isArray(fileUris), "Should return an array of URIs");
+    assert.strictEqual(fileUris.length, 2); // current + 1 rotated file
+    assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
+    assert.ok(fileUris[1].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`));
   });
 });

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -1,7 +1,5 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import * as fsWrappers from "./utils/fsWrappers";
-import { WriteableTmpDir } from "./utils/file";
 import { Uri } from "vscode";
 import {
   BASEFILE_PREFIX,
@@ -14,6 +12,8 @@ import {
   RotatingLogManager,
   RotatingLogOutputChannel,
 } from "./logging";
+import { WriteableTmpDir } from "./utils/file";
+import * as fsWrappers from "./utils/fsWrappers";
 
 describe("logging.ts Logger methods", function () {
   let sandbox: sinon.SinonSandbox;
@@ -129,294 +129,318 @@ describe("logging.ts rotatingFilenameGenerator", function () {
   });
 });
 
-// constants for testing RotatingLogManager and RotatingLogOutputChannel
-const TEST_BASEPATH = "test-base-path";
-const TEST_CHANNELNAME = "test-channel-name";
-const TEST_CONSOLENAME = "test-console-name";
-
-describe("logging.ts RotatingLogManager", function () {
+describe("logging.ts new classes", () => {
   let sandbox: sinon.SinonSandbox;
-  let logManager: RotatingLogManager;
 
-  let existsSyncStub: sinon.SinonStub;
-  let writeableTmpDirStub: sinon.SinonStub;
-
-  beforeEach(function () {
+  beforeEach(() => {
     sandbox = sinon.createSandbox();
-
-    // create new RotatingLogManager instance for each test
-    logManager = new RotatingLogManager(TEST_BASEPATH);
   });
 
-  afterEach(function () {
-    logManager.dispose();
+  afterEach(() => {
     sandbox.restore();
   });
 
-  it("should instantiate with empty _rotatedFileNames", function () {
-    const fileName = logManager.rotatingFilenameGenerator(new Date(), 0);
-    const currentFileName = (logManager as any)._currentFileName;
-    const rotatedFileNames = (logManager as any)._rotatedFileNames;
+  // constants for testing RotatingLogManager and RotatingLogOutputChannel
+  const TEST_BASEPATH = "test-base-path";
 
-    assert.strictEqual(fileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
-    // no rotations yet
-    assert.strictEqual(rotatedFileNames.length, 0);
-    assert.strictEqual(currentFileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
-  });
+  describe("RotatingLogManager", () => {
+    let instanceOfRotatingLogManager: RotatingLogManager;
 
-  it("should generate filename without index", function () {
-    const filename = logManager.rotatingFilenameGenerator(new Date());
-
-    assert.strictEqual(filename, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
-  });
-
-  it("should generate a new filename with a higher index", function () {
-    const fileName1 = logManager.rotatingFilenameGenerator(new Date(), 1);
-    const fileName2 = logManager.rotatingFilenameGenerator(new Date(), 2);
-    const currentFileName = (logManager as any)._currentFileName;
-    const rotatedFileNames = (logManager as any)._rotatedFileNames;
-
-    assert.strictEqual(fileName1, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
-    assert.strictEqual(fileName2, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
-    // one rotated file, current left alone
-    assert.strictEqual(rotatedFileNames.length, 2);
-    assert.strictEqual(rotatedFileNames[0], `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
-    assert.strictEqual(rotatedFileNames[1], `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
-    assert.strictEqual(currentFileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
-  });
-
-  it("should limit rotated file names to MAX_LOGFILES", function () {
-    const rotatedFileNames = (logManager as any)._rotatedFileNames;
-    for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
-      logManager.rotatingFilenameGenerator(new Date(), i);
-    }
-
-    assert.strictEqual(rotatedFileNames.length, MAX_LOGFILES);
-  });
-
-  it("should return existing stream on subsequent calls", function () {
-    const stream1 = logManager.getStream();
-    const stream2 = logManager.getStream();
-
-    assert.strictEqual(stream1, stream2);
-  });
-
-  describe("getFileUris", function () {
-    it("should return only current file URI when no rotated files exist", function () {
-      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
-      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
-      writeableTmpDirStub = sandbox.stub(WriteableTmpDir.getInstance(), "get").returns("/test/dir");
-      // mock that only the current file exists
-      existsSyncStub.callsFake((uri: Uri) => {
-        return uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
-      });
-
-      const fileUris = logManager.getFileUris();
-
-      assert.strictEqual(fileUris.length, 1);
-      assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
-      assert.strictEqual(writeableTmpDirStub.calledOnce, true);
+    beforeEach(() => {
+      // create new RotatingLogManager instance for each test
+      instanceOfRotatingLogManager = new RotatingLogManager(TEST_BASEPATH);
     });
 
-    it("should return current and rotated file URIs when rotated files exist", function () {
-      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
-      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
-      // generate some rotated files by calling the filename generator
-      logManager.rotatingFilenameGenerator(new Date(), 1);
-      logManager.rotatingFilenameGenerator(new Date(), 2);
+    afterEach(() => {
+      instanceOfRotatingLogManager.dispose();
+    });
 
-      // mock that all files exist
-      existsSyncStub.returns(true);
+    describe("rotatingFilenameGenerator", () => {
+      it("should instantiate with empty _rotatedFileNames", function () {
+        const fileName = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 0);
+        const currentFileName = instanceOfRotatingLogManager["_currentFileName"];
+        const rotatedFileNames = instanceOfRotatingLogManager["_rotatedFileNames"];
 
-      const fileUris = logManager.getFileUris();
+        assert.strictEqual(fileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+        // no rotations yet
+        assert.strictEqual(rotatedFileNames.length, 0);
+        assert.strictEqual(currentFileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+      });
 
-      assert.strictEqual(fileUris.length, 3);
+      it("should generate filename without index", function () {
+        const filename = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date());
 
-      // check current file is included
-      const currentFileUri = fileUris.find(
-        (uri) =>
-          uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`) &&
-          !uri.fsPath.includes(".1.") &&
-          !uri.fsPath.includes(".2."),
+        assert.strictEqual(filename, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+      });
+
+      it("should generate a new filename with a higher index", function () {
+        const fileName1 = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
+        const fileName2 = instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 2);
+        const currentFileName = instanceOfRotatingLogManager["_currentFileName"];
+        const rotatedFileNames = instanceOfRotatingLogManager["_rotatedFileNames"];
+
+        assert.strictEqual(fileName1, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
+        assert.strictEqual(fileName2, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
+        // one rotated file, current left alone
+        assert.strictEqual(rotatedFileNames.length, 2);
+        assert.strictEqual(rotatedFileNames[0], `${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`);
+        assert.strictEqual(rotatedFileNames[1], `${BASEFILE_PREFIX}-${TEST_BASEPATH}.2.log`);
+        assert.strictEqual(currentFileName, `${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+      });
+
+      it("should limit rotated file names to MAX_LOGFILES", function () {
+        const rotatedFileNames = instanceOfRotatingLogManager["_rotatedFileNames"];
+        for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
+          instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), i);
+        }
+
+        assert.strictEqual(rotatedFileNames.length, MAX_LOGFILES);
+      });
+    });
+
+    describe("getStream()", () => {
+      it("should create a new stream if one doesn't exist", function () {
+        // ensure we start with no existing stream
+        assert.strictEqual(instanceOfRotatingLogManager["stream"], undefined);
+
+        const stream = instanceOfRotatingLogManager.getStream();
+
+        // check that stream is created and has expected properties
+        assert.ok(stream, "Stream should be created");
+        // check that the stream is stored internally
+        assert.strictEqual(instanceOfRotatingLogManager["stream"], stream);
+        // check that stream is not closed initially
+        assert.strictEqual(stream.closed, false, "New stream should not be closed");
+      });
+
+      it("should return existing stream on subsequent calls", function () {
+        const stream1 = instanceOfRotatingLogManager.getStream();
+        const stream2 = instanceOfRotatingLogManager.getStream();
+
+        assert.strictEqual(stream1, stream2);
+      });
+    });
+
+    describe("getFileUris", () => {
+      let existsSyncStub: sinon.SinonStub;
+      let writeableTmpDirStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        // create stub for existsSync to mock creating files on disk
+        existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+      });
+
+      it("should return only current file URI when no rotated files exist", () => {
+        // create stub for writeableTmpDir to return a test directory
+        writeableTmpDirStub = sandbox
+          .stub(WriteableTmpDir.getInstance(), "get")
+          .returns("/test/dir");
+        // mock that only the current file exists
+        existsSyncStub.callsFake((uri: Uri) => {
+          return uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`);
+        });
+
+        const fileUris = instanceOfRotatingLogManager.getFileUris();
+
+        assert.strictEqual(fileUris.length, 1);
+        assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
+        sinon.assert.calledOnce(writeableTmpDirStub);
+      });
+
+      it("should return current and rotated file URIs when rotated files exist", () => {
+        // generate some rotated files by calling the filename generator
+        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
+        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 2);
+
+        // mock that all files exist
+        existsSyncStub.returns(true);
+
+        const fileUris = instanceOfRotatingLogManager.getFileUris();
+
+        assert.strictEqual(fileUris.length, 3);
+
+        // check current file is included
+        const currentFileUri = fileUris.find(
+          (uri) =>
+            uri.fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`) &&
+            !uri.fsPath.includes(".1.") &&
+            !uri.fsPath.includes(".2."),
+        );
+        assert.ok(currentFileUri, "Current file URI should be included");
+
+        // check rotated files are included
+        const rotatedFile1Uri = fileUris.find((uri) => uri.fsPath.includes(".1.log"));
+        const rotatedFile2Uri = fileUris.find((uri) => uri.fsPath.includes(".2.log"));
+        assert.ok(rotatedFile1Uri, "Rotated file 1 URI should be included");
+        assert.ok(rotatedFile2Uri, "Rotated file 2 URI should be included");
+      });
+
+      it("should filter out non-existent files", () => {
+        // generate some rotated files
+        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
+        instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), 2);
+
+        // mock that only current file and first rotated file exist
+        existsSyncStub.callsFake((uri: Uri) => {
+          return !uri.fsPath.includes(".2.log");
+        });
+
+        const fileUris = instanceOfRotatingLogManager.getFileUris();
+
+        assert.strictEqual(fileUris.length, 2);
+
+        // check that .2.log file is not included
+        const missingFile = fileUris.find((uri) => uri.fsPath.includes(".2.log"));
+        assert.strictEqual(missingFile, undefined, "Non-existent file should not be included");
+      });
+
+      it("should return empty array when no files exist", () => {
+        // mock that no files exist
+        existsSyncStub.returns(false);
+
+        const fileUris = instanceOfRotatingLogManager.getFileUris();
+
+        assert.strictEqual(fileUris.length, 0);
+      });
+
+      it("should return current file + MAX_LOGFILES rotated files", () => {
+        // generate maximum number of rotated files
+        for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
+          instanceOfRotatingLogManager.rotatingFilenameGenerator(new Date(), i);
+        }
+
+        existsSyncStub.returns(true);
+
+        const fileUris = instanceOfRotatingLogManager.getFileUris();
+
+        // should have current file + MAX_LOGFILES rotated files
+        assert.strictEqual(fileUris.length, MAX_LOGFILES + 1);
+      });
+    });
+  });
+
+  describe("RotatingLogOutputChannel", () => {
+    // constants for testing RotatingLogOutputChannel
+    const TEST_CHANNELNAME = "test-channel-name";
+    const TEST_CONSOLENAME = "test-console-name";
+
+    // stubs for methods to check that data member outputChannel is called correctly
+    let traceStub: sinon.SinonStub;
+    let debugStub: sinon.SinonStub;
+    let infoStub: sinon.SinonStub;
+    let warnStub: sinon.SinonStub;
+    let errorStub: sinon.SinonStub;
+    let appendStub: sinon.SinonStub;
+    let appendLineStub: sinon.SinonStub;
+    let replaceStub: sinon.SinonStub;
+
+    // stubs for methods to check that getFileUris() is called correctly
+    let existsSyncStub: sinon.SinonStub;
+    let writeableTmpDirStub: sinon.SinonStub;
+
+    // instance of RotatingLogOutputChannel to test
+    let instanceOfRotatingLogOutputChannel: RotatingLogOutputChannel;
+
+    beforeEach(() => {
+      // create new rotating log output channel instance for each test
+      instanceOfRotatingLogOutputChannel = new RotatingLogOutputChannel(
+        TEST_CHANNELNAME,
+        TEST_BASEPATH,
+        TEST_CONSOLENAME,
       );
-      assert.ok(currentFileUri, "Current file URI should be included");
 
-      // check rotated files are included
-      const rotatedFile1Uri = fileUris.find((uri) => uri.fsPath.includes(".1.log"));
-      const rotatedFile2Uri = fileUris.find((uri) => uri.fsPath.includes(".2.log"));
-      assert.ok(rotatedFile1Uri, "Rotated file 1 URI should be included");
-      assert.ok(rotatedFile2Uri, "Rotated file 2 URI should be included");
+      // stub rotating log output channel methods
+      const outputChannel = instanceOfRotatingLogOutputChannel["outputChannel"];
+
+      traceStub = sandbox.stub(outputChannel, "trace");
+      debugStub = sandbox.stub(outputChannel, "debug");
+      infoStub = sandbox.stub(outputChannel, "info");
+      warnStub = sandbox.stub(outputChannel, "warn");
+      errorStub = sandbox.stub(outputChannel, "error");
+      appendStub = sandbox.stub(outputChannel, "append");
+      appendLineStub = sandbox.stub(outputChannel, "appendLine");
+      replaceStub = sandbox.stub(outputChannel, "replace");
     });
 
-    it("should filter out non-existent files", function () {
-      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
-      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
-
-      // generate some rotated files
-      logManager.rotatingFilenameGenerator(new Date(), 1);
-      logManager.rotatingFilenameGenerator(new Date(), 2);
-
-      // mock that only current file and first rotated file exist
-      existsSyncStub.callsFake((uri: Uri) => {
-        return !uri.fsPath.includes(".2.log");
-      });
-
-      const fileUris = logManager.getFileUris();
-
-      assert.strictEqual(fileUris.length, 2);
-
-      // check that .2.log file is not included
-      const missingFile = fileUris.find((uri) => uri.fsPath.includes(".2.log"));
-      assert.strictEqual(missingFile, undefined, "Non-existent file should not be included");
+    afterEach(function () {
+      instanceOfRotatingLogOutputChannel.dispose();
+      sandbox.restore();
     });
 
-    it("should return empty array when no files exist", function () {
-      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
-      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+    it("should handle trace method", () => {
+      instanceOfRotatingLogOutputChannel.trace("test message");
 
-      // mock that no files exist
-      existsSyncStub.returns(false);
-
-      const fileUris = logManager.getFileUris();
-
-      assert.strictEqual(fileUris.length, 0);
+      sinon.assert.calledOnce(traceStub);
+      sinon.assert.calledWith(traceStub, `test message`);
     });
 
-    it("should handle maximum number of rotated files", function () {
-      // create stubs for existsSync and writeableTmpDir to mock creating files on disk
-      existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
-      // generate maximum number of rotated files
-      for (let i = 1; i <= MAX_LOGFILES + 2; i++) {
-        logManager.rotatingFilenameGenerator(new Date(), i);
-      }
+    it("should handle info method", () => {
+      instanceOfRotatingLogOutputChannel.info("info message");
 
-      existsSyncStub.returns(true);
-
-      const fileUris = logManager.getFileUris();
-
-      // should have current file + MAX_LOGFILES rotated files
-      assert.strictEqual(fileUris.length, MAX_LOGFILES + 1);
+      sinon.assert.calledOnce(infoStub);
+      sinon.assert.calledWith(infoStub, `info message`);
     });
-  });
-});
 
-describe("logging.ts RotatingLogOutputChannel", function () {
-  let sandbox: sinon.SinonSandbox;
+    it("should handle error method", () => {
+      instanceOfRotatingLogOutputChannel.error("error message");
 
-  let traceStub: sinon.SinonStub;
-  let debugStub: sinon.SinonStub;
-  let infoStub: sinon.SinonStub;
-  let warnStub: sinon.SinonStub;
-  let errorStub: sinon.SinonStub;
-  let appendStub: sinon.SinonStub;
-  let appendLineStub: sinon.SinonStub;
-  let replaceStub: sinon.SinonStub;
-  let existsSyncStub: sinon.SinonStub;
-  let writeableTmpDirStub: sinon.SinonStub;
+      sinon.assert.calledOnce(errorStub);
+      sinon.assert.calledWith(errorStub, `error message`);
+    });
 
-  let logOutputChannel: RotatingLogOutputChannel;
+    it("should handle warn method", () => {
+      instanceOfRotatingLogOutputChannel.warn("warn message");
 
-  beforeEach(function () {
-    sandbox = sinon.createSandbox();
+      sinon.assert.calledOnce(warnStub);
+      sinon.assert.calledWith(warnStub, `warn message`);
+    });
 
-    // create new rotating log output channel instance for each test
-    logOutputChannel = new RotatingLogOutputChannel(
-      TEST_CHANNELNAME,
-      TEST_BASEPATH,
-      TEST_CONSOLENAME,
-    );
+    it("should handle debug method", () => {
+      instanceOfRotatingLogOutputChannel.debug("debug message");
 
-    // stub rotating log output channel methods
-    const outputChannel = (logOutputChannel as any).outputChannel;
+      sinon.assert.calledOnce(debugStub);
+      sinon.assert.calledWith(debugStub, `debug message`);
+    });
 
-    traceStub = sandbox.stub(outputChannel, "trace");
-    debugStub = sandbox.stub(outputChannel, "debug");
-    infoStub = sandbox.stub(outputChannel, "info");
-    warnStub = sandbox.stub(outputChannel, "warn");
-    errorStub = sandbox.stub(outputChannel, "error");
-    appendStub = sandbox.stub(outputChannel, "append");
-    appendLineStub = sandbox.stub(outputChannel, "appendLine");
-    replaceStub = sandbox.stub(outputChannel, "replace");
-  });
+    // TODO: better tests to test writeToLogFile()
+    it("should handle append method", () => {
+      instanceOfRotatingLogOutputChannel.append("append message");
 
-  afterEach(function () {
-    logOutputChannel.dispose();
-    sandbox.restore();
-  });
+      sinon.assert.calledOnce(appendStub);
+      sinon.assert.calledWith(appendStub, "append message");
+    });
 
-  it("should handle trace method", function () {
-    logOutputChannel.trace("test message");
+    it("should handle appendLine method", () => {
+      instanceOfRotatingLogOutputChannel.appendLine("appendLine message");
 
-    assert.strictEqual(traceStub.calledOnce, true);
-    assert.strictEqual(traceStub.firstCall.args[0], `test message`);
-  });
+      sinon.assert.calledOnce(appendLineStub);
+      sinon.assert.calledWith(appendLineStub, "appendLine message");
+    });
 
-  it("should handle info method", function () {
-    logOutputChannel.info("info message");
+    it("should handle replace method", () => {
+      instanceOfRotatingLogOutputChannel.replace("replace message");
 
-    assert.strictEqual(infoStub.calledOnce, true);
-    console.log(infoStub.firstCall.args[0]);
-    assert.strictEqual(infoStub.firstCall.args[0], `info message`);
-  });
+      sinon.assert.calledOnce(replaceStub);
+      sinon.assert.calledWith(replaceStub, "replace message");
+    });
 
-  it("should handle error method", function () {
-    logOutputChannel.error("error message");
+    // it("should delegate getFileUris() method", function () {
+    //   existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
+    //   writeableTmpDirStub = sandbox.stub(WriteableTmpDir.getInstance(), "get").returns("/test/dir");
+    //   // generate some rotated files to have URIs to return
+    //   const rotatingLogManager = instanceOfRotatingLogOutputChannel["rotatingLogManager"];
+    //   rotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
 
-    assert.strictEqual(errorStub.calledOnce, true);
-    assert.strictEqual(errorStub.firstCall.args[0], `error message`);
-  });
+    //   existsSyncStub.returns(true);
 
-  it("should handle warn method", function () {
-    logOutputChannel.warn("warn message");
+    //   const fileUris = instanceOfRotatingLogOutputChannel.getFileUris();
 
-    assert.strictEqual(warnStub.calledOnce, true);
-    assert.strictEqual(warnStub.firstCall.args[0], `warn message`);
-  });
-
-  it("should handle debug method", function () {
-    logOutputChannel.debug("debug message");
-
-    assert.strictEqual(debugStub.calledOnce, true);
-    assert.strictEqual(debugStub.firstCall.args[0], `debug message`);
-  });
-
-  it("should handle append method", function () {
-    logOutputChannel.append("append message");
-
-    assert.strictEqual(appendStub.calledOnce, true);
-    assert.strictEqual(appendStub.firstCall.args[0], "append message");
-  });
-
-  it("should handle appendLine method", function () {
-    logOutputChannel.appendLine("appendLine message");
-
-    assert.strictEqual(appendLineStub.calledOnce, true);
-    assert.strictEqual(appendLineStub.firstCall.args[0], "appendLine message");
-  });
-
-  it("should handle replace method", function () {
-    logOutputChannel.replace("replace message");
-
-    assert.strictEqual(replaceStub.calledOnce, true);
-    assert.strictEqual(replaceStub.firstCall.args[0], "replace message");
-  });
-
-  it("should delegate getFileUris() method", function () {
-    existsSyncStub = sandbox.stub(fsWrappers, "existsSync");
-    writeableTmpDirStub = sandbox.stub(WriteableTmpDir.getInstance(), "get").returns("/test/dir");
-    // generate some rotated files to have URIs to return
-    const rotatingLogManager = (logOutputChannel as any).rotatingLogManager;
-    rotatingLogManager.rotatingFilenameGenerator(new Date(), 1);
-
-    existsSyncStub.returns(true);
-
-    const fileUris = logOutputChannel.getFileUris();
-
-    assert.strictEqual(existsSyncStub.called, true);
-    assert.strictEqual(writeableTmpDirStub.called, true);
-    assert.ok(Array.isArray(fileUris), "Should return an array of URIs");
-    assert.strictEqual(fileUris.length, 2); // current + 1 rotated file
-    assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
-    assert.ok(fileUris[1].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`));
+    //   assert.strictEqual(existsSyncStub.called, true);
+    //   assert.strictEqual(writeableTmpDirStub.called, true);
+    //   assert.ok(Array.isArray(fileUris), "Should return an array of URIs");
+    //   assert.strictEqual(fileUris.length, 2); // current + 1 rotated file
+    //   assert.ok(fileUris[0].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.log`));
+    //   assert.ok(fileUris[1].fsPath.includes(`${BASEFILE_PREFIX}-${TEST_BASEPATH}.1.log`));
+    // });
   });
 });

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -320,17 +320,7 @@ describe("logging.ts", () => {
     const TEST_CONSOLENAME = "test-console-name";
 
     // stubs for methods to check that data member outputChannel is called correctly
-    let traceStub: sinon.SinonStub;
-    let debugStub: sinon.SinonStub;
     let infoStub: sinon.SinonStub;
-    let warnStub: sinon.SinonStub;
-    let errorStub: sinon.SinonStub;
-    let appendStub: sinon.SinonStub;
-    let appendLineStub: sinon.SinonStub;
-    let replaceStub: sinon.SinonStub;
-    let clearStub: sinon.SinonStub;
-    let hideStub: sinon.SinonStub;
-    let showStub: sinon.SinonStub;
 
     // stub for stream to check method calls from writeToLogFile()
     let streamStub: sinon.SinonStubbedInstance<RotatingFileStream>;
@@ -349,17 +339,7 @@ describe("logging.ts", () => {
       // stub rotating log output channel methods
       outputChannelStub = instance["outputChannel"];
 
-      traceStub = sandbox.stub(outputChannelStub, "trace");
-      debugStub = sandbox.stub(outputChannelStub, "debug");
       infoStub = sandbox.stub(outputChannelStub, "info");
-      warnStub = sandbox.stub(outputChannelStub, "warn");
-      errorStub = sandbox.stub(outputChannelStub, "error");
-      appendStub = sandbox.stub(outputChannelStub, "append");
-      appendLineStub = sandbox.stub(outputChannelStub, "appendLine");
-      replaceStub = sandbox.stub(outputChannelStub, "replace");
-      clearStub = sandbox.stub(outputChannelStub, "clear");
-      hideStub = sandbox.stub(outputChannelStub, "hide");
-      showStub = sandbox.stub(outputChannelStub, "show");
 
       // stub rotating log manager methods
       logManagerStub = instance["rotatingLogManager"];
@@ -370,7 +350,6 @@ describe("logging.ts", () => {
 
     afterEach(function () {
       instance.dispose();
-      sandbox.restore();
     });
 
     it("should get name from member outputChannel", () => {
@@ -386,6 +365,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle trace method", () => {
+      const traceStub = sandbox.stub(outputChannelStub, "trace");
       instance.trace("test message");
       // stream should not be called for trace logs and writeToLogFile() should not be called because it's too verbose
       sinon.assert.notCalled(streamStub.write);
@@ -395,6 +375,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle debug method", () => {
+      const debugStub = sandbox.stub(outputChannelStub, "debug");
       instance.debug("debug message");
       // debug logs should be written to the stream with writeToLogFile()
       sinon.assert.calledOnce(streamStub.write);
@@ -422,6 +403,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle warn method", () => {
+      const warnStub = sandbox.stub(outputChannelStub, "warn");
       instance.warn("warn message");
       // warn logs should be written to the stream with writeToLogFile()
       sinon.assert.calledOnce(streamStub.write);
@@ -431,6 +413,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle error method", () => {
+      const errorStub = sandbox.stub(outputChannelStub, "error");
       instance.error("error message");
       // error logs should be written to the stream with writeToLogFile()
       sinon.assert.calledOnce(streamStub.write);
@@ -440,6 +423,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle append method", () => {
+      const appendStub = sandbox.stub(outputChannelStub, "append");
       instance.append("append message");
       // append logs should be written to the stream with writeToLogFile()
       sinon.assert.calledOnce(streamStub.write);
@@ -449,6 +433,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle appendLine method", () => {
+      const appendLineStub = sandbox.stub(outputChannelStub, "appendLine");
       instance.appendLine("appendLine message");
       // appendLine logs should be written to the stream with writeToLogFile()
       sinon.assert.calledOnce(streamStub.write);
@@ -458,6 +443,7 @@ describe("logging.ts", () => {
     });
 
     it("should handle replace method", () => {
+      const replaceStub = sandbox.stub(outputChannelStub, "replace");
       instance.replace("replace message");
       // replace logs should be written to the stream with writeToLogFile()
       sinon.assert.calledOnce(streamStub.write);
@@ -467,22 +453,25 @@ describe("logging.ts", () => {
     });
 
     it("should handle clear method", () => {
+      const clearStub = sandbox.stub(outputChannelStub, "clear");
       instance.clear();
       sinon.assert.calledOnce(clearStub);
     });
 
     it("should handle hide method", () => {
+      const hideStub = sandbox.stub(outputChannelStub, "hide");
       instance.hide();
       sinon.assert.calledOnce(hideStub);
     });
 
     it("should handle show method", () => {
+      const showStub = sandbox.stub(outputChannelStub, "show");
       instance.show();
       sinon.assert.calledOnce(showStub);
     });
 
     it("should delegate getFileUris() to member RotatingLogManager instance", function () {
-      let getFileUrisStub = sinon.stub(logManagerStub, "getFileUris");
+      const getFileUrisStub = sinon.stub(logManagerStub, "getFileUris");
 
       instance.getFileUris();
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Adds test coverage over changes associated with #2334 and #2362.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Next steps are to refactor existing Logger class and logging methods to use new classes
- Update test coverage of Logger from associated changes

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
