### PR TITLE
2615 conditionally display the avro schema codelens based on medusa container availability

### DIFF
--- a/package.json
+++ b/package.json
@@ -461,6 +461,12 @@
         "enablement": "confluent.localDocker.medusaEnable"
       },
       {
+        "command": "confluent.medusa.start",
+        "title": "Start Medusa container",
+        "category": "Confluent",
+        "enablement": "confluent.localDocker.medusaEnable"
+      },
+      {
         "command": "confluent.openCCloudApiKeysUrl",
         "icon": "$(confluent-logo)",
         "title": "Manage API Keys in Confluent Cloud",
@@ -1347,6 +1353,10 @@
         {
           "command": "confluent.medusa.generateDataset",
           "when": "false"
+        },
+        {
+          "command": "confluent.medusa.start",
+          "when": "confluent.localDocker.medusaEnable"
         },
         {
           "command": "confluent.openCCloudApiKeysUrl",

--- a/src/codelens/avroProvider.ts
+++ b/src/codelens/avroProvider.ts
@@ -35,7 +35,7 @@ export class AvroCodelensProvider extends DisposableCollection implements CodeLe
   private constructor() {
     super();
 
-    this.disposables.push(...this.setEventListeners());
+    this.disposables.push(this._onDidChangeCodeLenses, ...this.setEventListeners());
   }
 
   protected setEventListeners(): Disposable[] {

--- a/src/commands/medusaCodeLens.test.ts
+++ b/src/commands/medusaCodeLens.test.ts
@@ -2,9 +2,10 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import * as commands from "./index";
 import {
+  COMMANDS,
   generateMedusaDatasetCommand,
-  MEDUSA_COMMANDS,
   registerMedusaCodeLensCommands,
+  startMedusaCommand,
 } from "./medusaCodeLens";
 
 describe("medusaCodeLens", () => {
@@ -34,19 +35,35 @@ describe("medusaCodeLens", () => {
     });
   });
 
+  describe("startLocalMedusaCommand", () => {
+    it("should show information message", async () => {
+      const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
+
+      await startMedusaCommand();
+
+      sinon.assert.calledOnce(showInfoStub);
+      sinon.assert.calledWith(showInfoStub, "Start Local Medusa clicked!");
+    });
+  });
+
   describe("registerMedusaCodeLensCommands", () => {
-    it("should register the generateDataset command", () => {
+    it("should register both generateDataset and start commands", () => {
       const registerCommandWithLoggingStub = sandbox
         .stub(commands, "registerCommandWithLogging")
         .returns({} as vscode.Disposable);
 
       registerMedusaCodeLensCommands();
 
-      sinon.assert.calledOnce(registerCommandWithLoggingStub);
+      sinon.assert.calledTwice(registerCommandWithLoggingStub);
       sinon.assert.calledWithExactly(
-        registerCommandWithLoggingStub,
-        MEDUSA_COMMANDS.GENERATE_DATASET,
+        registerCommandWithLoggingStub.firstCall,
+        COMMANDS.GENERATE_DATASET,
         generateMedusaDatasetCommand,
+      );
+      sinon.assert.calledWithExactly(
+        registerCommandWithLoggingStub.secondCall,
+        COMMANDS.START_MEDUSA,
+        startMedusaCommand,
       );
     });
   });

--- a/src/commands/medusaCodeLens.ts
+++ b/src/commands/medusaCodeLens.ts
@@ -4,8 +4,9 @@ import { Logger } from "../logging";
 
 const logger = new Logger("commands.medusaCodeLens");
 
-export const MEDUSA_COMMANDS = {
+export const COMMANDS = {
   GENERATE_DATASET: "confluent.medusa.generateDataset",
+  START_MEDUSA: "confluent.medusa.start",
 } as const;
 /**
  * Command handler for generating a Medusa dataset from an Avro schema file.
@@ -23,11 +24,23 @@ export async function generateMedusaDatasetCommand(documentUri: Uri): Promise<vo
 }
 
 /**
+ * Command handler for starting the local Medusa container.
+ */
+export async function startMedusaCommand(): Promise<void> {
+  logger.info("Start Medusa command triggered");
+
+  // For now, just show an alert
+  // TODO Patrick: Implement actual Medusa container start logic
+  await window.showInformationMessage("Start Local Medusa clicked!");
+}
+
+/**
  * Register all Medusa-related commands.
  * @returns Array of disposables for the registered commands
  */
 export function registerMedusaCodeLensCommands(): Disposable[] {
   return [
-    registerCommandWithLogging(MEDUSA_COMMANDS.GENERATE_DATASET, generateMedusaDatasetCommand),
+    registerCommandWithLogging(COMMANDS.GENERATE_DATASET, generateMedusaDatasetCommand),
+    registerCommandWithLogging(COMMANDS.START_MEDUSA, startMedusaCommand),
   ];
 }

--- a/src/commands/medusaCodeLens.ts
+++ b/src/commands/medusaCodeLens.ts
@@ -1,6 +1,8 @@
 import { Disposable, Uri, window } from "vscode";
 import { registerCommandWithLogging } from ".";
+import { LocalResourceKind } from "../docker/constants";
 import { Logger } from "../logging";
+import { runWorkflowWithProgress } from "./docker";
 
 const logger = new Logger("commands.medusaCodeLens");
 
@@ -29,9 +31,14 @@ export async function generateMedusaDatasetCommand(documentUri: Uri): Promise<vo
 export async function startMedusaCommand(): Promise<void> {
   logger.info("Start Medusa command triggered");
 
-  // For now, just show an alert
-  // TODO Patrick: Implement actual Medusa container start logic
-  await window.showInformationMessage("Start Local Medusa clicked!");
+  try {
+    // Start the Medusa container using the existing workflow
+    await runWorkflowWithProgress(true, [LocalResourceKind.Medusa]);
+    logger.info("Medusa container start workflow completed");
+  } catch (error) {
+    logger.error("Failed to start Medusa container:", error);
+    await window.showErrorMessage("Failed to start Medusa container. Check the logs for details.");
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary of Changes

This PR implements conditional display of Avro schema CodeLens based on Medusa container availability and adds functionality to start the Medusa container directly from the schema file via code lens.

Key Features:
- Conditional CodeLens Display: Avro schema files now only show the 'Generate Dataset' CodeLens action when the Medusa container is running
- Start Medusa Container: Added a new "Start Medusa" CodeLens action that allows users to launch the local Medusa container directly from Avro schema files when the container is not running.

## Click test
1. Open below schema file in running extension without Medusa container running.
2. Only the 'Start Medusa' option should be visible. 
3. When clicked, Medusa container should start, be visible in local resources UI, and 'Start Medusa' code lens should be replaced with "Generate Dataset'.
4. Stop Medusa container and Code lens options should swap again

[schema.json](https://github.com/user-attachments/files/22407966/schema.json)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [X] Updated existing
- [ ] Deleted existing
