### PR TITLE
Update tooltip markdown generation

### DIFF
--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -1,11 +1,4 @@
-import {
-  MarkdownString,
-  ThemeColor,
-  ThemeIcon,
-  TreeItem,
-  TreeItemCollapsibleState,
-  Uri,
-} from "vscode";
+import { ThemeColor, ThemeIcon, TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import {
   CCLOUD_BASE_PATH,
@@ -401,35 +394,30 @@ export class EnvironmentTreeItem extends TreeItem {
   }
 }
 
-export function createEnvironmentTooltip(resource: Environment): MarkdownString {
-  let resourceLabel = "Environment";
-  const isDirectResource = isDirect(resource);
-  if (isDirectResource) {
-    // Direct connections are treated like environments, but calling it an environment will feel weird
-    const directEnv = resource as DirectEnvironment;
-    resourceLabel = `${directEnv.formConnectionType} Connection`;
-  }
-
-  const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${resource.iconName}) ${resourceLabel}`)
-    .appendMarkdown("\n\n---")
-    .appendMarkdown(`\n\nID: \`${resource.id}\``)
-    .appendMarkdown(`\n\nName: \`${resource.name}\``);
+export function createEnvironmentTooltip(resource: Environment): CustomMarkdownString {
+  const tooltip = new CustomMarkdownString();
   if (isCCloud(resource)) {
+    tooltip
+      .addHeader(`Environment`, resource.iconName)
+      .addField("ID", resource.id)
+      .addField("Name", resource.name);
     const ccloudEnv = resource as CCloudEnvironment;
     tooltip
-      .appendMarkdown(`\n\nStream Governance Package: \`${ccloudEnv.streamGovernancePackage}\``)
-      .appendMarkdown("\n\n---")
-      .appendMarkdown(
-        `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudEnv.ccloudUrl})`,
-      );
-  } else if (isDirectResource) {
+      .addField("Stream Governance Package", ccloudEnv.streamGovernancePackage)
+      .addCCloudLink(ccloudEnv.ccloudUrl);
+  } else if (isDirect(resource)) {
+    // Direct connections are treated like environments, but calling it an environment will feel weird
+    const directEnv = resource as DirectEnvironment;
+    tooltip
+      .addHeader(`${directEnv.formConnectionType} Connection`, resource.iconName)
+      .addField("ID", resource.id)
+      .addField("Name", resource.name);
+
     // check for any resources that the sidecar reported a `FAILED` connection status.
     // ideally, the ResourceViewProvider would react to events pushed by the ConnectionStateWatcher
     // and update the environments' `kafkaConnectionFailed` and `schemaRegistryConnectionFailed`
     // properties, but in the event we didn't get those websocket events (e.g. new workspace),
     // we can check to see if they're just "missing" based on the expected configuration(s)
-    const directEnv = resource as DirectEnvironment;
     const { missingKafka, missingSR } = directEnv.checkForMissingResources();
 
     const failedResources = [];
@@ -448,7 +436,7 @@ export function createEnvironmentTooltip(resource: Environment): MarkdownString 
     }
 
     if (failedResources.length) {
-      tooltip.appendMarkdown("\n\n---").appendMarkdown("\n\n$(error) **Unable to connect to**:");
+      tooltip.addWarning("**Unable to connect to**:", "error");
       failedResources.forEach((error) => {
         tooltip.appendMarkdown(`\n\n- ${error}`);
       });
@@ -456,11 +444,9 @@ export function createEnvironmentTooltip(resource: Environment): MarkdownString 
       const commandUri = Uri.parse(
         `command:confluent.connections.direct.edit?${encodeURIComponent(JSON.stringify([resource.connectionId]))}`,
       );
-      tooltip.appendMarkdown(`\n\n[View Connection Details](${commandUri})`);
+      tooltip.addLink("View Connection Details", commandUri.toString());
     } else if (missingResources.length) {
-      tooltip
-        .appendMarkdown("\n\n---")
-        .appendMarkdown(`\n\n$(error) Unable to connect to ${missingResources.join(" and ")}.`);
+      tooltip.addWarning(`Unable to connect to ${missingResources.join(" and ")}.`, "error");
     }
   }
 

