### PR TITLE
[main] Fix #2438 partial local resources gql warning through new pa…

### DIFF
--- a/src/graphql/ccloud.ts
+++ b/src/graphql/ccloud.ts
@@ -52,7 +52,7 @@ export async function getCCloudResources(): Promise<CCloudEnvironment[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
+    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, true, { id: CCLOUD_CONNECTION_ID });
   } catch (error) {
     logError(error, "CCloud environments", { extra: { connectionId: CCLOUD_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch CCloud resources: ${error}`);

--- a/src/graphql/direct.ts
+++ b/src/graphql/direct.ts
@@ -109,7 +109,7 @@ export async function getDirectResources(
     logger.debug("Done waiting for direct connection to stabilize, submitting GraphQL query", {
       connectionId,
     });
-    response = await sidecar.query(query, connectionId, { id: connectionId });
+    response = await sidecar.query(query, connectionId, true, { id: connectionId });
   } catch (error) {
     logError(error, "direct connection resources", {
       extra: { functionName: "getDirectResources" },

--- a/src/graphql/local.ts
+++ b/src/graphql/local.ts
@@ -32,7 +32,11 @@ export async function getLocalResources(): Promise<LocalEnvironment[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, LOCAL_CONNECTION_ID);
+    // Call with showPartialErrors=false to suppress error notifications for partial errors,
+    // which are expected for local connection if we're starting up both kafka and schema registry
+    // containers, but just queried sidecar and it could only contact Kafka (SR still coming online).
+    // When docker SR does come online, we'll re-query again and be happy.
+    response = await sidecar.query(query, LOCAL_CONNECTION_ID, false);
   } catch (error) {
     logError(error, "local resources", { extra: { connectionId: LOCAL_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch local resources: ${error}`);

--- a/src/graphql/organizations.ts
+++ b/src/graphql/organizations.ts
@@ -26,7 +26,9 @@ export async function getOrganizations(): Promise<CCloudOrganization[]> {
   const sidecar = await getSidecar();
   let response;
   try {
-    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, { id: CCLOUD_CONNECTION_ID });
+    response = await sidecar.query(query, CCLOUD_CONNECTION_ID, true, {
+      id: CCLOUD_CONNECTION_ID,
+    });
   } catch (error) {
     logError(error, "CCloud organizations", { extra: { connectionId: CCLOUD_CONNECTION_ID } });
     showErrorNotificationWithButtons(`Failed to fetch CCloud organizations: ${error}`);

--- a/src/sidecar/sidecarHandle.test.ts
+++ b/src/sidecar/sidecarHandle.test.ts
@@ -261,8 +261,99 @@ describe("sidecarHandle sandbox tests", () => {
       } as Response);
     });
 
+    describe("partial errors tests", () => {
+      let showWarningNotificationWithButtonsStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        showWarningNotificationWithButtonsStub = sandbox.stub(
+          notifications,
+          "showWarningNotificationWithButtons",
+        );
+      });
+
+      it("should return data and show warning if response has both data and single error and showPartialErrors is true", async () => {
+        const responseWithErrors: GraphQLResponse = {
+          data: {
+            ccloudConnectionById: { organizations: [{ id: "123", name: "foo", current: true }] },
+          },
+          errors: [{ message: "Some error occurred" }],
+        };
+
+        fetchStub.resolves({
+          ok: true,
+          json: async () => responseWithErrors,
+        } as Response);
+
+        const result = await handle.query(
+          organizationQuery,
+          constants.CCLOUD_CONNECTION_ID,
+          true, // DO show partial errors
+          {
+            id: "123",
+          },
+        );
+        assert.deepStrictEqual(result, responseWithErrors.data);
+        sinon.assert.calledOnceWithExactly(
+          showWarningNotificationWithButtonsStub,
+          'GraphQL query returned data but also an error: "Some error occurred"',
+        );
+      });
+
+      it("should not show warning if response has both data and single error and showPartialErrors is false", async () => {
+        const responseWithErrors: GraphQLResponse = {
+          data: {
+            ccloudConnectionById: { organizations: [{ id: "123", name: "foo", current: true }] },
+          },
+          errors: [{ message: "Some error occurred" }],
+        };
+
+        fetchStub.resolves({
+          ok: true,
+          json: async () => responseWithErrors,
+        } as Response);
+
+        const result = await handle.query(
+          organizationQuery,
+          constants.CCLOUD_CONNECTION_ID,
+          false, // do NOT show partial errors
+          {
+            id: "123",
+          },
+        );
+        assert.deepStrictEqual(result, responseWithErrors.data);
+        sinon.assert.notCalled(showWarningNotificationWithButtonsStub);
+      });
+
+      for (const testCaseValue of [false, true]) {
+        it(`should show error if response only had errors independent of showPartialErrors: ${testCaseValue}`, async () => {
+          const responseWithOnlyErrors: GraphQLResponse = {
+            data: null,
+            errors: [{ message: "Some error occurred" }],
+          };
+
+          fetchStub.resolves({
+            ok: true,
+            json: async () => responseWithOnlyErrors,
+          } as Response);
+
+          await assert.rejects(
+            handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, testCaseValue, {
+              id: "123",
+            }),
+            (err) => {
+              assert.strictEqual(
+                (err as Error).message,
+                "GraphQL query failed: Some error occurred",
+              );
+              return true;
+            },
+          );
+          sinon.assert.notCalled(showWarningNotificationWithButtonsStub);
+        });
+      }
+    });
     it("should call fetch and de-json successfully with single in-flight query", async () => {
-      const result = await handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+      const result = await handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
         id: "123",
       });
 
