### PR TITLE
feat: add dedicated URI handler command

### DIFF
--- a/package.json
+++ b/package.json
@@ -450,7 +450,8 @@
         "command": "confluent.handleUri",
         "title": "Handle URI",
         "icon": "$(link)",
-        "category": "Confluent"
+        "category": "Confluent",
+        "enablement": "confluent.e2eTesting"
       },
       {
         "command": "confluent.openCCloudApiKeysUrl",

--- a/package.json
+++ b/package.json
@@ -447,6 +447,12 @@
         "category": "Confluent: Flink Statements"
       },
       {
+        "command": "confluent.handleUri",
+        "title": "Handle URI",
+        "icon": "$(link)",
+        "category": "Confluent"
+      },
+      {
         "command": "confluent.openCCloudApiKeysUrl",
         "icon": "$(confluent-logo)",
         "title": "Manage API Keys in Confluent Cloud",

--- a/package.json
+++ b/package.json
@@ -1316,6 +1316,10 @@
           "when": "false"
         },
         {
+          "command": "confluent.handleUri",
+          "when": "confluent.e2eTesting"
+        },
+        {
           "command": "confluent.openCCloudApiKeysUrl",
           "when": "false"
         },

--- a/src/commands/uris.test.ts
+++ b/src/commands/uris.test.ts
@@ -1,0 +1,85 @@
+import assert from "assert";
+import sinon from "sinon";
+import { env, InputBoxValidationMessage, InputBoxValidationSeverity, window } from "vscode";
+import { EXTENSION_ID } from "../constants";
+import { UriEventHandler } from "../uriHandler";
+import { EXT_URI_PREFIX, handleUriCommand, uriValidator } from "./uris";
+
+describe("commands/uris.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("handleUriCommand", () => {
+    let showInputBoxStub: sinon.SinonStub;
+    let showErrorMessageStub: sinon.SinonStub;
+    let stubbedUriHandler: sinon.SinonStubbedInstance<UriEventHandler>;
+
+    beforeEach(() => {
+      showInputBoxStub = sandbox.stub(window, "showInputBox");
+      showErrorMessageStub = sandbox.stub(window, "showErrorMessage");
+
+      stubbedUriHandler = sandbox.createStubInstance(UriEventHandler);
+      sandbox
+        .stub(UriEventHandler, "getInstance")
+        .returns(stubbedUriHandler as unknown as UriEventHandler);
+    });
+
+    it("should handle valid URI strings", async () => {
+      const validUriString = `${env.uriScheme}://${EXTENSION_ID}/path`;
+      showInputBoxStub.resolves(validUriString);
+
+      await handleUriCommand();
+
+      sinon.assert.calledOnce(showInputBoxStub);
+      sinon.assert.notCalled(showErrorMessageStub);
+      sinon.assert.calledOnce(stubbedUriHandler.handleUri);
+      const calledWithUri = stubbedUriHandler.handleUri.getCall(0).args[0];
+      assert.strictEqual(calledWithUri.toString(), validUriString);
+    });
+
+    it("should do nothing if the user cancels the input box", async () => {
+      showInputBoxStub.resolves(undefined);
+
+      await handleUriCommand();
+
+      sinon.assert.calledOnce(showInputBoxStub);
+      sinon.assert.notCalled(showErrorMessageStub);
+      sinon.assert.notCalled(stubbedUriHandler.handleUri);
+    });
+  });
+
+  describe("uriValidator()", () => {
+    it("should return undefined for valid URIs", () => {
+      const validUriString = `${EXT_URI_PREFIX}/path`;
+      const result: InputBoxValidationMessage | undefined = uriValidator(validUriString);
+      assert.strictEqual(result, undefined);
+    });
+
+    it("should return a validation error message for URIs with incorrect scheme", () => {
+      const invalidUriString = `invalid-prefix:///${EXTENSION_ID}/path`;
+
+      const result: InputBoxValidationMessage | undefined = uriValidator(invalidUriString);
+
+      assert.ok(result);
+      assert.strictEqual(result.message, `URI must start with ${EXT_URI_PREFIX}`);
+      assert.strictEqual(result?.severity, InputBoxValidationSeverity.Error);
+    });
+
+    it("should return a validation error message for URIs with incorrect authority", () => {
+      const invalidUriString = `${env.uriScheme}://wrong-authority/path`;
+
+      const result: InputBoxValidationMessage | undefined = uriValidator(invalidUriString);
+
+      assert.ok(result);
+      assert.strictEqual(result.message, `URI must start with ${EXT_URI_PREFIX}`);
+      assert.strictEqual(result?.severity, InputBoxValidationSeverity.Error);
+    });
+  });
+});

