### PR TITLE
2417 medusa container start up alert stuck on waiting to be ready

### DIFF
--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -8,7 +8,6 @@ import {
   SystemApi,
   SystemEventsRequest,
 } from "../clients/docker";
-import { LOCAL_MEDUSA_INTERNAL_PORT } from "../constants";
 import { ContextValues, setContextValue } from "../context/values";
 import {
   localKafkaConnected,
@@ -24,7 +23,8 @@ import { Logger } from "../logging";
 import { updateLocalConnection } from "../sidecar/connections/local";
 import { IntervalPoller } from "../utils/timing";
 import { defaultRequestInit, isDockerAvailable } from "./configs";
-import { getContainer } from "./containers";
+import { LocalResourceWorkflow } from "./workflows/base";
+import { MedusaWorkflow } from "./workflows/medusa";
 
 const logger = new Logger("docker.eventListener");
 
@@ -363,7 +363,8 @@ export class EventListener {
           title: "Waiting for local resources to be ready...",
         },
         async () => {
-          started = await this.waitForMedusa(containerId);
+          const workflow = LocalResourceWorkflow.getMedusaWorkflow() as MedusaWorkflow; //todo Patrick: make generic
+          started = await workflow.waitForReadiness(containerId);
         },
       );
       await setContextValue(ContextValues.localMedusaAvailable, started);
@@ -445,80 +446,6 @@ export class EventListener {
       logger.debug(`error checking container state, waiting and trying again...`, { error });
     }
     return false;
-  }
-  /**
-   * Generic health check method for any containerized service.
-   */
-  async waitForServiceHealthCheck(
-    containerId: string,
-    internalPort: number,
-    healthEndpoint: string,
-    serviceName: string,
-    maxWaitTimeSec: number = 60,
-    requestTimeoutMs: number = 5000,
-  ): Promise<boolean> {
-    try {
-      let container: ContainerInspectResponse;
-      try {
-        container = await getContainer(containerId);
-      } catch (error) {
-        logger.error(
-          `Failed to inspect container ${containerId} for ${serviceName} health check:`,
-          error,
-        );
-        return false;
-      }
-      const portBindings = container.HostConfig?.PortBindings;
-      const externalPort = portBindings?.[`${internalPort}/tcp`]?.[0]?.HostPort;
-
-      if (!externalPort) {
-        logger.debug(
-          `Failed to find ${serviceName} external port mapping for port ${internalPort}`,
-        );
-        return false;
-      }
-
-      const healthUrl = `http://localhost:${externalPort}${healthEndpoint}`;
-      logger.debug(`Starting ${serviceName} health check at ${healthUrl}`);
-
-      const healthCheckStartTime = Date.now();
-      while (Date.now() - healthCheckStartTime < maxWaitTimeSec * 1000) {
-        try {
-          const response = await fetch(healthUrl, {
-            method: "GET",
-            signal: AbortSignal.timeout(requestTimeoutMs),
-          });
-
-          if (response.ok) {
-            logger.debug(`${serviceName} health check succeeded`);
-            return true;
-          }
-        } catch {
-          // Ignore individual request failures, keep trying
-        }
-
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
-
-      logger.debug(`${serviceName} health check timed out after ${maxWaitTimeSec}s`);
-      return false;
-    } catch (error) {
-      logger.error(`Error during ${serviceName} health check:`, error);
-      return false;
-    }
-  }
-
-  /**
-   * Wait for Medusa to be healthy and ready to serve requests.
-   */
-  async waitForMedusa(containerId: string, maxWaitTimeSec: number = 60): Promise<boolean> {
-    return this.waitForServiceHealthCheck(
-      containerId,
-      LOCAL_MEDUSA_INTERNAL_PORT,
-      "/v1/generators/categories",
-      "Medusa",
-      maxWaitTimeSec,
-    );
   }
 
   /** Make a request to `/containers/{id}/logs` and return a readable stream, then match the incoming

--- a/src/docker/workflows/medusa.ts
+++ b/src/docker/workflows/medusa.ts
@@ -14,12 +14,13 @@ import { Logger } from "../../logging";
 import { showErrorNotificationWithButtons } from "../../notifications";
 import { getLocalResourceContainers } from "../../sidecar/connections/local";
 import { UserEvent } from "../../telemetry/events";
-import { createContainer } from "../containers";
+import { createContainer, waitForServiceHealthCheck } from "../containers";
 import { createNetwork } from "../networks";
 import { findFreePort } from "../ports";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
 export const CONTAINER_NAME = "vscode-medusa";
+const HEALTHCHECK_ENDPOINT = "/v1/generators/categories";
 
 export class MedusaWorkflow extends LocalResourceWorkflow {
   resourceKind: string = "Medusa";
@@ -176,6 +177,15 @@ export class MedusaWorkflow extends LocalResourceWorkflow {
     }
 
     return { id: container.Id, name: CONTAINER_NAME };
+  }
+
+  waitForReadiness(containerId: string): Promise<boolean> {
+    return waitForServiceHealthCheck(
+      containerId,
+      LOCAL_MEDUSA_INTERNAL_PORT,
+      HEALTHCHECK_ENDPOINT,
+      this.resourceKind,
+    );
   }
 
   /** Block until we see the {@link localMedusaConnected} event fire. (Controlled by the EventListener


### PR DESCRIPTION
## Summary of Changes

Refactored the Medusa container workflow to include perform a health check on it's container. This fixes the bug found in #2417. This differs from current log checking approach done by schema registry and local-confluent containers.

Follow up  Sub-ticket: [#2442](https://github.com/confluentinc/vscode/issues/2442)

This Pr closes #2417 

## Any additional details or context that should be provided?

Previous Bug:

- Click start icon for Local resources
- Select Medusa
- Bottom right the 'Local: Waiting for Medusa container to be ready...' alert will display
- Checking docker will show that the container has already started successfully
- Restarting the existing but stopped medusa container repeats the forever 'waiting to be ready' alert

Fixed behaviour:

- Click start icon for Local resources
- Select Medusa
- Bottom right the 'Local: Waiting for Medusa container to be ready...' alert will display
- Once container has started, alert should disappear

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ X] Added new
- [ X] Updated existing
- [ ] Deleted existing


