### PR TITLE
Update FlinkDatabaseViewProvider for more consistent selected resource description

### DIFF
--- a/src/viewProviders/flinkDatabase.test.ts
+++ b/src/viewProviders/flinkDatabase.test.ts
@@ -277,28 +277,18 @@ describe("viewProviders/flinkDatabase.ts", () => {
       it("does nothing when no database is set", async () => {
         viewProvider["resource"] = null;
         await viewProvider.updateTreeViewDescription();
-        assert.strictEqual(getDescription(), initialDescription);
+        assert.strictEqual(getDescription(), "");
       });
 
       it("sets to mix of database name and environment name when database is set", async () => {
         viewProvider["resource"] = TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER; // in TEST_CCLOUD_ENVIRONMENT.
 
-        // Wire up ccloudLoader.getEnvironments to return two environments, one of which is the parent environment.
         const parentEnvironment = {
           ...TEST_CCLOUD_ENVIRONMENT,
           name: "Test Env Name",
         } as CCloudEnvironment;
 
-        const testEnvironments = [
-          {
-            ...TEST_CCLOUD_ENVIRONMENT,
-            id: "some other env" as EnvironmentId,
-            name: "Test Environment",
-          },
-          parentEnvironment,
-        ] as CCloudEnvironment[];
-
-        ccloudLoader.getEnvironments.resolves(testEnvironments);
+        ccloudLoader.getEnvironment.resolves(parentEnvironment);
 
         await viewProvider.updateTreeViewDescription();
 
@@ -311,8 +301,7 @@ describe("viewProviders/flinkDatabase.ts", () => {
       it("sets to database name when no parent environment is found", async () => {
         viewProvider["resource"] = TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER; // in TEST_CCLOUD_ENVIRONMENT.
 
-        // Wire up ccloudLoader.getEnvironments to return an empty array, hitting warning case.
-        ccloudLoader.getEnvironments.resolves([]);
+        ccloudLoader.getEnvironment.resolves(undefined);
 
         await viewProvider.updateTreeViewDescription();
 

--- a/src/viewProviders/flinkDatabase.ts
+++ b/src/viewProviders/flinkDatabase.ts
@@ -7,6 +7,7 @@ import {
   udfsChanged,
 } from "../emitters";
 import { logError } from "../errors";
+import { ResourceLoader } from "../loaders";
 import { FlinkArtifact } from "../models/flinkArtifact";
 import { FlinkUdf } from "../models/flinkUDF";
 import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
@@ -16,7 +17,6 @@ import { MultiModeViewProvider, ViewProviderDelegate } from "./baseModels/multiV
 import { FlinkDatabaseViewProviderMode } from "./multiViewDelegates/constants";
 import { FlinkArtifactsDelegate } from "./multiViewDelegates/flinkArtifactsDelegate";
 import { FlinkUDFsDelegate } from "./multiViewDelegates/flinkUDFsDelegate";
-import { ResourceLoader } from "../loaders";
 
 /** The row models used as view children */
 export type ArtifactOrUdf = FlinkArtifact | FlinkUdf;
@@ -151,13 +151,12 @@ export class FlinkDatabaseViewProvider extends MultiModeViewProvider<
   async updateTreeViewDescription(): Promise<void> {
     const db = this.database;
     if (!db) {
+      this.treeView.description = "";
       return;
     }
-    const loader = ResourceLoader.getInstance(db.connectionId);
-    const envs = await loader.getEnvironments();
-    const parentEnv = envs.find((env) => env.id === db.environmentId);
-    if (parentEnv) {
-      this.treeView.description = `${parentEnv.name} | ${db.name}`;
+    const env = await ResourceLoader.getEnvironment(db.connectionId, db.environmentId);
+    if (env) {
+      this.treeView.description = `${env.name} | ${db.name}`;
     } else {
       this.treeView.description = db.name;
     }


### PR DESCRIPTION
## Summary of Changes
<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Update Artifact/UDF view provider description to be the same as topics - `env_name` | `cluster_name`
- Add tests for new overridden `updateTreeViewDescription` method
<img width="580" height="295" alt="Screenshot 2025-09-23 at 2 42 43 PM" src="https://github.com/user-attachments/assets/5b9919aa-79cd-4914-aac9-fa26c64ed103" />


## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2664

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [X] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
