### PR TITLE
#2475 Link to artifact template generation in header, empty state

### DIFF
--- a/package.json
+++ b/package.json
@@ -496,7 +496,8 @@
       {
         "command": "confluent.resources.scaffold",
         "title": "Generate Project From Resource",
-        "category": "Confluent: Resource Project"
+        "category": "Confluent: Resource Project",
+        "icon": "$(plus)"
       },
       {
         "command": "confluent.scaffold",
@@ -1186,7 +1187,7 @@
       },
       {
         "view": "confluent-flink-artifacts",
-        "contents": "No Flink artifacts found.",
+        "contents": "No Flink artifacts found.\n[Generate a Flink Artifact from template](command:confluent.resources.scaffold)",
         "when": "config.confluent.flink.enableFlinkArtifacts && confluent.ccloudConnectionAvailable && confluent.flinkArtifactsPoolSelected"
       }
     ],
@@ -1556,6 +1557,11 @@
         {
           "command": "confluent.flink.setArtifactsViewMode",
           "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsPoolSelected && confluent.flinkArtifactsUDFsViewMode == 'UDFs'",
+          "group": "navigation@2"
+        },
+        {
+          "command": "confluent.resources.scaffold",
+          "when": "view == confluent-flink-artifacts && confluent.ccloudConnectionAvailable",
           "group": "navigation@2"
         },
         {

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -84,16 +84,18 @@ async function resourceScaffoldProjectRequest(
       },
       "topic",
     );
-  } else if (item instanceof CCloudFlinkComputePool) {
+    // TODO temporarily using "undefined" to signal call from Artifacts header, which only gives Table API examples
+    // Need to decide whether to make a new command for generating Artifacts specifically
+  } else if (item instanceof CCloudFlinkComputePool || item === undefined) {
     const organization: CCloudOrganization | undefined =
       await CCloudResourceLoader.getInstance().getOrganization();
     return await scaffoldProjectRequest(
       {
-        cc_environment_id: item.environmentId,
+        cc_environment_id: item?.environmentId,
         cc_organization_id: organization?.id,
-        cloud_region: item.region,
-        cloud_provider: item.provider,
-        cc_compute_pool_id: item.id,
+        cloud_region: item?.region,
+        cloud_provider: item?.provider,
+        cc_compute_pool_id: item?.id,
         templateType: "flink",
       },
       "compute pool",


### PR DESCRIPTION
# 🚧 WIP: need to adjust the command for artifacts, so we only show artifact templates when invoked this way

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
