### PR TITLE
Expand tooltip for flink artifacts

### DIFF
--- a/src/commands/flinkArtifacts.test.ts
+++ b/src/commands/flinkArtifacts.test.ts
@@ -3,7 +3,10 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
 import { createResponseError } from "../../tests/unit/testUtils";
-import { FlinkArtifactsArtifactV1Api } from "../clients/flinkArtifacts";
+import {
+  ArtifactV1FlinkArtifactMetadataFromJSON,
+  FlinkArtifactsArtifactV1Api,
+} from "../clients/flinkArtifacts";
 import {
   PresignedUploadUrlArtifactV1PresignedUrl200ResponseApiVersionEnum,
   PresignedUploadUrlArtifactV1PresignedUrl200ResponseKindEnum,
@@ -44,6 +47,14 @@ describe("flinkArtifacts", () => {
       environmentId: "env-id" as EnvironmentId,
       provider: "aws",
       region: "us-west-2",
+      documentationLink: "https://confluent.io",
+      metadata: ArtifactV1FlinkArtifactMetadataFromJSON({
+        self: {},
+        resource_name: "test-artifact",
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: new Date(),
+      }),
     });
     const openTextDocStub = sandbox
       .stub(vscode.workspace, "openTextDocument")
@@ -296,6 +307,17 @@ describe("deleteArtifactCommand", () => {
     description: "",
     searchableText: () => "",
     connectionType: ConnectionType.Local,
+    ccloudUrl: "https://confluent.io",
+    documentationLink: "https://confluent.io",
+    metadata: ArtifactV1FlinkArtifactMetadataFromJSON({
+      self: {},
+      resource_name: "test-artifact",
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: new Date(),
+    }),
+    createdAt: new Date(),
+    updatedAt: new Date(),
   };
 
   describe("deleteArtifactCommand", () => {

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -504,5 +504,7 @@ function restFlinkArtifactToModel(
     description: restArtifact.description || "",
     provider: restArtifact.cloud,
     region: restArtifact.region,
+    metadata: restArtifact.metadata,
+    documentationLink: restArtifact.documentation_link || "",
   });
 }

--- a/src/models/flinkArtifact.test.ts
+++ b/src/models/flinkArtifact.test.ts
@@ -1,37 +1,34 @@
 import assert from "assert";
 import { describe, it } from "mocha";
-import { ArtifactV1FlinkArtifactMetadataFromJSON } from "../clients/flinkArtifacts";
-import { ConnectionType } from "../clients/sidecar/models/ConnectionType";
-import { createFlinkArtifactToolTip, FlinkArtifact } from "./flinkArtifact";
-import { ConnectionId, EnvironmentId } from "./resource";
+import {
+  createFlinkArtifact,
+  TEST_CCLOUD_FLINK_ARTIFACT,
+} from "../../tests/unit/testResources/flinkArtifact";
+import { createFlinkArtifactToolTip, FlinkArtifactTreeItem } from "./flinkArtifact";
 
 describe("FlinkArtifactTreeItem", () => {
+  it("should have the correct context value", () => {
+    const treeItem = new FlinkArtifactTreeItem(TEST_CCLOUD_FLINK_ARTIFACT);
+    assert.strictEqual(treeItem.contextValue, "ccloud-flink-artifact");
+  });
+
   describe("createFlinkArtifactToolTip", () => {
     it("should return a CustomMarkdownString with all artifact details", () => {
-      const artifact = new FlinkArtifact({
-        connectionId: "conn-2" as ConnectionId,
-        connectionType: ConnectionType.Ccloud,
-        environmentId: "env-2" as EnvironmentId,
-        id: "artifact-2",
-        name: "Another Artifact",
-        description: "Another description.",
-        provider: "Azure",
-        region: "australiaeast",
-        documentationLink: "https://confluent.io",
-        metadata: ArtifactV1FlinkArtifactMetadataFromJSON({
-          self: {},
-          resource_name: "test-artifact",
-          created_at: new Date(),
-          updated_at: new Date(),
-          deleted_at: new Date(),
-        }),
-      });
-
+      const artifact = createFlinkArtifact({ documentationLink: "https://confluent.io" });
       const tooltip = createFlinkArtifactToolTip(artifact);
       const tooltipValue = tooltip.value;
 
       assert.strictEqual(typeof tooltipValue, "string");
-      assert.match(tooltipValue, /Description: `Another description\.`/);
+      assert.match(tooltipValue, /Description: `Test artifact description`/);
+      assert.match(tooltipValue, /\[See Documentation\]\(https:\/\/confluent\.io\)/);
+    });
+
+    it("should return a CustomMarkdownString with no documentation link", () => {
+      const tooltip = createFlinkArtifactToolTip(TEST_CCLOUD_FLINK_ARTIFACT);
+      const tooltipValue = tooltip.value;
+
+      assert.strictEqual(typeof tooltipValue, "string");
+      assert.match(tooltipValue, /\[No documentation link\]\(\)/);
     });
   });
 });

--- a/src/models/flinkArtifact.test.ts
+++ b/src/models/flinkArtifact.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { describe, it } from "mocha";
+import { ArtifactV1FlinkArtifactMetadataFromJSON } from "../clients/flinkArtifacts";
 import { ConnectionType } from "../clients/sidecar/models/ConnectionType";
 import { createFlinkArtifactToolTip, FlinkArtifact } from "./flinkArtifact";
 import { ConnectionId, EnvironmentId } from "./resource";
@@ -16,13 +17,21 @@ describe("FlinkArtifactTreeItem", () => {
         description: "Another description.",
         provider: "Azure",
         region: "australiaeast",
+        documentationLink: "https://confluent.io",
+        metadata: ArtifactV1FlinkArtifactMetadataFromJSON({
+          self: {},
+          resource_name: "test-artifact",
+          created_at: new Date(),
+          updated_at: new Date(),
+          deleted_at: new Date(),
+        }),
       });
 
       const tooltip = createFlinkArtifactToolTip(artifact);
       const tooltipValue = tooltip.value;
 
       assert.strictEqual(typeof tooltipValue, "string");
-      assert.match(tooltipValue, /Description: : `Another description\.`/);
+      assert.match(tooltipValue, /Description: `Another description\.`/);
     });
   });
 });

