### PR TITLE
🍒 [v1.6.x -> main] fix: Add comma to WarpStream-specific `client.id` suffix (#2507)

### DIFF
--- a/src/directConnect.test.ts
+++ b/src/directConnect.test.ts
@@ -355,12 +355,12 @@ describe("directConnect.ts", () => {
         name: "WarpStream Connection",
         formConnectionType: "WarpStream",
         "kafka_cluster.bootstrap_servers": "localhost:9092",
-        "kafka_cluster.client_id_suffix": "ws_host_override=localhost",
+        "kafka_cluster.client_id_suffix": ",ws_host_override=localhost",
       };
 
       const spec = getConnectionSpecFromFormData(formData);
       assert.ok(spec.kafka_cluster);
-      assert.strictEqual(spec.kafka_cluster.client_id_suffix, "ws_host_override=localhost");
+      assert.strictEqual(spec.kafka_cluster.client_id_suffix, ",ws_host_override=localhost");
     });
   });
 

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -1166,7 +1166,7 @@ test("sets the client ID suffix correctly when using K8s port-forwarding for War
       formConnectionType: "WarpStream",
       "kafka_cluster.bootstrap_servers": "localhost:9092",
       "kafka_cluster.auth_type": "None",
-      "kafka_cluster.client_id_suffix": "ws_host_override=localhost",
+      "kafka_cluster.client_id_suffix": ",ws_host_override=localhost",
       "kafka_cluster.ssl.enabled": "false",
     }),
   );

--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -27,7 +27,7 @@ const allAuthOptions: Array<{ label: string; value: SupportedAuthTypes }> = [
   { label: "SASL/OAUTHBEARER", value: "OAuth" },
   { label: "Kerberos (SASL/GSSAPI)", value: "Kerberos" },
 ];
-const WARPSTREAM_PORT_FORWARDING_CLIENT_ID_SUFFIX = "ws_host_override=localhost";
+const WARPSTREAM_PORT_FORWARDING_CLIENT_ID_SUFFIX = ",ws_host_override=localhost";
 class DirectConnectFormViewModel extends ViewModel {
   /** Load connection spec if it exists (for Edit) */
   spec = this.resolve(async () => {


### PR DESCRIPTION
This PR brings https://github.com/confluentinc/vscode/pull/2507 to main.