### PR TITLE
feat: Support connecting to WarpStream agents by port-forwarding

### DIFF
--- a/src/clients/sidecar-openapi-specs/sidecar.openapi.yaml
+++ b/src/clients/sidecar-openapi-specs/sidecar.openapi.yaml
@@ -381,6 +381,12 @@ components:
           allOf:
           - $ref: "#/components/schemas/TLSConfig"
           nullable: true
+        client_id_suffix:
+          description: "The suffix to append to the Kafka client config option client.id\
+            \ when interacting with this Kafka cluster. Is useful when, for instance,\
+            \ connecting to WarpStream agents via Kubernetes port-forwarding."
+          type: string
+          nullable: true
     KafkaClusterStatus:
       description: The status related to the specified Kafka cluster.
       required:

--- a/src/clients/sidecar/models/KafkaClusterConfig.ts
+++ b/src/clients/sidecar/models/KafkaClusterConfig.ts
@@ -52,6 +52,12 @@ export interface KafkaClusterConfig {
    * @memberof KafkaClusterConfig
    */
   ssl?: TLSConfig | null;
+  /**
+   * The suffix to append to the Kafka client config option client.id when interacting with this Kafka cluster. Is useful when, for instance, connecting to WarpStream agents via Kubernetes port-forwarding.
+   * @type {string}
+   * @memberof KafkaClusterConfig
+   */
+  client_id_suffix?: string | null;
 }
 
 /**
@@ -80,6 +86,7 @@ export function KafkaClusterConfigFromJSONTyped(
         ? undefined
         : KafkaClusterConfigCredentialsFromJSON(json["credentials"]),
     ssl: json["ssl"] == null ? undefined : TLSConfigFromJSON(json["ssl"]),
+    client_id_suffix: json["client_id_suffix"] == null ? undefined : json["client_id_suffix"],
   };
 }
 
@@ -99,5 +106,6 @@ export function KafkaClusterConfigToJSONTyped(
     bootstrap_servers: value["bootstrap_servers"],
     credentials: KafkaClusterConfigCredentialsToJSON(value["credentials"]),
     ssl: TLSConfigToJSON(value["ssl"]),
+    client_id_suffix: value["client_id_suffix"],
   };
 }

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -308,7 +308,8 @@ export function getConnectionSpecFromFormData(
           path.includes(".auth_type") ||
           path.includes(".credentials.") ||
           path.includes(".ssl.truststore") ||
-          path.includes(".ssl.keystore")
+          path.includes(".ssl.keystore") ||
+          path.includes(".client_id_suffix")
         ) {
           continue;
         }
@@ -354,6 +355,12 @@ export function getConnectionSpecFromFormData(
       }
     }
   }
+
+  // When using WarpStream, maybe enable Kubernetes port-forwarding for connecting to agents
+  if (formData["formconnectiontype"] === "WarpStream") {
+    setValueAtPath(spec, "kafka_cluster.client_id_suffix", formData["kafka_cluster.client_id_suffix"]);
+  }
+
   return spec;
 }
 

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -108,6 +108,18 @@
               comma-separated list for more than one server)</span
             >
           </div>
+          <template data-if="this.platformType() === 'WarpStream'">
+            <label class="checkbox" for="kafka_cluster.client_id_suffix">
+              <input
+                type="checkbox"
+                id="kafka_cluster.client_id_suffix"
+                name="kafka_cluster.client_id_suffix"
+                data-attr-checked="this.warpStreamPortForwardingEnabled()"
+                data-attr-value="this.warpStreamPortForwardingEnabled()"
+                data-on-change="this.updateValue(event)"
+              /><span>Connect to WarpStream agents via Kubernetes port-forwarding</span></label
+            >
+          </template>
           <div
             class="input-container"
             data-attr-title="this.editing() ? 'Changing the authentication type of an existing connection is not supported' : false"

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -1108,6 +1108,56 @@ test("enforces SCRAM_SHA_512 for WarpStream platform", async ({ execute, page })
       "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_512",
       "kafka_cluster.credentials.scram_username": "user",
       "kafka_cluster.credentials.scram_password": "password",
+      // Should not use Kubernetes port-forwarding by default for connecting to WarpStream agents
+      "kafka_cluster.client_id_suffix": "",
+    }),
+  );
+});
+
+test("sets the client ID suffix correctly when using K8s port-forwarding for WarpStream platform", async ({ execute, page }) => {
+  const sendWebviewMessage = await execute(async () => {
+    const { sendWebviewMessage } = await import("./comms/comms");
+    return sendWebviewMessage as SinonStub;
+  });
+
+  await execute(async (stub) => {
+    stub.withArgs("Submit").resolves(null);
+  }, sendWebviewMessage);
+
+  await execute(async () => {
+    await import("./main");
+    await import("./direct-connect-form");
+    window.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  // Fill in the form with WarpStream and SCRAM auth
+  await page.fill("input[name=name]", "WarpStream Test");
+  await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
+  await page.selectOption("select[name='formconnectiontype']", "WarpStream");
+  // Connect to WarpStream agents via Kubernetes port-forwarding
+  await page.check("input[type=checkbox][name='kafka_cluster.client_id_suffix']");
+
+  // Submit the form
+  await page.click("input[type=submit][value='Save']");
+
+  const submitCallHandle = await sendWebviewMessage.evaluateHandle(
+    (stub) => stub.getCalls().find((call) => call?.args[0] === "Submit")?.args,
+  );
+  const submitCall = await submitCallHandle?.jsonValue();
+  expect(submitCall).not.toBeUndefined();
+  expect(submitCall?.[0]).toBe("Submit");
+
+  // Verify client ID suffix is set correctly
+  expect(submitCall?.[1]).toEqual(
+    expect.objectContaining({
+      name: "WarpStream Test",
+      formconnectiontype: "WarpStream",
+      "kafka_cluster.bootstrap_servers": "localhost:9092",
+      "kafka_cluster.auth_type": "SCRAM",
+      "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_512",
+      "kafka_cluster.credentials.scram_username": "user",
+      "kafka_cluster.credentials.scram_password": "password",
+      "kafka_cluster.client_id_suffix": "ws_host_override=localhost",
     }),
   );
 });


### PR DESCRIPTION
## Summary of Changes

This change adds a new configuration option to Direct connections that allows users to connect to WarpStream agents
[via Kubernetes port-forwarding](https://docs.warpstream.com/warpstream/byoc/port-forwarding-k8s).

The configuration option is only available for WarpStream connections and adds a specific suffix (`ws_host_override=localhost`) to the Kafka client's client ID.

Fixes #2276

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
