### PR TITLE
(UDFs) Artifacts: allow upload from right-click on cluster, compute, or .jar file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1982,7 +1982,7 @@
       "explorer/context": [
         {
           "command": "confluent.uploadArtifact",
-          "group": "inline@1",
+          "group": "confluent@1",
           "when": "config.confluent.flink.enableFlinkArtifacts && confluent.ccloudConnectionAvailable && resourceExtname == .jar"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -1965,6 +1965,11 @@
           "group": "z_openInCloud"
         },
         {
+          "command": "confluent.uploadArtifact",
+          "when": "view == confluent-resources &&  viewItem =~ /.*compute-pool*/",
+          "group": "inline@3"
+        },
+        {
           "command": "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
           "when": "view == confluent-resources && viewItem =~ /.*ccloud-environment/",
           "group": "z_openInCloud"

--- a/package.json
+++ b/package.json
@@ -782,7 +782,7 @@
       {
         "command": "confluent.uploadArtifact",
         "icon": "$(cloud-upload)",
-        "title": "Upload Artifact",
+        "title": "Upload Flink Artifact to Confluent Cloud",
         "category": "Confluent: Flink Artifacts",
         "enablement": "isDevelopment && confluent.ccloudConnectionAvailable"
       }
@@ -1553,7 +1553,7 @@
         },
         {
           "command": "confluent.uploadArtifact",
-          "when": "true"
+          "when": "confluent.ccloudConnectionAvailable"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -1966,7 +1966,7 @@
         },
         {
           "command": "confluent.uploadArtifact",
-          "when": "view == confluent-resources &&  viewItem =~ /.*compute-pool*/",
+          "when": "view == confluent-resources &&  (viewItem =~ /.*compute-pool*/ || viewItem == ccloud-kafka-cluster)",
           "group": "inline@3"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1966,8 +1966,7 @@
         },
         {
           "command": "confluent.uploadArtifact",
-          "when": "view == confluent-resources &&  (viewItem =~ /.*compute-pool*/ || viewItem == ccloud-kafka-cluster)",
-          "group": "inline@3"
+          "when": "view in confluent.viewsWithResources && (viewItem =~ /.*-kafka-cluster.*/ || viewItem =~ /.*compute-pool*/)"
         },
         {
           "command": "confluent.resources.ccloudEnvironment.setPrivateNetworkEndpoint",
@@ -1978,6 +1977,13 @@
           "command": "confluent.flinkStatementResults",
           "when": "view == confluent-flink-statements && viewItem =~ /.*flink-statement$/",
           "group": "inline@1"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "confluent.uploadArtifact",
+          "group": "inline@1",
+          "when": "config.confluent.flink.enableFlinkArtifacts && confluent.ccloudConnectionAvailable && resourceExtname == .jar"
         }
       ]
     },

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -8,6 +8,7 @@ import { artifactUploadDeleted, flinkDatabaseViewMode } from "../emitters";
 import { extractResponseBody, isResponseError, logError } from "../errors";
 import { FlinkArtifact } from "../models/flinkArtifact";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