--- a/src/models/flinkArtifact.ts
+++ b/src/models/flinkArtifact.ts
@@ -90,7 +90,7 @@ export class FlinkArtifactTreeItem extends TreeItem {
 export function createFlinkArtifactToolTip(resource: FlinkArtifact): CustomMarkdownString {
   let documentationLabel: KeyValuePair;
   if (resource.documentationLink === undefined || resource.documentationLink === "") {
-    // Change to "Add documentation link" when we that command is implemented
+    // Change to "Add documentation link" command for adding during upload is implemented
     documentationLabel = ["No documentation link", ""];
   } else {
     documentationLabel = ["See Documentation", resource.documentationLink];

--- a/src/models/flinkArtifact.ts
+++ b/src/models/flinkArtifact.ts
@@ -1,8 +1,9 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
-import { IconNames } from "../constants";
+import { CCLOUD_BASE_PATH, IconNames, UTM_SOURCE_VSCODE } from "../constants";
 import { CustomMarkdownString, IdItem } from "./main";
 import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import { ArtifactV1FlinkArtifactMetadata } from "../clients/flinkArtifacts";
 
 export class FlinkArtifact implements IResourceBase, IdItem, ISearchable {
   connectionId!: ConnectionId;
@@ -18,17 +19,23 @@ export class FlinkArtifact implements IResourceBase, IdItem, ISearchable {
   provider!: string; // cloud
   region!: string;
 
+  metadata: ArtifactV1FlinkArtifactMetadata;
+
+  documentationLink: string;
+
   constructor(
     props: Pick<
       FlinkArtifact,
       | "connectionId"
       | "connectionType"
       | "environmentId"
+      | "provider"
+      | "region"
       | "id"
       | "name"
       | "description"
-      | "provider"
-      | "region"
+      | "documentationLink"
+      | "metadata"
     >,
   ) {
     this.connectionId = props.connectionId;
@@ -39,10 +46,25 @@ export class FlinkArtifact implements IResourceBase, IdItem, ISearchable {
     this.description = props.description;
     this.provider = props.provider;
     this.region = props.region;
+    this.documentationLink = props.documentationLink;
+
+    this.metadata = props.metadata;
   }
 
   searchableText(): string {
     return `${this.name} ${this.description}`;
+  }
+
+  get ccloudUrl(): string {
+    return `https://${CCLOUD_BASE_PATH}/environments/${this.environmentId}/artifacts/flink?utm_source=${UTM_SOURCE_VSCODE}`;
+  }
+
+  get createdAt(): Date | undefined {
+    return this.metadata?.created_at;
+  }
+
+  get updatedAt(): Date | undefined {
+    return this.metadata?.updated_at;
   }
 }
 
@@ -66,7 +88,16 @@ export class FlinkArtifactTreeItem extends TreeItem {
 }
 
 export function createFlinkArtifactToolTip(resource: FlinkArtifact): CustomMarkdownString {
-  return CustomMarkdownString.resourceTooltip(resource.name, IconNames.FLINK_ARTIFACT, undefined, [
-    ["Description: ", resource.description],
-  ]);
+  return CustomMarkdownString.resourceTooltip(
+    "Flink Artifact",
+    IconNames.FLINK_ARTIFACT,
+    resource.ccloudUrl,
+    [
+      ["ID", resource.id],
+      ["Description", resource.description],
+      ["Created At", resource.createdAt?.toLocaleString()],
+      ["Updated At", resource.updatedAt?.toLocaleString()],
+    ],
+    ["See Documentation", resource.documentationLink],
+  );
 }

--- a/src/models/flinkArtifact.ts
+++ b/src/models/flinkArtifact.ts
@@ -1,7 +1,7 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_BASE_PATH, IconNames, UTM_SOURCE_VSCODE } from "../constants";
-import { CustomMarkdownString, IdItem } from "./main";
+import { CustomMarkdownString, IdItem, KeyValuePair } from "./main";
 import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
 import { ArtifactV1FlinkArtifactMetadata } from "../clients/flinkArtifacts";
 
@@ -29,11 +29,11 @@ export class FlinkArtifact implements IResourceBase, IdItem, ISearchable {
       | "connectionId"
       | "connectionType"
       | "environmentId"
-      | "provider"
-      | "region"
       | "id"
       | "name"
       | "description"
+      | "provider"
+      | "region"
       | "documentationLink"
       | "metadata"
     >,
@@ -88,6 +88,14 @@ export class FlinkArtifactTreeItem extends TreeItem {
 }
 
 export function createFlinkArtifactToolTip(resource: FlinkArtifact): CustomMarkdownString {
+  let documentationLabel: KeyValuePair;
+  if (resource.documentationLink === undefined || resource.documentationLink === "") {
+    // Change to "Add documentation link" when we that command is implemented
+    documentationLabel = ["No documentation link", ""];
+  } else {
+    documentationLabel = ["See Documentation", resource.documentationLink];
+  }
+
   return CustomMarkdownString.resourceTooltip(
     "Flink Artifact",
     IconNames.FLINK_ARTIFACT,
@@ -98,6 +106,6 @@ export function createFlinkArtifactToolTip(resource: FlinkArtifact): CustomMarkd
       ["Created At", resource.createdAt?.toLocaleString()],
       ["Updated At", resource.updatedAt?.toLocaleString()],
     ],
-    ["See Documentation", resource.documentationLink],
+    documentationLabel,
   );
 }

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -95,7 +95,7 @@ export class CustomMarkdownString extends vscode.MarkdownString {
     iconName: IconNames | undefined,
     ccloudUrl: string | undefined,
     keyValuePairs: KeyValuePairArray,
-    label?: KeyValuePair,
+    linkUrl?: KeyValuePair,
   ): CustomMarkdownString {
     const tooltip = new CustomMarkdownString();
 
@@ -114,8 +114,10 @@ export class CustomMarkdownString extends vscode.MarkdownString {
       tooltip.appendMarkdown(`\n\n${key}: \`${value}\``);
     });
 
-    if (label) {
-      tooltip.appendMarkdown(`\n\n[${label[0]}](${label[1]})`);
+    if (linkUrl) {
+      if (linkUrl[1] !== undefined && linkUrl[1] !== "") {
+        tooltip.appendMarkdown(`\n\n[${linkUrl[0]}](${linkUrl[1]})`);
+      }
     }
 
     if (ccloudUrl) {

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -115,9 +115,7 @@ export class CustomMarkdownString extends vscode.MarkdownString {
     });
 
     if (linkUrl) {
-      if (linkUrl[1] !== undefined && linkUrl[1] !== "") {
-        tooltip.appendMarkdown(`\n\n[${linkUrl[0]}](${linkUrl[1]})`);
-      }
+      tooltip.appendMarkdown(`\n\n[${linkUrl[0]}](${linkUrl[1]})`);
     }
 
     if (ccloudUrl) {

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -87,6 +87,7 @@ export class CustomMarkdownString extends vscode.MarkdownString {
    * @param iconName Icon to use beside title, if any.
    * @param keyValuePairs attribute name + from-resource-value pairs. Any undefined value will be skipped.
    * @param ccloudUrl Optional URL to view this resource in Confluent Cloud.
+   * @param linkUrl Optional link label + URL pair to add a custom link at the bottom of the tooltip.
    * @returns
    */
   static resourceTooltip(
@@ -94,6 +95,7 @@ export class CustomMarkdownString extends vscode.MarkdownString {
     iconName: IconNames | undefined,
     ccloudUrl: string | undefined,
     keyValuePairs: KeyValuePairArray,
+    label?: KeyValuePair,
   ): CustomMarkdownString {
     const tooltip = new CustomMarkdownString();
 
@@ -111,6 +113,10 @@ export class CustomMarkdownString extends vscode.MarkdownString {
       }
       tooltip.appendMarkdown(`\n\n${key}: \`${value}\``);
     });
+
+    if (label) {
+      tooltip.appendMarkdown(`\n\n[${label[0]}](${label[1]})`);
+    }
 
     if (ccloudUrl) {
       // Ensure URL is vaguely valid

--- a/tests/unit/testResources/flinkArtifact.ts
+++ b/tests/unit/testResources/flinkArtifact.ts
@@ -4,6 +4,8 @@ import { CCLOUD_CONNECTION_ID } from "../../../src/constants";
 import { FlinkArtifact } from "../../../src/models/flinkArtifact";
 import { TEST_CCLOUD_ENVIRONMENT_ID } from "./environments";
 
+export const TEST_CCLOUD_FLINK_ARTIFACT = createFlinkArtifact();
+
 export function createFlinkArtifact(overrides: Partial<FlinkArtifact> = {}): FlinkArtifact {
   return new FlinkArtifact({
     connectionId: overrides.connectionId || CCLOUD_CONNECTION_ID,
@@ -14,7 +16,7 @@ export function createFlinkArtifact(overrides: Partial<FlinkArtifact> = {}): Fli
     description: overrides.description || "Test artifact description",
     provider: overrides.provider || "aws",
     region: overrides.region || "us-east-1",
-    documentationLink: overrides.documentationLink || "https://confluent.io",
+    documentationLink: overrides.documentationLink || "",
     metadata:
       overrides.metadata ||
       ArtifactV1FlinkArtifactMetadataFromJSON({

--- a/tests/unit/testResources/flinkArtifact.ts
+++ b/tests/unit/testResources/flinkArtifact.ts
@@ -1,3 +1,4 @@
+import { ArtifactV1FlinkArtifactMetadataFromJSON } from "../../../src/clients/flinkArtifacts";
 import { ConnectionType } from "../../../src/clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../../../src/constants";
 import { FlinkArtifact } from "../../../src/models/flinkArtifact";
@@ -13,5 +14,15 @@ export function createFlinkArtifact(overrides: Partial<FlinkArtifact> = {}): Fli
     description: overrides.description || "Test artifact description",
     provider: overrides.provider || "aws",
     region: overrides.region || "us-east-1",
+    documentationLink: overrides.documentationLink || "https://confluent.io",
+    metadata:
+      overrides.metadata ||
+      ArtifactV1FlinkArtifactMetadataFromJSON({
+        self: {},
+        resource_name: "test-artifact",
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: new Date(),
+      }),
   });
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Added more detailed information to Flink artifact tooltips
- Updated tooltip structure: to use `CustomMarkdownString.resourceTooltip` 
- Added optional argument for `CustomMarkdownString.resourceTooltip` to customize second external link for artifact documentation

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2457 

After:

https://github.com/user-attachments/assets/a65ff621-3572-4c3d-af4a-0710f7c01250


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [X] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
