### PR TITLE
Add `possiblyViewable` property to filter `FlinkStatement` results based on age

### DIFF
--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -262,6 +262,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       failed: ctx.statement.failed,
       stoppable: ctx.statement.stoppable,
       areResultsViewable: ctx.statement.canRequestResults,
+      possiblyViewable: ctx.statement.possiblyViewable,
       isForeground: ctx.statement.isForeground,
     });
   });

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -495,6 +495,7 @@ export class FlinkStatementResultsManager {
           failed: this.statement.failed,
           stoppable: this.statement.stoppable,
           areResultsViewable: this.statement.canRequestResults,
+          possiblyViewable: this.statement.possiblyViewable,
           isForeground: this.statement.isForeground,
         };
       }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Add `possiblyViewable` boolean property to `FlinkStatement` that indicates whether results might be viewable based on age (statements created more than 24h ago are not viewable).
- Refactored canRequestResults to use `possiblyViewable` getter as a prerequisite, keeping recent statements with `"ccloud-flink-statement"` context, old statements get `"ccloud-flink-statement-not-viewable"`
- Updated "View Results" command to only show for statements without `"-not-viewable"` suffix
- Added tests

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2567

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
