### PR TITLE
Add default name for artifact upload

### DIFF
--- a/src/commands/utils/uploadArtifact.test.ts
+++ b/src/commands/utils/uploadArtifact.test.ts
@@ -135,7 +135,8 @@ describe("uploadArtifact", () => {
       http_endpoint: "",
     };
     const mockEnvironment = TEST_CCLOUD_ENVIRONMENT;
-    const mockFileUri = vscode.Uri.file("/path/to/file.jar");
+    const mockFileName = "mock-file";
+    const mockFileUri = vscode.Uri.file(`/path/to/${mockFileName}.jar`);
     beforeEach(() => {
       flinkCcloudEnvironmentQuickPickStub = sandbox.stub(
         environments,
@@ -210,6 +211,23 @@ describe("uploadArtifact", () => {
         warningNotificationStub,
         "Upload Artifact cancelled: Artifact name is required.",
       );
+    });
+
+    it("should prefill artifact name with file base name when selecting a file", async () => {
+      flinkCcloudEnvironmentQuickPickStub.resolves(mockEnvironment);
+      cloudProviderRegionQuickPickStub.resolves({
+        ...fakeCloudProviderRegion,
+        provider: "AZURE",
+      });
+
+      sandbox.stub(vscode.window, "showOpenDialog").resolves([mockFileUri]);
+
+      const showInputBoxStub = sandbox.stub(vscode.window, "showInputBox").resolves(mockFileName);
+
+      const result = await promptForArtifactUploadParams();
+
+      sinon.assert.calledWithMatch(showInputBoxStub, sinon.match({ value: mockFileName }));
+      assert.deepStrictEqual(result?.selectedFile, mockFileUri);
     });
 
     it("returns the correct Artifact upload parameters", async () => {

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -115,10 +115,14 @@ export async function promptForArtifactUploadParams(): Promise<ArtifactUploadPar
   const selectedFile: vscode.Uri = selectedFiles[0];
   const fileFormat: string = selectedFiles[0].fsPath.split(".").pop()!;
 
+  // Default artifact name to the selected file's base name (without extension), but allow override.
+  const defaultArtifactName = path.basename(selectedFile.fsPath, path.extname(selectedFile.fsPath));
+
   const artifactName = await vscode.window.showInputBox({
     prompt: "Enter the artifact name for the Artifact",
+    value: defaultArtifactName,
     ignoreFocusOut: true,
-    validateInput: (value) => (value ? undefined : "Artifact name is required"),
+    validateInput: (value) => (value && value.trim() ? undefined : "Artifact name is required"),
   });
 
   if (!artifactName) {
@@ -132,7 +136,7 @@ export async function promptForArtifactUploadParams(): Promise<ArtifactUploadPar
     environment: environment.id,
     cloud,
     region: cloudRegion.region,
-    artifactName,
+    artifactName: artifactName.trim(),
     fileFormat,
     selectedFile,
   };


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Made name of uploaded artifact default to be the local selected file name (overridden by user input)
- Add test to check default artifact name

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2423

https://github.com/user-attachments/assets/62caf988-fbaf-4b80-85f1-ec5a86f0bb11

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [X] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
