### PR TITLE
#2477 add upload icon to invoke command from artifacts view header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1496,7 +1496,7 @@
         },
         {
           "command": "confluent.uploadArtifact",
-          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@2"
         },
         {

--- a/package.json
+++ b/package.json
@@ -274,7 +274,8 @@
     "commands": [
       {
         "command": "confluent.uploadArtifact",
-        "title": "Confluent: Upload Artifact",
+        "icon": "$(cloud-upload)",
+        "title": "Upload Artifact",
         "category": "Confluent: Flink Artifacts",
         "enablement": "isDevelopment"
       },
@@ -1491,6 +1492,11 @@
         {
           "command": "confluent.topics.create",
           "when": "view == confluent-topics && confluent.kafkaClusterSelected",
+          "group": "navigation@2"
+        },
+        {
+          "command": "confluent.uploadArtifact",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable",
           "group": "navigation@2"
         },
         {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2477
- Adds an icon to the Upload Artifact command, and makes it visible in the header of the Artifacts view if the user is connected to CCloud and `enableFlinkArtifacts` is true in the config.  
- I also renamed the title since the "Confluent: " prefix is redundant in the places where this appears. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
<img width="423" height="538" alt="Screenshot 2025-09-10 at 7 49 04 AM" src="https://github.com/user-attachments/assets/cbcd21c0-063e-4123-8bb3-89313d2465dd" />

- In future work we could link this upload command to the currently selected compute pool when one is selected in the view, or we could at least put it higher in the list (see also #2458).  For now it asks the user to choose a compute pool each time. 
- No new tests required - this is not new functionality, just an icon and link in view header to existing command. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests
- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
