### PR TITLE
'Generate Dataset' CodeLens creates Dataset file

### DIFF
--- a/src/commands/medusaCodeLens.test.ts
+++ b/src/commands/medusaCodeLens.test.ts
@@ -165,7 +165,8 @@ describe("medusaCodeLens", () => {
       // Verify file write
       sinon.assert.calledOnce(writeFileStub);
       const [savedUri, savedContent] = writeFileStub.getCall(0).args;
-      assert.strictEqual(savedUri.fsPath, "/workspace/my-dataset.dataset.json");
+      const expectedUri = vscode.Uri.file("/workspace/my-dataset.dataset.json");
+      assert.strictEqual(savedUri.path, expectedUri.path);
       const savedData = JSON.parse(savedContent.toString());
       assert.deepStrictEqual(savedData, mockDataset);
 
@@ -234,7 +235,8 @@ describe("medusaCodeLens", () => {
         await generateMedusaDatasetCommand(mockUri);
 
         const [savedUri] = writeFileStub.getCall(0).args;
-        assert.strictEqual(savedUri.fsPath, "/workspace/myfile.dataset.json");
+        const expectedUri = vscode.Uri.file("/workspace/myfile.dataset.json");
+        assert.strictEqual(savedUri.path, expectedUri.path);
       });
     });
 

