### PR TITLE
[v1.6.x] fix: Credential fields don't show up after switching connection type

### DIFF
--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -124,8 +124,8 @@ class DirectConnectFormViewModel extends ViewModel {
   });
 
   /** Get valid auth types based on form connection type */
-  getValidKafkaAuthTypes = this.derive(() => {
-    switch (this.platformType()) {
+  getValidKafkaAuthTypesForPlatform = (platformType: FormConnectionType) => {
+    switch (platformType) {
       case "Confluent Cloud":
         return allAuthOptions.filter((auth) => ["API", "SCRAM", "OAuth"].includes(auth.value));
       case "WarpStream":
@@ -133,6 +133,9 @@ class DirectConnectFormViewModel extends ViewModel {
       default:
         return allAuthOptions;
     }
+  };
+  getValidKafkaAuthTypes = this.derive(() => {
+    return this.getValidKafkaAuthTypesForPlatform(this.platformType());
   });
 
   /** Form State */
@@ -210,7 +213,9 @@ class DirectConnectFormViewModel extends ViewModel {
           this.schemaSslEnabled(true);
         }
         // Update auth type if it isn't valid for platform choice
-        const validAuthTypes = this.getValidKafkaAuthTypes().map((option) => option.value);
+        const validAuthTypes = this.getValidKafkaAuthTypesForPlatform(
+          input.value as FormConnectionType,
+        ).map((option) => option.value);
         if (!validAuthTypes.includes(this.kafkaAuthType())) {
           this.kafkaAuthType(validAuthTypes[0]);
         }


### PR DESCRIPTION
## Summary of Changes

This change makes sure we pass the new/updated platform type when checking the valid Kafka auth types, so that the credential-related form fields show up correctly after switching the connection type to, for instance, "Confluent Cloud".

Fixes #2463

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