+import { CCloudKafkaCluster } from "../models/kafkaCluster";
 import {
   showErrorNotificationWithButtons,
   showWarningNotificationWithButtons,
@@ -26,7 +27,9 @@ import {
  * Returns an object with these values, or undefined if the user cancels.
  */
 
-export async function uploadArtifactCommand(item?: CCloudFlinkComputePool): Promise<void> {
+export async function uploadArtifactCommand(
+  item?: CCloudFlinkComputePool | CCloudKafkaCluster,
+): Promise<void> {
   try {
     const params = await promptForArtifactUploadParams(item);
     if (!params) return; // User cancelled the prompt

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -23,14 +23,24 @@ import {
 } from "./utils/uploadArtifact";
 
 /**
- * Prompts the user for environment, cloud provider, region, and artifact name.
- * Returns an object with these values, or undefined if the user cancels.
+ * Orchestrates the sub-functions from uploadArtifact.ts to complete the artifact upload process.
+ * Logs error and shows a user notification if sub-functions fail.
+ * Steps are:
+ * 1. Gathering request parameters from the user or a provided item.
+ * 2. Requesting a presigned URL from Confluent Cloud via Sidecar.
+ * 3. Uploading the artifact to the presigned URL (supports AWS or Azure).
+ * 4. Displaying progress while creating the Artifact in Confluent Cloud.
+ *
+ * @param item Optional. If command is invoked from a Flink Compute Pool, CCloud Kafka Cluster, or `.jar` file we use that to pre-fill upload options.
+ * If not provided, the user will be prompted for all necessary information.
+ * In the near future this will become a webview form with more inputs. See: https://github.com/confluentinc/vscode/issues/2539
  */
 
 export async function uploadArtifactCommand(
   item?: CCloudFlinkComputePool | CCloudKafkaCluster | vscode.Uri,
 ): Promise<void> {
   try {
+    // 1. Gather the request parameters from user or item
     const params = await promptForArtifactUploadParams(item);
     if (!params) return; // User cancelled the prompt
 
@@ -42,14 +52,17 @@ export async function uploadArtifactCommand(
       content_format: params.fileFormat,
     };
 
+    // 2. Get presigned URL from Confluent Cloud via Sidecar
     const uploadUrl = await getPresignedUploadUrl(request);
 
     if (!uploadUrl) {
       throw new Error("Upload ID is missing from the presigned URL response.");
     }
 
+    // 3. Upload the artifact to the presigned URL (either AWS or Azure)
     await handleUploadToCloudProvider(params, uploadUrl);
 
+    // 4/Last. Show our progress while creating the Artifact in Confluent Cloud (TODO should this wrap all the steps?)
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -28,7 +28,7 @@ import {
  */
 
 export async function uploadArtifactCommand(
-  item?: CCloudFlinkComputePool | CCloudKafkaCluster,
+  item?: CCloudFlinkComputePool | CCloudKafkaCluster | vscode.Uri,
 ): Promise<void> {
   try {
     const params = await promptForArtifactUploadParams(item);

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -7,6 +7,7 @@ import { ContextValues, setContextValue } from "../context/values";
 import { artifactUploadDeleted, flinkDatabaseViewMode } from "../emitters";
 import { extractResponseBody, isResponseError, logError } from "../errors";
 import { FlinkArtifact } from "../models/flinkArtifact";
+import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import {
   showErrorNotificationWithButtons,
   showWarningNotificationWithButtons,
@@ -24,10 +25,11 @@ import {
  * Prompts the user for environment, cloud provider, region, and artifact name.
  * Returns an object with these values, or undefined if the user cancels.
  */
-export async function uploadArtifactCommand(): Promise<void> {
+
+export async function uploadArtifactCommand(item?: CCloudFlinkComputePool): Promise<void> {
   try {
-    const params = await promptForArtifactUploadParams();
-    if (!params) return; // User cancelled the input
+    const params = await promptForArtifactUploadParams(item);
+    if (!params) return; // User cancelled the prompt
 
     const request: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
       environment: params.environment,

--- a/src/commands/utils/uploadArtifact.test.ts
+++ b/src/commands/utils/uploadArtifact.test.ts
@@ -6,7 +6,11 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { getSidecarStub } from "../../../tests/stubs/sidecar";
-import { TEST_CCLOUD_ENVIRONMENT } from "../../../tests/unit/testResources";
+import {
+  TEST_CCLOUD_ENVIRONMENT,
+  TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER,
+} from "../../../tests/unit/testResources";
+import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../../tests/unit/testResources/flinkComputePool";
 import {
   FlinkArtifactsArtifactV1Api,
   PresignedUploadUrlArtifactV1PresignedUrl200Response,
@@ -284,6 +288,76 @@ describe("uploadArtifact", () => {
         cloud: "AWS",
         region: fakeCloudProviderRegion.region_name,
         artifactName: "test-artifact",
+        fileFormat: "jar",
+        selectedFile: mockFileUri,
+      });
+    });
+
+    it("should use provided CCloudFlinkComputePool context without prompting for environment/region", async () => {
+      const pool: any = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+      sandbox.stub(vscode.window, "showOpenDialog").resolves([mockFileUri]);
+      const showInputBoxStub = sandbox
+        .stub(vscode.window, "showInputBox")
+        .resolves("pool-artifact");
+
+      const result = await promptForArtifactUploadParams(pool);
+
+      // environment and cloud/region should be derived from the item, not from quick picks
+      sinon.assert.notCalled(flinkCcloudEnvironmentQuickPickStub);
+      sinon.assert.notCalled(cloudProviderRegionQuickPickStub);
+      sinon.assert.calledWithMatch(showInputBoxStub, sinon.match({ value: "mock-file" }));
+
+      assert.deepStrictEqual(result, {
+        environment: mockEnvironment.id,
+        cloud: "AWS",
+        region: "us-west-2",
+        artifactName: "pool-artifact",
+        fileFormat: "jar",
+        selectedFile: mockFileUri,
+      });
+    });
+
+    it("should use provided CCloudKafkaCluster context without prompting for environment/region", async () => {
+      const cluster: any = TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER;
+
+      sandbox.stub(vscode.window, "showOpenDialog").resolves([mockFileUri]);
+      sandbox.stub(vscode.window, "showInputBox").resolves("cluster-artifact");
+
+      const result = await promptForArtifactUploadParams(cluster);
+
+      sinon.assert.notCalled(flinkCcloudEnvironmentQuickPickStub);
+      sinon.assert.notCalled(cloudProviderRegionQuickPickStub);
+
+      assert.deepStrictEqual(result, {
+        environment: mockEnvironment.id,
+        cloud: "AWS",
+        region: "us-west-2",
+        artifactName: "cluster-artifact",
+        fileFormat: "jar",
+        selectedFile: mockFileUri,
+      });
+    });
+
+    it("should accept a vscode.Uri item and not prompt for file selection", async () => {
+      // environment and region picks still happen when URI is provided
+      flinkCcloudEnvironmentQuickPickStub.resolves(mockEnvironment);
+      cloudProviderRegionQuickPickStub.resolves({
+        ...fakeCloudProviderRegion,
+        provider: "AWS",
+        region: fakeCloudProviderRegion.region_name,
+      });
+      sandbox.stub(vscode.window, "showInputBox").resolves("mock-file");
+      const filePicker = sandbox.stub(vscode.window, "showOpenDialog");
+
+      const result = await promptForArtifactUploadParams(mockFileUri);
+      // file picker should not be called if we provided a URI
+      sinon.assert.notCalled(filePicker);
+      assert.deepStrictEqual(result, {
+        environment: mockEnvironment.id,
+        cloud: "AWS",
+        region: fakeCloudProviderRegion.region_name,
+        artifactName: "mock-file",
         fileFormat: "jar",
         selectedFile: mockFileUri,
       });

--- a/src/commands/utils/uploadArtifact.test.ts
+++ b/src/commands/utils/uploadArtifact.test.ts
@@ -20,6 +20,8 @@ import {
 import { PresignedUrlsArtifactV1Api } from "../../clients/flinkArtifacts/apis/PresignedUrlsArtifactV1Api";
 import { PresignedUploadUrlArtifactV1PresignedUrlRequest } from "../../clients/flinkArtifacts/models/PresignedUploadUrlArtifactV1PresignedUrlRequest";
 import { FcpmV2RegionListDataInner } from "../../clients/flinkComputePool/models/FcpmV2RegionListDataInner";
+import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
+import { CCloudKafkaCluster } from "../../models/kafkaCluster";
 import { CloudProvider } from "../../models/resource";
 import * as notifications from "../../notifications";
 import * as cloudProviderRegions from "../../quickpicks/cloudProviderRegions";
@@ -294,32 +296,29 @@ describe("uploadArtifact", () => {
     });
 
     it("should use provided CCloudFlinkComputePool context without prompting for environment/region", async () => {
-      const pool: any = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
 
       sandbox.stub(vscode.window, "showOpenDialog").resolves([mockFileUri]);
-      const showInputBoxStub = sandbox
-        .stub(vscode.window, "showInputBox")
-        .resolves("pool-artifact");
+      sandbox.stub(vscode.window, "showInputBox").resolves(mockFileName);
 
       const result = await promptForArtifactUploadParams(pool);
 
       // environment and cloud/region should be derived from the item, not from quick picks
       sinon.assert.notCalled(flinkCcloudEnvironmentQuickPickStub);
       sinon.assert.notCalled(cloudProviderRegionQuickPickStub);
-      sinon.assert.calledWithMatch(showInputBoxStub, sinon.match({ value: "mock-file" }));
 
       assert.deepStrictEqual(result, {
         environment: mockEnvironment.id,
         cloud: "AWS",
         region: "us-west-2",
-        artifactName: "pool-artifact",
+        artifactName: "mock-file",
         fileFormat: "jar",
         selectedFile: mockFileUri,
       });
     });
 
     it("should use provided CCloudKafkaCluster context without prompting for environment/region", async () => {
-      const cluster: any = TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER;
+      const cluster: CCloudKafkaCluster = TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER;
 
       sandbox.stub(vscode.window, "showOpenDialog").resolves([mockFileUri]);
       sandbox.stub(vscode.window, "showInputBox").resolves("cluster-artifact");

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -122,15 +122,14 @@ export async function promptForArtifactUploadParams(
     return undefined;
   }
 
-  const rawCloud = cloudRegion.provider.toUpperCase();
   let cloud: CloudProvider;
-  if (rawCloud === "AZURE") {
+  if (cloudRegion.provider === "AZURE") {
     cloud = CloudProvider.Azure;
-  } else if (rawCloud === "AWS") {
+  } else if (cloudRegion.provider === "AWS") {
     cloud = CloudProvider.AWS;
   } else {
     void showErrorNotificationWithButtons(
-      `Upload Artifact cancelled: Unsupported cloud provider: ${rawCloud}`,
+      `Upload Artifact cancelled: Unsupported cloud provider: ${cloudRegion.provider}`,
     );
     return undefined;
   }
@@ -158,7 +157,7 @@ export async function promptForArtifactUploadParams(
     selectedFile = selectedFiles[0];
   }
 
-  const fileFormat: string = selectedFile.fsPath.split(".").pop()!;
+  const fileFormat: string = selectedFile.fsPath.split(".").pop() ?? "";
 
   // Default artifact name to the selected file's base name (without extension), but allow override.
   const defaultArtifactName = path.basename(selectedFile.fsPath, path.extname(selectedFile.fsPath));

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -11,7 +11,12 @@ import { logError } from "../../errors";
 import { Logger } from "../../logging";
 import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
 import { CCloudKafkaCluster } from "../../models/kafkaCluster";
-import { CloudProvider, EnvironmentId, IEnvProviderRegion } from "../../models/resource";
+import {
+  CloudProvider,
+  EnvironmentId,
+  IEnvProviderRegion,
+  IProviderRegion,
+} from "../../models/resource";
 import { showErrorNotificationWithButtons } from "../../notifications";
 import { cloudProviderRegionQuickPick } from "../../quickpicks/cloudProviderRegions";
 import { flinkCcloudEnvironmentQuickPick } from "../../quickpicks/environments";
@@ -88,57 +93,71 @@ export async function getPresignedUploadUrl(
 }
 
 export async function promptForArtifactUploadParams(
-  item?: CCloudKafkaCluster | CCloudFlinkComputePool,
+  item?: CCloudKafkaCluster | CCloudFlinkComputePool | vscode.Uri,
 ): Promise<ArtifactUploadParams | undefined> {
-  if (item) {
-    logger.info("Uploading artifact using provided context", {
+  if (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster) {
+    logger.info("Starting upload artifact using provided context", {
       environment: item.environmentId,
       cloud: item.provider,
       region: item.region,
     });
   }
-  // Use the item's environment if provided, otherwise prompt for it
-  const environment = item?.environmentId
-    ? { id: item.environmentId }
-    : await flinkCcloudEnvironmentQuickPick();
 
-  // Use the item's provider and region if provided, otherwise prompt for it
-  let cloudRegion = item
-    ? { provider: item.provider, region: item.region, cloud: item.provider }
-    : await cloudProviderRegionQuickPick((region) => region.cloud !== "GCP");
+  // Use the item's environment if provided, otherwise prompt for it
+  const environment =
+    item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster)
+      ? { id: item.environmentId }
+      : await flinkCcloudEnvironmentQuickPick();
+
+  // Use the item's provider and region if exists, otherwise prompt for it
+  let cloudRegion: IProviderRegion | undefined;
+  if (item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster)) {
+    cloudRegion = { provider: item.provider, region: item.region };
+  } else {
+    cloudRegion = await cloudProviderRegionQuickPick((region) => region.cloud !== "GCP");
+  }
 
   if (!environment || !environment.id || !cloudRegion) {
     return undefined;
   }
 
+  const rawCloud = cloudRegion.provider.toUpperCase();
   let cloud: CloudProvider;
-  if (cloudRegion.provider === "AZURE") {
+  if (rawCloud === "AZURE") {
     cloud = CloudProvider.Azure;
-  } else if (cloudRegion.provider === "AWS") {
+  } else if (rawCloud === "AWS") {
     cloud = CloudProvider.AWS;
   } else {
     void showErrorNotificationWithButtons(
-      `Upload Artifact cancelled: Unsupported cloud provider: ${cloudRegion.provider}`,
+      `Upload Artifact cancelled: Unsupported cloud provider: ${rawCloud}`,
     );
     return undefined;
   }
 
-  const selectedFiles: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({
-    openLabel: "Select",
-    canSelectFiles: true,
-    canSelectFolders: false,
-    canSelectMany: false,
-    filters: {
-      "Flink Artifact Files": ["jar"],
-    },
-  });
-  if (!selectedFiles || selectedFiles.length === 0) {
-    // if the user cancels the file selection, silently exit
-    return;
+  // If the incoming item is a Uri, use it; otherwise prompt the user
+  let selectedFile: vscode.Uri | undefined;
+  if (item && item instanceof vscode.Uri) {
+    selectedFile = item;
+  } else {
+    const selectedFiles: vscode.Uri[] | undefined = await vscode.window.showOpenDialog({
+      openLabel: "Select",
+      canSelectFiles: true,
+      canSelectFolders: false,
+      canSelectMany: false,
+      filters: {
+        "Flink Artifact Files": ["jar"],
+      },
+    });
+
+    if (!selectedFiles || selectedFiles.length === 0) {
+      // if the user cancels the file selection, silently exit
+      return undefined;
+    }
+
+    selectedFile = selectedFiles[0];
   }
 
-  const selectedFile: vscode.Uri = selectedFiles[0];
-  const fileFormat: string = selectedFiles[0].fsPath.split(".").pop()!;
+  const fileFormat: string = selectedFile.fsPath.split(".").pop()!;
 
   // Default artifact name to the selected file's base name (without extension), but allow override.
   const defaultArtifactName = path.basename(selectedFile.fsPath, path.extname(selectedFile.fsPath));

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -103,15 +103,17 @@ export async function promptForArtifactUploadParams(
     });
   }
 
+  const isCcloudItem =
+    item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster);
   // Use the item's environment if provided, otherwise prompt for it
   const environment =
-    item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster)
+    isCcloudItem && item.environmentId
       ? { id: item.environmentId }
       : await flinkCcloudEnvironmentQuickPick();
 
   // Use the item's provider and region if exists, otherwise prompt for it
   let cloudRegion: IProviderRegion | undefined;
-  if (item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster)) {
+  if (isCcloudItem) {
     cloudRegion = { provider: item.provider, region: item.region };
   } else {
     cloudRegion = await cloudProviderRegionQuickPick((region) => region.cloud !== "GCP");

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -95,16 +95,15 @@ export async function getPresignedUploadUrl(
 export async function promptForArtifactUploadParams(
   item?: CCloudKafkaCluster | CCloudFlinkComputePool | vscode.Uri,
 ): Promise<ArtifactUploadParams | undefined> {
-  if (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster) {
-    logger.info("Starting upload artifact using provided context", {
+  const isCcloudItem =
+    item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster);
+  if (isCcloudItem) {
+    logger.debug("Starting upload artifact using provided context", {
       environment: item.environmentId,
       cloud: item.provider,
       region: item.region,
     });
   }
-
-  const isCcloudItem =
-    item && (item instanceof CCloudFlinkComputePool || item instanceof CCloudKafkaCluster);
   // Use the item's environment if provided, otherwise prompt for it
   const environment =
     isCcloudItem && item.environmentId

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -10,6 +10,7 @@ import { artifactUploadCompleted } from "../../emitters";
 import { logError } from "../../errors";
 import { Logger } from "../../logging";
 import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
+import { CCloudKafkaCluster } from "../../models/kafkaCluster";
 import { CloudProvider, EnvironmentId, IEnvProviderRegion } from "../../models/resource";
 import { showErrorNotificationWithButtons } from "../../notifications";
 import { cloudProviderRegionQuickPick } from "../../quickpicks/cloudProviderRegions";
@@ -87,23 +88,23 @@ export async function getPresignedUploadUrl(
 }
 
 export async function promptForArtifactUploadParams(
-  compute?: CCloudFlinkComputePool,
+  item?: CCloudKafkaCluster | CCloudFlinkComputePool,
 ): Promise<ArtifactUploadParams | undefined> {
-  if (compute) {
-    logger.info("Uploading artifact using compute context", {
-      environment: compute.environmentId,
-      cloud: compute.provider,
-      region: compute.region,
+  if (item) {
+    logger.info("Uploading artifact using provided context", {
+      environment: item.environmentId,
+      cloud: item.provider,
+      region: item.region,
     });
   }
-  // Use the compute's environment if provided, otherwise prompt for it
-  const environment = compute?.environmentId
-    ? { id: compute.environmentId }
+  // Use the item's environment if provided, otherwise prompt for it
+  const environment = item?.environmentId
+    ? { id: item.environmentId }
     : await flinkCcloudEnvironmentQuickPick();
 
-  // Use the compute's provider and region if provided, otherwise prompt for it
-  let cloudRegion = compute
-    ? { provider: compute.provider, region: compute.region, cloud: compute.provider }
+  // Use the item's provider and region if provided, otherwise prompt for it
+  let cloudRegion = item
+    ? { provider: item.provider, region: item.region, cloud: item.provider }
     : await cloudProviderRegionQuickPick((region) => region.cloud !== "GCP");
 
   if (!environment || !environment.id || !cloudRegion) {

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -9,6 +9,7 @@ import {
 import { artifactUploadCompleted } from "../../emitters";
 import { logError } from "../../errors";
 import { Logger } from "../../logging";
+import { CCloudFlinkComputePool } from "../../models/flinkComputePool";
 import { CloudProvider, EnvironmentId, IEnvProviderRegion } from "../../models/resource";
 import { showErrorNotificationWithButtons } from "../../notifications";
 import { cloudProviderRegionQuickPick } from "../../quickpicks/cloudProviderRegions";
@@ -85,9 +86,25 @@ export async function getPresignedUploadUrl(
   return urlResponse;
 }
 
-export async function promptForArtifactUploadParams(): Promise<ArtifactUploadParams | undefined> {
-  const environment = await flinkCcloudEnvironmentQuickPick();
-  const cloudRegion = await cloudProviderRegionQuickPick((region) => region.cloud !== "GCP");
+export async function promptForArtifactUploadParams(
+  compute?: CCloudFlinkComputePool,
+): Promise<ArtifactUploadParams | undefined> {
+  if (compute) {
+    logger.info("Uploading artifact using compute context", {
+      environment: compute.environmentId,
+      cloud: compute.provider,
+      region: compute.region,
+    });
+  }
+  // Use the compute's environment if provided, otherwise prompt for it
+  const environment = compute?.environmentId
+    ? { id: compute.environmentId }
+    : await flinkCcloudEnvironmentQuickPick();
+
+  // Use the compute's provider and region if provided, otherwise prompt for it
+  let cloudRegion = compute
+    ? { provider: compute.provider, region: compute.region, cloud: compute.provider }
+    : await cloudProviderRegionQuickPick((region) => region.cloud !== "GCP");
 
   if (!environment || !environment.id || !cloudRegion) {
     return undefined;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
- Rearrange some things so we can upload artifacts from _all the places_. Modifies existing upload command to accept a CCloud Cluster, CCloud Compute Pool, or File URI as `item`
- Refactor `promptForArtifactUploadParams` to use provided `item` info instead of asking the user to select when possible
- Adds a new "explorer/context" menu item - this will create the right-click context menu item for `.jar` files
- Adds a new "view/item/context" menu item to connect uploadArtifacts to these resources
- Another change to the wording of the `uploadArtifact` command `title` so that it looks good in the context menus. 
- Closes #2193
- Closes #2460

## Any additional details or context that should be provided?

| `.jar` file context menu | `cluster` context menu |
| --  | -- |
|<img width="684" height="651" alt="Screenshot 2025-09-10 at 8 03 26 AM" src="https://github.com/user-attachments/assets/f06969fe-1489-4d42-9496-e420c157302c" /> | <img width="582" height="525" alt="Screenshot 2025-09-12 at 1 02 40 PM" src="https://github.com/user-attachments/assets/1c41059a-88a0-4ee9-b3f1-06e119a0b7ec" /> |

- Played around a bit with a "View" button in the success notification, but I wasn't able to figure out how to force the Confluent extension to open and show the newly uploaded artifact. Maybe others have some ideas.
- I'm pretty sure I'll re-word this command title now that we see it in various places


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests
- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