--- a/src/models/flinkArtifact.ts
+++ b/src/models/flinkArtifact.ts
@@ -1,9 +1,9 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ArtifactV1FlinkArtifactMetadata } from "../clients/flinkArtifacts";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_BASE_PATH, IconNames, UTM_SOURCE_VSCODE } from "../constants";
-import { CustomMarkdownString, IdItem, KeyValuePair } from "./main";
+import { CustomMarkdownString, IdItem } from "./main";
 import { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
-import { ArtifactV1FlinkArtifactMetadata } from "../clients/flinkArtifacts";
 
 export class FlinkArtifact implements IResourceBase, IdItem, ISearchable {
   connectionId!: ConnectionId;
@@ -88,24 +88,20 @@ export class FlinkArtifactTreeItem extends TreeItem {
 }
 
 export function createFlinkArtifactToolTip(resource: FlinkArtifact): CustomMarkdownString {
-  let documentationLabel: KeyValuePair;
-  if (resource.documentationLink === undefined || resource.documentationLink === "") {
-    // Change to "Add documentation link" command for adding during upload is implemented
-    documentationLabel = ["No documentation link", ""];
+  const tooltip = new CustomMarkdownString()
+    .addHeader("Flink Artifact", IconNames.FLINK_ARTIFACT)
+    .addField("ID", resource.id)
+    .addField("Description", resource.description)
+    .addField("Created At", resource.createdAt?.toLocaleString())
+    .addField("Updated At", resource.updatedAt?.toLocaleString());
+
+  if (!resource.documentationLink || resource.documentationLink === "") {
+    tooltip.addLink("No documentation link", "");
   } else {
-    documentationLabel = ["See Documentation", resource.documentationLink];
+    tooltip.addLink("See Documentation", resource.documentationLink);
   }
 
-  return CustomMarkdownString.resourceTooltip(
-    "Flink Artifact",
-    IconNames.FLINK_ARTIFACT,
-    resource.ccloudUrl,
-    [
-      ["ID", resource.id],
-      ["Description", resource.description],
-      ["Created At", resource.createdAt?.toLocaleString()],
-      ["Updated At", resource.updatedAt?.toLocaleString()],
-    ],
-    documentationLabel,
-  );
+  tooltip.addCCloudLink(resource.ccloudUrl);
+
+  return tooltip;
 }

--- a/src/models/flinkComputePool.test.ts
+++ b/src/models/flinkComputePool.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
-import { CCLOUD_BASE_PATH, IconNames } from "../constants";
+import { CCLOUD_BASE_PATH, IconNames, UTM_SOURCE_VSCODE } from "../constants";
 import {
   CCloudFlinkComputePool,
   FlinkComputePoolTreeItem,
@@ -14,7 +14,7 @@ describe("models/flinkComputePool.ts CCloudFlinkComputePool", () => {
 
     assert.strictEqual(
       pool.ccloudUrl,
-      `https://${CCLOUD_BASE_PATH}/environments/${pool.environmentId}/flink/pools/${pool.id}/overview`,
+      `https://${CCLOUD_BASE_PATH}/environments/${pool.environmentId}/flink/pools/${pool.id}/overview?utm_source=${UTM_SOURCE_VSCODE}`,
     );
   });
 

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -1,6 +1,6 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
-import { CCLOUD_BASE_PATH, CCLOUD_CONNECTION_ID, IconNames } from "../constants";
+import { CCLOUD_BASE_PATH, CCLOUD_CONNECTION_ID, IconNames, UTM_SOURCE_VSCODE } from "../constants";
 import { CustomMarkdownString } from "./main";
 import {
   ConnectionId,
@@ -50,7 +50,7 @@ export class CCloudFlinkComputePool extends FlinkComputePool implements IEnvProv
   }
 
   get ccloudUrl(): string {
-    return `https://${CCLOUD_BASE_PATH}/environments/${this.environmentId}/flink/pools/${this.id}/overview`;
+    return `https://${CCLOUD_BASE_PATH}/environments/${this.environmentId}/flink/pools/${this.id}/overview?utm_source=${UTM_SOURCE_VSCODE}`;
   }
 
   searchableText(): string {
@@ -87,19 +87,17 @@ export class FlinkComputePoolTreeItem extends TreeItem {
 
 export function createFlinkComputePoolTooltip(resource: FlinkComputePool) {
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${resource.iconName}) Flink Compute Pool\n`)
-    .appendMarkdown("\n\n---")
-    .appendMarkdown(`\n\nID: \`${resource.id}\``)
-    .appendMarkdown(`\n\nName: \`${resource.name}\``);
+    .addHeader("Flink Compute Pool", resource.iconName)
+    .addField("ID", resource.id)
+    .addField("Name", resource.name);
+
   if (isCCloud(resource)) {
     const ccloudPool = resource as CCloudFlinkComputePool;
-    tooltip.appendMarkdown(`\n\nProvider: \`${ccloudPool.provider}\``);
-    tooltip.appendMarkdown(`\n\nRegion: \`${ccloudPool.region}\``);
-    tooltip.appendMarkdown(`\n\nMax CFU: \`${ccloudPool.maxCfu}\``);
-    tooltip.appendMarkdown("\n\n---");
-    tooltip.appendMarkdown(
-      `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudPool.ccloudUrl})`,
-    );
+    tooltip
+      .addField("Provider", ccloudPool.provider)
+      .addField("Region", ccloudPool.region)
+      .addField("Max CFU", ccloudPool.maxCfu.toString());
+    tooltip.addCCloudLink(ccloudPool.ccloudUrl);
   }
 
   return tooltip;

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -294,20 +294,7 @@ export class FlinkStatementTreeItem extends TreeItem {
       : resource.phase;
     this.iconPath = this.getThemeIcon();
 
-    this.tooltip = CustomMarkdownString.resourceTooltip(
-      "Flink Statement",
-      this.iconPath.id as IconNames,
-      resource.ccloudUrl,
-      [
-        ["Kind", resource.sqlKindDisplay],
-        ["Status", resource.phase],
-        ["Created At", resource.createdAt?.toLocaleString()],
-        ["Updated At", resource.updatedAt?.toLocaleString()],
-        ["Environment", resource.environmentId],
-        ["Compute Pool", resource.computePoolId],
-        ["Detail", resource.status.detail],
-      ],
-    );
+    this.tooltip = createFlinkStatementTooltip(resource);
 
     this.command = {
       command: "confluent.statements.viewstatementsql",
@@ -320,26 +307,7 @@ export class FlinkStatementTreeItem extends TreeItem {
    * Determine icon + color based on the `phase` of the statement.
    */
   getThemeIcon(): ThemeIcon {
-    switch (this.resource.phase.toUpperCase()) {
-      case Phase.FAILED:
-      case Phase.FAILING:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_FAILED, STATUS_RED);
-      case Phase.DEGRADED:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_DEGRADED, STATUS_YELLOW);
-      case Phase.RUNNING:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_RUNNING, STATUS_GREEN);
-      case Phase.COMPLETED:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_COMPLETED, STATUS_GRAY);
-      case Phase.DELETING:
-      case Phase.STOPPING:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_DELETING, STATUS_GRAY);
-      case Phase.STOPPED:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_STOPPED, STATUS_BLUE);
-      case Phase.PENDING:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_PENDING, STATUS_BLUE);
-      default:
-        return new ThemeIcon(IconNames.FLINK_STATEMENT);
-    }
+    return getFlinkStatementThemeIcon(this.resource.phase);
   }
 }
 