@@ -274,10 +365,10 @@ describe("sidecarHandle sandbox tests", () => {
 
     it("handles multiple awaiters for the same query", async () => {
       // Call the query twice concurrently, exercising the in-flight promise cache.
-      const queryPromise1 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+      const queryPromise1 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
         id: "123",
       });
-      const queryPromise2 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+      const queryPromise2 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
         id: "123",
       });
 
@@ -295,10 +386,10 @@ describe("sidecarHandle sandbox tests", () => {
 
     it("Separate queries with different variables should not share the same cache entry", async () => {
       // Call the query twice with different variables, should not share the same cache entry.
-      const queryPromise1 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+      const queryPromise1 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
         id: "123",
       });
-      const queryPromise2 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+      const queryPromise2 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
         id: "456",
       });
 
@@ -316,10 +407,10 @@ describe("sidecarHandle sandbox tests", () => {
     // Likewise separate connection ids
     it("Separate queries with different connection ids should not share the same cache entry", async () => {
       // Call the query twice with different variables, should not share the same cache entry.
-      const queryPromise1 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+      const queryPromise1 = handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
         id: "123",
       });
-      const queryPromise2 = handle.query(organizationQuery, constants.LOCAL_CONNECTION_ID, {
+      const queryPromise2 = handle.query(organizationQuery, constants.LOCAL_CONNECTION_ID, true, {
         id: "123",
       });
 
@@ -339,12 +430,14 @@ describe("sidecarHandle sandbox tests", () => {
       const queryPromise1 = handle.query(
         organizationQuery,
         constants.CCLOUD_CONNECTION_ID,
+        true,
         // @ts-expect-error We are intentionally passing undefined here to simulate no variables, but don't have a better query onhand.
         undefined,
       );
       const queryPromise2 = handle.query(
         organizationQuery,
         constants.CCLOUD_CONNECTION_ID,
+        true,
         // @ts-expect-error See above.
         undefined,
       );
@@ -366,7 +459,7 @@ describe("sidecarHandle sandbox tests", () => {
       fetchStub.rejects(new Error(errorMessage));
 
       await assert.rejects(
-        handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, { id: "123" }),
+        handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, { id: "123" }),
         (err) => {
           assert.strictEqual((err as Error).message, errorMessage);
           return true;
@@ -384,7 +477,7 @@ describe("sidecarHandle sandbox tests", () => {
       } as Response);
 
       await assert.rejects(
-        handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, { id: "123" }),
+        handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, { id: "123" }),
         (err) => {
           assert.strictEqual((err as Error).message, "GraphQL query failed: Bad Query");
           return true;
@@ -402,7 +495,7 @@ describe("sidecarHandle sandbox tests", () => {
       } as Response);
 
       await assert.rejects(
-        handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, { id: "123" }),
+        handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, { id: "123" }),
         (err) => {
           assert.strictEqual(
             (err as Error).message,
@@ -446,7 +539,7 @@ describe("sidecarHandle sandbox tests", () => {
           "showWarningNotificationWithButtons",
         );
 
-        const result = await handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, {
+        const result = await handle.query(organizationQuery, constants.CCLOUD_CONNECTION_ID, true, {
           id: "123",
         });
         assert.deepStrictEqual(result, responseWithErrors.data);

--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -442,10 +442,20 @@ export class SidecarHandle {
    * All such concurrent requests will return the same result.
    *
    * Any Error raised by the fetch() call will be propagated to the caller.
+   *
+   * @param query The GraphQL query document, created via the `graphql` template tag from `gql.tada`.
+   * @param connectionId The connection ID to set in the `x-connection-id` header.
+   * @param showPartialErrors If true, if the response contains both `data` and `errors`, log the errors
+   * and show a warning notification to the user, but still return the `data`. If false, will not show a
+   * notification, but will still log the errors.
+   * @param variables Optional variables for the GraphQL query. Omit or pass `undefined` if there are no variables.
+   * @returns The `data` portion of the GraphQL response.
+   * @throws {Error} if the fetch fails entirely, or returns only `error` payload w/o also `data`.
    */
   public async query<Result, Variables>(
     query: TadaDocumentNode<Result, Variables>,
     connectionId: ConnectionId,
+    showPartialErrors: boolean,
     // Mark third parameter as optional if Variables is an empty object type
     // The signature looks odd, but it's the only way to make optional param by condition
     ...[variables]: Variables extends Record<any, never> ? [never?] : [Variables]
@@ -521,7 +531,7 @@ export class SidecarHandle {
       });
       throw new Error(errorString);
     } else if (payload.errors) {
-      // If we got a response with data but also errors, log the errors and then also show the
+      // If we got a response with data but also errors, log the errors and then also perhaps show the
       // user a warning.
 
       const errorMessages: string[] = payload.errors.map((error) => error.message);
@@ -541,7 +551,12 @@ export class SidecarHandle {
         response: JSON.stringify(payload),
       });
 
-      void showWarningNotificationWithButtons(message);
+      if (showPartialErrors) {
+        // Show the warning message to the user if allowed (disallowed in local resources fetching
+        // since we know we query both Kafka and Schema Registry connections, but schema registry
+        // image may still be starting up.
+        void showWarningNotificationWithButtons(message);
+      }
 
       // fall through to return the data anyway, as the query "was at least partially successful".
     }


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

* Fix #2438 in main through new parameter controlling if GQL query() should show the partial error popup, supress said popup when being driven for local GQL since we know we will sometimes query when kafka has started but schema registry has not.
* Direct cherry-pick of f1bcfc15e344d43eba101c0ae2e1f57e829e5ce7 from v1.6.x (PR #2449) into main 
* Choosing not to refine any further, in that it would make the code read a whole lot worse. Just did not plan ahead to make it easy for `LocalResourceLoader.getEnvironments()` to take an additional parameter that would make it all the way down to the local GraphQL calling function.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2451 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
