### PR TITLE
[v1.6.x] Fix flinkComputePoolQuickPick() issues

### DIFF
--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -36,8 +36,15 @@ export async function setCCloudComputePoolForUriCommand(uri?: Uri, database?: CC
     ? (pool: CCloudFlinkComputePool) =>
         pool.provider === database.provider && pool.region === database.region
     : undefined;
-  const pool: CCloudFlinkComputePool | undefined = await flinkComputePoolQuickPick(filter);
+
+  // Present quickpick to the user.
+  const pool: CCloudFlinkComputePool | undefined = await flinkComputePoolQuickPick(
+    null, // do not pre-select any pool
+    filter, // if a database is provided, filter pools to match provider/region
+  );
+
   if (!pool) {
+    // User canceled the quickpick
     return;
   }
 

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -50,15 +50,19 @@ export async function selectPoolFromResourcesViewCommand(item?: CCloudFlinkCompu
 /**
  * Select a {@link FlinkComputePool} to focus in the "Statements" view.
  */
-export async function selectPoolForStatementsViewCommand(item?: CCloudFlinkComputePool) {
+export async function selectPoolForStatementsViewCommand(pool?: CCloudFlinkComputePool) {
   // the user either clicked a pool in the Flink Statements view or used the command palette
-  const pool: CCloudFlinkComputePool | undefined =
-    item instanceof CCloudFlinkComputePool
-      ? item
-      : await flinkComputePoolQuickPickWithViewProgress("confluent-flink-statements");
 
   if (!pool) {
-    // user canceled the quickpick
+    pool = await flinkComputePoolQuickPickWithViewProgress(
+      "confluent-flink-statements",
+      // Initially select whatever the view is currently set to. Will be null if not focused on exactly one pool.
+      FlinkStatementsViewProvider.getInstance().computePool,
+    );
+  }
+
+  if (!pool) {
+    // none provided by caller and then user canceled the quickpick
     return;
   }
 

--- a/src/quickpicks/flinkComputePools.test.ts
+++ b/src/quickpicks/flinkComputePools.test.ts
@@ -1,0 +1,182 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
+import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
+import {
+  TEST_CCLOUD_ENVIRONMENT,
+  TEST_CCLOUD_ENVIRONMENT_ID,
+  TEST_CCLOUD_KAFKA_CLUSTER,
+  TEST_CCLOUD_PROVIDER,
+  TEST_CCLOUD_REGION,
+  TEST_CCLOUD_SCHEMA_REGISTRY,
+} from "../../tests/unit/testResources";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { IconNames } from "../constants";
+import { FLINK_CONFIG_COMPUTE_POOL } from "../extensionSettings/constants";
+import { CCloudResourceLoader } from "../loaders";
+import { CCloudEnvironment } from "../models/environment";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import * as notifications from "../notifications";
+import { flinkComputePoolQuickPick } from "./flinkComputePools";
+
+describe("quickpicks/flinkComputePools.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let showQuickPickStub: sinon.SinonStub;
+  let stubbedConfigs: StubbedWorkspaceConfiguration;
+  let stubbedCcloudResourceLoader: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+
+  const TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID = "lfcp-some-other-id";
+  const TEST_CCLOUD_FLINK_COMPUTE_POOL_2 = new CCloudFlinkComputePool({
+    name: "ccloud-pool2",
+    provider: TEST_CCLOUD_PROVIDER,
+    region: TEST_CCLOUD_REGION,
+    maxCfu: 10,
+    environmentId: TEST_CCLOUD_ENVIRONMENT_ID,
+    id: TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID,
+  });
+
+  // This needs a home. We have a couple of tests declaring similar things in other files.
+  const TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR_AND_FLINK = new CCloudEnvironment({
+    ...TEST_CCLOUD_ENVIRONMENT,
+    kafkaClusters: [TEST_CCLOUD_KAFKA_CLUSTER],
+    schemaRegistry: TEST_CCLOUD_SCHEMA_REGISTRY,
+    flinkComputePools: [TEST_CCLOUD_FLINK_COMPUTE_POOL, TEST_CCLOUD_FLINK_COMPUTE_POOL_2],
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
+    showQuickPickStub = sandbox.stub(vscode.window, "showQuickPick");
+    stubbedCcloudResourceLoader = getStubbedCCloudResourceLoader(sandbox);
+    // logged into ccloud with an env that has a single flink compute pool
+    // by default.
+    stubbedCcloudResourceLoader.getEnvironments.resolves([
+      TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR_AND_FLINK,
+    ]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  /** Strip away the annoying kind=Separator items passed into showQuickPick */
+  function extractPoolItemsFromQuickPickCall(): vscode.QuickPickItem[] {
+    sinon.assert.calledOnce(showQuickPickStub);
+    const quickPickItems = showQuickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
+    return quickPickItems.filter((item) => item.kind !== vscode.QuickPickItemKind.Separator);
+  }
+
+  describe("flinkComputePoolQuickPick()", () => {
+    it("should prompt the user to sign in if not signed in to ccloud", async () => {
+      // simulate not being signed in to ccloud
+      stubbedCcloudResourceLoader.getEnvironments.resolves([]);
+      const showInfoNotificationWithButtonsStub = sandbox.stub(
+        notifications,
+        "showInfoNotificationWithButtons",
+      );
+
+      await flinkComputePoolQuickPick();
+      sinon.assert.calledOnce(showInfoNotificationWithButtonsStub);
+      const callArgs = showInfoNotificationWithButtonsStub.firstCall.args;
+      assert.strictEqual(callArgs[0], "No Flink compute pools available.");
+    });
+
+    it("should return the selected pool", async () => {
+      // simulate user selecting the second pool in the list
+      showQuickPickStub.resolves({
+        label: TEST_CCLOUD_FLINK_COMPUTE_POOL_2.name,
+        description: TEST_CCLOUD_FLINK_COMPUTE_POOL_2.id,
+        value: TEST_CCLOUD_FLINK_COMPUTE_POOL_2,
+      });
+
+      const selectedPool = await flinkComputePoolQuickPick();
+      assert.deepStrictEqual(selectedPool, TEST_CCLOUD_FLINK_COMPUTE_POOL_2);
+    });
+
+    it("should call and honor predicate if provided", async () => {
+      const predicate = sandbox.spy(
+        // we hate TEST_CCLOUD_FLINK_COMPUTE_POOL and want it filtered out.
+        (pool: CCloudFlinkComputePool) => pool.id !== TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
+      );
+      await flinkComputePoolQuickPick(null, predicate);
+      sinon.assert.calledTwice(predicate);
+
+      // and should have only let TEST_CCLOUD_FLINK_COMPUTE_POOL_2 through
+      const quickPickItems = extractPoolItemsFromQuickPickCall();
+      assert.strictEqual(quickPickItems.length, 1);
+      const onlyPool = quickPickItems[0];
+      assert.strictEqual(onlyPool.description, TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID);
+    });
+
+    for (const preferredPool of [
+      TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      TEST_CCLOUD_FLINK_COMPUTE_POOL_2,
+    ]) {
+      it(`If user has default compute pool set, but not called with a selected pool, the default should be at the top of the list: ${preferredPool.id}`, async () => {
+        stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, preferredPool.id);
+
+        // We're not testing the quickpick result here, just the generation of items passed into showQuickPickStub
+        await flinkComputePoolQuickPick();
+
+        const quickPickItems = extractPoolItemsFromQuickPickCall();
+        assert.strictEqual(quickPickItems.length, 2);
+        const firstItem = quickPickItems[0];
+        // The pool's id is in the description field.
+        assert.strictEqual(firstItem.description, preferredPool.id);
+      });
+
+      it(`If user has default compute pool set, and called with that selected pool, the default/selected should be at the top of the list and not duplicated: ${preferredPool.id}`, async () => {
+        stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, preferredPool.id);
+
+        // We're not testing the quickpick result here, just the generation of items passed into showQuickPickStub
+        await flinkComputePoolQuickPick(preferredPool);
+
+        const quickPickItems = extractPoolItemsFromQuickPickCall();
+        assert.strictEqual(quickPickItems.length, 2);
+        const firstItem = quickPickItems[0];
+        // The pool's id is in the description field.
+        assert.strictEqual(firstItem.description, preferredPool.id);
+        // Should use icon checked
+        assert.strictEqual((firstItem.iconPath as vscode.ThemeIcon).id, IconNames.CURRENT_RESOURCE);
+
+        // the second item should be the other pool
+        const secondItem = quickPickItems[1];
+        const secondPool =
+          preferredPool === TEST_CCLOUD_FLINK_COMPUTE_POOL
+            ? TEST_CCLOUD_FLINK_COMPUTE_POOL_2
+            : TEST_CCLOUD_FLINK_COMPUTE_POOL;
+        assert.strictEqual(secondItem.description, secondPool.id);
+        // and should use the pool's own icon, not the 'selected' icon
+        assert.strictEqual((secondItem.iconPath as vscode.ThemeIcon).id, secondPool.iconName);
+      });
+
+      it(`If user has default compute pool set, and called with a different selected pool, the selected should be at the top of the list and the default should be second: ${preferredPool.id}`, async () => {
+        stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, preferredPool.id);
+        // invert which pool is passed as selected
+        const selectedPool =
+          preferredPool === TEST_CCLOUD_FLINK_COMPUTE_POOL
+            ? TEST_CCLOUD_FLINK_COMPUTE_POOL_2
+            : TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+        // We're not testing the quickpick result here, just the generation of items passed into showQuickPickStub
+        await flinkComputePoolQuickPick(selectedPool);
+
+        const quickPickItems = extractPoolItemsFromQuickPickCall();
+        assert.strictEqual(quickPickItems.length, 2);
+        const firstItem = quickPickItems[0];
+        // The pool's id is in the description field.
+        assert.strictEqual(firstItem.description, selectedPool.id);
+        // Should use icon checked
+        assert.strictEqual((firstItem.iconPath as vscode.ThemeIcon).id, IconNames.CURRENT_RESOURCE);
+
+        // the second item should be the other pool
+        const secondItem = quickPickItems[1];
+        assert.strictEqual(secondItem.description, preferredPool.id);
+        // and should use the pool's own icon, not the 'selected' icon
+        assert.strictEqual((secondItem.iconPath as vscode.ThemeIcon).id, preferredPool.iconName);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix #2435:
  - Have explicit parameter representing the single compute pool to pre-select, treat differently from the user default one.
  - Fix logic
  - Write tests 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2435 in v1.6.0 branch, doing so in a way that should be easy to integrate with udf/artifacts view in main.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
