### PR TITLE
PROTOTYPE: add "quickpick form" for artifact upload flow

### DIFF
--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -16,9 +16,9 @@ import {
 import { getSidecar } from "../sidecar";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 import {
+  artifactUploadQuickPickForm,
   getPresignedUploadUrl,
   handleUploadToCloudProvider,
-  promptForArtifactUploadParams,
   uploadArtifactToCCloud,
 } from "./utils/uploadArtifact";
 
@@ -41,7 +41,8 @@ export async function uploadArtifactCommand(
 ): Promise<void> {
   try {
     // 1. Gather the request parameters from user or item
-    const params = await promptForArtifactUploadParams(item);
+    // PROTOTYPE: quickpick "form" for the whole artifact upload flow
+    const params = await artifactUploadQuickPickForm();
     if (!params) return; // User cancelled the prompt
 
     const request: PresignedUploadUrlArtifactV1PresignedUrlRequest = {


### PR DESCRIPTION
https://github.com/user-attachments/assets/6d25c98a-3415-4808-a5a2-52dca02618da

Basically boils down to:
- establish "steps" in the flow that need to be met
- create top-level quickpick with items representing each step
- track completion state for the whole flow and conditionally update icons/descriptions based on user provided inputs
- wrap in a `while` loop until all completed steps are done or exited from the top-level quickpick

Ideally we could abstract this to its own class or helper function, but defining the steps generically may be more work than just setting them up explicitly in a few examples before a pattern emerges.