--- a/src/commands/medusaCodeLens.test.ts
+++ b/src/commands/medusaCodeLens.test.ts
@@ -1,5 +1,19 @@
+import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
+import { ContainerSummary, Port, PortTypeEnum } from "../clients/docker";
+import {
+  DatasetDTO,
+  EventDTO,
+  FieldDTO,
+  GenerationDTO,
+  GenerationDTOGeneratorEnum,
+  SchemaManagementApi,
+} from "../clients/medusa";
+import * as medusaApi from "../medusa/api";
+import * as localConnections from "../sidecar/connections/local";
+import * as fileUtils from "../utils/file";
+import * as fsWrappers from "../utils/fsWrappers";
 import * as commands from "./index";
 import {
   generateMedusaDatasetCommand,
@@ -19,18 +33,266 @@ describe("medusaCodeLens", () => {
   });
 
   describe("generateMedusaDatasetCommand", () => {
-    // todo patrick: this test will be replaced once proper call out to medusa is added in follow up pr
-    it("should show information message with document URI path", async () => {
-      const mockUri = vscode.Uri.file("/path/to/test.avsc");
-      const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
+    let mockUri: vscode.Uri;
+    let getEditorOrFileContentsStub: sinon.SinonStub;
+    let withProgressStub: sinon.SinonStub;
+    let showInformationMessageStub: sinon.SinonStub;
+    let showErrorMessageStub: sinon.SinonStub;
+    let showSaveDialogStub: sinon.SinonStub;
+    let writeFileStub: sinon.SinonStub;
+    let showTextDocumentStub: sinon.SinonStub;
+    let getMedusaSchemaManagementApiStub: sinon.SinonStub;
+    let getMedusaContainerStub: sinon.SinonStub;
+    let getContainerPublicPortStub: sinon.SinonStub;
+    let mockSchemaManagementApi: sinon.SinonStubbedInstance<SchemaManagementApi>;
+
+    const validAvroSchema = {
+      type: "record",
+      name: "TestRecord",
+      fields: [
+        { name: "id", type: "string" },
+        { name: "value", type: "int" },
+      ],
+    };
+
+    const mockFieldGeneration: GenerationDTO = {
+      generator: GenerationDTOGeneratorEnum.StringUuid,
+      arguments: [],
+    };
+
+    const mockFields: FieldDTO[] = [
+      {
+        name: "id",
+        generation: mockFieldGeneration,
+        ignored: false,
+      },
+      {
+        name: "value",
+        generation: {
+          generator: GenerationDTOGeneratorEnum.NumberIteratingInteger,
+          arguments: [],
+        },
+        ignored: false,
+      },
+    ];
+
+    const mockEvent: EventDTO = {
+      event_name: "TestEvent",
+      key_field_name: "id",
+      fields: mockFields,
+    };
+
+    const mockDataset: DatasetDTO = {
+      events: [mockEvent],
+      tables: [],
+    };
+
+    beforeEach(() => {
+      mockUri = vscode.Uri.file("/path/to/test.avsc");
+
+      getEditorOrFileContentsStub = sandbox
+        .stub(fileUtils, "getEditorOrFileContents")
+        .resolves({ content: JSON.stringify(validAvroSchema) });
+      withProgressStub = sandbox.stub(vscode.window, "withProgress");
+      showInformationMessageStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
+      showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage").resolves();
+      showSaveDialogStub = sandbox.stub(vscode.window, "showSaveDialog");
+      writeFileStub = sandbox.stub(fsWrappers, "writeFile").resolves();
+      showTextDocumentStub = sandbox.stub(vscode.window, "showTextDocument").resolves();
+
+      // Mock the Medusa API
+      mockSchemaManagementApi = sandbox.createStubInstance(SchemaManagementApi);
+      getMedusaSchemaManagementApiStub = sandbox
+        .stub(medusaApi, "getMedusaSchemaManagementApi")
+        .returns(mockSchemaManagementApi);
+
+      // Mock the container functions
+      const mockPort: Port = {
+        PrivatePort: 8082,
+        PublicPort: 8082,
+        Type: PortTypeEnum.Tcp,
+      };
+      const mockContainer: ContainerSummary = {
+        Id: "mock-container",
+        Ports: [mockPort],
+      };
+      getMedusaContainerStub = sandbox
+        .stub(localConnections, "getMedusaContainer")
+        .resolves(mockContainer);
+      getContainerPublicPortStub = sandbox
+        .stub(localConnections, "getContainerPublicPort")
+        .withArgs(mockContainer)
+        .returns(8082);
+    });
+
+    it("should successfully generate dataset and save to file", async () => {
+      // Setup mocks
+      mockSchemaManagementApi.convertAvroSchemaToDataset.resolves(mockDataset);
+      withProgressStub.callsFake(async (options, callback) => await callback());
+      showSaveDialogStub.resolves(vscode.Uri.file("/workspace/my-dataset.dataset.json"));
+      showInformationMessageStub.resolves("Open File");
 
       await generateMedusaDatasetCommand(mockUri);
 
-      sinon.assert.calledOnce(showInfoStub);
-      sinon.assert.calledWithMatch(
-        showInfoStub,
-        sinon.match(/Generate Medusa Dataset clicked for: .*test\.avsc/),
+      // Verify file reading
+      sinon.assert.calledOnceWithExactly(getEditorOrFileContentsStub, mockUri);
+
+      // Verify container functions called
+      sinon.assert.calledOnce(getMedusaContainerStub);
+      sinon.assert.calledOnce(getContainerPublicPortStub);
+
+      // Verify API call
+      sinon.assert.calledOnceWithExactly(getMedusaSchemaManagementApiStub, 8082);
+      sinon.assert.calledOnceWithExactly(
+        mockSchemaManagementApi.convertAvroSchemaToDataset,
+        sinon.match({ body: validAvroSchema }),
       );
+
+      // Verify progress dialog
+      sinon.assert.calledOnce(withProgressStub);
+      const progressOptions = withProgressStub.getCall(0).args[0];
+      assert.strictEqual(progressOptions.title, "Generating Medusa Dataset...");
+
+      // Verify success message (should be called once for file save)
+      sinon.assert.calledOnce(showInformationMessageStub);
+      sinon.assert.calledWithMatch(showInformationMessageStub, /Dataset saved to.*\.dataset\.json/);
+
+      // Verify save dialog
+      sinon.assert.calledOnce(showSaveDialogStub);
+      const saveOptions = showSaveDialogStub.getCall(0).args[0];
+      assert.deepStrictEqual(saveOptions.filters, { "Dataset Files": ["dataset.json"] });
+
+      // Verify file write
+      sinon.assert.calledOnce(writeFileStub);
+      const [savedUri, savedContent] = writeFileStub.getCall(0).args;
+      assert.strictEqual(savedUri.fsPath, "/workspace/my-dataset.dataset.json");
+      const savedData = JSON.parse(savedContent.toString());
+      assert.deepStrictEqual(savedData, mockDataset);
+
+      // Verify file opened
+      sinon.assert.calledOnce(showTextDocumentStub);
+    });
+
+    it("should handle empty file error", async () => {
+      getEditorOrFileContentsStub.resolves({ content: "" });
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledOnceWithExactly(showErrorMessageStub, "The Avro schema file is empty.");
+      sinon.assert.notCalled(withProgressStub);
+    });
+
+    it("should handle invalid JSON error", async () => {
+      getEditorOrFileContentsStub.resolves({ content: "{ invalid json" });
+      withProgressStub.callsFake(async (options, callback) => await callback());
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledWithMatch(
+        showErrorMessageStub,
+        /Failed to generate Medusa dataset: Invalid JSON in Avro schema file/,
+      );
+      sinon.assert.notCalled(mockSchemaManagementApi.convertAvroSchemaToDataset);
+    });
+
+    it("should handle API error", async () => {
+      const apiError = new Error("API connection failed");
+      mockSchemaManagementApi.convertAvroSchemaToDataset.rejects(apiError);
+      withProgressStub.callsFake(async (options, callback) => await callback());
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledWithMatch(
+        showErrorMessageStub,
+        /Failed to generate Medusa dataset: API connection failed/,
+      );
+      sinon.assert.notCalled(showSaveDialogStub);
+    });
+
+    it("should handle user canceling save dialog", async () => {
+      mockSchemaManagementApi.convertAvroSchemaToDataset.resolves(mockDataset);
+      withProgressStub.callsFake(async (options, task) => await task());
+      showSaveDialogStub.resolves(undefined); // User canceled
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledOnce(showSaveDialogStub);
+      sinon.assert.notCalled(writeFileStub);
+    });
+
+    [
+      "/workspace/myfile.json",
+      "/workspace/myfile",
+      "/workspace/myfile.txt",
+      "/workspace/myfile.dataset",
+    ].forEach((inputPath) => {
+      it(`should enforce .dataset.json extension for file name input '${inputPath}'`, async () => {
+        mockSchemaManagementApi.convertAvroSchemaToDataset.resolves(mockDataset);
+        withProgressStub.callsFake(async (options, task) => await task());
+        showSaveDialogStub.resolves(vscode.Uri.file(inputPath));
+
+        await generateMedusaDatasetCommand(mockUri);
+
+        const [savedUri] = writeFileStub.getCall(0).args;
+        assert.strictEqual(savedUri.fsPath, "/workspace/myfile.dataset.json");
+      });
+    });
+
+    it("should handle file write error", async () => {
+      mockSchemaManagementApi.convertAvroSchemaToDataset.resolves(mockDataset);
+      withProgressStub.callsFake(async (options, task) => await task());
+      showSaveDialogStub.resolves(vscode.Uri.file("/workspace/test.dataset.json"));
+      writeFileStub.rejects(new Error("Permission denied"));
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledWithMatch(
+        showErrorMessageStub,
+        /Failed to save dataset file: Permission denied/,
+      );
+    });
+
+    it("should not open file when user doesn't click 'Open File'", async () => {
+      mockSchemaManagementApi.convertAvroSchemaToDataset.resolves(mockDataset);
+      withProgressStub.callsFake(async (options, task) => await task());
+      showSaveDialogStub.resolves(vscode.Uri.file("/workspace/test.dataset.json"));
+      showInformationMessageStub.resolves(undefined); // User didn't click "Open File"
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.notCalled(showTextDocumentStub);
+    });
+
+    it("should handle missing Medusa container error", async () => {
+      getMedusaContainerStub.resolves(undefined); // No container found
+      withProgressStub.callsFake(async (options, callback) => await callback());
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledWithMatch(
+        showErrorMessageStub,
+        /Failed to generate Medusa dataset: Medusa container not found. Please start the local Medusa service./,
+      );
+      sinon.assert.notCalled(getContainerPublicPortStub);
+      sinon.assert.notCalled(mockSchemaManagementApi.convertAvroSchemaToDataset);
+    });
+
+    it("should handle missing container port error", async () => {
+      const containerWithoutPorts: ContainerSummary = {
+        Id: "mock-container",
+        Ports: [], // No ports
+      };
+      getMedusaContainerStub.resolves(containerWithoutPorts);
+      getContainerPublicPortStub.withArgs(containerWithoutPorts).returns(undefined);
+      withProgressStub.callsFake(async (options, callback) => await callback());
+
+      await generateMedusaDatasetCommand(mockUri);
+
+      sinon.assert.calledWithMatch(
+        showErrorMessageStub,
+        /Failed to generate Medusa dataset: Medusa container port not accessible. Please check container configuration./,
+      );
+      sinon.assert.notCalled(mockSchemaManagementApi.convertAvroSchemaToDataset);
     });
   });
 

--- a/src/commands/medusaCodeLens.test.ts
+++ b/src/commands/medusaCodeLens.test.ts
@@ -101,6 +101,14 @@ describe("medusaCodeLens", () => {
       writeFileStub = sandbox.stub(fsWrappers, "writeFile").resolves();
       showTextDocumentStub = sandbox.stub(vscode.window, "showTextDocument").resolves();
 
+      // Mock workspace folders
+      const mockWorkspaceFolder = {
+        uri: vscode.Uri.file("/workspace"),
+        name: "test-workspace",
+        index: 0,
+      };
+      sandbox.stub(vscode.workspace, "workspaceFolders").value([mockWorkspaceFolder]);
+
       // Mock the Medusa API
       mockSchemaManagementApi = sandbox.createStubInstance(SchemaManagementApi);
       getMedusaSchemaManagementApiStub = sandbox
@@ -130,7 +138,7 @@ describe("medusaCodeLens", () => {
       // Setup mocks
       mockSchemaManagementApi.convertAvroSchemaToDataset.resolves(mockDataset);
       withProgressStub.callsFake(async (options, callback) => await callback());
-      showSaveDialogStub.resolves(vscode.Uri.file("/workspace/my-dataset.dataset.json"));
+      showSaveDialogStub.resolves(vscode.Uri.file("/workspace/TestEvent.dataset.json"));
       showInformationMessageStub.resolves("Open File");
 
       await generateMedusaDatasetCommand(mockUri);
@@ -164,12 +172,12 @@ describe("medusaCodeLens", () => {
       // Verify save dialog
       sinon.assert.calledOnce(showSaveDialogStub);
       const saveOptions = showSaveDialogStub.getCall(0).args[0];
-      assert.deepStrictEqual(saveOptions.filters, { "Dataset Files": ["dataset.json"] });
+      assert.deepStrictEqual(saveOptions.filters, { "Medusa Dataset Files": ["dataset.json"] });
 
       // Verify file write
       sinon.assert.calledOnce(writeFileStub);
       const [savedUri, savedContent] = writeFileStub.getCall(0).args;
-      const expectedUri = vscode.Uri.file("/workspace/my-dataset.dataset.json");
+      const expectedUri = vscode.Uri.file("/workspace/TestEvent.dataset.json");
       assert.strictEqual(savedUri.path, expectedUri.path);
       const savedData = JSON.parse(savedContent.toString());
       assert.deepStrictEqual(savedData, mockDataset);

--- a/src/commands/medusaCodeLens.ts
+++ b/src/commands/medusaCodeLens.ts
@@ -66,7 +66,7 @@ async function convertAvroSchemaToDataset(avroSchemaContent: string): Promise<Da
     );
   }
 
-  const medusaContainer = await getMedusaContainer();
+  const medusaContainer = await getMedusaContainer(); //todo Patrick: add this and port look up to helper function
   if (!medusaContainer) {
     throw new Error("Medusa container not found. Please start the local Medusa service.");
   }
@@ -105,7 +105,7 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
     const defaultFilename = `my-dataset.dataset.json`;
 
     // Show save dialog
-    const saveUri = await window.showSaveDialog({
+    let saveUri = await window.showSaveDialog({
       defaultUri: defaultUri ? Uri.joinPath(defaultUri, defaultFilename) : undefined,
       filters: {
         "Dataset Files": ["dataset.json"],
@@ -119,31 +119,30 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
     }
 
     // Ensure the file has the correct .dataset.json extension
-    let finalUri = saveUri;
     const parsed = parse(saveUri.fsPath);
     const nameWithoutAnyExt = parsed.name.split(".")[0];
-    finalUri = Uri.file(join(parsed.dir, `${nameWithoutAnyExt}.dataset.json`));
+    saveUri = Uri.file(join(parsed.dir, `${nameWithoutAnyExt}.dataset.json`));
 
     // Convert dataset to JSON string with pretty formatting
     const datasetJson = JSON.stringify(dataset, null, 2);
 
     // Write the file
-    await writeFile(finalUri, Buffer.from(datasetJson, "utf8"));
+    await writeFile(saveUri, Buffer.from(datasetJson, "utf8"));
 
     logger.info("Dataset saved successfully", {
-      filePath: finalUri.fsPath,
+      filePath: saveUri.fsPath,
       fileSize: datasetJson.length,
     });
 
     // Show success message with option to open the file
     const openFile = "Open File";
     const result = await window.showInformationMessage(
-      `Dataset saved to ${path.basename(finalUri.fsPath)}`,
+      `Dataset saved to ${path.basename(saveUri.fsPath)}`,
       openFile,
     );
 
     if (result === openFile) {
-      await window.showTextDocument(finalUri);
+      await window.showTextDocument(saveUri);
     }
   } catch (error) {
     logger.error("Failed to save dataset file", error);

--- a/src/commands/medusaCodeLens.ts
+++ b/src/commands/medusaCodeLens.ts
@@ -1,6 +1,13 @@
-import { Disposable, Uri, window } from "vscode";
+import * as path from "path";
+import { join, parse } from "path";
+import { Disposable, Uri, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
+import { DatasetDTO } from "../clients/medusa";
 import { Logger } from "../logging";
+import { getMedusaSchemaManagementApi } from "../medusa/api";
+import { getContainerPublicPort, getMedusaContainer } from "../sidecar/connections/local";
+import { getEditorOrFileContents } from "../utils/file";
+import { writeFile } from "../utils/fsWrappers";
 
 const logger = new Logger("commands.medusaCodeLens");
 
@@ -15,11 +22,134 @@ export async function generateMedusaDatasetCommand(documentUri: Uri): Promise<vo
     documentUri: documentUri?.toString(),
   });
 
-  // For now, just show an alert
-  // TODO: Implement actual Medusa dataset generation logic
-  await window.showInformationMessage(
-    `Generate Medusa Dataset clicked for: ${documentUri?.fsPath || "Unknown file"}`,
-  );
+  try {
+    // Read the Avro schema file contents
+    const { content: avroSchemaContent } = await getEditorOrFileContents(documentUri);
+
+    if (!avroSchemaContent.trim()) {
+      await window.showErrorMessage("The Avro schema file is empty.");
+      return;
+    }
+
+    logger.info("Reading Avro schema file", {
+      filePath: documentUri.fsPath,
+      contentLength: avroSchemaContent.length,
+    });
+
+    // Show progress while calling the API
+    const dataset = await window.withProgress(
+      {
+        location: { viewId: "confluent" },
+        title: "Generating Medusa Dataset...",
+        cancellable: false,
+      },
+      () => convertAvroSchemaToDataset(avroSchemaContent),
+    );
+
+    // Save the dataset to a file
+    await saveDatasetToFile(dataset);
+  } catch (error) {
+    logger.error("Failed to generate Medusa dataset", error);
+    const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+    await window.showErrorMessage(`Failed to generate Medusa dataset: ${errorMessage}`);
+  }
+}
+
+async function convertAvroSchemaToDataset(avroSchemaContent: string): Promise<DatasetDTO> {
+  // Parse and validate the Avro schema content
+  let parsedSchema;
+  try {
+    parsedSchema = JSON.parse(avroSchemaContent);
+  } catch (parseError) {
+    throw new Error(
+      `Invalid JSON in Avro schema file: ${parseError instanceof Error ? parseError.message : "Unknown parsing error"}`,
+    );
+  }
+
+  const medusaContainer = await getMedusaContainer();
+  if (!medusaContainer) {
+    throw new Error("Medusa container not found. Please start the local Medusa service.");
+  }
+  const medusaPort = getContainerPublicPort(medusaContainer);
+  if (!medusaPort) {
+    throw new Error("Medusa container port not accessible. Please check container configuration.");
+  }
+  logger.info("Calling Medusa API", {
+    port: medusaPort,
+    schemaType: parsedSchema.type,
+    schemaName: parsedSchema.name,
+  });
+
+  // Call the Medusa API to convert the Avro schema to dataset
+  const medusaApi = getMedusaSchemaManagementApi(medusaPort);
+  const dataset = await medusaApi.convertAvroSchemaToDataset({
+    body: parsedSchema,
+  });
+
+  logger.info("Successfully generated Medusa dataset", {
+    eventsCount: dataset.events?.length || 0,
+  });
+
+  return dataset;
+}
+
+/**
+ * Prompts the user to save a DatasetDTO to a file with .dataset.json extension.
+ * Defaults to the current workspace directory.
+ */
+async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
+  try {
+    // Get the workspace folder as default location
+    const workspaceFolder = workspace.workspaceFolders?.[0];
+    const defaultUri = workspaceFolder ? workspaceFolder.uri : undefined;
+    const defaultFilename = `my-dataset.dataset.json`;
+
+    // Show save dialog
+    const saveUri = await window.showSaveDialog({
+      defaultUri: defaultUri ? Uri.joinPath(defaultUri, defaultFilename) : undefined,
+      filters: {
+        "Dataset Files": ["dataset.json"],
+      },
+      saveLabel: "Save Dataset",
+    });
+
+    if (!saveUri) {
+      // User cancelled the save dialog
+      return;
+    }
+
+    // Ensure the file has the correct .dataset.json extension
+    let finalUri = saveUri;
+    const parsed = parse(saveUri.fsPath);
+    const nameWithoutAnyExt = parsed.name.split(".")[0];
+    finalUri = Uri.file(join(parsed.dir, `${nameWithoutAnyExt}.dataset.json`));
+
+    // Convert dataset to JSON string with pretty formatting
+    const datasetJson = JSON.stringify(dataset, null, 2);
+
+    // Write the file
+    await writeFile(finalUri, Buffer.from(datasetJson, "utf8"));
+
+    logger.info("Dataset saved successfully", {
+      filePath: finalUri.fsPath,
+      fileSize: datasetJson.length,
+    });
+
+    // Show success message with option to open the file
+    const openFile = "Open File";
+    const result = await window.showInformationMessage(
+      `Dataset saved to ${path.basename(finalUri.fsPath)}`,
+      openFile,
+    );
+
+    if (result === openFile) {
+      await window.showTextDocument(finalUri);
+    }
+  } catch (error) {
+    logger.error("Failed to save dataset file", error);
+    const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
+    await window.showErrorMessage(`Failed to save dataset file: ${errorMessage}`);
+  }
 }
 
 /**

--- a/src/commands/medusaCodeLens.ts
+++ b/src/commands/medusaCodeLens.ts
@@ -49,9 +49,9 @@ export async function generateMedusaDatasetCommand(documentUri: Uri): Promise<vo
     // Save the dataset to a file
     await saveDatasetToFile(dataset);
   } catch (error) {
-    logger.error("Failed to generate Medusa dataset", error);
+    logger.error("Failed to generate Medusa Dataset", error);
     const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-    await window.showErrorMessage(`Failed to generate Medusa dataset: ${errorMessage}`);
+    await window.showErrorMessage(`Failed to generate Medusa Dataset: ${errorMessage}`);
   }
 }
 
@@ -86,7 +86,7 @@ async function convertAvroSchemaToDataset(avroSchemaContent: string): Promise<Da
     body: parsedSchema,
   });
 
-  logger.info("Successfully generated Medusa dataset", {
+  logger.info("Successfully generated Medusa Dataset", {
     eventsCount: dataset.events?.length || 0,
   });
 
@@ -110,7 +110,7 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
       filters: {
         "Dataset Files": ["dataset.json"],
       },
-      saveLabel: "Save Dataset",
+      saveLabel: "Save Medusa Dataset",
     });
 
     if (!saveUri) {
@@ -129,7 +129,7 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
     // Write the file
     await writeFile(saveUri, Buffer.from(datasetJson, "utf8"));
 
-    logger.info("Dataset saved successfully", {
+    logger.info("Medusa Dataset saved successfully", {
       filePath: saveUri.fsPath,
       fileSize: datasetJson.length,
     });
@@ -137,7 +137,7 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
     // Show success message with option to open the file
     const openFile = "Open File";
     const result = await window.showInformationMessage(
-      `Dataset saved to ${path.basename(saveUri.fsPath)}`,
+      `Medusa Dataset saved to ${path.basename(saveUri.fsPath)}`,
       openFile,
     );
 
@@ -145,9 +145,9 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
       await window.showTextDocument(saveUri);
     }
   } catch (error) {
-    logger.error("Failed to save dataset file", error);
+    logger.error("Failed to save Medusa Dataset file", error);
     const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
-    await window.showErrorMessage(`Failed to save dataset file: ${errorMessage}`);
+    await window.showErrorMessage(`Failed to save Medusa Dataset file: ${errorMessage}`);
   }
 }
 

--- a/src/commands/medusaCodeLens.ts
+++ b/src/commands/medusaCodeLens.ts
@@ -118,13 +118,15 @@ async function saveDatasetToFile(dataset: DatasetDTO): Promise<void> {
     // Get the workspace folder as default location
     const workspaceFolder = workspace.workspaceFolders?.[0];
     const defaultUri = workspaceFolder ? workspaceFolder.uri : undefined;
-    const defaultFilename = `my-dataset.dataset.json`;
+    // when converting an avro schema there will only ever be one event in subsequent Dataset
+    const baseName = dataset.events[0].event_name;
+    const defaultFilename = `${baseName}.dataset.json`;
 
     // Show save dialog
     let saveUri = await window.showSaveDialog({
       defaultUri: defaultUri ? Uri.joinPath(defaultUri, defaultFilename) : undefined,
       filters: {
-        "Dataset Files": ["dataset.json"],
+        "Medusa Dataset Files": ["dataset.json"],
       },
       saveLabel: "Save Medusa Dataset",
     });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,6 +4,7 @@ import { ResponseError as FlinkArtifactsResponseError } from "./clients/flinkArt
 import { ResponseError as FlinkComputePoolResponseError } from "./clients/flinkComputePool";
 import { ResponseError as FlinkSqlResponseError } from "./clients/flinkSql";
 import { ResponseError as KafkaResponseError } from "./clients/kafkaRest";
+import { ResponseError as MedusaResponseError } from "./clients/medusa";
 import { ResponseError as ScaffoldingServiceResponseError } from "./clients/scaffoldingService";
 import { ResponseError as SchemaRegistryResponseError } from "./clients/schemaRegistryRest";
 import { ResponseError as SidecarResponseError } from "./clients/sidecar";
@@ -27,6 +28,7 @@ export type AnyResponseError =
   | FlinkArtifactsResponseError
   | FlinkComputePoolResponseError
   | FlinkSqlResponseError
+  | MedusaResponseError
   | ScaffoldingServiceResponseError
   | DockerResponseError;
 
@@ -39,6 +41,7 @@ export function isResponseError(error: unknown): error is AnyResponseError {
     error instanceof FlinkArtifactsResponseError ||
     error instanceof FlinkComputePoolResponseError ||
     error instanceof FlinkSqlResponseError ||
+    error instanceof MedusaResponseError ||
     error instanceof ScaffoldingServiceResponseError ||
     error instanceof DockerResponseError
   );

--- a/src/medusa/api.ts
+++ b/src/medusa/api.ts
@@ -8,7 +8,7 @@ import {
 } from "../clients/medusa/apis";
 
 function createApi<T>(ApiClass: new (config: Configuration) => T) {
-  return function (port: string): T {
+  return function (port: number): T {
     const config = new Configuration({ basePath: `http://localhost:${port}` });
     return new ApiClass(config);
   };


### PR DESCRIPTION
## Summary of Changes

Transforms the placeholder "Generate Dataset" CodeLens command so that it:

1. Reads the contents of the Avro schema file.
2. Sends the schema as the POST body to the local Medusa endpoint /_/v1/schemas/avro/convert.
3. Receives the converted Medusa Dataset from the endpoint.
4. Prompts the user to save the result as a *.dataset.json file containing the generated dataset.

Attached schema file can be used for click testing: [schema.json](https://github.com/user-attachments/files/22389256/schema.json)

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

