### PR TITLE
Simplify getFlinkArtifacts(): is only being called with CCloudFlinkDbKafkaCluster

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -781,7 +781,7 @@ describe("CCloudResourceLoader", () => {
 
       flinkArtifactsApiStub.listArtifactV1FlinkArtifacts.resolves(mockResponse);
 
-      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
       assert.strictEqual(artifacts.length, 0);
       sinon.assert.calledOnce(flinkArtifactsApiStub.listArtifactV1FlinkArtifacts);
 
@@ -800,7 +800,7 @@ describe("CCloudResourceLoader", () => {
       const mockResponse = makeFakeListArtifactsResponse(false, 3);
 
       flinkArtifactsApiStub.listArtifactV1FlinkArtifacts.resolves(mockResponse);
-      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
       assert.strictEqual(artifacts.length, 3);
       sinon.assert.calledOnce(flinkArtifactsApiStub.listArtifactV1FlinkArtifacts);
     });
@@ -814,7 +814,7 @@ describe("CCloudResourceLoader", () => {
         .resolves(mockResponse)
         .onSecondCall()
         .resolves(mockResponse2);
-      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_COMPUTE_POOL);
+      const artifacts = await loader.getFlinkArtifacts(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
       assert.strictEqual(artifacts.length, 5);
       sinon.assert.calledTwice(flinkArtifactsApiStub.listArtifactV1FlinkArtifacts);
     });

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -179,30 +179,15 @@ export class CCloudResourceLoader extends CachingResourceLoader<
   public async determineFlinkQueryables(
     resource: CCloudEnvironment | CCloudFlinkComputePool | CCloudKafkaCluster,
   ): Promise<IFlinkQueryable[]> {
-    const org: CCloudOrganization | undefined = await this.getOrganization();
-    if (!org) {
-      return [];
-    }
-
     if (resource instanceof CCloudFlinkComputePool || resource instanceof CCloudKafkaCluster) {
-      // If we have a single compute pool or kafka cluster, just reexpress it as a single
-      // IFlinkQueryable .
-      const singleton: IFlinkQueryable = {
-        organizationId: org.id,
-        environmentId: resource.environmentId,
-        provider: resource.provider,
-        region: resource.region,
-      };
-
-      if (resource instanceof CCloudFlinkComputePool) {
-        // Only fix to a single compute pool if we were given a compute pool.
-        singleton.computePoolId = resource.id;
-      }
-      return [singleton];
+      return [await this.toFlinkQueryable(resource)];
     } else {
       // Must be a CCloudEnvironment. Gather all provider-region pairs.
       // The environment may have many resources in the same
       // provider-region pair. We need to deduplicate them by provider-region.
+
+      const org: CCloudOrganization = await this.getOrganization();
+
       const providerRegionSet: ObjectSet<IFlinkQueryable> = new ObjectSet(
         (queryable) => `${queryable.provider}-${queryable.region}`,
       );
@@ -227,6 +212,29 @@ export class CCloudResourceLoader extends CachingResourceLoader<
 
       return providerRegionSet.items();
     }
+  }
+
+  /**
+   * Convert the given CCloudFlinkComputePool CCloudKafkaCluster
+   * into a single IFlinkQueryable object.
+   */
+  public async toFlinkQueryable(
+    resource: CCloudFlinkComputePool | CCloudKafkaCluster,
+  ): Promise<IFlinkQueryable> {
+    const org: CCloudOrganization = await this.getOrganization();
+
+    const singleton: IFlinkQueryable = {
+      organizationId: org.id,
+      environmentId: resource.environmentId,
+      provider: resource.provider,
+      region: resource.region,
+    };
+
+    if (resource instanceof CCloudFlinkComputePool) {
+      // Only fix to a single compute pool if we were given a compute pool.
+      singleton.computePoolId = resource.id;
+    }
+    return singleton;
   }
 
   /**
@@ -273,35 +281,15 @@ export class CCloudResourceLoader extends CachingResourceLoader<
   }
 
   /**
-   * Query the Flink artifacts for the given CCloud environment + provider-region.
+   * Query the Flink artifacts for the given CCloudFlinkDbKafkaCluster's CCloud environment + provider-region.
    * @returns The Flink artifacts for the given environment + provider-region.
-   * @param resource The CCloud compute pool or environment to get the Flink artifacts for.
+   * @param resource The CCloud Flink Database (a Flink-enabled Kafka Cluster) to get the Flink artifacts for.
    */
-  public async getFlinkArtifacts(
-    resource: CCloudEnvironment | CCloudFlinkComputePool | CCloudKafkaCluster,
-  ): Promise<FlinkArtifact[]> {
-    const queryables: IFlinkQueryable[] = await this.determineFlinkQueryables(resource);
+  public async getFlinkArtifacts(resource: CCloudFlinkDbKafkaCluster): Promise<FlinkArtifact[]> {
+    const queryable = await this.toFlinkQueryable(resource);
     const handle = await getSidecar();
 
-    // For each provider-region pair, get the Flink artifacts with reasonable concurrency.
-    const concurrentResults: ExecutionResult<FlinkArtifact[]>[] = await executeInWorkerPool(
-      (queryable: IFlinkQueryable) => loadArtifactsForProviderRegion(handle, queryable),
-      queryables,
-      { maxWorkers: 5 },
-    );
-
-    logger.debug(`getFlinkArtifacts() loaded ${concurrentResults.length} provider-region pairs`);
-
-    // Assemble the results into a single array of Flink artifacts.
-    const flinkArtifacts: FlinkArtifact[] = [];
-
-    // extract will raise first error if any error was encountered.
-    const blocks: FlinkArtifact[][] = extract(concurrentResults);
-    for (const block of blocks) {
-      flinkArtifacts.push(...block);
-    }
-
-    return flinkArtifacts;
+    return await loadArtifactsForProviderRegion(handle, queryable);
   }
 
   /**

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -215,7 +215,7 @@ export class CCloudResourceLoader extends CachingResourceLoader<
   }
 
   /**
-   * Convert the given CCloudFlinkComputePool CCloudKafkaCluster
+   * Convert the given CCloudFlinkComputePool or CCloudKafkaCluster
    * into a single IFlinkQueryable object.
    */
   public async toFlinkQueryable(


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Refactor `determineFlinkQueryables()` into a side part: `toFlinkQueryable()` which can convert either a `CloudFlinkComputePool` or `CCloudKafkaCluster` to a single `IFlinkQueryable`. 
- Simplify the argument of `getFlinkArtifacts()` to match its peer `getUDFs()`: a single `CCloudFlinkDbKafkaCluster`:
  - Can then use `toFlinkQueryable`
  - No longer any need to drive API calls in parallel, now that will only be making a single API call.
  - The only caller to this, from the Flink Database view provider's sub-mode, is doing so with a `CCloudFlinkDbKafkaCluster` instance.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- `toFlinkQueryable()` gets 100% test coverage through existing tests over `determineFlinkQueryables()`.
- This is preliminary work towards enabling caching for `getFlinkArtifacts()`, #2606.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