--- a/src/commands/uris.ts
+++ b/src/commands/uris.ts
@@ -1,0 +1,48 @@
+import {
+  Disposable,
+  env,
+  InputBoxValidationMessage,
+  InputBoxValidationSeverity,
+  Uri,
+  window,
+} from "vscode";
+import { registerCommandWithLogging } from ".";
+import { EXTENSION_ID } from "../constants";
+import { UriEventHandler } from "../uriHandler";
+
+export const EXT_URI_PREFIX = `${env.uriScheme}://${EXTENSION_ID}/`;
+
+/**
+ * Explicitly handle a URI by prompting the user for input, parsing it, and passing it to the
+ * {@link UriEventHandler}.
+ * This is mainly used for environments where the default URI handling and/or protocol registration
+ * does not work (e.g. in CI environments).
+ */
+export async function handleUriCommand(): Promise<void> {
+  const inputString = await window.showInputBox({
+    prompt: "Enter a URI",
+    placeHolder: `${EXT_URI_PREFIX}path`,
+    validateInput: uriValidator,
+  });
+  if (!inputString) {
+    return;
+  }
+
+  const inputUri = Uri.parse(inputString);
+  const handler = UriEventHandler.getInstance();
+  await handler.handleUri(inputUri);
+}
+
+export function registerUriCommands(): Disposable[] {
+  return [registerCommandWithLogging("confluent.handleUri", handleUriCommand)];
+}
+
+export function uriValidator(value: string): InputBoxValidationMessage | undefined {
+  if (!value.startsWith(EXT_URI_PREFIX)) {
+    return {
+      message: `URI must start with ${EXT_URI_PREFIX}`,
+      severity: InputBoxValidationSeverity.Error,
+    };
+  }
+  return;
+}

--- a/src/context/values.ts
+++ b/src/context/values.ts
@@ -41,6 +41,8 @@ export enum ContextValues {
   RESOURCES_WITH_URIS = "confluent.resourcesWithURIs",
   /** Array of resources that can be selected for comparison and presented in a diff view. */
   DIFFABLE_RESOURCES = "confluent.diffableResources",
+  /** Whether the extension is running in an end-to-end testing environment. */
+  E2E_TESTING = "confluent.e2eTesting",
 
   // -- ADJUSTABLE CONTEXT VALUES --
   /** The user has a valid, authenticated connection to Confluent Cloud.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import { registerSchemaCommands } from "./commands/schemas";
 import { registerSearchCommands } from "./commands/search";
 import { registerSupportCommands } from "./commands/support";
 import { registerTopicCommands } from "./commands/topics";
+import { registerUriCommands } from "./commands/uris";
 import { AUTH_PROVIDER_ID, AUTH_PROVIDER_LABEL, IconNames } from "./constants";
 import { activateMessageViewer } from "./consume";
 import { setExtensionContext } from "./context/extension";
@@ -268,6 +269,7 @@ async function _activateExtension(
     ...registerSearchCommands(),
     ...registerFlinkArtifactCommands(),
     ...registerNewResourceViewCommands(),
+    ...registerUriCommands(),
   ];
   logger.info("Commands registered");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -359,7 +359,13 @@ async function _activateExtension(
 
 /** Configure any starting contextValues to use for view/menu controls during activation. */
 async function setupContextValues() {
-  // EXPERIMENTAL/PREVIEW: set default values for enabling the Flink view, resource fetching, and associated actions
+  // indicate to the UI that we are running in an end-to-end testing environment, since we can't
+  // easily use the "testing" extension mode like we can for Mocha tests
+  const e2eTestEnvironment = setContextValue(
+    ContextValues.E2E_TESTING,
+    process.env.CONFLUENT_VSCODE_E2E_TESTING === "true",
+  );
+  // EXPERIMENTAL/PREVIEW: set default values for any early opt-in/-out functionality
   const chatParticipantEnabled = setContextValue(
     ContextValues.chatParticipantEnabled,
     ENABLE_CHAT_PARTICIPANT.value,
@@ -382,7 +388,6 @@ async function setupContextValues() {
   // allow for easier matching using "in" clauses for our Resources/Topics/Schemas views
   const viewsWithResources = setContextValue(ContextValues.VIEWS_WITH_RESOURCES, [
     "confluent-resources",
-    "new-confluent-resources",
     "confluent-topics",
     "confluent-schemas",
     "confluent-flink-statements",
@@ -435,6 +440,7 @@ async function setupContextValues() {
     FlinkDatabaseViewProviderMode.Artifacts,
   );
   await Promise.all([
+    e2eTestEnvironment,
     chatParticipantEnabled,
     kafkaClusterSelected,
     schemaRegistrySelected,

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -25,6 +25,7 @@ export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements 
   }
 
   public async handleUri(uri: vscode.Uri) {
+    logger.info(`Handling URI: ${uri.toString()}`);
     const { path } = uri;
     switch (path) {
       case "/authCallback":


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Part 1 of 2 for https://github.com/confluentinc/vscode/issues/2528:
- add the `confluent.handleUri` command 👈 
  - update E2E tests to use this command for CCloud auth (https://github.com/confluentinc/vscode/pull/2585)

<img width="1055" height="414" alt="image" src="https://github.com/user-attachments/assets/7223a751-66a8-461a-945c-b65946a2914a" />
<img width="1104" height="160" alt="image" src="https://github.com/user-attachments/assets/ab6b8570-2d81-440c-8159-7baf059b70aa" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
