### PR TITLE
[v1.6.x] Fix #2438 partial local resources gql warning through new parameter controlling if GQL query() should sho…

### DIFF
--- a/src/graphql/ccloud.ts
+++ b/src/graphql/ccloud.ts
@@ -52,7 +52,7 @@ export async function getCCloudResources(): Promise<CCloudEnvironment[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
+    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, true, { id: CCLOUD_CONNECTION_ID });
   } catch (error) {
     logError(error, "CCloud environments", { extra: { connectionId: CCLOUD_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch CCloud resources: ${error}`);

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -109,7 +109,7 @@ export async function getDirectResources(
     logger.debug("Done waiting for direct connection to stabilize, submitting GraphQL query", {
       connectionId,
     });
-    response = await sidecar.query(query, connectionId, { id: connectionId });
+    response = await sidecar.query(query, connectionId, true, { id: connectionId });
   } catch (error) {
     logError(error, "direct connection resources", {
       extra: { functionName: "getDirectResources" },

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -32,7 +32,11 @@ export async function getLocalResources(): Promise<LocalEnvironment[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, LOCAL_CONNECTION_ID);
+    // Call with showPartialErrors=false to suppress error notifications for partial errors,
+    // which are expected for local connection if we're starting up both kafka and schema registry
+    // containers, but just queried sidecar and it could only contact Kafka (SR still coming online).
+    // When docker SR does come online, we'll re-query again and be happy.
+    response = await sidecar.query(query, LOCAL_CONNECTION_ID, false);
   } catch (error) {
     logError(error, "local resources", { extra: { connectionId: LOCAL_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch local resources: ${error}`);

--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -26,7 +26,7 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, false, {
+    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, true, {
       id: CCLOUD_CONNECTION_ID,
     });
   } catch (error) {

--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -26,7 +26,9 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
+    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, false, {
+      id: CCLOUD_CONNECTION_ID,
+    });
   } catch (error) {
     logError(error, "CCloud organizations", { extra: { connectionId: CCLOUD_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch CCloud organizations: ${error}`);

--- a/src/sidecar/sidecarHandle.test.ts
+++ b/src/sidecar/sidecarHandle.test.ts
@@ -262,6 +262,15 @@ describe("sidecarHandle sandbox tests", () => {
     });
 
     describe("partial errors tests", () => {
+      let showWarningNotificationWithButtonsStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        showWarningNotificationWithButtonsStub = sandbox.stub(
+          notifications,
+          "showWarningNotificationWithButtons",
+        );
+      });
+
       it("should return data and show warning if response has both data and single error and showPartialErrors is true", async () => {
         const responseWithErrors: GraphQLResponse = {
           data: {
@@ -274,11 +283,6 @@ describe("sidecarHandle sandbox tests", () => {
           ok: true,
           json: async () => responseWithErrors,
         } as Response);
-
-        const showWarningNotificationWithButtonsStub = sandbox.stub(
-          notifications,
-          "showWarningNotificationWithButtons",
-        );
 
         const result = await handle.query(
           organizationQuery,
@@ -308,11 +312,6 @@ describe("sidecarHandle sandbox tests", () => {
           json: async () => responseWithErrors,
         } as Response);
 
-        const showWarningNotificationWithButtonsStub = sandbox.stub(
-          notifications,
-          "showWarningNotificationWithButtons",
-        );
-
         const result = await handle.query(
           organizationQuery,
           constants.CCLOUD_CONNECTION_ID,
@@ -336,11 +335,6 @@ describe("sidecarHandle sandbox tests", () => {
             ok: true,
             json: async () => responseWithOnlyErrors,
           } as Response);
-
-          const showWarningNotificationWithButtonsStub = sandbox.stub(
-            notifications,
-            "showWarningNotificationWithButtons",
-          );
 
           await assert.rejects(
             handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, testCaseValue, {

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -450,7 +450,7 @@ export class SidecarHandle {
    * notification, but will still log the errors.
    * @param variables Optional variables for the GraphQL query. Omit or pass `undefined` if there are no variables.
    * @returns The `data` portion of the GraphQL response.
-   * @throws {Error} if the fetch fails, or if the response contains `errors` and `showPartialErrors` is false.
+   * @throws {Error} if the fetch fails entirely, or returns only `error` payload w/o also `data`.
    */
   public async query<Result, Variables>(
     query: TadaDocumentNode<Result, Variables>,


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix #2438 in `v1.6.x `partial local resources gql warning through new parameter controlling if GQL query should suppress said popup when being driven for local GQL since we know we will sometimes query when kafka has started but schema registry has not.
- Had to make it a required parameter since we already had trailing optional params for `query()`.
- New tests.


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- The root issue here is that the resources view provider implementations handle two separate events when either of local Kafka or local schema registry change status, as discovered by the Docker event listeners. When we're starting up both the Kafka and Schema Registry containers, we may get the 'local Kafka is up' event after we've told sidecar about the upcoming schema registry, but when handling the 'local Kafka is up' event, we query GraphQL. New in 1.6 timeline is the feature to show the user a notification in the case of 'we got some GQL data back, but also errors' (partial success). In this case, we expect some transient partial successes (Kafka but not yet SR). The user will be able to see that the resource row does not (yet) show the SR the configured, but hopefully Very Soon we'll get the 'local SR container is up' event from the Docker monitor, and we'll refresh the resources view row and all will be well.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
