### PR TITLE
Simplify validateFlinkSettings(), then fix its test suite 

### DIFF
--- a/src/flinkSql/flinkLanguageClientManager.ts
+++ b/src/flinkSql/flinkLanguageClientManager.ts
@@ -427,22 +427,16 @@ export class FlinkLanguageClientManager extends DisposableCollection {
         return false;
       }
       // Check if the configured compute pool exists in any environment
-      let poolFound = false;
       for (const env of environments) {
         if (env.flinkComputePools.some((pool) => pool.id === computePoolId)) {
-          poolFound = true;
-          break;
+          return true;
         }
       }
 
-      if (poolFound) {
-        return true;
-      } else {
-        logger.warn(
-          `Configured Flink compute pool ${computePoolId} not found in available resources`,
-        );
-        return false;
-      }
+      logger.warn(
+        `Configured Flink compute pool ${computePoolId} not found in available resources`,
+      );
+      return false;
     } catch (error) {
       logger.error("Error checking Flink resources availability", error);
       return false;


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Simplify `validateFlinkSettings()`, then fix its test suite to cover the right cases and use the right stub.
- Closes #2373

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
