### PR TITLE
Fix kafkaclusterpick vs not ccloud logged in.

### DIFF
--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -166,6 +166,13 @@ export async function submitFlinkStatementCommand(
     // 5. Gotta grab the organization ID to submit as.
     const ccloudLoader = CCloudResourceLoader.getInstance();
     const organization = await ccloudLoader.getOrganization();
+    if (!organization) {
+      // This should never happen, as the user can't pick a compute pool
+      // if they're not connected to CCloud.
+      funcLogger.error("Could not determine current CCloud organization");
+      await showErrorNotificationWithButtons("Not connected to Confluent Cloud");
+      return;
+    }
 
     // 5. Prep to submit, submit.
     const submission: IFlinkStatementSubmitParameters = {

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -194,17 +194,10 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.calledOnce(getCurrentOrganizationStub);
     });
 
-    it("should throw if no organization is available", async () => {
+    it("should return undefined if no organization is available", async () => {
       getCurrentOrganizationStub.resolves(undefined);
-      await assert.rejects(
-        async () => {
-          await loader.getOrganization();
-        },
-        {
-          name: "Error",
-          message: "Could not determine the current CCloud organization!",
-        },
-      );
+      const org = await loader.getOrganization();
+      assert.strictEqual(org, undefined);
       sinon.assert.calledOnce(getCurrentOrganizationStub);
     });
   });
@@ -687,19 +680,14 @@ describe("CCloudResourceLoader", () => {
       getCurrentOrganizationStub = sandbox.stub(graphqlOrgs, "getCurrentOrganization");
     });
 
-    it("will throw when no CCloud org is available", async () => {
+    it("does nothing when no CCloud org is available", async () => {
       getEnvironmentsStub.resolves([]);
       getCurrentOrganizationStub.resolves(undefined);
 
-      await assert.rejects(
-        async () => {
-          await loader["doLoadCoarseResources"]();
-        },
-        {
-          name: "Error",
-          message: "Could not determine the current CCloud organization!",
-        },
-      );
+      await loader["doLoadCoarseResources"]();
+      sinon.assert.calledOnce(getEnvironmentsStub);
+      sinon.assert.calledOnce(getCurrentOrganizationStub);
+      assert.strictEqual(loader["organization"], null);
     });
 
     it("should set CCloud resources when available", async () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix #2631 through logically reverting recent change where `CCloudResourceLoader.getOrganization()` as made to never return `undefined`, but instead to raise an Error. That good deed was misguided in not realizing that `getOrganization()` was the closest thing to checking for "are we logged into ccloud", directly or indirectly, by codepaths that gather up all accessible environments through a loop over all `ResourceLoader.loaders()`. CCloudResourceLoader is always returned, for better or worse at this point, and its `getEnvironments() is ultimately coded to eventually short circuit if `getOrganization` ultimately returns undefined. So, reinstate that behavior, then respell the recent bits of Flink-ness which were coded assuming it would always return a number (or an Error).
- Now the Kafka Cluster QP works again when not ccloud auth'd:

<img width="1006" height="249" alt="image" src="https://github.com/user-attachments/assets/e4f93c23-38cc-4dfd-a42d-a4861803b2f7" />

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- I think there's clearer designs to be had here, but CCloudResourceLoader always being returned by `ResourceLoader.loaders()` and that an unknown amount of code is ultimately gated by its `getOrganization()` returning `undefined`, but that's for a rainier day and a spike then a plan.




## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
