### PR TITLE
[minor] Artifact flow: exit silently

### DIFF
--- a/src/commands/utils/uploadArtifact.test.ts
+++ b/src/commands/utils/uploadArtifact.test.ts
@@ -200,30 +200,6 @@ describe("uploadArtifact", () => {
       assert.strictEqual(result, undefined);
     });
 
-    it("should show warning notification if there is no artifact name", async () => {
-      flinkCcloudEnvironmentQuickPickStub.resolves(mockEnvironment);
-      cloudProviderRegionQuickPickStub.resolves({
-        ...fakeCloudProviderRegion,
-        provider: "AZURE",
-      });
-
-      sandbox.stub(vscode.window, "showOpenDialog").resolves([mockFileUri]);
-      sandbox.stub(vscode.window, "showInputBox").resolves(undefined);
-
-      const warningNotificationStub = sandbox
-        .stub(notifications, "showWarningNotificationWithButtons")
-        .resolves(undefined);
-
-      const result = await promptForArtifactUploadParams();
-
-      assert.strictEqual(result, undefined);
-
-      sinon.assert.calledWith(
-        warningNotificationStub,
-        "Upload Artifact cancelled: Artifact name is required.",
-      );
-    });
-
     it("should prefill artifact name with file base name when selecting a file", async () => {
       flinkCcloudEnvironmentQuickPickStub.resolves(mockEnvironment);
       cloudProviderRegionQuickPickStub.resolves({

--- a/src/commands/utils/uploadArtifact.ts
+++ b/src/commands/utils/uploadArtifact.ts
@@ -10,10 +10,7 @@ import { artifactUploadCompleted } from "../../emitters";
 import { isResponseError, logError } from "../../errors";
 import { Logger } from "../../logging";
 import { CloudProvider, EnvironmentId, IEnvProviderRegion } from "../../models/resource";
-import {
-  showErrorNotificationWithButtons,
-  showWarningNotificationWithButtons,
-} from "../../notifications";
+import { showErrorNotificationWithButtons } from "../../notifications";
 import { cloudProviderRegionQuickPick } from "../../quickpicks/cloudProviderRegions";
 import { flinkCcloudEnvironmentQuickPick } from "../../quickpicks/environments";
 import { getSidecar } from "../../sidecar";
@@ -128,9 +125,6 @@ export async function promptForArtifactUploadParams(): Promise<ArtifactUploadPar
   });
 
   if (!artifactName) {
-    void showWarningNotificationWithButtons(
-      "Upload Artifact cancelled: Artifact name is required.",
-    );
     return undefined;
   }
 


### PR DESCRIPTION
## Summary of Changes

This PR is a follow-on to [2371](https://github.com/confluentinc/vscode/pull/2371#discussion_r2299545062) and fixes issue [2398](https://github.com/confluentinc/vscode/issues/2398) 

## Any additional details or context that should be provided?

To test, start the extension dev host, log in to CC, start the artifact flow and hit 'excape' at any point along it, verifying that you receive no error notification. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [x] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
