### PR TITLE
fix: ignore `src/webviews/baseTest.ts` when building webview stuff

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -156,7 +156,9 @@ export function build(done) {
 
   /** @type {import("rollup").RollupOptions} */
   const webInput = {
-    input: globSync("src/webview/*.ts", { ignore: "src/webview/*.spec.ts" }),
+    input: globSync("src/webview/*.ts", {
+      ignore: ["src/webview/*.spec.ts", "src/webview/baseTest.ts"],
+    }),
     plugins: [
       stylesheet({
         include: ["**/*.css"],


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/vscode/pull/2633; including `src/webviews/baseTest.ts` in the normal build process resulted in `gulp build` errors on macOS:
```
[16:57:49] 'build' errored after 2.68 s
[16:57:49] RollupError: node_modules/fsevents/fsevents.node (1:0): Unexpected character '�' (Note that you need plugins to import files that are not JavaScript)
    at getRollupError (file:///Users/dshoup/Dev/confluent_dev/vscode/node_modules/rollup/dist/es/shared/parseAst.js:395:41)
    at ParseError.initialise (file:///Users/dshoup/Dev/confluent_dev/vscode/node_modules/rollup/dist/es/shared/node-entry.js:13231:28)
    at convertNode (file:///Users/dshoup/Dev/confluent_dev/vscode/node_modules/rollup/dist/es/shared/node-entry.js:14939:10)
```

All clear locally:
<img width="800" height="590" alt="image" src="https://github.com/user-attachments/assets/f42d088b-a7c3-4c4b-a6b6-30d24e84ccde" />
