### PR TITLE
fix from 1.6 to main - Pass new `required` prop to auth creds component for skipping validation

### DIFF
--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -37,7 +37,7 @@ export class AuthCredentials extends HTMLElement {
   authType = this.os.signal<SupportedAuthTypes>("None");
   connectionType = this.os.signal<FormConnectionType>("Confluent Cloud");
   creds = this.os.signal<SupportedCredentialTypes | null>(null);
-
+  shouldValidateInputs = this.os.signal<boolean>(true);
   // Setters for component props
   set credentials(value: SupportedCredentialTypes) {
     this.creds(value);
@@ -50,6 +50,9 @@ export class AuthCredentials extends HTMLElement {
   }
   set platform(value: FormConnectionType) {
     this.connectionType(value);
+  }
+  set required(value: boolean) {
+    this.shouldValidateInputs(value);
   }
 
   getInputId(name: string) {
@@ -118,8 +121,10 @@ export class AuthCredentials extends HTMLElement {
     this.entries.set(name, value.toString());
     this._internals.setFormValue(this.entries);
 
-    // Validate the input
-    this.validateInput(input);
+    // Validate the input if this section of the form is required
+    if (this.shouldValidateInputs()) {
+      this.validateInput(input);
+    }
 
     // Dispatch a change event to the parent html for other actions
     this.dispatchEvent(
@@ -132,6 +137,8 @@ export class AuthCredentials extends HTMLElement {
   // Check validity of all inputs in this (auth) section
   // Handles reporting validation to form before submit
   checkValidity() {
+    // Only need to check the validity if the inputs are required, otherwise we consider it valid
+    if (!this.shouldValidateInputs()) return true;
     const inputs: NodeListOf<HTMLInputElement> | undefined =
       this.shadowRoot?.querySelectorAll("input");
 

--- a/src/webview/direct-connect-form.html
+++ b/src/webview/direct-connect-form.html
@@ -160,6 +160,7 @@
               data-prop-platform="this.platformType()"
               data-prop-type="this.kafkaAuthType()"
               data-prop-credentials="this.kafkaCreds()"
+              data-prop-required="!this.kafkaBootstrapServers() ? false : true"
             />
           </div>
           <label class="checkbox" for="kafka_cluster.ssl.enabled">
@@ -237,6 +238,7 @@
               data-prop-platform="this.platformType()"
               data-prop-type="this.schemaAuthType()"
               data-prop-credentials="this.schemaCreds()"
+              data-prop-required="!this.schemaUri() ? false : true"
             />
           </div>
           <label class="checkbox" for="schema_registry.ssl.enabled">


### PR DESCRIPTION
Cherry pick PR #2493 to main

* pass required prop to auth creds for skipping validation

* revert extra check

* clarify comment

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