@@ -352,6 +320,32 @@ export const STATUS_BLUE = new ThemeColor("notificationsInfoIcon.foreground");
 // there aren't as many green or gray options to choose from without using `chart` colors
 export const STATUS_GREEN = new ThemeColor("charts.green");
 export const STATUS_GRAY = new ThemeColor("charts.lines");
+
+/**
+ * Get the appropriate ThemeIcon for a Flink statement based on its phase.
+ */
+function getFlinkStatementThemeIcon(phase: Phase): ThemeIcon {
+  switch (phase.toUpperCase()) {
+    case Phase.FAILED:
+    case Phase.FAILING:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_FAILED, STATUS_RED);
+    case Phase.DEGRADED:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_DEGRADED, STATUS_YELLOW);
+    case Phase.RUNNING:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_RUNNING, STATUS_GREEN);
+    case Phase.COMPLETED:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_COMPLETED, STATUS_GRAY);
+    case Phase.DELETING:
+    case Phase.STOPPING:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_DELETING, STATUS_GRAY);
+    case Phase.STOPPED:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_STOPPED, STATUS_BLUE);
+    case Phase.PENDING:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT_STATUS_PENDING, STATUS_BLUE);
+    default:
+      return new ThemeIcon(IconNames.FLINK_STATEMENT);
+  }
+}
 
 /**
  * Convert a from-REST API depiction of a Flink statement to
@@ -381,6 +375,21 @@ export function restFlinkStatementToModel(
     metadata: restFlinkStatement.metadata!,
     status: restFlinkStatement.status,
   });
+}
+
+export function createFlinkStatementTooltip(resource: FlinkStatement) {
+  const tooltip = new CustomMarkdownString()
+    .addHeader("Flink Statement", getFlinkStatementThemeIcon(resource.phase).id as IconNames)
+    .addField("Kind", resource.sqlKindDisplay)
+    .addField("Status", resource.phase)
+    .addField("Created At", resource.createdAt?.toLocaleString())
+    .addField("Updated At", resource.updatedAt?.toLocaleString())
+    .addField("Environment", resource.environmentId)
+    .addField("Compute Pool", resource.computePoolId)
+    .addField("Detail", resource.status.detail)
+    .addCCloudLink(resource.ccloudUrl);
+
+  return tooltip;
 }
 
 export class FlinkSpecProperties {

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -1,5 +1,5 @@
 import { Data, type Require as Enforced } from "dataclass";
-import { MarkdownString, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import {
   CCLOUD_BASE_PATH,
@@ -173,29 +173,19 @@ export class KafkaClusterTreeItem extends TreeItem {
   }
 }
 
-// todo make this a method of KafkaCluster family.
-export function createKafkaClusterTooltip(resource: KafkaCluster): MarkdownString {
+export function createKafkaClusterTooltip(resource: KafkaCluster): CustomMarkdownString {
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${resource.iconName}) Kafka Cluster`)
-    .appendMarkdown("\n\n---");
-  if (resource.name) {
-    tooltip.appendMarkdown(`\n\nName: \`${resource.name}\``);
-  }
-  tooltip
-    .appendMarkdown(`\n\nID: \`${resource.id}\``) // TODO: remove this?
-    .appendMarkdown(`\n\nBootstrap Servers: \`${resource.bootstrapServers}\``);
-  if (resource.uri) {
-    tooltip.appendMarkdown(`\n\nURI: \`${resource.uri}\``);
-  }
+    .addHeader("Kafka Cluster", resource.iconName)
+    .addField("Name", resource.name)
+    .addField("ID", resource.id)
+    .addField("Bootstrap Servers", resource.bootstrapServers)
+    .addField("URI", resource.uri);
   if (isCCloud(resource)) {
     const ccloudCluster = resource as CCloudKafkaCluster;
     tooltip
-      .appendMarkdown(`\n\nProvider: \`${ccloudCluster.provider}\``)
-      .appendMarkdown(`\n\nRegion: \`${ccloudCluster.region}\``)
-      .appendMarkdown("\n\n---")
-      .appendMarkdown(
-        `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudCluster.ccloudUrl})`,
-      );
+      .addField("Provider", ccloudCluster.provider)
+      .addField("Region", ccloudCluster.region)
+      .addCCloudLink(ccloudCluster.ccloudUrl);
   }
   return tooltip;
 }

--- a/src/models/main.test.ts
+++ b/src/models/main.test.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 import { TreeItemCollapsibleState } from "vscode";
-import { CCLOUD_BASE_PATH, IconNames } from "../constants";
-import { ContainerTreeItem, CustomMarkdownString, IdItem, KeyValuePairArray } from "./main";
+import { ContainerTreeItem, IdItem } from "./main";
 import { ISearchable } from "./resource";
 
 /** Mock class to be used as a child of a {@link ContainerTreeItem} for testing. */
