### PR TITLE
MINOR: fix `window.menuStyle` setting for Windows to unblock running E2E tests

### DIFF
--- a/tests/e2e/utils/settings.ts
+++ b/tests/e2e/utils/settings.ts
@@ -2,11 +2,17 @@ import { ElectronApplication, Page } from "@playwright/test";
 import { TextDocument } from "../objects/editor/TextDocument";
 import { executeVSCodeCommand } from "./commands";
 
-const DEFAULT_UI_SETTINGS = {
-  // required for right-click context menu action to delete subject schemas
-  // (see https://code.visualstudio.com/updates/v1_101#_custom-menus-with-native-window-title-bar)
-  "window.menuStyle": "custom",
-};
+// `window.menuStyle` must be set to "custom" for right-click context menu actions (e.g. deleting
+// schemas, generating projects from sidebar resources, etc), but Windows already sets this to
+// inherit the "custom" setting value from `window.titleBarStyle`, so we shouldn't set it or it will
+// require a restart to take effect. (Also, based on our system dialog stubbing, if we updated this
+// on Windows, we would auto-reload the window and lose our Electron/page context, which will cause
+// all sorts of odd test failures.)
+//
+// see:
+//   - https://code.visualstudio.com/updates/v1_101#_custom-menus-with-native-window-title-bar
+//   - https://github.com/confluentinc/vscode/issues/2609#issuecomment-3300206479
+const DEFAULT_UI_SETTINGS = process.platform === "win32" ? {} : { "window.menuStyle": "custom" };
 
 const DEFAULT_EDITOR_SETTINGS = {
   // this is to avoid VS Code incorrectly setting the language of .proto files as C# so they


### PR DESCRIPTION
The main problem was this highlighted part from this screenshot in https://github.com/confluentinc/vscode/issues/2609#issuecomment-3300206479:
<img width="1198" height="537" alt="image" src="https://github.com/user-attachments/assets/2f5f3b82-44a8-4d8a-9e57-5bcc66466d30" />

Where, upon changing the `window.menuStyle` setting on Windows, a system dialog would show up saying the window needed to be reloaded. That combined with this:
https://github.com/confluentinc/vscode/blob/33195f2a1189891b00c68b649ac954c6ff6f2017/tests/e2e/baseTest.ts#L85-L88
...meant we were automatically restarting the (test) VS Code window and losing our `page` context before tests even started.



Closes #2609, confirmed working on Windows locally.
<img width="1117" height="993" alt="image" src="https://github.com/user-attachments/assets/e166bffc-f4a4-4657-8c21-df75602f6cb7" />
