### PR TITLE
Refactor `wrappedCommand` to be testable

### DIFF
--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -53,10 +53,6 @@ describe("commands/index.ts", () => {
       sandbox.stub(errors, "logError");
     });
 
-    afterEach(() => {
-      sandbox.restore();
-    });
-
     it("should call showErrorNotificationWithButtons when async command rejects with Error", async () => {
       // set extension to be enabled by default
       checkForExtensionDisabledReasonStub.resolves(undefined);

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -1,15 +1,97 @@
 import * as assert from "assert";
-import { getCommandArgsContext, registerCommandWithLogging, RESOURCE_ID_FIELDS } from ".";
+import * as sinon from "sinon";
+import {
+  createWrappedCommand,
+  getCommandArgsContext,
+  registerCommandWithLogging,
+  RESOURCE_ID_FIELDS,
+} from ".";
 import { ConnectionType } from "../clients/sidecar";
+import * as errors from "../errors";
+import * as featureFlags from "../featureFlags/evaluation";
 import { ConnectionId, IResourceBase } from "../models/resource";
+import * as notifications from "../notifications";
+import * as telemetry from "../telemetry/events";
 import { titleCase } from "../utils";
 
 describe("commands/index.ts", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
   describe("registerCommandWithLogging", () => {
     it("should throw if command name does not start with 'confluent.'", () => {
       assert.throws(() => {
         registerCommandWithLogging("not-a-valid-command", () => {});
       }, /must start with "confluent."/);
+    });
+  });
+
+  describe("createWrappedCommand", () => {
+    let showErrorNotificationWithButtonsStub: sinon.SinonStub;
+    let checkForExtensionDisabledReasonStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      checkForExtensionDisabledReasonStub = sandbox.stub(
+        featureFlags,
+        "checkForExtensionDisabledReason",
+      );
+
+      showErrorNotificationWithButtonsStub = sandbox.stub(
+        notifications,
+        "showErrorNotificationWithButtons",
+      );
+
+      // stub other dependencies to avoid side effects
+      sandbox.stub(telemetry, "logUsage");
+      sandbox.stub(errors, "logError");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should call showErrorNotificationWithButtons when async command rejects with Error", async () => {
+      // set extension to be enabled by default
+      checkForExtensionDisabledReasonStub.resolves(undefined);
+      const testError = new Error("Async command failed");
+      const asyncCommand = sandbox.stub().rejects(testError);
+      const wrappedCommand = createWrappedCommand("confluent.test", asyncCommand);
+
+      await wrappedCommand();
+
+      sinon.assert.calledOnceWithExactly(
+        showErrorNotificationWithButtonsStub,
+        `Error invoking command "confluent.test": ${testError}`,
+      );
+    });
+
+    it("should show extension disabled notification and not execute command when extension is disabled", async () => {
+      // set extension to be disabled
+      checkForExtensionDisabledReasonStub.resolves("Extension has been disabled due to policy");
+
+      const showExtensionDisabledNotificationStub = sandbox.stub(
+        featureFlags,
+        "showExtensionDisabledNotification",
+      );
+
+      const mockCommand = sandbox.stub();
+      const wrappedCommand = createWrappedCommand("confluent.test", mockCommand);
+
+      await wrappedCommand();
+
+      sinon.assert.calledOnce(checkForExtensionDisabledReasonStub);
+      sinon.assert.calledOnceWithExactly(
+        showExtensionDisabledNotificationStub,
+        "Extension has been disabled due to policy",
+      );
+      sinon.assert.notCalled(mockCommand);
     });
   });
 

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -42,6 +42,8 @@ describe("commands/index.ts", () => {
         featureFlags,
         "checkForExtensionDisabledReason",
       );
+      // default to extension being enabled unless explicitly set otherwise in individual tests
+      checkForExtensionDisabledReasonStub.resolves(undefined);
 
       showErrorNotificationWithButtonsStub = sandbox.stub(
         notifications,
@@ -54,8 +56,6 @@ describe("commands/index.ts", () => {
     });
 
     it("should call showErrorNotificationWithButtons when async command rejects with Error", async () => {
-      // set extension to be enabled by default
-      checkForExtensionDisabledReasonStub.resolves(undefined);
       const testError = new Error("Async command failed");
       const asyncCommand = sandbox.stub().rejects(testError);
       const wrappedCommand = createWrappedCommand("confluent.test", asyncCommand);
@@ -69,7 +69,8 @@ describe("commands/index.ts", () => {
     });
 
     it("should show extension disabled notification and not execute command when extension is disabled", async () => {
-      // set extension to be disabled
+      // force extension to be disabled by resetting the stub and setting the reason
+      checkForExtensionDisabledReasonStub.reset();
       checkForExtensionDisabledReasonStub.resolves("Extension has been disabled due to policy");
 
       const showExtensionDisabledNotificationStub = sandbox.stub(

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -70,7 +70,6 @@ describe("commands/index.ts", () => {
 
     it("should show extension disabled notification and not execute command when extension is disabled", async () => {
       // force extension to be disabled by resetting the stub and setting the reason
-      checkForExtensionDisabledReasonStub.reset();
       checkForExtensionDisabledReasonStub.resolves("Extension has been disabled due to policy");
 
       const showExtensionDisabledNotificationStub = sandbox.stub(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -28,7 +28,10 @@ export function registerCommandWithLogging(
   return vscode.commands.registerCommand(commandName, wrappedCommand);
 }
 
-/** Wraps a command with extension disabled state checking, telemetry logging, and error handling */
+/**
+ *  Wraps a command's function with extension disabled state checking, telemetry logging, and error handling
+ *  Intended to only be called by {@link registerCommandWithLogging}.
+ */
 export function createWrappedCommand(
   commandName: string,
   command: ((...args: any[]) => void) | ((...args: any[]) => Promise<void>),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,26 @@ import { showErrorNotificationWithButtons } from "../notifications";
 import { UserEvent, logUsage } from "../telemetry/events";
 import { titleCase } from "../utils";
 
+/**
+ * Registers a command with logging, telemetry, and error handling
+ *
+ * @param commandName - The name of the command, MUST start with "confluent."
+ * @param command - The command function to wrap
+ */
+export function registerCommandWithLogging(
+  commandName: string,
+  command: ((...args: any[]) => void) | ((...args: any[]) => Promise<void>),
+): vscode.Disposable {
+  if (!commandName.startsWith("confluent.")) {
+    // developer error.
+    throw new Error(`Command name "${commandName}" must start with "confluent."`);
+  }
+
+  const wrappedCommand = createWrappedCommand(commandName, command);
+  return vscode.commands.registerCommand(commandName, wrappedCommand);
+}
+
+/** Wraps a command with extension disabled state checking, telemetry logging, and error handling */
 export function createWrappedCommand(
   commandName: string,
   command: ((...args: any[]) => void) | ((...args: any[]) => Promise<void>),
@@ -38,19 +58,6 @@ export function createWrappedCommand(
       }
     }
   };
-}
-
-export function registerCommandWithLogging(
-  commandName: string,
-  command: ((...args: any[]) => void) | ((...args: any[]) => Promise<void>),
-): vscode.Disposable {
-  if (!commandName.startsWith("confluent.")) {
-    // developer error.
-    throw new Error(`Command name "${commandName}" must start with "confluent."`);
-  }
-
-  const wrappedCommand = createWrappedCommand(commandName, command);
-  return vscode.commands.registerCommand(commandName, wrappedCommand);
 }
 
 // TODO: move this somewhere else if we need it other than telemetry:


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Refactor `wrappedCommand` to `createWrappedCommand`
- Added tests for when wrapped commands are async and raise Errors

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2445 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