@@ -70,64 +69,5 @@ describe("ContainerTreeItem tests", () => {
     );
     const children = [new MockContainerChild("1"), new MockContainerChild("1")];
     assert.throws(() => (container.children = children));
-  });
-});
-
-describe("CustomMarkdownString tests", () => {
-  describe("resourceTooltip", () => {
-    it("title line should include icon if provided", () => {
-      const iconName = IconNames.TOPIC;
-      const title = "MyResource";
-      const markdownString = CustomMarkdownString.resourceTooltip(title, iconName, undefined, []);
-      assert.ok(markdownString.value.startsWith(`#### $(${iconName}) ${title}\n`));
-    });
-
-    it("title line omits icon if not provided", () => {
-      const title = "MyResource";
-      const markdownString = CustomMarkdownString.resourceTooltip(title, undefined, undefined, []);
-      assert.ok(markdownString.value.startsWith(`#### ${title}\n`));
-    });
-
-    it("includes truthy key + value pairs, skips empty values", () => {
-      const keyValuePairs: KeyValuePairArray = [
-        ["Key1", "Value1"],
-        ["Key2", "Value2"],
-        ["Key3", undefined], // should be skipped.
-        ["Key4", ""], // should be skipped.
-      ];
-
-      const markdownString = CustomMarkdownString.resourceTooltip(
-        "MyResource",
-        undefined,
-        undefined,
-        keyValuePairs,
-      );
-      assert.ok(markdownString.value.includes("Key1: `Value1`"));
-      assert.ok(markdownString.value.includes("Key2: `Value2`"));
-      assert.ok(!markdownString.value.includes("Key3:"));
-      assert.ok(!markdownString.value.includes("Key4:"));
-    });
-
-    it("includes ccloudUrl if provided", () => {
-      const ccloudUrl = `https://${CCLOUD_BASE_PATH}/resource`;
-      const markdownString = CustomMarkdownString.resourceTooltip(
-        "MyResource",
-        undefined,
-        ccloudUrl,
-        [],
-      );
-      assert.ok(
-        markdownString.value.includes(
-          `[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudUrl})`,
-        ),
-      );
-    });
-
-    it("throws on invalid ccloudUrl", () => {
-      const invalidUrl = "invalid-url";
-      assert.throws(() => {
-        CustomMarkdownString.resourceTooltip("MyResource", undefined, invalidUrl, []);
-      }, /Invalid URL/);
-    });
   });
 });

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -82,53 +82,61 @@ export class CustomMarkdownString extends vscode.MarkdownString {
   }
 
   /**
-   * Construct a tooltip markdown string from a resource and a set of key-value pairs.
-   * @param title The kind of resource (e.g. "Kafka Cluster", "Compute Pool", etc.)
-   * @param iconName Icon to use beside title, if any.
-   * @param keyValuePairs attribute name + from-resource-value pairs. Any undefined value will be skipped.
-   * @param ccloudUrl Optional URL to view this resource in Confluent Cloud.
-   * @param linkUrl Optional link label + URL pair to add a custom link at the bottom of the tooltip.
-   * @returns
+   * Add a title with optional icon to the tooltip
    */
