### PR TITLE
Jlr/2446 bring flink quickpick fix into main

### DIFF
--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -36,8 +36,15 @@ export async function setCCloudComputePoolForUriCommand(uri?: Uri, database?: CC
     ? (pool: CCloudFlinkComputePool) =>
         pool.provider === database.provider && pool.region === database.region
     : undefined;
-  const pool: CCloudFlinkComputePool | undefined = await flinkComputePoolQuickPick(filter);
+
+  // Present quickpick to the user.
+  const pool: CCloudFlinkComputePool | undefined = await flinkComputePoolQuickPick(
+    null, // do not pre-select any pool
+    filter, // if a database is provided, filter pools to match provider/region
+  );
+
   if (!pool) {
+    // User canceled the quickpick
     return;
   }
 

--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -4,13 +4,16 @@ import * as vscode from "vscode";
 import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
 import { TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { createFlinkStatement } from "../../tests/unit/testResources/flinkStatement";
 import {
   ENABLE_FLINK_ARTIFACTS,
   FLINK_CONFIG_COMPUTE_POOL,
   FLINK_CONFIG_DATABASE,
 } from "../extensionSettings/constants";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import * as quickpicks from "../quickpicks/flinkComputePools";
 import * as kafkaQuickpicks from "../quickpicks/kafkaClusters";
+import * as flinkStatementsViewModule from "../viewProviders/flinkStatements";
 import * as commandsModule from "./flinkComputePools";
 
 describe("flinkComputePools.ts", () => {
@@ -85,6 +88,68 @@ describe("flinkComputePools.ts", () => {
           "@ext:confluentinc.vscode-confluent flink",
         ),
       );
+    });
+  });
+
+  describe("selectPoolForStatementsViewCommand", () => {
+    let flinkComputePoolQuickPickWithViewProgressStub: sinon.SinonStub;
+    let fakeFlinkStatementsViewProvider: {
+      computePool: CCloudFlinkComputePool | null;
+      setParentResource: sinon.SinonStub;
+    };
+
+    beforeEach(() => {
+      flinkComputePoolQuickPickWithViewProgressStub = sandbox.stub(
+        quickpicks,
+        "flinkComputePoolQuickPickWithViewProgress",
+      );
+
+      sandbox.stub(vscode.commands, "executeCommand").resolves();
+
+      // stub FlinkStatementsViewProvider.getInstance()
+      fakeFlinkStatementsViewProvider = {
+        computePool: null,
+        setParentResource: sandbox.stub().resolves(),
+      };
+
+      sandbox
+        .stub(flinkStatementsViewModule.FlinkStatementsViewProvider, "getInstance")
+        .returns(fakeFlinkStatementsViewProvider as any);
+    });
+
+    const testCases: Array<[string, any]> = [
+      ["undefined", undefined],
+      ["a FlinkStatement instance", createFlinkStatement()],
+    ];
+    for (const [description, param] of testCases) {
+      it(`should call flinkComputePoolQuickPickWithViewProgress when passed something not a pool: ${description}`, async () => {
+        const testPool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+        flinkComputePoolQuickPickWithViewProgressStub.resolves(testPool);
+
+        await commandsModule.selectPoolForStatementsViewCommand(param);
+
+        sinon.assert.calledOnce(flinkComputePoolQuickPickWithViewProgressStub);
+        sinon.assert.calledWith(fakeFlinkStatementsViewProvider.setParentResource, testPool);
+      });
+    }
+
+    it("should return early when user cancels pool selection", async () => {
+      flinkComputePoolQuickPickWithViewProgressStub.resolves(undefined);
+
+      await commandsModule.selectPoolForStatementsViewCommand();
+
+      sinon.assert.calledOnce(flinkComputePoolQuickPickWithViewProgressStub);
+      sinon.assert.notCalled(fakeFlinkStatementsViewProvider.setParentResource);
+    });
+
+    it("should skip call to flinkComputePoolQuickPickWithViewProgress when passed a pool", async () => {
+      const testPool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+      await commandsModule.selectPoolForStatementsViewCommand(testPool);
+
+      sinon.assert.notCalled(flinkComputePoolQuickPickWithViewProgressStub);
+      sinon.assert.calledWith(fakeFlinkStatementsViewProvider.setParentResource, testPool);
     });
   });
 

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -60,15 +60,23 @@ export async function selectPoolFromResourcesViewCommand(item?: CCloudFlinkCompu
 /**
  * Select a {@link FlinkComputePool} to focus in the "Statements" view.
  */
-export async function selectPoolForStatementsViewCommand(item?: CCloudFlinkComputePool) {
+export async function selectPoolForStatementsViewCommand(pool?: CCloudFlinkComputePool) {
   // the user either clicked a pool in the Flink Statements view or used the command palette
-  const pool: CCloudFlinkComputePool | undefined =
-    item instanceof CCloudFlinkComputePool
-      ? item
-      : await flinkComputePoolQuickPickWithViewProgress("confluent-flink-statements");
+
+  // (If the user had a Flink Statement selected in the statements view, then hits the
+  //  icon to select a different pool, the command is invoked with *the FlinkStatement*,
+  //  so be sure to treat that the same as if nothing provided at all, and to ask the
+  //  user to pick a new pool.)
+  if (!pool || !(pool instanceof CCloudFlinkComputePool)) {
+    pool = await flinkComputePoolQuickPickWithViewProgress(
+      "confluent-flink-statements",
+      // Initially select whatever the view is currently set to. Will be null if not focused on exactly one pool.
+      FlinkStatementsViewProvider.getInstance().computePool,
+    );
+  }
 
   if (!pool) {
-    // user canceled the quickpick
+    // none provided by caller and then user canceled the quickpick
     return;
   }
 

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -1,6 +1,5 @@
 import { commands, Disposable, window } from "vscode";
 import { registerCommandWithLogging } from ".";
-import { currentFlinkArtifactsPoolChanged } from "../emitters";
 import {
   ENABLE_FLINK_ARTIFACTS,
   FLINK_CONFIG_COMPUTE_POOL,
@@ -14,6 +13,7 @@ import {
   flinkComputePoolQuickPickWithViewProgress,
 } from "../quickpicks/flinkComputePools";
 import { flinkDatabaseQuickpick } from "../quickpicks/kafkaClusters";
+import { FlinkArtifactsUDFsViewProvider } from "../viewProviders/flinkArtifacts";
 import { FlinkStatementsViewProvider } from "../viewProviders/flinkStatements";
 
 const logger = new Logger("commands.flinkComputePools");
@@ -91,16 +91,29 @@ export async function selectPoolForStatementsViewCommand(pool?: CCloudFlinkCompu
 
 /** Select a {@link FlinkComputePool} to focus in the "Artifacts" view. */
 export async function selectPoolForArtifactsViewCommand(item?: CCloudFlinkComputePool) {
-  // the user either clicked a pool in the Flink Artifacts view or used the command palette
-  const pool: CCloudFlinkComputePool | undefined =
-    item instanceof CCloudFlinkComputePool
-      ? item
-      : await flinkComputePoolQuickPickWithViewProgress("confluent-flink-artifacts");
-  if (!pool) {
+  // the user either clicked a pool in the Flink Artifacts/UDFs view or used the command palette
+
+  // If invoked with a non-pool argument (e.g., an artifact item), prompt for a pool and preselect the
+  // current Artifacts view pool if exactly one is focused.
+  if (!item || !(item instanceof CCloudFlinkComputePool)) {
+    item = await flinkComputePoolQuickPickWithViewProgress(
+      "confluent-flink-artifacts",
+      FlinkArtifactsUDFsViewProvider.getInstance().computePool,
+    );
+  }
+
+  if (!item) {
+    // none provided by caller and then user canceled the quickpick
     return;
   }
-  currentFlinkArtifactsPoolChanged.fire(pool);
+
+  // Focus the Flink Artifacts view to make sure it is visible.
   commands.executeCommand("confluent-flink-artifacts.focus");
+
+  // Inform the Flink Artifacts view that the user has selected a new compute pool, and wait
+  // for the view to load the new pool's artifacts/UDFs.
+  const flinkArtifactsView = FlinkArtifactsUDFsViewProvider.getInstance();
+  await flinkArtifactsView.setParentResource(item);
 }
 
 /**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,7 @@ import { titleCase } from "../utils";
 
 export function registerCommandWithLogging(
   commandName: string,
-  command: (...args: any[]) => void,
+  command: ((...args: any[]) => void) | ((...args: any[]) => Promise<void>),
 ): vscode.Disposable {
   const wrappedCommand = async (...args: any[]) => {
     // if the extension was disabled, we need to prevent any commands from running and show an error
@@ -27,7 +27,7 @@ export function registerCommandWithLogging(
       ...getCommandArgsContext(args),
     });
     try {
-      return command(...args);
+      return await command(...args);
     } catch (e) {
       if (e instanceof Error) {
         // gather more (possibly-ResponseError) context and send to Sentry (only enabled in

--- a/src/quickpicks/flinkComputePools.test.ts
+++ b/src/quickpicks/flinkComputePools.test.ts
@@ -1,0 +1,182 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
+import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
+import {
+  TEST_CCLOUD_ENVIRONMENT,
+  TEST_CCLOUD_ENVIRONMENT_ID,
+  TEST_CCLOUD_KAFKA_CLUSTER,
+  TEST_CCLOUD_PROVIDER,
+  TEST_CCLOUD_REGION,
+  TEST_CCLOUD_SCHEMA_REGISTRY,
+} from "../../tests/unit/testResources";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { IconNames } from "../constants";
+import { FLINK_CONFIG_COMPUTE_POOL } from "../extensionSettings/constants";
+import { CCloudResourceLoader } from "../loaders";
+import { CCloudEnvironment } from "../models/environment";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import * as notifications from "../notifications";
+import { flinkComputePoolQuickPick } from "./flinkComputePools";
+
+describe("quickpicks/flinkComputePools.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+  let showQuickPickStub: sinon.SinonStub;
+  let stubbedConfigs: StubbedWorkspaceConfiguration;
+  let stubbedCcloudResourceLoader: sinon.SinonStubbedInstance<CCloudResourceLoader>;
+
+  const TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID = "lfcp-some-other-id";
+  const TEST_CCLOUD_FLINK_COMPUTE_POOL_2 = new CCloudFlinkComputePool({
+    name: "ccloud-pool2",
+    provider: TEST_CCLOUD_PROVIDER,
+    region: TEST_CCLOUD_REGION,
+    maxCfu: 10,
+    environmentId: TEST_CCLOUD_ENVIRONMENT_ID,
+    id: TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID,
+  });
+
+  // This needs a home. We have a couple of tests declaring similar things in other files.
+  const TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR_AND_FLINK = new CCloudEnvironment({
+    ...TEST_CCLOUD_ENVIRONMENT,
+    kafkaClusters: [TEST_CCLOUD_KAFKA_CLUSTER],
+    schemaRegistry: TEST_CCLOUD_SCHEMA_REGISTRY,
+    flinkComputePools: [TEST_CCLOUD_FLINK_COMPUTE_POOL, TEST_CCLOUD_FLINK_COMPUTE_POOL_2],
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
+    showQuickPickStub = sandbox.stub(vscode.window, "showQuickPick");
+    stubbedCcloudResourceLoader = getStubbedCCloudResourceLoader(sandbox);
+    // logged into ccloud with an env that has a single flink compute pool
+    // by default.
+    stubbedCcloudResourceLoader.getEnvironments.resolves([
+      TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR_AND_FLINK,
+    ]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  /** Strip away the annoying kind=Separator items passed into showQuickPick */
+  function extractPoolItemsFromQuickPickCall(): vscode.QuickPickItem[] {
+    sinon.assert.calledOnce(showQuickPickStub);
+    const quickPickItems = showQuickPickStub.firstCall.args[0] as vscode.QuickPickItem[];
+    return quickPickItems.filter((item) => item.kind !== vscode.QuickPickItemKind.Separator);
+  }
+
+  describe("flinkComputePoolQuickPick()", () => {
+    it("should prompt the user to sign in if not signed in to ccloud", async () => {
+      // simulate not being signed in to ccloud
+      stubbedCcloudResourceLoader.getEnvironments.resolves([]);
+      const showInfoNotificationWithButtonsStub = sandbox.stub(
+        notifications,
+        "showInfoNotificationWithButtons",
+      );
+
+      await flinkComputePoolQuickPick();
+      sinon.assert.calledOnce(showInfoNotificationWithButtonsStub);
+      const callArgs = showInfoNotificationWithButtonsStub.firstCall.args;
+      assert.strictEqual(callArgs[0], "No Flink compute pools available.");
+    });
+
+    it("should return the selected pool", async () => {
+      // simulate user selecting the second pool in the list
+      showQuickPickStub.resolves({
+        label: TEST_CCLOUD_FLINK_COMPUTE_POOL_2.name,
+        description: TEST_CCLOUD_FLINK_COMPUTE_POOL_2.id,
+        value: TEST_CCLOUD_FLINK_COMPUTE_POOL_2,
+      });
+
+      const selectedPool = await flinkComputePoolQuickPick();
+      assert.deepStrictEqual(selectedPool, TEST_CCLOUD_FLINK_COMPUTE_POOL_2);
+    });
+
+    it("should call and honor predicate if provided", async () => {
+      const predicate = sandbox.spy(
+        // we hate TEST_CCLOUD_FLINK_COMPUTE_POOL and want it filtered out.
+        (pool: CCloudFlinkComputePool) => pool.id !== TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
+      );
+      await flinkComputePoolQuickPick(null, predicate);
+      sinon.assert.calledTwice(predicate);
+
+      // and should have only let TEST_CCLOUD_FLINK_COMPUTE_POOL_2 through
+      const quickPickItems = extractPoolItemsFromQuickPickCall();
+      assert.strictEqual(quickPickItems.length, 1);
+      const onlyPool = quickPickItems[0];
+      assert.strictEqual(onlyPool.description, TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID);
+    });
+
+    for (const preferredPool of [
+      TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      TEST_CCLOUD_FLINK_COMPUTE_POOL_2,
+    ]) {
+      it(`If user has default compute pool set, but not called with a selected pool, the default should be at the top of the list: ${preferredPool.id}`, async () => {
+        stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, preferredPool.id);
+
+        // We're not testing the quickpick result here, just the generation of items passed into showQuickPickStub
+        await flinkComputePoolQuickPick();
+
+        const quickPickItems = extractPoolItemsFromQuickPickCall();
+        assert.strictEqual(quickPickItems.length, 2);
+        const firstItem = quickPickItems[0];
+        // The pool's id is in the description field.
+        assert.strictEqual(firstItem.description, preferredPool.id);
+      });
+
+      it(`If user has default compute pool set, and called with that selected pool, the default/selected should be at the top of the list and not duplicated: ${preferredPool.id}`, async () => {
+        stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, preferredPool.id);
+
+        // We're not testing the quickpick result here, just the generation of items passed into showQuickPickStub
+        await flinkComputePoolQuickPick(preferredPool);
+
+        const quickPickItems = extractPoolItemsFromQuickPickCall();
+        assert.strictEqual(quickPickItems.length, 2);
+        const firstItem = quickPickItems[0];
+        // The pool's id is in the description field.
+        assert.strictEqual(firstItem.description, preferredPool.id);
+        // Should use icon checked
+        assert.strictEqual((firstItem.iconPath as vscode.ThemeIcon).id, IconNames.CURRENT_RESOURCE);
+
+        // the second item should be the other pool
+        const secondItem = quickPickItems[1];
+        const secondPool =
+          preferredPool === TEST_CCLOUD_FLINK_COMPUTE_POOL
+            ? TEST_CCLOUD_FLINK_COMPUTE_POOL_2
+            : TEST_CCLOUD_FLINK_COMPUTE_POOL;
+        assert.strictEqual(secondItem.description, secondPool.id);
+        // and should use the pool's own icon, not the 'selected' icon
+        assert.strictEqual((secondItem.iconPath as vscode.ThemeIcon).id, secondPool.iconName);
+      });
+
+      it(`If user has default compute pool set, and called with a different selected pool, the selected should be at the top of the list and the default should be second: ${preferredPool.id}`, async () => {
+        stubbedConfigs.stubGet(FLINK_CONFIG_COMPUTE_POOL, preferredPool.id);
+        // invert which pool is passed as selected
+        const selectedPool =
+          preferredPool === TEST_CCLOUD_FLINK_COMPUTE_POOL
+            ? TEST_CCLOUD_FLINK_COMPUTE_POOL_2
+            : TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+        // We're not testing the quickpick result here, just the generation of items passed into showQuickPickStub
+        await flinkComputePoolQuickPick(selectedPool);
+
+        const quickPickItems = extractPoolItemsFromQuickPickCall();
+        assert.strictEqual(quickPickItems.length, 2);
+        const firstItem = quickPickItems[0];
+        // The pool's id is in the description field.
+        assert.strictEqual(firstItem.description, selectedPool.id);
+        // Should use icon checked
+        assert.strictEqual((firstItem.iconPath as vscode.ThemeIcon).id, IconNames.CURRENT_RESOURCE);
+
+        // the second item should be the other pool
+        const secondItem = quickPickItems[1];
+        assert.strictEqual(secondItem.description, preferredPool.id);
+        // and should use the pool's own icon, not the 'selected' icon
+        assert.strictEqual((secondItem.iconPath as vscode.ThemeIcon).id, preferredPool.iconName);
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Bring https://github.com/confluentinc/vscode/issues/2435 forward into main
- While doing so, adjust `selectPoolForArtifactsViewCommand()` to be parallel to `selectPoolForStatementsViewCommand()`:
   - Handle when being invoked from the view when the user happened to have an artifact selected (treat as if was undefined, deferring to the current view compute pool)
   - Provide the artifact view's current computePool, if any, to use as the currently checked compute pool in its call to `flinkComputePoolQuickPickWithViewProgress()`.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2446

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [x] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
