### PR TITLE
fix `gulp functional` coverage reporting

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     viewport: { width: 1920, height: 1080 },
   },
   workers: 1,
-  testMatch: "src/**/*.spec.ts",
+  testDir: "src/webview/",
+  testMatch: "**/*.spec.ts",
   reporter: reporters,
 });

--- a/src/webview/baseTest.ts
+++ b/src/webview/baseTest.ts
@@ -1,0 +1,22 @@
+import { type RollwrightFixtures, test as testBase } from "rollwright";
+
+// centralized test base with default coverage configs
+export const test = testBase.extend<RollwrightFixtures>({
+  coverage: async ({ coverage }, use) => {
+    const updatedCoverage =
+      coverage === false
+        ? false
+        : {
+            extensions: coverage?.extensions ?? [],
+            include: coverage?.include ?? ["**/*.ts"],
+            exclude: [
+              ...(coverage?.exclude ?? []),
+              "src/clients/**/*",
+              "**/*.spec.ts",
+              "**/*.test.ts",
+            ],
+          };
+
+    await use(updatedCoverage);
+  },
+});

--- a/src/webview/bindings/bindings.spec.ts
+++ b/src/webview/bindings/bindings.spec.ts
@@ -1,7 +1,7 @@
-import { test } from "rollwright";
 import { expect } from "@playwright/test";
 import replace from "@rollup/plugin-replace";
 import esbuild from "rollup-plugin-esbuild";
+import { test } from "../baseTest";
 
 test.use({
   plugins: [

--- a/src/webview/bindings/custom-elements.spec.ts
+++ b/src/webview/bindings/custom-elements.spec.ts
@@ -1,7 +1,7 @@
-import { test } from "rollwright";
 import { expect } from "@playwright/test";
 import replace from "@rollup/plugin-replace";
 import esbuild from "rollup-plugin-esbuild";
+import { test } from "../baseTest";
 
 test.use({
   plugins: [

--- a/src/webview/direct-connect-form.spec.ts
+++ b/src/webview/direct-connect-form.spec.ts
@@ -5,7 +5,6 @@ import { createFilter } from "@rollup/pluginutils";
 import { readFileSync } from "node:fs";
 import { Plugin } from "rollup";
 import esbuild from "rollup-plugin-esbuild";
-import { test } from "rollwright";
 import sanitize from "sanitize-html";
 import { SinonStub } from "sinon";
 import {
@@ -16,6 +15,7 @@ import {
   OAuthCredentials,
   ScramCredentials,
 } from "../clients/sidecar";
+import { test } from "./baseTest";
 
 const template = readFileSync(new URL("direct-connect-form.html", import.meta.url), "utf8");
 function render(template: string, variables: Record<string, any>) {

--- a/src/webview/scaffold-form.spec.ts
+++ b/src/webview/scaffold-form.spec.ts
@@ -5,10 +5,10 @@ import { createFilter } from "@rollup/pluginutils";
 import { readFileSync } from "node:fs";
 import { Plugin } from "rollup";
 import esbuild from "rollup-plugin-esbuild";
-import { test } from "rollwright";
-import { SinonStub } from "sinon";
 import sanitize from "sanitize-html";
+import { SinonStub } from "sinon";
 import { ScaffoldV1TemplateSpec } from "../clients/scaffoldingService";
+import { test } from "./baseTest";
 import { ScaffoldV1TemplateSpecAlt } from "./scaffold-form";
 
 const template = readFileSync(new URL("scaffold-form.html", import.meta.url), "utf8");


### PR DESCRIPTION
We were accidentally including `src/clients/` in the webview coverage reporting, and the most straightforward way to include/exclude specific file patterns is to set the [`coverage` fixture](https://github.com/UnknownPrinciple/rollwright/blob/ab6b27a071d9789979f647e2d8faf8a0bebddf9c/packages/rollwright/fixture.d.ts#L14-L16) config to exclude that directory (and some other sensible defaults).

Also updated `playwright.config.ts` to only point at `src/webviews/` since we don't run (let alone have) any `*.spec.ts` files elsewhere that would be run from `gulp functional`.

## Before
<img width="791" height="901" alt="image" src="https://github.com/user-attachments/assets/c37ec76c-9456-49e5-820b-7de440d5ccf7" />
...
<img width="689" height="540" alt="image" src="https://github.com/user-attachments/assets/fdea8441-aa71-49f4-bc8f-075a330a0cc9" />

## After
<img width="704" height="957" alt="image" src="https://github.com/user-attachments/assets/cf605e16-2d6d-4982-aee3-26e6eed8e82e" />