-  static resourceTooltip(
-    title: string,
-    iconName: IconNames | undefined,
-    ccloudUrl: string | undefined,
-    keyValuePairs: KeyValuePairArray,
-    linkUrl?: KeyValuePair,
-  ): CustomMarkdownString {
-    const tooltip = new CustomMarkdownString();
-
+  addHeader(title: string, iconName?: IconNames): this {
     if (iconName) {
-      tooltip.appendMarkdown(`#### $(${iconName}) ${title}\n`);
+      this.appendMarkdown(`#### $(${iconName}) ${title}\n`);
     } else {
-      tooltip.appendMarkdown(`#### ${title}\n`);
+      this.appendMarkdown(`#### ${title}\n`);
     }
-    tooltip.appendMarkdown("\n\n---");
+    this.appendMarkdown("\n\n---");
+    return this;
+  }
 
-    keyValuePairs.forEach(([key, value]) => {
-      // Skip undefined or empty values
-      if (value === undefined || value === "") {
-        return;
-      }
-      tooltip.appendMarkdown(`\n\n${key}: \`${value}\``);
-    });
-
-    if (linkUrl) {
-      tooltip.appendMarkdown(`\n\n[${linkUrl[0]}](${linkUrl[1]})`);
+  /**
+   * Add a standard field (key: value) to the tooltip
+   */
+  addField(label: string, value: string | undefined): this {
+    if (value !== undefined && value !== "") {
+      this.appendMarkdown(`\n\n${label}: \`${value}\``);
     }
+    return this;
+  }
 
-    if (ccloudUrl) {
-      // Ensure URL is vaguely valid
-      if (!ccloudUrl.startsWith("https://")) {
-        throw new Error(`Invalid URL: ${ccloudUrl}`);
-      }
-      tooltip.appendMarkdown("\n\n---");
-      tooltip.appendMarkdown(
-        `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudUrl})`,
-      );
+  /**
+   * Add a warning message with icon. Automatically adds a divider before each warning.
+   */
+  addWarning(message: string, icon: string = "warning"): this {
+    this.addDivider();
+    this.appendMarkdown(`\n\n$(${icon}) ${message}`);
+    return this;
+  }
+
+  /**
+   * Add a divider line
+   */
+  addDivider(): this {
+    this.appendMarkdown("\n\n---");
+    return this;
+  }
+
+  /**
+   * Add Confluent Cloud link
+   */
+  addCCloudLink(url: string): this {
+    if (url && url.startsWith("https://")) {
+      this.addDivider();
+      this.appendMarkdown(`\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${url})`);
     }
+    return this;
+  }
 
-    return tooltip;
+  /**
+   * Add a custom link
+   */
+  addLink(label: string, url: string): this {
+    this.appendMarkdown(`\n\n[${label}](${url})`);
+    return this;
   }
 }

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -316,20 +316,15 @@ export class SchemaTreeItem extends vscode.TreeItem {
   }
 }
 
-function createSchemaTooltip(resource: Schema): vscode.MarkdownString {
+export function createSchemaTooltip(resource: Schema): CustomMarkdownString {
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown("#### Schema")
-    .appendMarkdown("\n\n---")
-    .appendMarkdown(`\n\nID: \`${resource.id}\``)
-    .appendMarkdown(`\n\nSubject: \`${resource.subject}\``)
-    .appendMarkdown(`\n\nVersion: \`${resource.version}\``)
-    .appendMarkdown(`\n\nType: \`${resource.type}\``);
+    .addHeader("Schema")
+    .addField("ID", resource.id)
+    .addField("Subject", resource.subject)
+    .addField("Version", resource.version.toString())
+    .addField("Type", resource.type);
   if (isCCloud(resource)) {
-    tooltip
-      .appendMarkdown("\n\n---")
-      .appendMarkdown(
-        `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${resource.ccloudUrl})`,
-      );
+    tooltip.addCCloudLink(resource.ccloudUrl);
   }
   return tooltip;
 }

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -1,5 +1,5 @@
 import { Data, type Require as Enforced } from "dataclass";
-import { MarkdownString, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import {
   CCLOUD_BASE_PATH,
@@ -119,22 +119,17 @@ export class SchemaRegistryTreeItem extends TreeItem {
   }
 }
 
-// todo easy peasy make this a method of SchemaRegistry family.
-function createSchemaRegistryTooltip(resource: SchemaRegistry): MarkdownString {
+export function createSchemaRegistryTooltip(resource: SchemaRegistry): CustomMarkdownString {
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${resource.iconName}) Schema Registry`)
-    .appendMarkdown("\n\n---")
-    .appendMarkdown(`\n\nID: \`${resource.id}\``)
-    .appendMarkdown(`\n\nURI: \`${resource.uri}\``);
+    .addHeader("Schema Registry", resource.iconName)
+    .addField("ID", resource.id)
+    .addField("URI", resource.uri);
   if (isCCloud(resource)) {
     const ccloudSchemaRegistry = resource as CCloudSchemaRegistry;
     tooltip
-      .appendMarkdown(`\n\nProvider: \`${ccloudSchemaRegistry.provider}\``)
-      .appendMarkdown(`\n\nRegion: \`${ccloudSchemaRegistry.region}\``)
-      .appendMarkdown("\n\n---")
-      .appendMarkdown(
-        `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${ccloudSchemaRegistry.ccloudUrl})`,
-      );
+      .addField("Provider", ccloudSchemaRegistry.provider)
+      .addField("Region", ccloudSchemaRegistry.region)
+      .addCCloudLink(ccloudSchemaRegistry.ccloudUrl);
   }
   return tooltip;
 }

--- a/src/models/topic.ts
+++ b/src/models/topic.ts
@@ -108,36 +108,28 @@ export class KafkaTopicTreeItem extends vscode.TreeItem {
 function createKafkaTopicTooltip(
   resource: KafkaTopic,
   missingAuthz: KafkaTopicOperation[],
-): vscode.MarkdownString {
+): CustomMarkdownString {
   const iconName = resource.hasSchema ? IconNames.TOPIC : IconNames.TOPIC_WITHOUT_SCHEMA;
 
   const tooltip = new CustomMarkdownString()
-    .appendMarkdown(`#### $(${iconName}) Kafka Topic`)
-    .appendMarkdown("\n\n---")
-    .appendMarkdown(`\n\nName: \`${resource.name}\``)
-    .appendMarkdown(`\n\nReplication Factor: \`${resource.replication_factor}\``)
-    .appendMarkdown(`\n\nPartition Count: \`${resource.partition_count}\``)
-    .appendMarkdown(`\n\nInternal: \`${resource.is_internal}\``);
+    .addHeader("Kafka Topic", iconName)
+    .addField("Name", resource.name)
+    .addField("Replication Factor", resource.replication_factor.toString())
+    .addField("Partition Count", resource.partition_count.toString())
+    .addField("Internal", resource.is_internal.toString());
 
   if (!resource.hasSchema) {
-    tooltip
-      .appendMarkdown("\n\n---")
-      .appendMarkdown("\n\n$(warning) No schema(s) found for topic.");
+    tooltip.addWarning("No schema(s) found for topic.");
   }
 
   // list any missing authorized operations
   if (missingAuthz.length > 0) {
-    tooltip
-      .appendMarkdown("\n\n---")
-      .appendMarkdown("\n\n$(warning) Missing authorization for the following actions:");
+    tooltip.addWarning("Missing authorization for the following actions:");
     missingAuthz.forEach((op) => tooltip.appendMarkdown(` - ${op}\n`));
   }
 
   if (isCCloud(resource)) {
-    tooltip.appendMarkdown("\n\n---");
-    tooltip.appendMarkdown(
-      `\n\n[$(${IconNames.CONFLUENT_LOGO}) Open in Confluent Cloud](${resource.ccloudUrl})`,
-    );
+    tooltip.addCCloudLink(resource.ccloudUrl);
   }
 
   return tooltip;

--- a/src/viewProviders/newResources.test.ts
+++ b/src/viewProviders/newResources.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
-import { MarkdownString, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { TreeItem, TreeItemCollapsibleState } from "vscode";
 import { eventEmitterStubs, StubbedEventEmitters } from "../../tests/stubs/emitters";
 import {
   TEST_CCLOUD_ENVIRONMENT,
@@ -34,6 +34,7 @@ import {
 } from "../models/environment";
 import { FlinkComputePoolTreeItem } from "../models/flinkComputePool";
 import { KafkaClusterTreeItem } from "../models/kafkaCluster";
+import { CustomMarkdownString } from "../models/main";
 import { ConnectionId } from "../models/resource";
 import { SchemaRegistryTreeItem } from "../models/schemaRegistry";
 import * as notifications from "../notifications";
@@ -314,7 +315,7 @@ describe("viewProviders/newResources.ts", () => {
       describe("tooltip", () => {
         it("calls + returns createEnvironmentTooltip() result when env set", () => {
           const envToolTipStub = sandbox.stub(environmentModels, "createEnvironmentTooltip");
-          envToolTipStub.returns(new MarkdownString("Test tooltip"));
+          envToolTipStub.returns(new CustomMarkdownString("Test tooltip"));
           directConnectionRow.environments.push(TEST_DIRECT_ENVIRONMENT_WITH_KAFKA_AND_SR);
           assert.strictEqual(directConnectionRow.tooltip.value, "Test tooltip");
           sinon.assert.calledOnce(envToolTipStub);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Removed `CustomMarkdownString.resourceTooltip()` and simplified into sub methods for more flexible field customization of tooltips while still maintaining a  general defined structure of:
1. **Header** - Resource type with icon
2. **Fields** - Key-value pairs for resource properties
3. **Warnings** - Error/warning messages (if any)
4. **Links** - External links and Confluent Cloud links (if any)
- Updated outdated tooltip markdown generation in `flinkComputePool`, `environment`, `kafkaCluster`, `schema`, `schemaRegistry`, `topic` to new methods
### Pattern:
```
#### $(icon-name) Resource Type
---
Field Name: `value`
Another Field: `value`
---
$(warning/error) Warning message
---
$(warning/error) Another warning
---
[Custom Link](url)
---
[(confluent-logo) Open in Confluent Cloud](ccloud-url)
```
## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2524

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [X] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [X] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
