### PR TITLE
2442 refactor local kafka and schema registry containers to follow new readiness pattern

### DIFF
--- a/src/docker/containers.test.ts
+++ b/src/docker/containers.test.ts
@@ -174,23 +174,11 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
 
 describe("docker/containers.ts waitForServiceHealthCheck", () => {
   let sandbox: sinon.SinonSandbox;
-  let containerInspectStub: sinon.SinonStub;
   let fetchStub: sinon.SinonStub;
-
-  const mockContainer: dockerClients.ContainerInspectResponse = {
-    Id: "test-container",
-    HostConfig: {
-      PortBindings: {
-        "8080/tcp": [{ HostPort: "9090", HostIp: "0.0.0.0" }],
-      },
-    },
-  };
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    containerInspectStub = sandbox.stub(dockerClients.ContainerApi.prototype, "containerInspect");
     fetchStub = sandbox.stub(globalThis, "fetch");
-    containerInspectStub.resolves(mockContainer);
   });
 
   afterEach(() => {
@@ -200,43 +188,28 @@ describe("docker/containers.ts waitForServiceHealthCheck", () => {
   it("should return true when service health check succeeds", async () => {
     fetchStub.resolves({ ok: true, status: 200 });
 
-    const result = await waitForServiceHealthCheck(
-      "test-container",
-      8080,
-      "/health",
-      "TestService",
-    );
+    const result = await waitForServiceHealthCheck("9090", "/health", "TestService");
 
     assert.strictEqual(result, true);
     assert.ok(fetchStub.calledWith("http://localhost:9090/health"));
   });
 
-  it("should return false when container inspection fails", async () => {
-    containerInspectStub.rejects(new Error("Container not found"));
+  it("should return false when health check fails consistently", async () => {
+    fetchStub.rejects(new Error("Connection refused"));
 
-    const result = await waitForServiceHealthCheck(
-      "test-container",
-      8080,
-      "/health",
-      "TestService",
-    );
+    const result = await waitForServiceHealthCheck("9090", "/health", "TestService", 3);
 
     assert.strictEqual(result, false);
-    assert.ok(fetchStub.notCalled);
+    assert.ok(fetchStub.called);
   });
 
-  it("should return false when port mapping not found", async () => {
-    containerInspectStub.resolves({ Id: "test", HostConfig: { PortBindings: {} } });
+  it("should return false when service returns non-ok status", async () => {
+    fetchStub.resolves({ ok: false, status: 503 });
 
-    const result = await waitForServiceHealthCheck(
-      "test-container",
-      8080,
-      "/health",
-      "TestService",
-    );
+    const result = await waitForServiceHealthCheck("9090", "/health", "TestService", 3);
 
     assert.strictEqual(result, false);
-    assert.ok(fetchStub.notCalled);
+    assert.ok(fetchStub.called);
   });
 
   it("should retry failed requests and eventually succeed", async () => {
@@ -244,13 +217,7 @@ describe("docker/containers.ts waitForServiceHealthCheck", () => {
     fetchStub.onFirstCall().rejects(new Error("Connection refused"));
     fetchStub.onSecondCall().resolves({ ok: true, status: 200 });
 
-    const result = await waitForServiceHealthCheck(
-      "test-container",
-      8080,
-      "/health",
-      "TestService",
-      5,
-    );
+    const result = await waitForServiceHealthCheck("9090", "/health", "TestService", 5);
 
     assert.strictEqual(result, true);
     assert.strictEqual(fetchStub.callCount, 2);

--- a/src/docker/eventListener.ts
+++ b/src/docker/eventListener.ts
@@ -318,14 +318,22 @@ export class EventListener {
       return;
     }
 
+    logger.debug("container status shows 'running', checking container readiness...", {
+      imageName,
+    });
+
     await window.withProgress(
       {
         location: { viewId: "confluent-resources" },
         title: "Waiting for local resources to be ready...",
       },
       async () => {
-        const workflow = LocalResourceWorkflow.getWorkflowForKind(resourceKind);
-        started = await workflow.waitForReadiness(containerId);
+        if (resourceKind === LocalResourceKind.Kafka) {
+          started = await this.waitForContainerLog(containerId, SERVER_STARTED_LOG_LINE, eventTime);
+        } else {
+          const workflow = LocalResourceWorkflow.getWorkflowForKind(resourceKind);
+          started = await workflow.waitForReadiness(containerId);
+        }
       },
     );
 

--- a/src/docker/workflows/base.test.ts
+++ b/src/docker/workflows/base.test.ts
@@ -17,6 +17,9 @@ import { MedusaWorkflow } from "./medusa";
 import { registerLocalResourceWorkflows } from "./workflowInitialization";
 
 class TestWorkflow extends LocalResourceWorkflow {
+  waitForReadiness(containerId: string): Promise<boolean> {
+    throw new Error(containerId);
+  }
   protected logger = new Logger("test");
   resourceKind = "test";
 

--- a/src/docker/workflows/base.ts
+++ b/src/docker/workflows/base.ts
@@ -119,6 +119,8 @@ export abstract class LocalResourceWorkflow {
     ...args: any[]
   ): Promise<void>;
 
+  abstract waitForReadiness(containerId: string): Promise<boolean>;
+
   /**
    * Common flow for attempting to start a container by its Start a specific container for a workflow by its provided ID. If any errors occur, a notification
    * will be shown to the user and no {@link ContainerInspectResponse} will be returned. */

--- a/src/docker/workflows/confluent-local.ts
+++ b/src/docker/workflows/confluent-local.ts
@@ -221,6 +221,11 @@ export class ConfluentLocalWorkflow extends LocalResourceWorkflow {
     });
   }
 
+  async waitForReadiness(containerId: string): Promise<boolean> {
+    console.log(containerId);
+    return false; // TODO Patrick: Add readiness check
+  }
+
   /** Create a Kafka container with the provided broker configuration and environment variables. */
   async createKafkaContainer(
     brokerConfig: KafkaBrokerConfig,

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -47,6 +47,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
   let createContainerStub: sinon.SinonStub;
   let getContainersForImageStub: sinon.SinonStub;
   let getContainerStub: sinon.SinonStub;
+  let waitForServiceHealthCheckStub: sinon.SinonStub;
 
   let workflow: ConfluentPlatformSchemaRegistryWorkflow;
   // base class stubs
@@ -82,6 +83,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
       .stub(dockerContainers, "getContainersForImage")
       .resolves([]);
     getContainerStub = sandbox.stub(dockerContainers, "getContainer");
+    waitForServiceHealthCheckStub = sandbox.stub(dockerContainers, "waitForServiceHealthCheck");
 
     workflow = ConfluentPlatformSchemaRegistryWorkflow.getInstance();
 
@@ -399,14 +401,6 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
   });
 
   describe("waitForReadiness()", () => {
-    let getContainerStub: sinon.SinonStub;
-    let waitForServiceHealthCheckStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      getContainerStub = sandbox.stub(dockerContainers, "getContainer");
-      waitForServiceHealthCheckStub = sandbox.stub(dockerContainers, "waitForServiceHealthCheck");
-    });
-
     it("should return true when health check succeeds", async () => {
       const mockContainer: ContainerInspectResponse = {
         Id: "test-container-id",
@@ -423,7 +417,8 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
       assert.strictEqual(result, true);
       assert.ok(getContainerStub.calledOnceWith("test-container-id"));
-      assert.ok(waitForServiceHealthCheckStub.calledOnceWith("8081", "/config", "Schema Registry"));
+      assert.ok(waitForServiceHealthCheckStub.calledOnce);
+      assert.ok(waitForServiceHealthCheckStub.calledWith("8081", "/config", "Schema Registry"));
     });
 
     it("should return false when health check fails", async () => {
@@ -442,7 +437,8 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
       assert.strictEqual(result, false);
       assert.ok(getContainerStub.calledOnceWith("test-container-id"));
-      assert.ok(waitForServiceHealthCheckStub.calledOnceWith("8081", "/config", "Schema Registry"));
+      assert.ok(waitForServiceHealthCheckStub.calledOnce);
+      assert.ok(waitForServiceHealthCheckStub.calledWith("8081", "/config", "Schema Registry"));
     });
   });
 });

--- a/src/docker/workflows/cp-schema-registry.ts
+++ b/src/docker/workflows/cp-schema-registry.ts
@@ -25,11 +25,14 @@ import {
   getContainerEnvVars,
   getContainerPorts,
   getContainersForImage,
+  getFirstExternalPort,
+  waitForServiceHealthCheck,
 } from "../containers";
 import { findFreePort } from "../ports";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
 
 export const CONTAINER_NAME = "vscode-confluent-schema-registry";
+const HEALTHCHECK_ENDPOINT = "/config";
 
 export const START_KAFKA_BUTTON = "Start Kafka";
 export const IMAGE_SETTINGS_BUTTON = "Configure Image Settings";
@@ -286,6 +289,12 @@ export class ConfluentPlatformSchemaRegistryWorkflow extends LocalResourceWorkfl
     this.logger.debug("Kafka container ports:", kafkaPorts);
 
     return kafkaContainers;
+  }
+
+  async waitForReadiness(containerId: string): Promise<boolean> {
+    const container = await getContainer(containerId);
+    const firstExternalPort = getFirstExternalPort(container);
+    return waitForServiceHealthCheck(firstExternalPort, HEALTHCHECK_ENDPOINT, this.resourceKind);
   }
 
   async createSchemaRegistryContainer(

--- a/src/docker/workflows/medusa.test.ts
+++ b/src/docker/workflows/medusa.test.ts
@@ -32,6 +32,8 @@ describe("docker/workflows/medusa.ts MedusaWorkflow", () => {
   // docker/containers.ts+networks.ts wrapper function stubs
   let createContainerStub: sinon.SinonStub;
   let getContainersForImageStub: sinon.SinonStub;
+  let getContainerStub: sinon.SinonStub;
+  let waitForServiceHealthCheckStub: sinon.SinonStub;
   let createNetworkStub: sinon.SinonStub;
   let findFreePortStub: sinon.SinonStub;
 
@@ -59,6 +61,8 @@ describe("docker/workflows/medusa.ts MedusaWorkflow", () => {
     getContainersForImageStub = sandbox
       .stub(dockerContainers, "getContainersForImage")
       .resolves([]);
+    getContainerStub = sandbox.stub(dockerContainers, "getContainer");
+    waitForServiceHealthCheckStub = sandbox.stub(dockerContainers, "waitForServiceHealthCheck");
     createNetworkStub = sandbox.stub(dockerNetworks, "createNetwork");
     findFreePortStub = sandbox.stub(ports, "findFreePort").resolves(8083);
 
@@ -278,14 +282,6 @@ describe("docker/workflows/medusa.ts MedusaWorkflow", () => {
   });
 
   describe("waitForReadiness()", () => {
-    let getContainerStub: sinon.SinonStub;
-    let waitForServiceHealthCheckStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      getContainerStub = sandbox.stub(dockerContainers, "getContainer");
-      waitForServiceHealthCheckStub = sandbox.stub(dockerContainers, "waitForServiceHealthCheck");
-    });
-
     it("should return true when health check succeeds", async () => {
       const mockContainer: ContainerInspectResponse = {
         Id: "test-container-id",
@@ -302,7 +298,10 @@ describe("docker/workflows/medusa.ts MedusaWorkflow", () => {
 
       assert.strictEqual(result, true);
       assert.ok(getContainerStub.calledOnceWith("test-container-id"));
-      assert.ok(waitForServiceHealthCheckStub.calledOnceWith("51475", "/health", "Medusa"));
+      assert.ok(waitForServiceHealthCheckStub.calledOnce);
+      assert.ok(
+        waitForServiceHealthCheckStub.calledWith("51475", "/v1/generators/categories", "Medusa"),
+      );
     });
 
     it("should return false when health check fails", async () => {
@@ -321,7 +320,10 @@ describe("docker/workflows/medusa.ts MedusaWorkflow", () => {
 
       assert.strictEqual(result, false);
       assert.ok(getContainerStub.calledOnceWith("test-container-id"));
-      assert.ok(waitForServiceHealthCheckStub.calledOnceWith("51475", "/health", "Medusa"));
+      assert.ok(waitForServiceHealthCheckStub.calledOnce);
+      assert.ok(
+        waitForServiceHealthCheckStub.calledWith("51475", "/v1/generators/categories", "Medusa"),
+      );
     });
   });
 });

--- a/src/docker/workflows/medusa.ts
+++ b/src/docker/workflows/medusa.ts
@@ -14,7 +14,12 @@ import { Logger } from "../../logging";
 import { showErrorNotificationWithButtons } from "../../notifications";
 import { getLocalResourceContainers } from "../../sidecar/connections/local";
 import { UserEvent } from "../../telemetry/events";
-import { createContainer, waitForServiceHealthCheck } from "../containers";
+import {
+  createContainer,
+  getContainer,
+  getFirstExternalPort,
+  waitForServiceHealthCheck,
+} from "../containers";
 import { createNetwork } from "../networks";
 import { findFreePort } from "../ports";
 import { LocalResourceContainer, LocalResourceWorkflow } from "./base";
@@ -179,13 +184,10 @@ export class MedusaWorkflow extends LocalResourceWorkflow {
     return { id: container.Id, name: CONTAINER_NAME };
   }
 
-  waitForReadiness(containerId: string): Promise<boolean> {
-    return waitForServiceHealthCheck(
-      containerId,
-      LOCAL_MEDUSA_INTERNAL_PORT,
-      HEALTHCHECK_ENDPOINT,
-      this.resourceKind,
-    );
+  async waitForReadiness(containerId: string): Promise<boolean> {
+    const container = await getContainer(containerId);
+    const firstExternalPort = getFirstExternalPort(container);
+    return waitForServiceHealthCheck(firstExternalPort, HEALTHCHECK_ENDPOINT, this.resourceKind);
   }
 
   /** Block until we see the {@link localMedusaConnected} event fire. (Controlled by the EventListener


### PR DESCRIPTION
## Summary of Changes

This PR cleans up how we check if Schema Registry and Medusa containers are ready by switching from watching logs to using proper health checks in a unified workflow. Kafka still uses the old log-watching method - we'll move that to its own 'waitForReadiness' implementation later to keep this PR from getting too big.

Closes #2442 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [X] Updated existing
- [ ] Deleted existing


