### PR TITLE
add E2E tests for direct connection CRUD

### DIFF
--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -371,10 +371,10 @@ export class EnvironmentTreeItem extends TreeItem {
     // "ccloud-environment", "direct-environment", "local-environment"
     this.contextValue = contextParts.join("-");
 
-    if (isDirect(resource)) {
-      // mainly to help E2E tests distinguish direct connections from other tree items
-      this.accessibilityInformation = { label: `Direct connection: "${resource.name}"` };
-    }
+    // mainly to help E2E tests distinguish direct connections from other tree items
+    this.accessibilityInformation = {
+      label: `${this.resource.connectionType}: connection "${resource.name}"`,
+    };
 
     // user-facing properties
     this.description = isDirect(this.resource) ? "" : this.resource.id;

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -164,6 +164,11 @@ export class KafkaClusterTreeItem extends TreeItem {
     this.iconPath = new ThemeIcon(this.resource.iconName);
     this.tooltip = createKafkaClusterTooltip(this.resource);
 
+    // mainly to help E2E tests more easily identify these items between different connection types
+    this.accessibilityInformation = {
+      label: `${this.resource.connectionType} connection: Kafka Cluster`,
+    };
+
     // set primary click action to select this cluster as the current one, focusing it in the Topics view
     this.command = {
       command: "confluent.topics.kafka-cluster.select",

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -110,6 +110,13 @@ export class SchemaRegistryTreeItem extends TreeItem {
     this.iconPath = new ThemeIcon(this.resource.iconName);
     this.tooltip = createSchemaRegistryTooltip(this.resource);
 
+    // all Schema Registry items show up with the "Schema Registry" label, so we need to add more
+    // information for accessibility and E2E testing purposes
+    // (we may eventually want connection/environment names in here as well)
+    this.accessibilityInformation = {
+      label: `${this.resource.connectionType} connection: Schema Registry`,
+    };
+
     // set primary click action to select this cluster as the current one, focusing it in the Schemas view
     this.command = {
       command: "confluent.resources.schema-registry.select",

--- a/src/viewProviders/newResources.ts
+++ b/src/viewProviders/newResources.ts
@@ -174,7 +174,7 @@ export abstract class ConnectionRow<ET extends ConcreteEnvironment, LT extends R
 
     // mainly to help E2E tests distinguish direct connections from other tree items
     item.accessibilityInformation = {
-      label: `${this.connectionType} connection: "${this.name}"`,
+      label: `${this.connectionType}: connection "${this.name}"`,
     };
 
     return item;

--- a/src/viewProviders/newResources.ts
+++ b/src/viewProviders/newResources.ts
@@ -50,7 +50,6 @@ import {
   ConnectionId,
   connectionIdToType,
   IResourceBase,
-  isDirect,
   ISearchable,
   IUpdatableResource,
 } from "../models/resource";
@@ -173,10 +172,10 @@ export abstract class ConnectionRow<ET extends ConcreteEnvironment, LT extends R
     item.description = this.status;
     item.tooltip = this.tooltip;
 
-    if (isDirect(this)) {
-      // mainly to help E2E tests distinguish direct connections from other tree items
-      item.accessibilityInformation = { label: `Direct connection: "${this.name}"` };
-    }
+    // mainly to help E2E tests distinguish direct connections from other tree items
+    item.accessibilityInformation = {
+      label: `${this.connectionType} connection: "${this.name}"`,
+    };
 
     return item;
   }

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -170,7 +170,7 @@ export class ResourcesView extends View {
    *
    * @returns A DirectConnectionForm instance for the imported connection
    */
-  async importNewConnectionFromFile(): Promise<DirectConnectionForm> {
+  async addNewConnectionFromFileImport(): Promise<DirectConnectionForm> {
     await this.clickAddNewConnection();
 
     const quickpick = new Quickpick(this.page);

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -62,9 +62,8 @@ export class ResourcesView extends View {
 
   /** Locator for all root-level direct connection tree items. */
   get directConnections(): Locator {
-    // we can't use this.treeItems since we have to look for an attribute instead of filtering
-    // based on the existing selector
-    return this.body.locator('[role="treeitem"][aria-label^="Direct connection: "]');
+    // use the accessibilityInformation label we're adding instead of trying to filter by icons/names
+    return this.treeItems.and(this.page.locator('[aria-label^="DIRECT: connection "]'));
   }
 
   // Kafka cluster locators:
@@ -80,9 +79,9 @@ export class ResourcesView extends View {
    */
   get ccloudKafkaClusters(): Locator {
     // third nested element: Confluent Cloud item -> environment item -> Kafka cluster item
-    return this.body
-      .locator("[role='treeitem'][aria-level='3']")
-      .filter({ has: this.page.locator(".codicon-confluent-kafka-cluster") });
+    return this.kafkaClusters.and(
+      this.page.locator("[aria-level='3'][aria-label^='CCLOUD connection: Kafka Cluster']"),
+    );
   }
 
   /**
@@ -90,16 +89,22 @@ export class ResourcesView extends View {
    * Only visible when the {@link localItem "Local" item} is expanded.
    */
   get localKafkaClusters(): Locator {
-    return this.kafkaClusters.filter({ hasText: "confluent-local" });
+    // second nested element: Local connection item -> Kafka cluster item
+    return this.kafkaClusters.and(
+      this.page.locator("[aria-level='2'][aria-label^='LOCAL connection: Kafka Cluster']"),
+    );
   }
 
   /**
    * Locator for direct connection Kafka cluster tree items.
    * Only visible when a {@link directConnections "Direct Connections" item} is available and
-   * expanded.
+   * expanded with a Kafka cluster configured.
    */
   get directKafkaClusters(): Locator {
-    return this.kafkaClusters.filter({ hasText: "Kafka Cluster" });
+    // second nested element: Direct connection item -> Kafka cluster item
+    return this.kafkaClusters.and(
+      this.page.locator("[aria-level='2'][aria-label^='DIRECT connection: Kafka Cluster']"),
+    );
   }
 
   /** Locator for all Schema Registry tree items. */
@@ -113,9 +118,9 @@ export class ResourcesView extends View {
    */
   get ccloudSchemaRegistries(): Locator {
     // third nested element: Confluent Cloud item -> environment item -> Schema Registry item
-    return this.body
-      .locator("[role='treeitem'][aria-level='3']")
-      .filter({ has: this.page.locator(".codicon-confluent-schema-registry") });
+    return this.schemaRegistries.and(
+      this.page.locator("[aria-level='3'][aria-label^='CCLOUD connection: Schema Registry']"),
+    );
   }
 
   /**
@@ -123,16 +128,30 @@ export class ResourcesView extends View {
    * Only visible when the {@link localItem "Local" item} is expanded.
    */
   get localSchemaRegistries(): Locator {
-    return this.schemaRegistries.filter({ hasText: "local-sr" });
+    // second nested element: Local connection item -> Schema Registry item
+    return this.schemaRegistries.and(
+      this.page.locator("[aria-level='2'][aria-label^='LOCAL connection: Schema Registry']"),
+    );
   }
 
   /**
    * Locator for direct connection Schema Registry tree items.
-   * Only visible when a {@link directConnections "Direct Connections" item} is available and
-   * expanded.
+   * Only visible when a {@link directConnections direct connection item} is available and
+   * expanded with a Schema Registry configured.
    */
   get directSchemaRegistries(): Locator {
-    return this.schemaRegistries.filter({ hasText: "Schema Registry" });
+    // second nested element: Direct connection item -> Schema Registry item
+    return this.schemaRegistries.and(
+      this.page.locator("[aria-level='2'][aria-label^='DIRECT connection: Schema Registry']"),
+    );
+  }
+
+  /** Locator for all Flink Compute Pool tree items.*/
+  get flinkComputePools(): Locator {
+    // only available for CCloud connections
+    return this.treeItems.filter({
+      has: this.page.locator(".codicon-confluent-flink-compute-pool"),
+    });
   }
 
   /**
@@ -141,9 +160,7 @@ export class ResourcesView extends View {
    */
   get ccloudFlinkComputePools(): Locator {
     // third nested element: Confluent Cloud item -> environment item -> Flink Compute Pool item
-    return this.body
-      .locator("[role='treeitem'][aria-level='3']")
-      .filter({ has: this.page.locator(".codicon-confluent-flink-compute-pool") });
+    return this.flinkComputePools.and(this.page.locator("[aria-level='3']"));
   }
 
   /**

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -182,44 +182,68 @@ export class ResourcesView extends View {
   }
 
   /**
-   * Expand a connection's environment in the Resources view.
+   * Locate a connection environment item in the view for a given {@link ConnectionType connection type}.
+   * If there are multiple environments for the connection type, you can optionally provide a
+   * `label` string or regex to filter the results.
    *
-   * NOTE: This requires the connection to be fully set up beforehand (e.g. CCloud authentication,
+   * This requires the connection to be fully set up beforehand (e.g. CCloud authentication,
    * direct connection form completion, etc.) so that the environment item is present.
+   *
+   * NOTE: CCloud connections may have multiple environments, but the local connection and direct
+   * connections are each treated as individual "environments" in the Resources view.
+   *
+   * @param connectionType The type of connection (CCloud or Direct)
+   * @param label Optional string or regex to filter the located environments
+   * @returns A Locator for the environment item
    */
-  async expandConnectionEnvironment(
-    connectionType: ConnectionType,
-    label?: string | RegExp,
-  ): Promise<void> {
+  async getEnvironment(connectionType: ConnectionType, label?: string | RegExp): Promise<Locator> {
+    let environment: Locator;
+
     switch (connectionType) {
       case ConnectionType.Ccloud: {
         await expect(this.ccloudEnvironments).not.toHaveCount(0);
-        const ccloudEnv: Locator = label
+        environment = label
           ? this.ccloudEnvironments.filter({ hasText: label }).first()
           : this.ccloudEnvironments.first();
-        // CCloud environments are always collapsed by default, but we may have opened it already
-        if ((await ccloudEnv.getAttribute("aria-expanded")) === "false") {
-          await ccloudEnv.click();
-        }
-        await expect(ccloudEnv).toHaveAttribute("aria-expanded", "true");
         break;
       }
       case ConnectionType.Direct: {
         await expect(this.directConnections).not.toHaveCount(0);
-        const directEnv: Locator = label
+        environment = label
           ? this.directConnections.filter({ hasText: label }).first()
           : this.directConnections.first();
-        // direct connections are only collapsed by default in the old Resources view
-        if ((await directEnv.getAttribute("aria-expanded")) === "false") {
-          await directEnv.click();
-        }
-        await expect(directEnv).toHaveAttribute("aria-expanded", "true");
         break;
       }
       // FUTURE: add support for LOCAL connections, see https://github.com/confluentinc/vscode/issues/2140
       default:
         throw new Error(`Unsupported connection type: ${connectionType}`);
     }
+
+    await expect(environment).toBeVisible();
+    return environment;
+  }
+
+  /**
+   * Expand a connection's environment in the Resources view.
+   *
+   * NOTE: CCloud connections may have multiple environments, but the local connection and direct
+   * connections are each treated as individual "environments" in the Resources view.
+   */
+  async expandConnectionEnvironment(
+    connectionType: ConnectionType,
+    label?: string | RegExp,
+  ): Promise<void> {
+    const environment = await this.getEnvironment(connectionType, label);
+
+    if ((await environment.getAttribute("aria-expanded")) === "false") {
+      await environment.click();
+    }
+    await expect(environment).toHaveAttribute("aria-expanded", "true");
+  }
+
+  /** Locate a direct connection item in the view by its label. */
+  async getDirectConnection(label: string | RegExp): Promise<Locator> {
+    return await this.getEnvironment(ConnectionType.Direct, label);
   }
 
   /**

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -162,6 +162,26 @@ export class ResourcesView extends View {
   }
 
   /**
+   * Open the Direct Connection form by clicking "Add New Connection" -> "Import from file".
+   *
+   * To avoid saving off any sensitive connection details for these tests, the file picker dialog
+   * should be handled through a stub in the test that calls this method and provides the JSON
+   * content to import.
+   *
+   * @returns A DirectConnectionForm instance for the imported connection
+   */
+  async importNewConnectionFromFile(): Promise<DirectConnectionForm> {
+    await this.clickAddNewConnection();
+
+    const quickpick = new Quickpick(this.page);
+    // choices will be either "Enter manually" or "Import from file"
+    const importFromFileItem = quickpick.items.filter({ hasText: /Import from file/ });
+    await expect(importFromFileItem).not.toHaveCount(0);
+    await importFromFileItem.first().click();
+    return new DirectConnectionForm(this.page);
+  }
+
+  /**
    * Expand a connection's environment in the Resources view.
    *
    * NOTE: This requires the connection to be fully set up beforehand (e.g. CCloud authentication,

--- a/tests/e2e/objects/views/View.ts
+++ b/tests/e2e/objects/views/View.ts
@@ -37,7 +37,7 @@ export class View {
     return this.body.locator(".welcome-view-content");
   }
 
-  /** Get all tree items in this view. Use Playwright's filter methods to narrow down the selection. */
+  /** Get all tree items in this view. */
   get treeItems(): Locator {
     return this.body.locator('[role="treeitem"]');
   }

--- a/tests/e2e/objects/views/viewItems/DirectConnectionItem.ts
+++ b/tests/e2e/objects/views/viewItems/DirectConnectionItem.ts
@@ -1,0 +1,20 @@
+import { DirectConnectionForm } from "../../webviews/DirectConnectionFormWebview";
+import { ViewItem } from "./ViewItem";
+
+export class DirectConnectionItem extends ViewItem {
+  /** Click the "Export connection details" inline action to export the connection details to a JSON file. */
+  async clickExportConnectionDetails(): Promise<void> {
+    await this.clickInlineAction("Export connection details");
+  }
+
+  /** Click the "Edit connection" inline action to open the direct connection form. */
+  async clickEditConnection(): Promise<DirectConnectionForm> {
+    await this.clickInlineAction("Edit connection");
+    return new DirectConnectionForm(this.page);
+  }
+
+  /** Click the "Disconnect" inline action to remove the direct connection. */
+  async clickDisconnect(): Promise<void> {
+    await this.clickInlineAction("Disconnect");
+  }
+}

--- a/tests/e2e/objects/views/viewItems/ViewItem.ts
+++ b/tests/e2e/objects/views/viewItems/ViewItem.ts
@@ -55,4 +55,12 @@ export class ViewItem {
     // clicking doesn't work here, so use keyboard navigation instead:
     await this.page.keyboard.press("Enter");
   }
+
+  /** Hover over the item to show its tooltip and return the tooltip locator. */
+  async showTooltip(): Promise<Locator> {
+    await this.locator.hover();
+    const tooltip = this.page.locator(".monaco-hover");
+    await tooltip.waitFor({ state: "visible" });
+    return tooltip;
+  }
 }

--- a/tests/e2e/objects/webviews/DirectConnectionFormWebview.ts
+++ b/tests/e2e/objects/webviews/DirectConnectionFormWebview.ts
@@ -18,10 +18,24 @@ export enum SupportedAuthType {
   Kerberos = "Kerberos",
 }
 
-/** Configuration options for setting up a direct connection. */
-export interface DirectConnectionConfig {
+/** Base requirements for Kafka and/or Schema Registry configurations. */
+interface DirectConnectionConfig {
   authType: SupportedAuthType;
   credentials: Record<string, any>;
+}
+export interface DirectConnectionKafkaConfig extends DirectConnectionConfig {
+  bootstrapServers: string;
+}
+export interface DirectConnectionSchemaRegistryConfig extends DirectConnectionConfig {
+  uri: string;
+}
+
+/** Configuration options for setting up a direct connection. */
+export interface DirectConnectionOptions {
+  name?: string;
+  formConnectionType?: FormConnectionType;
+  kafkaConfig?: DirectConnectionKafkaConfig;
+  schemaRegistryConfig?: DirectConnectionSchemaRegistryConfig;
 }
 
 /**
@@ -31,6 +45,11 @@ export interface DirectConnectionConfig {
 export class DirectConnectionForm extends Webview {
   constructor(page: Page) {
     super(page);
+  }
+
+  // form header+description area
+  get formHeader(): Locator {
+    return this.webview.locator(".form-header");
   }
 
   // top-level/general form fields
@@ -85,6 +104,9 @@ export class DirectConnectionForm extends Webview {
   }
   get saveButton(): Locator {
     return this.webview.getByRole("button", { name: "Save" });
+  }
+  get updateButton(): Locator {
+    return this.webview.getByRole("button", { name: "Update" });
   }
 
   // status and message elements

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -1,0 +1,266 @@
+import { expect, Page } from "@playwright/test";
+import { stubMultipleDialogs } from "electron-playwright-helpers";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { test } from "../baseTest";
+import { ConnectionType } from "../connectionTypes";
+import { TextDocument } from "../objects/editor/TextDocument";
+import { Notification } from "../objects/notifications/Notification";
+import { NotificationArea } from "../objects/notifications/NotificationArea";
+import { ResourcesView } from "../objects/views/ResourcesView";
+import { SchemasView, SelectSchemaRegistry } from "../objects/views/SchemasView";
+import { SelectKafkaCluster, TopicsView } from "../objects/views/TopicsView";
+import { DirectConnectionItem } from "../objects/views/viewItems/DirectConnectionItem";
+import {
+  DirectConnectionForm,
+  DirectConnectionKafkaConfig,
+  DirectConnectionSchemaRegistryConfig,
+  FormConnectionType,
+  SupportedAuthType,
+} from "../objects/webviews/DirectConnectionFormWebview";
+import { Tag } from "../tags";
+import { setupDirectConnection } from "../utils/connections";
+import { openConfluentSidebar } from "../utils/sidebarNavigation";
+
+/**
+ * E2E test suite for testing the direct connection CRUD lifecycle.
+ * {@see https://github.com/confluentinc/vscode/issues/2025}
+ *
+ * Test flow:
+ * 1. Create a connection based on the current target cluster (CCloud, local, CP)
+ * 2. Fill out the configuration based on the config dimension:
+ * - Kafka only
+ * - Schema Registry only
+ * - Kafka + Schema Registry
+ * 3. Test connection within the form through the "Test" button
+ * 4. Save the connection and verify it appears in the Resources view with expected child resources
+ * 5. Edit the connection through the connection item's inline action
+ * 6. Export the connection to a file
+ * 7. Delete the connection through the connection item's inline action
+ * 8. Import a connection config from a file
+ */
+
+enum ConfigType {
+  Kafka = "Kafka",
+  SchemaRegistry = "Schema Registry",
+  KafkaAndSchemaRegistry = "Kafka+Schema Registry",
+}
+
+test.describe("Direct Connection CRUD Lifecycle", () => {
+  test.beforeEach(async ({ page, electronApp }) => {
+    await openConfluentSidebar(page);
+
+    // stub the disconnect confirmation dialog
+    const confirmButtonIndex = process.platform === "linux" ? 1 : 0;
+    await stubMultipleDialogs(electronApp, [
+      {
+        method: "showMessageBox",
+        value: {
+          response: confirmButtonIndex, // Simulates clicking "Yes, disconnect"
+          checkboxChecked: false,
+        },
+      },
+    ]);
+  });
+
+  // test dimensions:
+  const connectionTypes: Array<
+    [
+      string,
+      Tag,
+      FormConnectionType,
+      // function for setting up the Kafka config
+      (page: Page) => DirectConnectionKafkaConfig | Promise<DirectConnectionKafkaConfig>,
+      // function for setting up the Schema Registry config
+      (
+        page: Page,
+      ) => DirectConnectionSchemaRegistryConfig | Promise<DirectConnectionSchemaRegistryConfig>,
+    ]
+  > = [
+    [
+      "CCloud API key+secret",
+      Tag.Direct,
+      FormConnectionType.ConfluentCloud,
+      () => {
+        return {
+          bootstrapServers: process.env.E2E_KAFKA_BOOTSTRAP_SERVERS!,
+          authType: SupportedAuthType.API,
+          credentials: {
+            api_key: process.env.E2E_KAFKA_API_KEY!,
+            api_secret: process.env.E2E_KAFKA_API_SECRET!,
+          },
+        };
+      },
+      () => {
+        return {
+          uri: process.env.E2E_SR_URL!,
+          authType: SupportedAuthType.API,
+          credentials: {
+            api_key: process.env.E2E_SR_API_KEY!,
+            api_secret: process.env.E2E_SR_API_SECRET!,
+          },
+        };
+      },
+    ],
+    // FUTURE: add support for LOCAL config, see https://github.com/confluentinc/vscode/issues/2140
+    // FUTURE: add support for CP config
+  ];
+  const configTypes: Array<ConfigType> = [
+    ConfigType.Kafka,
+    ConfigType.SchemaRegistry,
+    ConfigType.KafkaAndSchemaRegistry,
+  ];
+
+  for (const [
+    connectionTypeName,
+    connectionTag,
+    formConnectionType,
+    loadKafkaConfig,
+    loadSchemaRegistryConfig,
+  ] of connectionTypes) {
+    test.describe(connectionTypeName, { tag: [connectionTag] }, () => {
+      for (const configType of configTypes) {
+        test.describe(configType, () => {
+          let kafkaConfig: DirectConnectionKafkaConfig | undefined;
+          let schemaRegistryConfig: DirectConnectionSchemaRegistryConfig | undefined;
+
+          test.beforeEach(async ({ page }) => {
+            if (
+              configType === ConfigType.Kafka ||
+              configType === ConfigType.KafkaAndSchemaRegistry
+            ) {
+              kafkaConfig = await loadKafkaConfig(page);
+            }
+            if (
+              configType === ConfigType.SchemaRegistry ||
+              configType === ConfigType.KafkaAndSchemaRegistry
+            ) {
+              schemaRegistryConfig = await loadSchemaRegistryConfig(page);
+            }
+          });
+
+          test("should create, edit, export, and delete a valid direct connection", async ({
+            page,
+            electronApp,
+          }) => {
+            const resourcesView = new ResourcesView(page);
+
+            // 1. create the connection
+            const connectionName = `Playwright ${connectionTypeName} (${configType})`;
+            const connectionItem: DirectConnectionItem = await setupDirectConnection(page, {
+              name: connectionName,
+              formConnectionType,
+              kafkaConfig,
+              schemaRegistryConfig,
+            });
+            await expectConnectionResources(resourcesView, configType);
+
+            // 2. edit the connection
+            const form: DirectConnectionForm = await connectionItem.clickEditConnection();
+            await expect(form.formHeader).toContainText("Edit connection details");
+            const newName = `${connectionName} v2`;
+            await form.nameField.clear();
+            await form.fillConnectionName(newName);
+            await form.updateButton.click();
+            // make sure the resources view refreshes and shows the updated connection name
+            await expect(connectionItem.label).toHaveText(newName);
+
+            // 3. export the connection to a JSON file
+            const tmpConnectionDir = mkdtempSync(join(tmpdir(), "vscode-test-direct-connection-"));
+            await stubMultipleDialogs(electronApp, [
+              {
+                method: "showOpenDialog",
+                value: {
+                  filePaths: [tmpConnectionDir],
+                },
+              },
+            ]);
+            await connectionItem.clickExportConnectionDetails();
+            const notificationArea = new NotificationArea(page);
+            await expect(notificationArea.infoNotifications).toHaveCount(1);
+            const notification = new Notification(page, notificationArea.infoNotifications.first());
+            await expect(notification.message).toContainText("Connection file saved at");
+            // inspect exported file contents
+            await notification.clickActionButton("Open File");
+            const exportFileName = `${newName.replaceAll(" ", "_")}.json`;
+            const exportDoc = new TextDocument(page, exportFileName);
+            await expect(exportDoc.tab).toBeVisible();
+            await expect(exportDoc.editorContent).toContainText(`"name": "${newName}"`);
+
+            // 4. disconnect
+            await connectionItem.clickDisconnect();
+            // warning modal is already stubbed to confirm disconnect
+            await expect(resourcesView.directConnections).toHaveCount(0);
+
+            // 5. import the exported connection file
+            await stubMultipleDialogs(electronApp, [
+              {
+                method: "showOpenDialog",
+                value: {
+                  filePaths: [join(tmpConnectionDir, exportFileName)],
+                },
+              },
+            ]);
+            const importForm: DirectConnectionForm =
+              await resourcesView.importNewConnectionFromFile();
+            await expect(importForm.formHeader).toContainText("Import connection");
+            await importForm.nameField.clear();
+            const importName = `Imported ${newName}`;
+            await importForm.fillConnectionName(importName);
+            await importForm.saveButton.click();
+
+            // 6. focus the connection resources (Topics and/or Schemas views, depending on config)
+            const topicsView = new TopicsView(page);
+            const schemasView = new SchemasView(page);
+            await focusConnectionResources(topicsView, schemasView, configType);
+
+            // 7. disconnect again and verify Topics and/or Schemas views reset
+            await connectionItem.clickDisconnect();
+            await expect(resourcesView.directConnections).toHaveCount(0);
+            await expect(topicsView.topics).toHaveCount(0);
+            await expect(schemasView.subjects).toHaveCount(0);
+          });
+        });
+      }
+    });
+  }
+});
+
+/** Verify that the expected resources appear in the Resources view for the given {@link ConfigType}. */
+async function expectConnectionResources(
+  resourcesView: ResourcesView,
+  configType: ConfigType,
+): Promise<void> {
+  if (configType === ConfigType.Kafka || configType === ConfigType.KafkaAndSchemaRegistry) {
+    const kafkaCluster = await resourcesView.getKafkaCluster(ConnectionType.Direct);
+    await expect(kafkaCluster).toHaveCount(1);
+  }
+  if (
+    configType === ConfigType.SchemaRegistry ||
+    configType === ConfigType.KafkaAndSchemaRegistry
+  ) {
+    const schemaRegistry = await resourcesView.getSchemaRegistry(ConnectionType.Direct);
+    await expect(schemaRegistry).toHaveCount(1);
+  }
+}
+
+/** Focus the Topics and/or Schemas views to load resources for the given {@link ConfigType}. */
+async function focusConnectionResources(
+  topicsView: TopicsView,
+  schemasView: SchemasView,
+  configType: ConfigType,
+): Promise<void> {
+  if (configType === ConfigType.Kafka || configType === ConfigType.KafkaAndSchemaRegistry) {
+    await topicsView.loadTopics(ConnectionType.Direct, SelectKafkaCluster.FromResourcesView);
+  }
+  if (
+    configType === ConfigType.SchemaRegistry ||
+    configType === ConfigType.KafkaAndSchemaRegistry
+  ) {
+    await schemasView.loadSchemaSubjects(
+      ConnectionType.Direct,
+      SelectSchemaRegistry.FromResourcesView,
+    );
+  }
+}

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -214,6 +214,13 @@ test.describe("Direct Connection CRUD Lifecycle", () => {
             await focusConnectionResources(topicsView, schemasView, configType);
 
             // 7. disconnect again and verify Topics and/or Schemas views reset
+            const importedConnection = await resourcesView.getDirectConnection(importName);
+            await expect(importedConnection).toHaveCount(1);
+            const importedConnectionItem = new DirectConnectionItem(
+              page,
+              importedConnection.first(),
+            );
+            await expect(importedConnectionItem.locator).toBeVisible();
             await connectionItem.clickDisconnect();
             await expect(resourcesView.directConnections).toHaveCount(0);
             await expect(topicsView.topics).toHaveCount(0);

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -180,7 +180,8 @@ test.describe("Direct Connection CRUD Lifecycle", () => {
             await expect(notification.message).toContainText("Connection file saved at");
             // inspect exported file contents
             await notification.clickActionButton("Open File");
-            const exportFileName = `${newName.replaceAll(" ", "_")}.json`;
+            // same name transformation as what `confluent.connections.direct.export` uses
+            const exportFileName = `${newName.trim().replace(/\s+/g, "_")}.json`;
             const exportDoc = new TextDocument(page, exportFileName);
             await expect(exportDoc.tab).toBeVisible();
             await expect(exportDoc.editorContent).toContainText(`"name": "${newName}"`);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

New tests that only cover basic CCloud API key/secret connection management.
- valid connection creation, edit, export, disconnect, import
- invalid connection creation and some basic assertions over the error info we show from the notification area and Resources view item

<img width="896" height="655" alt="image" src="https://github.com/user-attachments/assets/8514155f-09b9-43d4-abdf-de20bacf1700" />

Once https://github.com/confluentinc/vscode/issues/2140 is done, this can be updated so the Kafka/SR config functions use right-click actions on existing local resources to copy Kafka bootstrap server + Schema Registry URL values.

Closes #2025

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- This set of tests was more or less the tipping point for some of our connection-setup patterns, and I don't like how much boilerplate has to be copied. The [next branch](https://github.com/confluentinc/vscode/pull/2616) will start refactoring connection-specific setup and teardown to simplify those aspects of E2E tests.
- While running tests with local resources running, I noticed that our locators for Schema Registry items weren't filtering enough, and trying to locate a direct connection `"Schema Registry"` would accidentally select the local connection's SR view item. As a result, I'm also updating the `accessibilityInformation` for those tree view items to give the tests a little more help. 
  - That also meant updating some of the getter methods for those locators (like `.directConnections`), but then I saw this getter's inner comment: https://github.com/confluentinc/vscode/blob/90a959ae8cff1a033860b17d2b2a6eb5ac27b59b/tests/e2e/objects/views/ResourcesView.ts#L64-L68
  ...and then I went down a rabbit hole to clean it (and others) up to use [`treeItems`](https://github.com/confluentinc/vscode/blob/90a959ae8cff1a033860b17d2b2a6eb5ac27b59b/tests/e2e/objects/views/View.ts#L41-L43) directly. After poring over playwright Locator documentation, I realized I wasn't thinking about `<locator>.filter()` correctly. As I currently understand it, we should go by the following:
    1. Use [`.and()`](https://playwright.dev/docs/api/class-locator#locator-and) when we want to take an existing locator and add some extra criteria to it to make it more restrictive (example: one locator for `role="treeItem"` combined with another locator for `aria-label="direct connection"` to match tree items with the "direct connection" ARIA label)
    2. Use [`.filter`](https://playwright.dev/docs/api/class-locator#locator-filter) to limit the number of matched elements by their child elements (example: one locator for `role="treeItem"` that matches a subset of elements based on their child elements containing the `codicon-confluent-logo` class)
    3. Use [`.locator`](https://playwright.dev/docs/api/class-locator#locator-locator) to target a sub-element (example: start with one locator for `role="treeItem"` and end up with a locator that's specifically targeting tree item icons and not their higher-level `div`s)
    <img width="735" height="705" alt="image" src="https://github.com/user-attachments/assets/b8b1f29b-cb8a-4755-95dc-ec4c37ddecaa" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
