### PR TITLE
cleanup: use `confluent.handleUri` command for E2E tests' CCloud auth flow

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -754,27 +754,6 @@ export function functional(done) {
 }
 
 export function e2eRun(done) {
-  // check if the E2E tests are being run from a VS Code terminal (stable and insiders both use "vscode" here)
-  if (process.env.TERM_PROGRAM === "vscode") {
-    const vscodeVersion = process.env.VSCODE_VERSION ?? "stable";
-    // check for VS Code stable vs Insiders based on TERM_PROGRAM_VERSION
-    // - stable: "1.x.x"
-    // - insiders: "1.x.x-insider"
-    const runningFromVSCodeInsidersTerminal =
-      process.env.TERM_PROGRAM_VERSION?.endsWith("insider") ?? false;
-    // the only way we should allow E2E tests to run is if we're starting them from a different
-    // terminal version than the specified in the VSCODE_VERSION env var
-    const runStableFromStable = vscodeVersion !== "insiders" && !runningFromVSCodeInsidersTerminal;
-    const runInsidersFromInsiders =
-      vscodeVersion === "insiders" && runningFromVSCodeInsidersTerminal;
-    if (runStableFromStable || runInsidersFromInsiders) {
-      console.error(
-        "If you want to run E2E tests from a VS Code terminal, you must set the VSCODE_VERSION env var to the opposite of what VS Code version you are currently using. (For example, if you are running VS Code Insiders, set VSCODE_VERSION=stable to run E2E tests.)",
-      );
-      return done(1);
-    }
-  }
-
   // set env var so extension knows it's in E2E test mode, which is mainly used for CCloud auth:
   // - the auth provider will store the sign-in URL to a temp file for easier test handling of the
   //   browser-based sign-in flow through Playwright

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -17,6 +17,9 @@ import { configureVSCodeSettings } from "./utils/settings";
 // cached test setup file path that's shared across worker processes
 const TEST_SETUP_CACHE_FILE = path.join(tmpdir(), "vscode-e2e-test-setup-cache.json");
 
+const VSCODE_VERSION = process.env.VSCODE_VERSION || "stable";
+export const URI_SCHEME = VSCODE_VERSION === "insiders" ? "vscode-insiders" : "vscode";
+
 interface TestSetupCache {
   vscodeExecutablePath: string;
   outPath: string;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Part 2 of 2 for https://github.com/confluentinc/vscode/issues/2528:
- [x] add the `confluent.handleUri` command (https://github.com/confluentinc/vscode/pull/2584)
- [x] update E2E tests to use this command for CCloud auth 👈

This removes our previous workaround of cancelling the "Signing in to Confluent Cloud" progress notification and refreshing the CCloud connection for the more direct passing of the CCloud auth callback URI via the `confluent.handleUri` command.

Requires #2584 to be merged first, but was added as a child branch of #2557 to avoid merge conflicts.

Closes #2528

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
