### PR TITLE
MINOR: test cleanup: add param to test name

### DIFF
--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -134,7 +134,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       });
 
       for (const connected of [true, false]) {
-        it("ccloudConnectedHandler() should call onDidChangeCodeLenses.fire()", () => {
+        it(`ccloudConnectedHandler(${connected}) should call onDidChangeCodeLenses.fire()`, () => {
           provider.ccloudConnectedHandler(connected);
 
           sinon.assert.calledOnce(onDidChangeCodeLensesFireStub);


### PR DESCRIPTION
We were creating duplicate tests by not including the `connected` value in the name:
<img width="1035" height="459" alt="image" src="https://github.com/user-attachments/assets/a3ffc760-a162-48aa-97a2-a556d42d0f39" />
