### PR TITLE
Allow 

### DIFF
--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -140,7 +140,7 @@ export class FlinkSqlCodelensProvider extends DisposableCollection implements Co
     };
     const resetLens = new CodeLens(range, resetCommand);
 
-    if (computePool && database) {
+    if (computePool) {
       const submitCommand: Command = {
         title: "▶️ Submit Statement",
         command: "confluent.statements.create",
@@ -151,7 +151,7 @@ export class FlinkSqlCodelensProvider extends DisposableCollection implements Co
       // show the "Submit Statement" | <current pool> | <current catalog+db> codelenses
       codeLenses.push(submitLens, computePoolLens, databaseLens, resetLens);
     } else {
-      // don't show the submit codelens if we don't have a compute pool and database
+      // don't show the submit codelens if we don't have a compute pool
       codeLenses.push(computePoolLens, databaseLens, resetLens);
     }
 

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -121,11 +121,9 @@ export async function submitFlinkStatementCommand(
   const currentDatabaseKafkaCluster: KafkaCluster | undefined = validDatabaseProvided
     ? database
     : await flinkDatabaseQuickpick(computePool);
-  if (!currentDatabaseKafkaCluster) {
-    funcLogger.debug("User canceled the default database quickpick");
-    return;
-  }
-  const currentDatabase = currentDatabaseKafkaCluster.name;
+  // Database selection is now optional - user can dismiss the quickpick and submit without it
+  const currentDatabase = currentDatabaseKafkaCluster?.name;
+  const environmentId = currentDatabaseKafkaCluster?.environmentId || computePool.environmentId;
 
   // 5. Prep to submit, submit.
   const submission: IFlinkStatementSubmitParameters = {
@@ -135,7 +133,7 @@ export async function submitFlinkStatementCommand(
     hidden: false, // Do not create a hidden statement, the user authored it.
     properties: new FlinkSpecProperties({
       currentDatabase,
-      currentCatalog: currentDatabaseKafkaCluster.environmentId,
+      currentCatalog: environmentId,
       localTimezone: localTimezoneOffset(),
     }),
   };

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -70,7 +70,8 @@ export async function viewStatementSqlCommand(statement: FlinkStatement): Promis
  *  2) Create **statement name** (auto-generated from template pattern, but user can override)
  *  3) (If no `pool` is passed): show a quickpick to **choose a Flink compute pool** to send the statement
  *  4) (if no `database` is passed): show a quickpick to **choose a database** (Kafka cluster) to
- *     submit along with the **catalog name** (the environment, inferable from the chosen database).
+ *     submit along with the **catalog name** (the environment, inferable from the chosen database),
+ *     user can choose to skip this, their query will only work if the table name is fully qualified.
  *  5) Submit!
  *  6) Show error notification for any submission errors.
  *  7) Refresh the statements view if the view is focused on the chosen compute pool.
@@ -123,7 +124,6 @@ export async function submitFlinkStatementCommand(
     : await flinkDatabaseQuickpick(computePool);
   // Database selection is now optional - user can dismiss the quickpick and submit without it
   const currentDatabase = currentDatabaseKafkaCluster?.name;
-  const environmentId = currentDatabaseKafkaCluster?.environmentId || computePool.environmentId;
 
   // 5. Prep to submit, submit.
   const submission: IFlinkStatementSubmitParameters = {
@@ -133,7 +133,7 @@ export async function submitFlinkStatementCommand(
     hidden: false, // Do not create a hidden statement, the user authored it.
     properties: new FlinkSpecProperties({
       currentDatabase,
-      currentCatalog: environmentId,
+      currentCatalog: currentDatabaseKafkaCluster?.environmentId,
       localTimezone: localTimezoneOffset(),
     }),
   };

--- a/src/quickpicks/kafkaClusters.test.ts
+++ b/src/quickpicks/kafkaClusters.test.ts
@@ -220,12 +220,17 @@ describe("flinkDatabaseQuickPick", () => {
     await flinkDatabaseQuickpick(computePool);
     const itemsCalledWith = showQuickPickStub.getCall(0).args[0];
     // one separator for the single environment, one for the single cloud
-    // cluster in same provider/region.
-    assert.strictEqual(itemsCalledWith.length, 2);
+    // cluster in same provider/region, plus separator with message and skip option
+    assert.strictEqual(itemsCalledWith.length, 4);
     assert.strictEqual(itemsCalledWith[0].kind, QuickPickItemKind.Separator);
-    // other two items are the clusters. Their description should be the id.
-    // and their .value should be the cluster.
+    // cluster item should be the second item (after environment separator)
     assert.strictEqual(itemsCalledWith[1].description, ccloudClusters[0].id);
     assert.strictEqual(itemsCalledWith[1].value, TEST_CCLOUD_KAFKA_CLUSTER);
+    // third item should be the separator before skip with message
+    assert.strictEqual(itemsCalledWith[2].kind, QuickPickItemKind.Separator);
+    assert.strictEqual(itemsCalledWith[2].label, "Must use fully qualified table name");
+    // fourth item should be the skip option
+    assert.strictEqual(itemsCalledWith[3].label, "Skip");
+    assert.strictEqual(itemsCalledWith[3].value, null);
   });
 });


### PR DESCRIPTION
## Summary of Changes

* Allow user to submit a Flink statement, without setting catalog/database via CodeLens.
* Currently, user must set compute pool, catalog & database before "Submit statement" action is enabled in CodeLens.
* However, the selection of catalog & database is not required for successful SQL statement submission, as long as the table name(s) is fully qualified.
* This change also allow users without any catalog/database to submit statement against the `example` catalog / `marketplace` database.
* Fixes #1711 
-

## Any additional details or context that should be provided?

Submit action enabled as soon as a pool is selected:
<img width="517" height="97" alt="Screenshot 2025-08-25 at 3 03 35 PM" src="https://github.com/user-attachments/assets/a15265da-b89a-45ab-9487-554159a1f6d1" />

Option to skip catalog/database selection after selecting submit statement:
<img width="623" height="191" alt="Screenshot 2025-08-25 at 3 03 52 PM" src="https://github.com/user-attachments/assets/f18f38f5-c71e-4143-8792-f554aa28b602" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
