### PR TITLE
UDFs (Artifacts): Fix TypeError when uploading to unavailable AWS region 

### DIFF
--- a/src/clients/flinkArtifacts/models/ArtifactV1FlinkArtifactList.ts
+++ b/src/clients/flinkArtifacts/models/ArtifactV1FlinkArtifactList.ts
@@ -61,7 +61,7 @@ export interface ArtifactV1FlinkArtifactList {
    * @type {Set<ArtifactV1FlinkArtifactListDataInner>}
    * @memberof ArtifactV1FlinkArtifactList
    */
-  data: Set<ArtifactV1FlinkArtifactListDataInner>;
+  data: Set<ArtifactV1FlinkArtifactListDataInner> | null;
 }
 
 /**
@@ -107,7 +107,10 @@ export function ArtifactV1FlinkArtifactListFromJSONTyped(
     api_version: json["api_version"],
     kind: json["kind"],
     metadata: ArtifactV1FlinkArtifactListMetadataFromJSON(json["metadata"]),
-    data: new Set((json["data"] as Array<any>).map(ArtifactV1FlinkArtifactListDataInnerFromJSON)),
+    data:
+      json["data"] == null
+        ? null
+        : new Set((json["data"] as Array<any>).map(ArtifactV1FlinkArtifactListDataInnerFromJSON)),
   };
 }
 
@@ -125,6 +128,9 @@ export function ArtifactV1FlinkArtifactListToJSONTyped(
 
   return {
     metadata: ArtifactV1FlinkArtifactListMetadataToJSON(value["metadata"]),
-    data: Array.from(value["data"] as Set<any>).map(ArtifactV1FlinkArtifactListDataInnerToJSON),
+    data:
+      value["data"] == null
+        ? null
+        : Array.from(value["data"] as Set<any>).map(ArtifactV1FlinkArtifactListDataInnerToJSON),
   };
 }

--- a/src/clients/sidecar-openapi-specs/flink-artifacts.openapi.yaml
+++ b/src/clients/sidecar-openapi-specs/flink-artifacts.openapi.yaml
@@ -946,6 +946,8 @@ components:
                   example: https://api.confluent.cloud/artifact/v1/flink-artifacts?page_token=UvmDWOB1iwfAIBPj6EYb
         data:
           type: array
+          # manually added due to TypeError when null
+          nullable: true
           description: A data property that contains an array of resource items. Each entry in the array is a separate resource.
           items:
             allOf:

--- a/src/clients/sidecar-openapi-specs/patches/flinkartifactlist.patch
+++ b/src/clients/sidecar-openapi-specs/patches/flinkartifactlist.patch
@@ -1,0 +1,13 @@
+diff --git a/src/clients/sidecar-openapi-specs/flink-artifacts.openapi.yaml b/src/clients/sidecar-openapi-specs/flink-artifacts.openapi.yaml
+index a01859ed..bba405f3 100644
+--- a/src/clients/sidecar-openapi-specs/flink-artifacts.openapi.yaml
++++ b/src/clients/sidecar-openapi-specs/flink-artifacts.openapi.yaml
+@@ -946,6 +946,8 @@ components:
+                   example: https://api.confluent.cloud/artifact/v1/flink-artifacts?page_token=UvmDWOB1iwfAIBPj6EYb
+         data:
+           type: array
++          # manually added due to TypeError when null
++          nullable: true
+           description: A data property that contains an array of resource items. Each entry in the array is a separate resource.
+           items:
+             allOf:

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -722,6 +722,35 @@ describe("CCloudResourceLoader", () => {
     });
   });
 
+  describe("loadStatementsForProviderRegion", () => {
+    let flinkArtifactsApiStub: sinon.SinonStubbedInstance<FlinkArtifactsArtifactV1Api>;
+    beforeEach(() => {
+      const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
+        sandbox.createStubInstance(sidecar.SidecarHandle);
+      flinkArtifactsApiStub = sandbox.createStubInstance(FlinkArtifactsArtifactV1Api);
+      mockSidecarHandle.getFlinkArtifactsApi.returns(flinkArtifactsApiStub);
+      sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+
+      sandbox.stub(loader, "getOrganization").resolves(TEST_CCLOUD_ORGANIZATION);
+    });
+    it("should return empty array if response from 'listArtifactV1FlinkArtifacts' returns null data", async () => {
+      const mockResponse = {
+        api_version: ArtifactV1FlinkArtifactListApiVersionEnum.ArtifactV1,
+        kind: ArtifactV1FlinkArtifactListKindEnum.FlinkArtifactList,
+        metadata: {
+          next: "",
+        },
+        data: null,
+      } as unknown as ArtifactV1FlinkArtifactList;
+
+      flinkArtifactsApiStub.listArtifactV1FlinkArtifacts.resolves(mockResponse);
+
+      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+      assert.strictEqual(artifacts.length, 0);
+      sinon.assert.calledOnce(flinkArtifactsApiStub.listArtifactV1FlinkArtifacts);
+    });
+  });
+
   describe("getFlinkArtifacts", () => {
     let flinkArtifactsApiStub: sinon.SinonStubbedInstance<FlinkArtifactsArtifactV1Api>;
 

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -503,9 +503,9 @@ async function loadArtifactsForProviderRegion(
   while (needMore) {
     try {
       const restResult = await artifactsClient.listArtifactV1FlinkArtifacts(request);
-
+      const responseData = restResult.data ?? [];
       // Convert each Flink artifact from the REST API representation to our codebase model.
-      for (const restArtifact of restResult.data) {
+      for (const restArtifact of responseData) {
         const artifact = restFlinkArtifactToModel(restArtifact, queryable);
         flinkArtifacts.push(artifact);
       }

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -478,7 +478,7 @@ async function loadStatementsForProviderRegion(
  * (Sub-unit of getFlinkArtifacts(), factored out for concurrency
  *  via executeInWorkerPool())
  */
-async function loadArtifactsForProviderRegion(
+export async function loadArtifactsForProviderRegion(
   handle: SidecarHandle,
   queryable: IFlinkQueryable,
 ): Promise<FlinkArtifact[]> {


### PR DESCRIPTION
## Summary of Changes

Patches the sidecar openapi spec to allow a nullable field for response.data and so swallow the TypeError that is otherwise thrown. Fixes #2278 

-

## Any additional details or context that should be provided?

To test, run the extension dev host.

1. select the Artifacts view. 
2. select a cluster like `ccn_e2e_testmultizone`
3. Verify that no TypeError is thrown 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
