### PR TITLE
[v1.6.x] MINOR: update "Use New Resources View Provider" setting's id, description, tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -773,10 +773,13 @@
             "default": true,
             "markdownDescription": "Show notifications when the extension is first installed or updated to a new version. Disabling this will prevent welcome messages and update notifications from appearing during extension activation.\n\n_NOTE: This does not affect error notifications or other extension functionality._"
           },
-          "confluent.experimental.useNewResourcesViewProvider": {
+          "confluent.preview.useNewResourcesViewProvider": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "Use the new resources view provider for displaying resources in the Confluent extension. This is an experimental feature and may change in future releases.\n\n---\n\n⚠️ **WARNING**: This setting is experimental and may not be fully functional or stable. Must restart extensions for change to take effect."
+            "markdownDescription": "Use the new Resources view provider for displaying resources in the Confluent extension.\n\n---\n\n⚠️ **WARNING**: This setting is currently in preview and may not be fully functional or stable. Must restart extensions for change to take effect.",
+            "tags": [
+              "preview"
+            ]
           }
         }
       },
@@ -1360,7 +1363,7 @@
         },
         {
           "command": "confluent.resources.refresh",
-          "when": "!config.confluent.experimental.useNewResourcesViewProvider && view == confluent-resources",
+          "when": "!config.confluent.preview.useNewResourcesViewProvider && view == confluent-resources",
           "group": "navigation@3"
         },
         {
@@ -1487,7 +1490,7 @@
         },
         {
           "command": "confluent.resources.refreshConnection",
-          "when": "config.confluent.experimental.useNewResourcesViewProvider && view == confluent-resources && viewItem =~ /.*-container.*/",
+          "when": "config.confluent.preview.useNewResourcesViewProvider && view == confluent-resources && viewItem =~ /.*-container.*/",
           "group": "inline"
         },
         {

--- a/src/extensionSettings/constants.ts
+++ b/src/extensionSettings/constants.ts
@@ -31,7 +31,7 @@ export const SHOW_NEW_INSTALL_OR_UPDATE_NOTIFICATIONS = new ExtensionSetting<boo
 );
 
 export const USE_NEW_RESOURCES_VIEW_PROVIDER = new ExtensionSetting<boolean>(
-  "confluent.experimental.useNewResourcesViewProvider",
+  "confluent.preview.useNewResourcesViewProvider",
   SettingsSection.GENERAL,
 );
 


### PR DESCRIPTION
Mainly to follow expectations of "experimental" vs "preview" settings per VS Code [docs](https://code.visualstudio.com/docs/configure/settings#_feature-lifecycle)

<img width="809" height="299" alt="image" src="https://github.com/user-attachments/assets/fa0f1294-0c00-40bb-a49c-7ebec4d33d5d" />
