### PR TITLE
Fix newResourceViewProvider gap in resetting direct connection context values

### DIFF
--- a/src/viewProviders/newResources.test.ts
+++ b/src/viewProviders/newResources.test.ts
@@ -700,6 +700,12 @@ describe("viewProviders/newResources.ts", () => {
   });
 
   describe("NewResourceViewProvider", () => {
+    const TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR = new CCloudEnvironment({
+      ...TEST_CCLOUD_ENVIRONMENT,
+      kafkaClusters: [TEST_CCLOUD_KAFKA_CLUSTER],
+      schemaRegistry: TEST_CCLOUD_SCHEMA_REGISTRY,
+    });
+
     let provider: NewResourceViewProvider;
 
     beforeEach(() => {
@@ -962,8 +968,11 @@ describe("viewProviders/newResources.ts", () => {
           }),
         );
 
-        // shove into the provider's connections map.
-        provider["connections"].set(connectionRow.connectionId, connectionRow);
+        storeConnectionRow(connectionRow);
+      }
+
+      function storeConnectionRow(row: AnyConnectionRow) {
+        provider["connections"].set(row.connectionId, row);
       }
 
       beforeEach(() => {
@@ -995,6 +1004,38 @@ describe("viewProviders/newResources.ts", () => {
           );
         });
       }
+
+      it("Ignores non-direct connection rows", async () => {
+        // Add a local connection row with Kafka and Schema Registry
+        const localConnectionRow = new LocalConnectionRow();
+        localConnectionRow.environments.push(
+          new LocalEnvironment({
+            ...TEST_LOCAL_ENVIRONMENT,
+            kafkaClusters: [TEST_LOCAL_KAFKA_CLUSTER],
+            schemaRegistry: TEST_LOCAL_SCHEMA_REGISTRY,
+          }),
+        );
+        storeConnectionRow(localConnectionRow);
+
+        // Add a ccloud connection row with Kafka and Schema Registry
+        const ccloudConnectionRow = new CCloudConnectionRow();
+        ccloudConnectionRow.environments.push(TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR);
+        storeConnectionRow(ccloudConnectionRow);
+
+        await provider.updateEnvironmentContextValues();
+
+        // Both context values should be false, since there are no direct connection rows.
+        sinon.assert.calledWith(
+          setContextValueStub,
+          contextValues.ContextValues.directKafkaClusterAvailable,
+          false,
+        );
+        sinon.assert.calledWith(
+          setContextValueStub,
+          contextValues.ContextValues.directSchemaRegistryAvailable,
+          false,
+        );
+      });
     });
 
     describe("lazyInitializeConnections()", () => {
@@ -1109,12 +1150,6 @@ describe("viewProviders/newResources.ts", () => {
 
         const childrenOfRow = provider.getChildren(localConnectionRow);
         assert.deepStrictEqual(childrenOfRow, expectedLocalChildren);
-      });
-
-      const TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR = new CCloudEnvironment({
-        ...TEST_CCLOUD_ENVIRONMENT,
-        kafkaClusters: [TEST_CCLOUD_KAFKA_CLUSTER],
-        schemaRegistry: TEST_CCLOUD_SCHEMA_REGISTRY,
       });
 
       const TEST_CCLOUD_ENVIRONMENT_WITH_KAFKA_AND_SR_AND_FLINK = new CCloudEnvironment({

--- a/src/viewProviders/newResources.test.ts
+++ b/src/viewProviders/newResources.test.ts
@@ -911,15 +911,22 @@ describe("viewProviders/newResources.ts", () => {
 
     describe("repaint()", () => {
       let onDidChangeTreeDataFireStub: sinon.SinonStub;
+      let updateEnvironmentContextValuesStub: sinon.SinonStub;
 
       beforeEach(() => {
         onDidChangeTreeDataFireStub = sandbox.stub(provider["_onDidChangeTreeData"], "fire");
+        updateEnvironmentContextValuesStub = sandbox.stub(
+          provider,
+          "updateEnvironmentContextValues",
+        );
       });
 
       it("toplevel repaint", () => {
         provider["repaint"]();
         sinon.assert.calledOnce(onDidChangeTreeDataFireStub);
         sinon.assert.calledWithExactly(onDidChangeTreeDataFireStub, undefined);
+
+        sinon.assert.calledOnce(updateEnvironmentContextValuesStub);
       });
 
       it("repaint a specific connection row", () => {
@@ -928,7 +935,66 @@ describe("viewProviders/newResources.ts", () => {
         provider["repaint"](connectionRow);
         sinon.assert.calledOnce(onDidChangeTreeDataFireStub);
         sinon.assert.calledWithExactly(onDidChangeTreeDataFireStub, connectionRow);
+        sinon.assert.calledOnce(updateEnvironmentContextValuesStub);
       });
+    });
+
+    describe("updateEnvironmentContextValues()", () => {
+      let setContextValueStub: sinon.SinonStub;
+
+      /** Construct and add a new direct connection row to the view provider.*/
+      function addConnectionRow(opts: { withKafka: boolean; withSchemaRegistry: boolean }): void {
+        const { withKafka, withSchemaRegistry } = opts;
+
+        const stubbedDirectResourceLoader = sandbox.createStubInstance(DirectResourceLoader);
+        stubbedDirectResourceLoader.connectionId =
+          `test-connection-id-${withKafka ? "with" : "without"}-${
+            withSchemaRegistry ? "with" : "without"
+          }-sr` as ConnectionId;
+
+        const connectionRow = new DirectConnectionRow(stubbedDirectResourceLoader);
+        connectionRow.environments.push(
+          new DirectEnvironment({
+            ...TEST_DIRECT_ENVIRONMENT,
+            connectionId: stubbedDirectResourceLoader.connectionId,
+            kafkaClusters: withKafka ? [TEST_DIRECT_KAFKA_CLUSTER] : [],
+            schemaRegistry: withSchemaRegistry ? TEST_DIRECT_SCHEMA_REGISTRY : undefined,
+          }),
+        );
+
+        // shove into the provider's connections map.
+        provider["connections"].set(connectionRow.connectionId, connectionRow);
+      }
+
+      beforeEach(() => {
+        setContextValueStub = sandbox.stub(contextValues, "setContextValue");
+      });
+
+      // Test directKafkaClusterAvailable context value
+      for (const withKafka of [true, false]) {
+        it(`sets directKafkaClusterAvailable to ${withKafka} when any direct connection has${withKafka ? "" : " no"} Kafka cluster`, async () => {
+          addConnectionRow({ withKafka, withSchemaRegistry: false });
+          await provider.updateEnvironmentContextValues();
+          sinon.assert.calledWith(
+            setContextValueStub,
+            contextValues.ContextValues.directKafkaClusterAvailable,
+            withKafka,
+          );
+        });
+      }
+
+      // Test directSchemaRegistryAvailable context value
+      for (const withSchemaRegistry of [true, false]) {
+        it(`sets directSchemaRegistryAvailable to ${withSchemaRegistry} when any direct connection has${withSchemaRegistry ? "" : " no"} schema registry`, async () => {
+          addConnectionRow({ withKafka: false, withSchemaRegistry });
+          await provider.updateEnvironmentContextValues();
+          sinon.assert.calledWith(
+            setContextValueStub,
+            contextValues.ContextValues.directSchemaRegistryAvailable,
+            withSchemaRegistry,
+          );
+        });
+      }
     });
 
     describe("lazyInitializeConnections()", () => {

--- a/src/viewProviders/newResources.ts
+++ b/src/viewProviders/newResources.ts
@@ -112,6 +112,10 @@ export abstract class ConnectionRow<ET extends ConcreteEnvironment, LT extends R
     // In-place merge of updated environments to the existing environments array, keeping
     // object
     mergeUpdates(this.environments, refreshedEnvironments);
+
+    this.logger.debug("Refreshed cache of environments", {
+      environments: this.environments.length,
+    });
   }
 
   /** Drive getting the environment(s) from the ResourceLoader. */

--- a/src/viewProviders/newResources.ts
+++ b/src/viewProviders/newResources.ts
@@ -112,10 +112,6 @@ export abstract class ConnectionRow<ET extends ConcreteEnvironment, LT extends R
     // In-place merge of updated environments to the existing environments array, keeping
     // object
     mergeUpdates(this.environments, refreshedEnvironments);
-
-    this.logger.debug("Refreshed cache of environments", {
-      environments: this.environments.length,
-    });
   }
 
   /** Drive getting the environment(s) from the ResourceLoader. */
@@ -578,9 +574,49 @@ export class NewResourceViewProvider
     });
   }
 
-  /** Repaint this node in the treeview. Pass nothing if wanting a toplevel repaint.*/
-  private repaint(object: NewResourceViewProviderData | undefined = undefined): void {
+  /**
+   * Repaint this node in the treeview. Pass nothing if wanting a toplevel repaint.
+   * Also reevaluates some global context values based on the data
+   * we have across all of our ConnectionRow instances after the repaint.
+   */
+  repaint(object: NewResourceViewProviderData | undefined = undefined): void {
     this._onDidChangeTreeData.fire(object);
+
+    // And since some view data has changed, reevaluate context values
+    // that depend on the whole set of environments we have.
+    void this.updateEnvironmentContextValues();
+  }
+
+  /**
+   * Update the context values for the current environments' resource availability. This is used
+   * to change the empty state of our primary resource views and toggle actions in the UI.
+   */
+  async updateEnvironmentContextValues() {
+    // Reevaluate direct-connection-related context values
+    // after some view data has changed.
+
+    // (If needing to expand to consider non-direct connections,
+    //  revise here.)
+
+    // Collect all direct environments from all direct connections.
+    const directEnvs: DirectEnvironment[] = [];
+    for (const connectionRow of this.connections.values()) {
+      if (connectionRow instanceof DirectConnectionRow) {
+        directEnvs.push(...connectionRow.environments);
+      }
+    }
+
+    // And update context values based on what we found.
+    await Promise.all([
+      setContextValue(
+        ContextValues.directKafkaClusterAvailable,
+        directEnvs.some((env) => env.kafkaClusters.length > 0),
+      ),
+      setContextValue(
+        ContextValues.directSchemaRegistryAvailable,
+        directEnvs.some((env) => !!env.schemaRegistry),
+      ),
+    ]);
   }
 
   /**


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix a gap in the new resources view provider that the old provider handled: resetting context values `ContextValues.directSchemaRegistryAvailable` and `ContextValues.directKafkaClusterAvailable` based on if any of the direct connections have a kafka cluster or schema registry. These context values help inform the empty states of the Topics and Schemas views.
- Do so by hooking into whenever `NewResourceViewProvider` signals to VS Code to repaint any portion of the view, which is the tailmost operation of whenever one of the connection rows have been updated.
- Having the view responsible for this action doesn't seem the best possible place for this responsibility, but it 1) does have all of the necessary information (access to all of the direct connections with updated state) and also 2) it was a responsibility of the old resources view provider. So be it for now.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2548 .

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
