### PR TITLE
Assign label `needs triage` to new bug/doc issues by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: 'Report a bug'
 description: Report a bug with Confluent for VS Code.
 labels:
   - 'bug'
+  - 'needs triage'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -2,7 +2,8 @@ name: 'Report a documentation issue'
 description: Report an issue with the Confluent for VS Code documentation.
 title: 'Docs: '
 labels:
-  - 'docs'
+  - 'documentation'
+  - 'needs triage'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary of Changes

Make sure that bug and doc issues created with our issue templates are labeled with `needs triage` by default.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
