### PR TITLE
Direct Connections form bug fixes

### DIFF
--- a/src/directConnect.test.ts
+++ b/src/directConnect.test.ts
@@ -19,7 +19,7 @@ describe("directConnect.ts", () => {
     it("should not include `schema_registry` if uri not provided", async () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Apache Kafka",
+        formConnectionType: "Apache Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "None",
         "schema_registry.auth_type": "None",
@@ -36,7 +36,7 @@ describe("directConnect.ts", () => {
     it("should not include `kafka_cluster` if bootstrap server not provided", async () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Apache Kafka",
+        formConnectionType: "Apache Kafka",
         "schema_registry.uri": "http://localhost:8081",
         "schema_registry.auth_type": "None",
         "kafka_cluster.ssl.enabled": "true",
@@ -51,7 +51,7 @@ describe("directConnect.ts", () => {
     it("should return a valid CustomConnectionSpec with Basic auth credentials", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "Basic",
         "kafka_cluster.credentials.username": "user",
@@ -87,7 +87,7 @@ describe("directConnect.ts", () => {
     it("should return a valid CustomConnectionSpec with API key credentials", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "API",
         "kafka_cluster.credentials.api_key": "key",
@@ -123,7 +123,7 @@ describe("directConnect.ts", () => {
     it("should return a valid CustomConnectionSpec with SCRAM credentials", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "SCRAM",
         "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_512",
@@ -151,7 +151,7 @@ describe("directConnect.ts", () => {
     it("should return a valid CustomConnectionSpec with OAuth credentials", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "OAuth",
         "kafka_cluster.credentials.tokens_url": "http://localhost:8080/token",
@@ -197,7 +197,7 @@ describe("directConnect.ts", () => {
     it("should return a valid CustomConnectionSpec with Kerberos credentials", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "Kerberos",
         "kafka_cluster.credentials.principal": "user@EXAMPLE.COM",
@@ -228,7 +228,7 @@ describe("directConnect.ts", () => {
     it("should not include credentials if the auth type is None", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Apache Kafka",
+        formConnectionType: "Apache Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "None",
         "schema_registry.uri": "http://localhost:8081",
@@ -249,7 +249,7 @@ describe("directConnect.ts", () => {
     it("should not include truststore or keystore for kafka if paths are empty", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "None",
         "schema_registry.uri": "http://localhost:8081",
@@ -275,7 +275,7 @@ describe("directConnect.ts", () => {
     it("should include keystore and truststore information if paths are provided", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Apache Kafka",
+        formConnectionType: "Apache Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "None",
         "kafka_cluster.ssl.enabled": "true",
@@ -306,7 +306,7 @@ describe("directConnect.ts", () => {
     it("should not include truststore or keystore for schema if paths are empty", () => {
       const formData = {
         name: "Test Connection",
-        formconnectiontype: "Kafka",
+        formConnectionType: "Kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "None",
         "schema_registry.uri": "http://localhost:8081",
@@ -332,7 +332,7 @@ describe("directConnect.ts", () => {
     it("filters out credentials that dont match the auth type submitted", () => {
       const formData = {
         name: "Mixed Auth Fields",
-        formconnectiontype: "kafka",
+        formConnectionType: "kafka",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.auth_type": "Basic",
         "kafka_cluster.credentials.username": "testuser",
@@ -353,7 +353,7 @@ describe("directConnect.ts", () => {
     it("should correctly set `kafka_cluster.client_id_suffix` for WarpStream connections", () => {
       const formData = {
         name: "WarpStream Connection",
-        formconnectiontype: "WarpStream",
+        formConnectionType: "WarpStream",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
         "kafka_cluster.client_id_suffix": "ws_host_override=localhost",
       };

--- a/src/directConnect.ts
+++ b/src/directConnect.ts
@@ -277,9 +277,9 @@ export function getConnectionSpecFromFormData(
     id: connectionId ?? (randomUUID() as ConnectionId),
     name: formData["name"] || "New Connection",
     type: ConnectionType.Direct,
-    formConnectionType: formData["formconnectiontype"],
+    formConnectionType: formData["formConnectionType"],
   };
-  if (formData["formconnectiontype"] === "Other") {
+  if (formData["formConnectionType"] === "Other") {
     spec.specifiedConnectionType = formData["othertype"];
   }
 
@@ -357,7 +357,7 @@ export function getConnectionSpecFromFormData(
   }
 
   // When using WarpStream, maybe enable Kubernetes port-forwarding for connecting to agents
-  if (formData["formconnectiontype"] === "WarpStream") {
+  if (formData["formConnectionType"] === "WarpStream") {
     setValueAtPath(
       spec,
       "kafka_cluster.client_id_suffix",

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -52,8 +52,8 @@
               <label class="label">Connection Type</label>
               <select
                 class="input dropdown"
-                id="formconnectiontype"
-                name="formconnectiontype"
+                id="formConnectionType"
+                name="formConnectionType"
                 data-on-input="this.updateValue(event)"
                 data-value="this.platformType()"
               >

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -76,7 +76,7 @@ test("renders form html correctly", async ({ page }) => {
   await expect(form).toBeVisible();
 
   // Check for our various field types to be visible in the form:
-  const typeSelect = page.locator("select[name='formconnectiontype']");
+  const typeSelect = page.locator("select[name='formConnectionType']");
   await expect(typeSelect).toBeVisible();
   const typeOptions = await typeSelect.locator("option").all();
   await expect(typeOptions.length).toBe(5);
@@ -216,7 +216,7 @@ test("submits the form with defaults & dummy data", async ({ execute, page }) =>
     "kafka_cluster.client_id_suffix": "",
     "kafka_cluster.ssl.enabled": "true",
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
     "schema_registry.uri": "https://fakehost:8081",
@@ -270,7 +270,7 @@ test("changes the checkbox for ssl to false if localhost", async ({ execute, pag
     "kafka_cluster.ssl.enabled": "false",
     "kafka_cluster.client_id_suffix": "",
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "false",
     "schema_registry.uri": "http://localhost:8081",
@@ -365,7 +365,7 @@ test("submits the form with empty trust/key stores as defaults when ssl enabled"
     "kafka_cluster.client_id_suffix": "",
     "kafka_cluster.ssl.enabled": "true",
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
     "schema_registry.uri": "https://fakehost:8081",
@@ -421,7 +421,7 @@ test("submits the form with namespaced TLS config fields when filled", async ({
     "kafka_cluster.auth_type": "None",
     "kafka_cluster.client_id_suffix": "",
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "schema_registry.auth_type": "None",
     "schema_registry.ssl.enabled": "true",
     "schema_registry.uri": "",
@@ -540,7 +540,7 @@ test("adds advanced ssl fields even if section is collapsed", async ({ execute, 
   // Verify correct form data
   expect(submitCall?.[1]).toEqual({
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "kafka_cluster.bootstrap_servers": "fakehost:9092",
     "kafka_cluster.auth_type": "None",
     "kafka_cluster.client_id_suffix": "",
@@ -598,7 +598,7 @@ test("submits values for SASL/SCRAM auth type when filled in", async ({ execute,
   // Verify correct form data
   expect(submitCall?.[1]).toEqual({
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "kafka_cluster.bootstrap_servers": "fakehost:9092",
     "kafka_cluster.auth_type": "SCRAM",
     "kafka_cluster.client_id_suffix": "",
@@ -685,7 +685,7 @@ test("submits values for SASL/OAUTHBEARER auth type when filled in", async ({ ex
   // Fill in the form with SASL/OAUTHBEARER auth type
   await page.fill("input[name=name]", "Test Connection");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "fakehost:9092");
-  await page.selectOption("select[name='formconnectiontype']", "Confluent Cloud");
+  await page.selectOption("select[name='formConnectionType']", "Confluent Cloud");
   await page.selectOption("select[name='kafka_cluster.auth_type']", "OAuth");
   await page.fill(
     "input[name='kafka_cluster.credentials.tokens_url']",
@@ -732,7 +732,7 @@ test("submits values for SASL/OAUTHBEARER auth type when filled in", async ({ ex
   // Verify correct form data
   expect(submitCall?.[1]).toEqual({
     name: "Test Connection",
-    formconnectiontype: "Confluent Cloud",
+    formConnectionType: "Confluent Cloud",
     "kafka_cluster.bootstrap_servers": "fakehost:9092",
     "kafka_cluster.auth_type": "OAuth",
     "kafka_cluster.client_id_suffix": "",
@@ -781,7 +781,7 @@ test("populates values for SASL/OAUTHBEARER auth type when they exist in the spe
 
   const form = page.locator("form");
   await expect(form).toBeVisible();
-  await page.selectOption("select[name='formconnectiontype']", "Confluent Cloud");
+  await page.selectOption("select[name='formConnectionType']", "Confluent Cloud");
 
   // Check that the form fields are populated with OAuth connection spec values
   const nameInput = page.locator("input[name='name']");
@@ -887,7 +887,7 @@ test("submits values for Kerberos auth type when filled in", async ({ execute, p
   // Verify correct form data
   expect(submitCall?.[1]).toEqual({
     name: "Test Connection",
-    formconnectiontype: "Apache Kafka",
+    formConnectionType: "Apache Kafka",
     "kafka_cluster.bootstrap_servers": "fakehost:9092",
     "kafka_cluster.auth_type": "Kerberos",
     "kafka_cluster.client_id_suffix": "",
@@ -1089,7 +1089,7 @@ test("enforces SCRAM_SHA_512 for WarpStream platform", async ({ execute, page })
   // Fill in the form with WarpStream and SCRAM auth
   await page.fill("input[name=name]", "WarpStream Test");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
-  await page.selectOption("select[name='formconnectiontype']", "WarpStream");
+  await page.selectOption("select[name='formConnectionType']", "WarpStream");
   await page.selectOption("select[name='kafka_cluster.auth_type']", "SCRAM");
 
   // No need to select hash_algorithm as it should be enforced
@@ -1110,7 +1110,7 @@ test("enforces SCRAM_SHA_512 for WarpStream platform", async ({ execute, page })
   expect(submitCall?.[1]).toEqual(
     expect.objectContaining({
       name: "WarpStream Test",
-      formconnectiontype: "WarpStream",
+      formConnectionType: "WarpStream",
       "kafka_cluster.bootstrap_servers": "localhost:9092",
       "kafka_cluster.auth_type": "SCRAM",
       "kafka_cluster.credentials.hash_algorithm": "SCRAM_SHA_512",
@@ -1145,7 +1145,7 @@ test("sets the client ID suffix correctly when using K8s port-forwarding for War
   await page.fill("input[name=name]", "WarpStream Test");
   await page.fill("input[name='kafka_cluster.bootstrap_servers']", "localhost:9092");
   await page.selectOption("select[name='kafka_cluster.auth_type']", "None");
-  await page.selectOption("select[name='formconnectiontype']", "WarpStream");
+  await page.selectOption("select[name='formConnectionType']", "WarpStream");
   // Connect to WarpStream agents via Kubernetes port-forwarding
   await page.check("input[type=checkbox][name='kafka_cluster.client_id_suffix']");
 
@@ -1163,7 +1163,7 @@ test("sets the client ID suffix correctly when using K8s port-forwarding for War
   expect(submitCall?.[1]).toEqual(
     expect.objectContaining({
       name: "WarpStream Test",
-      formconnectiontype: "WarpStream",
+      formConnectionType: "WarpStream",
       "kafka_cluster.bootstrap_servers": "localhost:9092",
       "kafka_cluster.auth_type": "None",
       "kafka_cluster.client_id_suffix": "ws_host_override=localhost",

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -203,7 +203,7 @@ class DirectConnectFormViewModel extends ViewModel {
     }
     // The switch statement performs local side effects for certain inputs
     switch (input.name) {
-      case "formconnectiontype":
+      case "formConnectionType": {
         this.platformType(input.value as FormConnectionType);
         if (input.value === "Confluent Cloud") {
           this.kafkaSslEnabled(true);
@@ -314,7 +314,7 @@ class DirectConnectFormViewModel extends ViewModel {
     }
 
     if (
-      data["formconnectiontype"] === "WarpStream" &&
+      data["formConnectionType"] === "WarpStream" &&
       data["kafka_cluster.auth_type"] === "SCRAM"
     ) {
       // Enforce SCRAM_SHA_512 for WarpStream in the data; that's all WarpStream supports
@@ -326,7 +326,7 @@ class DirectConnectFormViewModel extends ViewModel {
       data["kafka_cluster.client_id_suffix"] = "";
     }
 
-    if (data["formconnectiontype"] === "Confluent Cloud") {
+    if (data["formConnectionType"] === "Confluent Cloud") {
       // these fields are disabled when CCloud selected; add them back in form data
       data["kafka_cluster.ssl.enabled"] = "true";
       data["schema_registry.ssl.enabled"] = "true";

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -209,7 +209,13 @@ class DirectConnectFormViewModel extends ViewModel {
           this.kafkaSslEnabled(true);
           this.schemaSslEnabled(true);
         }
+        // Update auth type if it isn't valid for platform choice
+        const validAuthTypes = this.getValidKafkaAuthTypes().map((option) => option.value);
+        if (!validAuthTypes.includes(this.kafkaAuthType())) {
+          this.kafkaAuthType(validAuthTypes[0]);
+        }
         break;
+      }
       case "kafka_cluster.auth_type":
         this.kafkaAuthType(input.value as SupportedAuthTypes);
         break;

--- a/tests/e2e/objects/webviews/DirectConnectionFormWebview.ts
+++ b/tests/e2e/objects/webviews/DirectConnectionFormWebview.ts
@@ -32,7 +32,7 @@ export class DirectConnectionForm extends Webview {
     return this.webview.locator("#name");
   }
   get connectionTypeDropdown(): Locator {
-    return this.webview.locator("#formconnectiontype");
+    return this.webview.locator("#formConnectionType");
   }
   get otherTypeField(): Locator {
     return this.webview.locator("#othertype");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2444. Details in issue report

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

It's two underlying issues; fixes are in separate commits to help with review. (When filed we weren't sure if the issues were related but I found they were not.)
1. Connection type (aka platformType) was not saved in the form when the user left the window in background and came back. It was because the html field had been respelled with all lowercase while the js stayed camel case, so the field's string name was not passing strict equality to re-populate. Simple re-write to all camel case to avoid this, but required changing a lot of files.  
2. The auth type was not updated to a valid type when user changed the platform to CCloud, so the auth component would not show the fields at first. Now we'll check for a valid auth type when the user updates the platform to force the fields to render. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
