### PR TITLE
Remove `environment` property from `SchemasViewProvider`, `TopicViewProviderData`, and `ParentedBaseViewProvider`

### DIFF
--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -12,10 +12,12 @@ import {
   TEST_LOCAL_SCHEMA,
 } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
 import { ProduceRecordRequest, RecordsV3Api, ResponseError } from "../clients/kafkaRest";
 import { ConfluentCloudProduceRecordsResourceApi } from "../clients/sidecar";
 import { MessageViewerConfig } from "../consume";
 import { FLINK_SQL_LANGUAGE_ID } from "../flinkSql/constants";
+import { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import * as schemaQuickPicks from "../quickpicks/schemas";
 import * as uriQuickpicks from "../quickpicks/uris";
@@ -33,7 +35,6 @@ import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import * as fileUtils from "../utils/file";
 import { ExecutionResult } from "../utils/workerPool";
-import * as topicViewProvider from "../viewProviders/topics";
 import {
   handleSchemaValidationErrors,
   produceMessage,
@@ -927,7 +928,7 @@ describe("commands/topics.ts queryTopicWithFlink()", function () {
   let sandbox: sinon.SinonSandbox;
   let openTextDocumentStub: sinon.SinonStub;
   let showTextDocumentStub: sinon.SinonStub;
-  let getTopicViewProviderStub: sinon.SinonStub;
+  let ccloudLoader: sinon.SinonStubbedInstance<CCloudResourceLoader>;
   let setUriMetadataStub: sinon.SinonStub;
   let stubResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
 
@@ -941,7 +942,7 @@ describe("commands/topics.ts queryTopicWithFlink()", function () {
 
     openTextDocumentStub = sandbox.stub(vscode.workspace, "openTextDocument");
     showTextDocumentStub = sandbox.stub(vscode.window, "showTextDocument");
-    getTopicViewProviderStub = sandbox.stub(topicViewProvider, "getTopicViewProvider");
+    ccloudLoader = getStubbedCCloudResourceLoader(sandbox);
 
     stubResourceManager = sandbox.createStubInstance(ResourceManager);
     sandbox.stub(ResourceManager, "getInstance").returns(stubResourceManager);
@@ -953,11 +954,8 @@ describe("commands/topics.ts queryTopicWithFlink()", function () {
   });
 
   it("should create a new document with Flink SQL language and correct placeholder query for CCloud topic", async function () {
-    const mockTopicViewProvider = {
-      kafkaCluster: TEST_CCLOUD_KAFKA_CLUSTER,
-      environment: TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK,
-    };
-    getTopicViewProviderStub.returns(mockTopicViewProvider);
+    ccloudLoader.getEnvironment.resolves(TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK);
+    ccloudLoader.getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
 
     const mockDocument = { uri: vscode.Uri.file("test.flink.sql") };
     openTextDocumentStub.resolves(mockDocument);
@@ -982,11 +980,9 @@ LIMIT 10;`;
   });
 
   it("should set URI metadata correctly with compute pool ID and database ID", async function () {
-    const mockTopicViewProvider = {
-      kafkaCluster: TEST_CCLOUD_KAFKA_CLUSTER_WITH_POOL,
-      environment: TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK,
-    };
-    getTopicViewProviderStub.returns(mockTopicViewProvider);
+    ccloudLoader.getEnvironment.resolves(TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK);
+    ccloudLoader.getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER_WITH_POOL]);
+
     const mockDocument = { uri: vscode.Uri.file("test.flink.sql") };
     openTextDocumentStub.resolves(mockDocument);
     showTextDocumentStub.resolves({ document: mockDocument });
@@ -1003,17 +999,15 @@ LIMIT 10;`;
       [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: TEST_CCLOUD_FLINK_COMPUTE_POOL.id,
       [UriMetadataKeys.FLINK_CATALOG_ID]: TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK.id,
       [UriMetadataKeys.FLINK_CATALOG_NAME]: TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK.name,
-      [UriMetadataKeys.FLINK_DATABASE_ID]: TEST_CCLOUD_KAFKA_CLUSTER.id,
-      [UriMetadataKeys.FLINK_DATABASE_NAME]: TEST_CCLOUD_KAFKA_CLUSTER.name,
+      [UriMetadataKeys.FLINK_DATABASE_ID]: TEST_CCLOUD_KAFKA_CLUSTER_WITH_POOL.id,
+      [UriMetadataKeys.FLINK_DATABASE_NAME]: TEST_CCLOUD_KAFKA_CLUSTER_WITH_POOL.name,
     });
   });
 
   it("should NOT set metadata if kafka cluster had no related Flink compute pools", async function () {
-    const mockTopicViewProvider = {
-      kafkaCluster: TEST_CCLOUD_KAFKA_CLUSTER,
-      environment: TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK,
-    };
-    getTopicViewProviderStub.returns(mockTopicViewProvider);
+    ccloudLoader.getEnvironment.resolves(TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_FLINK);
+    ccloudLoader.getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
+
     const mockDocument = { uri: vscode.Uri.file("test.flink.sql") };
     openTextDocumentStub.resolves(mockDocument);
     showTextDocumentStub.resolves({ document: mockDocument });
@@ -1032,7 +1026,8 @@ LIMIT 10;`;
 
     assert.ok(openTextDocumentStub.notCalled);
     assert.ok(showTextDocumentStub.notCalled);
-    assert.ok(getTopicViewProviderStub.notCalled);
+    sinon.assert.notCalled(ccloudLoader.getEnvironment);
+    sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
 
   it("should return early if topic is not a KafkaTopic instance", async function () {
@@ -1042,33 +1037,29 @@ LIMIT 10;`;
 
     assert.ok(openTextDocumentStub.notCalled);
     assert.ok(showTextDocumentStub.notCalled);
-    assert.ok(getTopicViewProviderStub.notCalled);
+    sinon.assert.notCalled(ccloudLoader.getEnvironment);
+    sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
 
   it("should return early if environment is missing", async function () {
-    const mockTopicViewProvider = {
-      kafkaCluster: TEST_CCLOUD_KAFKA_CLUSTER,
-      environment: null,
-    };
-    getTopicViewProviderStub.returns(mockTopicViewProvider);
+    ccloudLoader.getEnvironment.resolves(undefined);
+    ccloudLoader.getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
 
     await queryTopicWithFlink(TEST_CCLOUD_KAFKA_TOPIC);
 
-    assert.ok(getTopicViewProviderStub.calledOnce);
+    sinon.assert.calledOnce(ccloudLoader.getEnvironment);
     assert.ok(openTextDocumentStub.notCalled);
     assert.ok(showTextDocumentStub.notCalled);
   });
 
   it("should return early if cluster is missing", async function () {
-    const mockTopicViewProvider = {
-      kafkaCluster: null,
-      environment: TEST_CCLOUD_ENVIRONMENT,
-    };
-    getTopicViewProviderStub.returns(mockTopicViewProvider);
+    ccloudLoader.getEnvironment.resolves(TEST_CCLOUD_ENVIRONMENT);
+    ccloudLoader.getKafkaClustersForEnvironmentId.resolves([]);
 
     await queryTopicWithFlink(TEST_CCLOUD_KAFKA_TOPIC);
 
-    assert.ok(getTopicViewProviderStub.calledOnce);
+    sinon.assert.calledOnce(ccloudLoader.getEnvironment);
+    sinon.assert.calledOnce(ccloudLoader.getKafkaClustersForEnvironmentId);
     assert.ok(openTextDocumentStub.notCalled);
     assert.ok(showTextDocumentStub.notCalled);
   });
@@ -1078,7 +1069,8 @@ LIMIT 10;`;
 
     assert.ok(openTextDocumentStub.notCalled);
     assert.ok(showTextDocumentStub.notCalled);
-    assert.ok(getTopicViewProviderStub.notCalled);
+    sinon.assert.notCalled(ccloudLoader.getEnvironment);
+    sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
 
   it("should return early if topic is a direct connection topic", async function () {
@@ -1086,15 +1078,13 @@ LIMIT 10;`;
 
     assert.ok(openTextDocumentStub.notCalled);
     assert.ok(showTextDocumentStub.notCalled);
-    assert.ok(getTopicViewProviderStub.notCalled);
+    sinon.assert.notCalled(ccloudLoader.getEnvironment);
+    sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
 
   it("should not set metadata when no compute pool is available", async function () {
-    const mockTopicViewProvider = {
-      kafkaCluster: TEST_CCLOUD_KAFKA_CLUSTER,
-      environment: TEST_CCLOUD_ENVIRONMENT, // Using regular environment with no Flink compute pools
-    };
-    getTopicViewProviderStub.returns(mockTopicViewProvider);
+    ccloudLoader.getEnvironment.resolves(TEST_CCLOUD_ENVIRONMENT); // Using regular environment with no Flink compute pools
+    ccloudLoader.getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
 
     const mockDocument = { uri: vscode.Uri.file("test.flink.sql") };
     openTextDocumentStub.resolves(mockDocument);

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -56,6 +56,7 @@ import { post } from "../webview/topic-config-form";
 import topicFormTemplate from "../webview/topic-config-form.html";
 import { createProduceRequestData } from "./utils/produceMessage";
 import { ProduceMessageSchemaOptions } from "./utils/types";
+import { CCloudResourceLoader } from "../loaders";
 
 const logger = new Logger("topics");
 
@@ -492,9 +493,12 @@ export async function queryTopicWithFlink(topic: KafkaTopic) {
   }
 
   // Get the environment and cluster for the topic to generate a fully qualified table name
-  const topicViewProvider = getTopicViewProvider();
-  const cluster = topicViewProvider.kafkaCluster;
-  const topicEnvironment = topicViewProvider.environment;
+  const loader = CCloudResourceLoader.getInstance();
+  const topicEnvironment = await loader.getEnvironment(topic.environmentId);
+  const clusters: CCloudKafkaCluster[] = await loader.getKafkaClustersForEnvironmentId(
+    topic.environmentId,
+  );
+  const cluster: CCloudKafkaCluster | undefined = clusters.find((c) => c.id === topic.clusterId);
 
   if (!topicEnvironment || !cluster) {
     return;

--- a/src/viewProviders/baseModels/parentedBase.test.ts
+++ b/src/viewProviders/baseModels/parentedBase.test.ts
@@ -103,14 +103,12 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
 
   describe("updateTreeViewDescription()", () => {
     it("should clear the description and clear .environment when no resource is focused", async () => {
-      provider.environment = TEST_CCLOUD_ENVIRONMENT;
       provider.resource = null;
       provider["treeView"].description = "this should go away";
 
       await provider.updateTreeViewDescription();
 
       assert.strictEqual(provider["treeView"].description, "");
-      assert.strictEqual(provider.environment, null);
     });
 
     it("should set the description and set .environment when a resource is focused", async () => {
@@ -120,7 +118,6 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
         getStubbedCCloudResourceLoader(sandbox);
       stubbedLoader.getEnvironment.resolves(TEST_CCLOUD_ENVIRONMENT);
 
-      provider.environment = TEST_CCLOUD_ENVIRONMENT;
       provider.resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       provider["treeView"].description = "";
 
@@ -130,7 +127,6 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
         provider["treeView"].description,
         `${TEST_CCLOUD_ENVIRONMENT.name} | ${TEST_CCLOUD_FLINK_COMPUTE_POOL.id}`,
       );
-      assert.strictEqual(provider.environment, TEST_CCLOUD_ENVIRONMENT);
     });
 
     it("Should set the description to empty when environment is not found within loader", async () => {
@@ -139,27 +135,23 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
       stubbedLoader.getEnvironments.resolves([]);
 
       provider.resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-      provider.environment = TEST_CCLOUD_ENVIRONMENT;
 
       provider["treeView"].description = "this should go away";
 
       await provider.updateTreeViewDescription();
 
       assert.strictEqual(provider["treeView"].description, "");
-      assert.strictEqual(provider.environment, null);
     });
   });
 
   describe("reset()", () => {
     it("should clear the tree view AND focused resources", async () => {
-      provider.environment = TEST_CCLOUD_ENVIRONMENT;
       provider.resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       provider["treeView"].description = "this should go away";
       provider["treeView"].message = "this should go away too";
 
       await provider.reset();
 
-      assert.strictEqual(provider.environment, null);
       assert.strictEqual(provider.resource, null);
       assert.strictEqual(provider["treeView"].description, undefined);
       assert.strictEqual(provider["treeView"].message, undefined);

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -37,10 +37,6 @@ export abstract class ParentedBaseViewProvider<
    * - Flink Artifacts view: `FlinkComputePool`
    */
   resource: P | null = null;
-
-  /** The parent {@link Environment} of the focused resource.  */
-  environment: Environment | null = null;
-
   /**
    * Required {@link EventEmitter} to listen for when this view provider's parent
    * {@linkcode resource} is set/unset. This is used in order to control the tree view description,
@@ -106,7 +102,6 @@ export abstract class ParentedBaseViewProvider<
 
   async reset(): Promise<void> {
     this.resource = null;
-    this.environment = null;
 
     await super.reset();
   }
@@ -124,7 +119,6 @@ export abstract class ParentedBaseViewProvider<
     if (!focusedResource) {
       subLogger.debug("called with no focused resource, clearing view description");
       this.treeView.description = "";
-      this.environment = null;
       return;
     }
 
@@ -136,7 +130,6 @@ export abstract class ParentedBaseViewProvider<
       focusedResource.environmentId,
     );
 
-    this.environment = parentEnv ?? null;
     if (parentEnv) {
       subLogger.debug("found environment, setting view description");
       this.treeView.description = `${parentEnv.name} | ${focusedResource.id}`;

--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -14,7 +14,7 @@ import {
   STATEMENT_POLLING_FREQUENCY_SECONDS,
   STATEMENT_POLLING_LIMIT,
 } from "../extensionSettings/constants";
-import { CCloudResourceLoader, ResourceLoader } from "../loaders";
+import { CCloudResourceLoader } from "../loaders";
 import { FlinkStatement, FlinkStatementId, Phase } from "../models/flinkStatement";
 import * as telemetryEvents from "../telemetry/events";
 import { FlinkStatementsViewProvider } from "./flinkStatements";
@@ -542,41 +542,26 @@ describe("FlinkStatementsViewProvider", () => {
   });
 
   describe("updateTreeViewDescription()", () => {
-    let resourceLoaderGetEnvironmentStub: sinon.SinonStub;
-
     beforeEach(() => {
-      resourceLoaderGetEnvironmentStub = sandbox.stub(ResourceLoader, "getEnvironment");
       // start each test with no selection, as users would initially see
       viewProvider["resource"] = null;
       viewProvider["treeView"].description = "";
-      viewProvider["environment"] = null;
     });
 
     it("handles initial state with no resource focused", async () => {
       await viewProvider.updateTreeViewDescription();
 
       assert.strictEqual(viewProvider["treeView"].description, "");
-      assert.strictEqual(viewProvider["environment"], null);
-      sinon.assert.notCalled(resourceLoaderGetEnvironmentStub);
     });
 
     it("updates to FCP description when user selects a compute pool", async () => {
       viewProvider["resource"] = TEST_CCLOUD_FLINK_COMPUTE_POOL;
-      resourceLoaderGetEnvironmentStub.resolves(TEST_CCLOUD_ENVIRONMENT);
 
       await viewProvider.updateTreeViewDescription();
 
       assert.strictEqual(
         viewProvider["treeView"].description,
         `FCP: ${TEST_CCLOUD_FLINK_COMPUTE_POOL.name} | ${TEST_CCLOUD_FLINK_COMPUTE_POOL.id}`,
-      );
-      assert.strictEqual(viewProvider["environment"], TEST_CCLOUD_ENVIRONMENT);
-
-      sinon.assert.calledOnce(resourceLoaderGetEnvironmentStub);
-      sinon.assert.calledWith(
-        resourceLoaderGetEnvironmentStub,
-        TEST_CCLOUD_FLINK_COMPUTE_POOL.connectionId,
-        TEST_CCLOUD_FLINK_COMPUTE_POOL.environmentId,
       );
     });
 
@@ -589,9 +574,6 @@ describe("FlinkStatementsViewProvider", () => {
         viewProvider["treeView"].description,
         `ENV: ${TEST_CCLOUD_ENVIRONMENT.name} | ${TEST_CCLOUD_ENVIRONMENT.id}`,
       );
-      assert.strictEqual(viewProvider["environment"], TEST_CCLOUD_ENVIRONMENT);
-
-      sinon.assert.notCalled(resourceLoaderGetEnvironmentStub);
     });
   });
 });

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -255,7 +255,6 @@ export class FlinkStatementsViewProvider
         "updateTreeViewDescription() called with no focused resource, clearing view description",
       );
       this.treeView.description = "";
-      this.environment = null;
       return;
     }
 
@@ -269,20 +268,12 @@ export class FlinkStatementsViewProvider
         "updateTreeViewDescription() focused on compute pool, setting FCP description",
       );
       this.treeView.description = `FCP: ${focusedResource.name} | ${focusedResource.id}`;
-
-      // still need to set the environment for other functionality
-      const parentEnv = await ResourceLoader.getEnvironment(
-        focusedResource.connectionId,
-        focusedResource.environmentId,
-      );
-      this.environment = parentEnv ?? null;
     } else if (focusedResource instanceof CCloudEnvironment) {
       // environment mode: show environment name and ID
       this.logger.debug(
         "updateTreeViewDescription() focused on environment, setting Env description",
       );
       this.treeView.description = `ENV: ${focusedResource.name} | ${focusedResource.id}`;
-      this.environment = focusedResource;
     }
   }
 }

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -25,7 +25,6 @@ import {
 import { ExtensionContextNotSetError, logError } from "../errors";
 import { ResourceLoader } from "../loaders";
 import { Logger } from "../logging";
-import { Environment } from "../models/environment";
 import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { SchemaRegistry } from "../models/schemaRegistry";
@@ -137,9 +136,7 @@ export class SchemasViewProvider
 
   readonly viewId: string = "confluent-schemas";
   private treeView: TreeView<SchemasViewProviderData>;
-  /** The parent of the focused Schema Registry.  */
-  public environment: Environment | null = null;
-  /** The focused Schema Registry; set by clicking a Schema Registry item in the Resources view. */
+  /** The focused Kafka cluster; set by clicking a Kafka cluster item in the Resources view. Includes parent Environment ID */
   public schemaRegistry: SchemaRegistry | null = null;
 
   /** String to filter items returned by `getChildren`, if provided. */
@@ -500,7 +497,6 @@ export class SchemasViewProvider
     if (!schemaRegistry) {
       subLogger.debug("called with no schema registry, simple short-circuit");
       this.treeView.description = "";
-      this.environment = null;
       return;
     } else {
       subLogger.debug("called with schema registry");
@@ -511,7 +507,6 @@ export class SchemasViewProvider
     const loader = ResourceLoader.getInstance(schemaRegistry.connectionId);
     const envs = await loader.getEnvironments();
     const parentEnv = envs.find((env) => env.id === schemaRegistry.environmentId);
-    this.environment = parentEnv ?? null;
     if (parentEnv) {
       subLogger.debug("found environment.");
 

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -136,7 +136,7 @@ export class SchemasViewProvider
 
   readonly viewId: string = "confluent-schemas";
   private treeView: TreeView<SchemasViewProviderData>;
-  /** The focused Kafka cluster; set by clicking a Kafka cluster item in the Resources view. Includes parent Environment ID */
+  /** The focused Schema Registry; set by clicking a Schema Registry item in the Resources view. Includes parent Environment ID */
   public schemaRegistry: SchemaRegistry | null = null;
 
   /** String to filter items returned by `getChildren`, if provided. */

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -26,7 +26,6 @@ import { ExtensionContextNotSetError } from "../errors";
 import { ResourceLoader } from "../loaders";
 import { TopicFetchError } from "../loaders/loaderUtils";
 import { Logger } from "../logging";
-import { Environment } from "../models/environment";
 import { KafkaCluster } from "../models/kafkaCluster";
 import { isCCloud, ISearchable, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
@@ -74,9 +73,7 @@ export class TopicViewProvider
   }
 
   private treeView: TreeView<TopicViewProviderData>;
-  /** The parent of the focused Kafka cluster.  */
-  public environment: Environment | null = null;
-  /** The focused Kafka cluster; set by clicking a Kafka cluster item in the Resources view. */
+  /** The focused Kafka cluster; set by clicking a Kafka cluster item in the Resources view. Includes Environment ID*/
   public kafkaCluster: KafkaCluster | null = null;
 
   /** String to filter items returned by `getChildren`, if provided. */
@@ -358,7 +355,6 @@ export class TopicViewProvider
     const loader = ResourceLoader.getInstance(cluster.connectionId);
     const envs = await loader.getEnvironments();
     const parentEnv = envs.find((env) => env.id === cluster.environmentId);
-    this.environment = parentEnv ?? null;
     if (parentEnv) {
       this.treeView.description = `${parentEnv.name} | ${cluster.name}`;
     } else {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Remove `environment` property from `SchemasViewProvider`, `TopicViewProviderData`, and `ParentedBaseViewProvider` 
- Update `queryTopicWithFlink()` in topics command to directly get environment and clusters using `CCloudResourceLoader` instead of from`TopicViewProviderData`. 
- Update tests for `queryTopicWithFlink()` using `getStubbedCCloudResourceLoader`

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fix: #2504 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [X] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
