### PR TITLE
test: Add E2E tests on Project Scaffolding feature

### DIFF
--- a/tests/e2e/objects/views/SupportView.ts
+++ b/tests/e2e/objects/views/SupportView.ts
@@ -1,0 +1,13 @@
+import { Page } from "@playwright/test";
+import { View } from "./View";
+
+/**
+ * Object representing the "Support"
+ * {@link https://code.visualstudio.com/api/ux-guidelines/views#tree-views view} in the "Confluent"
+ * {@link https://code.visualstudio.com/api/ux-guidelines/views#view-containers view container}.
+ */
+export class SupportView extends View {
+  constructor(page: Page) {
+    super(page, /Support.*/);
+  }
+}

--- a/tests/e2e/objects/webviews/ProjectScaffoldWebview.ts
+++ b/tests/e2e/objects/webviews/ProjectScaffoldWebview.ts
@@ -1,0 +1,23 @@
+import { Locator } from "@playwright/test";
+import { Webview } from "./Webview";
+
+/**
+ * Object representing the Project Scaffold {@link https://code.visualstudio.com/api/ux-guidelines/webviews webview}.
+ */
+export class ProjectScaffoldWebview extends Webview {
+  get wrapper(): Locator {
+    return this.webview.locator("main.webview-form");
+  }
+
+  get form(): Locator {
+    return this.wrapper.locator("form.form-container");
+  }
+
+  get bootstrapServersField(): Locator {
+    return this.webview.locator('[name="cc_bootstrap_server"]');
+  }
+
+  async submitForm(): Promise<void> {
+    return this.webview.locator('input[type="submit"]').click();
+  }
+}

--- a/tests/e2e/specs/scaffold.spec.ts
+++ b/tests/e2e/specs/scaffold.spec.ts
@@ -1,0 +1,84 @@
+import { expect, Page } from "@playwright/test";
+import { stubMultipleDialogs } from "electron-playwright-helpers";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { test } from "../baseTest";
+import { SupportView } from "../objects/views/SupportView";
+import { ProjectScaffoldWebview } from "../objects/webviews/ProjectScaffoldWebview";
+import { openConfluentExtension } from "./utils/confluent";
+
+const DEFAULT_TIMEOUT_MS = 2000;
+
+/**
+ * E2E test suite for testing the Project Scaffolding functionality.
+ * {@see https://github.com/confluentinc/vscode/issues/1840}
+ */
+
+/**
+ * Waits for a specified amount of time and then presses a key on the Playwright page.
+ * @param page - The Playwright page object.
+ * @param key - The key to press, e.g., "Enter", "Escape", etc.
+ * @param timeout - The time to wait before pressing the key, in milliseconds. Default is 2000ms.
+ */
+async function pressKey(page: Page, key: string, timeout = DEFAULT_TIMEOUT_MS) {
+  await page.waitForTimeout(timeout);
+  await page.keyboard.press(key, { delay: 100 });
+}
+
+test.describe("Project Scaffolding", () => {
+  test.beforeEach(async ({ page }) => {
+    await openConfluentExtension(page);
+  });
+
+  const templates: Array<[string, string]> = [
+    ["Kafka Client in Go", "go-client"],
+    ["Kafka Client in Java", "java-client"],
+    ["Kafka Client in JavaScript", "javascript-client"],
+    ["Kafka Client in .NET", "dotnet-client"],
+  ];
+  
+  test.describe("Support view", () => {
+    for (const [templateName, projectDirName] of templates) {
+      test(`should generate ${templateName} template from Support view`, async ({
+        page,
+        electronApp,
+      }) => {
+          // Given we navigate to the Support view and start the generate project flow
+          const supportView = new SupportView(page);
+          await (await supportView.body.getByText("Generate Project from Template")).click();
+          // and we choose a project template
+          const projectTemplateInput = await page.getByPlaceholder("Select a project template");
+          await expect(projectTemplateInput).toBeVisible();
+          await projectTemplateInput.fill(templateName);
+          await projectTemplateInput.click();
+          await pressKey(page, "Enter");
+          // and we provide a simple example configuration and submit the form
+          const scaffoldForm = new ProjectScaffoldWebview(page);
+          await (await scaffoldForm.bootstrapServersField).fill("localhost:9092");
+          await scaffoldForm.submitForm();
+          // and we store the generated project in a temporary directory
+          const tmpProjectDir = mkdtempSync(path.join(tmpdir(), "vscode-test-scaffold-"));
+          await stubMultipleDialogs(electronApp, [
+            {
+              method: "showOpenDialog",
+              value: {
+                filePaths: [tmpProjectDir]
+              },
+            },
+          ]);
+
+          // When we open the generated project (the dialog stub is still in effect here)
+          await pressKey(page, "ControlOrMeta+O");
+          // and we open the configuration file `.env`
+          await (await page.getByText(projectDirName)).click();
+          await (await page.getByText(".env")).click();
+
+          // Then we should see the generated configuration
+          await expect(await page.getByText(/CC_BOOTSTRAP_SERVER\s*=\s*"localhost:9092"/)).toBeVisible();
+          // and we should see a client.id starting with the expected prefix
+          await expect(await page.getByText(/CLIENT_ID\s*=\s*"vscode-/)).toBeVisible();
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary of Changes

This change adds E2E tests that cover generating projects from the Support view in the extension. The tests cover the templates `go-client`, `java-client`, `javascript-client`, and `dotnet-client`.

## Any additional details or context that should be provided?

Other entry points into the project scaffolding flow, like the Resources or Topics view, are considered as follow-up work.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
