### PR TITLE
MINOR: fix Flink artifact/UDF view nav actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1724,8 +1724,8 @@
           "group": "navigation@5"
         },
         {
-          "command": "confluent.flinkdatabase.kafka-cluster.select",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
+          "command": "confluent.artifacts.scaffold",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'artifacts'",
           "group": "navigation@1"
         },
         {
@@ -1734,19 +1734,19 @@
           "group": "navigation@2"
         },
         {
-          "command": "confluent.flinkdatabase.setArtifactsViewMode",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'UDFs'",
+          "command": "confluent.flinkdatabase.kafka-cluster.select",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@3"
         },
         {
-          "command": "confluent.artifacts.scaffold",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'artifacts'",
-          "group": "navigation@2"
+          "command": "confluent.flinkdatabase.setArtifactsViewMode",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'UDFs'",
+          "group": "navigation@999"
         },
         {
           "command": "confluent.flinkdatabase.setUDFsViewMode",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkArtifactsPoolSelected && confluent.flinkDatabaseViewMode == 'artifacts'",
-          "group": "navigation@2"
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'artifacts'",
+          "group": "navigation@999"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
This PR mainly swaps out the mention of the `confluent.flinkArtifactsPoolSelected` context value (which was removed in https://github.com/confluentinc/vscode/pull/2510) for `confluent.flinkDatabaseSelected` to enable `confluent.flinkdatabase.setUDFsViewMode` in the view again.

I also updated the ordering of the nav actions for that view to more closely match the Schemas view.
<img width="352" height="31" alt="image" src="https://github.com/user-attachments/assets/7b2154cc-bb7d-467c-9ef1-c87a94531df4" />


## Before
<img width="353" height="35" alt="image" src="https://github.com/user-attachments/assets/1e1e07d2-4225-4395-857a-afd83db6efb2" />



## After
<img width="371" height="36" alt="image" src="https://github.com/user-attachments/assets/3a3be269-1086-45ef-aaf7-742cd7f86e45" />



No tests, but more justification for https://github.com/confluentinc/vscode/issues/2549 to be done!
