### PR TITLE
Artifacts upload: region/provider quickpick should prefer regions with compute pools

### DIFF
--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -24,7 +24,7 @@ import { FlinkStatement, Phase, restFlinkStatementToModel } from "../models/flin
 import { FlinkUdf } from "../models/flinkUDF";
 import { CCloudFlinkDbKafkaCluster, CCloudKafkaCluster } from "../models/kafkaCluster";
 import { CCloudOrganization } from "../models/organization";
-import { EnvironmentId, IFlinkQueryable } from "../models/resource";
+import { EnvironmentId, IFlinkQueryable, IProviderRegion } from "../models/resource";
 import { CCloudSchemaRegistry } from "../models/schemaRegistry";
 import { getSidecar, SidecarHandle } from "../sidecar";
 import { ObjectSet } from "../utils/objectset";
@@ -399,6 +399,28 @@ export class CCloudResourceLoader extends CachingResourceLoader<
 
     // Parse and return all results.
     return await parseAllFlinkStatementResults<RT>(statement);
+  }
+
+  /**
+   * Returns a deduplicated list of provider/region pairs for all Flink compute pools
+   * across all environments the user has access to.
+   */
+  public async getComputePoolProviderRegions(): Promise<IProviderRegion[]> {
+    const envs: CCloudEnvironment[] = await this.getEnvironments();
+    const providerRegionSet: ObjectSet<IProviderRegion> = new ObjectSet(
+      (pr) => `${pr.provider}-${pr.region}`,
+    );
+
+    for (const env of envs) {
+      (env.flinkComputePools || []).forEach((pool) => {
+        providerRegionSet.add({
+          provider: pool.provider,
+          region: pool.region,
+        });
+      });
+    }
+
+    return providerRegionSet.items();
   }
 }
 /**

--- a/src/quickpicks/cloudProviderRegions.ts
+++ b/src/quickpicks/cloudProviderRegions.ts
@@ -1,6 +1,7 @@
 import { QuickPickItemKind, ThemeIcon, window } from "vscode";
 import { FcpmV2RegionListDataInner } from "../clients/flinkComputePool";
-import { loadProviderRegions } from "../loaders/ccloudResourceLoader";
+import { FLINK_CONFIG_COMPUTE_POOL } from "../extensionSettings/constants";
+import { CCloudResourceLoader, loadProviderRegions } from "../loaders/ccloudResourceLoader";
 import { IProviderRegion } from "../models/resource";
 import { QuickPickItemWithValue } from "./types";
 
@@ -17,6 +18,52 @@ export async function cloudProviderRegionQuickPick(
     return undefined;
   }
   let lastSeparator: string = "";
+  // Sorts regions so that:
+  //  (0) the default compute pool's provider+region appears first (if configured),
+  //  (1) regions that match existing compute pools come next,
+  //  (2) all others follow.
+  const loader = CCloudResourceLoader.getInstance();
+  const computePoolRegions = await loader.getComputePoolProviderRegions();
+  const defaultComputePoolId = FLINK_CONFIG_COMPUTE_POOL.value;
+  const defaultPool = defaultComputePoolId
+    ? await loader.getFlinkComputePool(defaultComputePoolId)
+    : undefined;
+
+  const hasComputePool = (region: FcpmV2RegionListDataInner) =>
+    computePoolRegions.some(
+      (pr) => pr.provider === region.cloud && pr.region === region.region_name,
+    );
+
+  const rankFor = (region: FcpmV2RegionListDataInner) => {
+    if (hasComputePool(region)) {
+      return 0;
+    }
+    return 1;
+  };
+
+  filteredRegions.sort((a, b) => {
+    const ra = rankFor(a);
+    const rb = rankFor(b);
+    if (ra !== rb) {
+      return ra - rb;
+    }
+    // Tie-breaker to keep grouping by cloud provider for separators.
+    if (a.cloud !== b.cloud) {
+      return a.cloud.localeCompare(b.cloud);
+    }
+    return a.region_name.localeCompare(b.region_name);
+  });
+
+  if (defaultPool) {
+    // Move the default compute pool's region to the top.
+    const defaultIndex = filteredRegions.findIndex(
+      (r) => r.cloud === defaultPool.provider && r.region_name === defaultPool.region,
+    );
+    if (defaultIndex > 0) {
+      const [defaultRegion] = filteredRegions.splice(defaultIndex, 1);
+      filteredRegions.unshift(defaultRegion);
+    }
+  }
 
   const regionItems: QuickPickItemWithValue<IProviderRegion>[] = [];
   filteredRegions.forEach((region) => {


### PR DESCRIPTION
# 🚧 WIP
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2458
- ❓ Should this be an optional sort? Currently we _only_ call this region quick pick from Artifact Upload so I think not yet. 
- ❓ Can I access the UDF/Artifact View's selected cluster and also float the related region/provider to the top? 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

| Wow this is much better than searching for the provider I want every time |
| -- |
| <img width="645" height="469" alt="Screenshot 2025-09-16 at 2 16 08 PM" src="https://github.com/user-attachments/assets/199c0ab7-86b3-483b-8f81-46e43f7b4154" /> |
| in this image, my default is Azure `westus3` and the top 2 AWS regions are where our other compute pools exist |

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
