### PR TITLE
Refresh action for the FlinkDB view + misc state change fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1311,7 +1311,7 @@
         },
         {
           "command": "confluent.flinkdatabase.refresh",
-          "when": "false"
+          "when": "true"
         },
         {
           "command": "confluent.flinkdatabase.setArtifactsViewMode",
@@ -1750,7 +1750,7 @@
         },
         {
           "command": "confluent.flinkdatabase.refresh",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@998"
         },
         {

--- a/package.json
+++ b/package.json
@@ -429,6 +429,12 @@
         "category": "Confluent: Resources"
       },
       {
+        "command": "confluent.flinkdatabase.refresh",
+        "icon": "$(sync)",
+        "title": "Refresh Flink Database",
+        "category": "Confluent: Flink Database View"
+      },
+      {
         "command": "confluent.flinkdatabase.setArtifactsViewMode",
         "title": "Switch to Flink Artifacts",
         "icon": "$(folder-library)",
@@ -1304,6 +1310,10 @@
           "when": "true"
         },
         {
+          "command": "confluent.flinkdatabase.refresh",
+          "when": "false"
+        },
+        {
           "command": "confluent.flinkdatabase.setArtifactsViewMode",
           "when": "confluent.flinkDatabaseViewMode == 'UDFs'"
         },
@@ -1730,13 +1740,18 @@
         },
         {
           "command": "confluent.uploadArtifact",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@2"
         },
         {
           "command": "confluent.flinkdatabase.kafka-cluster.select",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@3"
+        },
+        {
+          "command": "confluent.flinkdatabase.refresh",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected",
+          "group": "navigation@998"
         },
         {
           "command": "confluent.flinkdatabase.setArtifactsViewMode",

--- a/package.json
+++ b/package.json
@@ -1745,7 +1745,7 @@
         },
         {
           "command": "confluent.flinkdatabase.kafka-cluster.select",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected && config.confluent.flink.enableFlinkArtifacts",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.enableFlinkArtifacts",
           "group": "navigation@3"
         },
         {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -101,7 +101,7 @@ describe("Refreshable views tests", () => {
    *
    * When a new one is added, its `kind` attribute value should be added to this list.
    */
-  const expectedKinds = ["resources", "topics", "schemas", "statements"];
+  const expectedKinds = ["resources", "topics", "schemas", "statements", "flinkdatabase"];
 
   before(async () => {
     await getTestExtensionContext();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -503,13 +503,14 @@ async function setupFeatureFlags(): Promise<void> {
 export function getRefreshableViewProviders(
   resourcesViewProviderInstance: ResourceViewProvider | NewResourceViewProvider,
 ): RefreshableTreeViewProvider[] {
-  // When adding a new view provider pair, also update the test
-  // mentioning "viewProviderNameFragments" in extension.test.ts.
+  // When adding a new refreshable view, also update the test block
+  // "Refreshable views tests" in extension.test.ts.
   const refreshables = [
     resourcesViewProviderInstance,
     TopicViewProvider.getInstance(),
     SchemasViewProvider.getInstance(),
     FlinkStatementsViewProvider.getInstance(),
+    FlinkDatabaseViewProvider.getInstance(),
   ];
 
   return refreshables;

--- a/src/viewProviders/baseModels/base.ts
+++ b/src/viewProviders/baseModels/base.ts
@@ -22,7 +22,7 @@ import { filterItems, itemMatchesSearch } from "../utils/search";
 /** View providers offering our common refresh() pattern. */
 export interface RefreshableTreeViewProvider {
   kind: string;
-  refresh(forceDeepRefresh?: boolean): void;
+  refresh(forceDeepRefresh?: boolean): void | Promise<void>;
 }
 
 /** Requirement interfaces for BaseViewProvider data elements */
@@ -49,7 +49,7 @@ export abstract class BaseViewProvider<T extends BaseViewProviderData>
    * Refresh the tree view with data from the current {@linkcode resource} and {@linkcode environment}.
    *
    * Subclasses should ensure that their implementations fire this._onDidChangeTreeData() after doing any
-   * data loading.
+   * data loading (or to call super.refresh() to do it for them).
    * @returns A promise that resolves when and data loading is complete, for when callers need to wait for it.
    */
   async refresh(): Promise<void> {

--- a/src/viewProviders/baseModels/parentedBase.test.ts
+++ b/src/viewProviders/baseModels/parentedBase.test.ts
@@ -171,19 +171,38 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
       updateTreeViewDescriptionStub = sandbox.stub(provider, "updateTreeViewDescription");
     });
 
-    it("Should handle setting to null", async () => {
+    it("Should handle setting from something to null", async () => {
+      // As if was focused on something and then set to null
+      provider.resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
       await provider.setParentResource(null);
+
       assert.strictEqual(provider.resource, null, "resource should be null");
+      sinon.assert.calledOnce(setSearchStub); // reset search when parent resource changes
+      sinon.assert.calledWith(setSearchStub, null);
+
       sinon.assert.calledOnce(refreshStub);
+      sinon.assert.calledOnce(updateTreeViewDescriptionStub);
+      sinon.assert.calledOnce(setContextValueStub);
+      sinon.assert.calledWith(
+        setContextValueStub,
+        provider.parentResourceChangedContextValue,
+        false,
+      );
     });
 
-    it("Should handle setting to a resource", async () => {
+    it("Should handle setting from null to a resource", async () => {
+      // As if was focused on nothing and then set to something
+      provider.resource = null;
+
       const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       await provider.setParentResource(resource);
+
       assert.strictEqual(provider.resource, resource, "resource should be set");
-      sinon.assert.calledOnce(refreshStub);
-      sinon.assert.calledOnce(setSearchStub);
+      sinon.assert.calledOnce(setSearchStub); // reset search when parent resource changes
       sinon.assert.calledWith(setSearchStub, null);
+
+      sinon.assert.calledOnce(refreshStub);
       sinon.assert.calledOnce(updateTreeViewDescriptionStub);
       sinon.assert.calledOnce(setContextValueStub);
       sinon.assert.calledWith(
@@ -191,6 +210,42 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
         provider.parentResourceChangedContextValue,
         true,
       );
+    });
+
+    it("Should handle setting from one resource to a different resource", async () => {
+      // As if was focused on something and then set to something else
+      provider.resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+
+      const resource = new CCloudFlinkComputePool({
+        ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
+        id: "different-id",
+        name: "different-name",
+      });
+      await provider.setParentResource(resource);
+
+      assert.strictEqual(provider.resource, resource, "resource should be set");
+      sinon.assert.calledOnce(setSearchStub); // reset search when parent resource changes
+      sinon.assert.calledWith(setSearchStub, null);
+
+      sinon.assert.calledOnce(refreshStub);
+      sinon.assert.calledOnce(updateTreeViewDescriptionStub);
+      // was not-undefined -> not undefined, so should not change context value
+      // (was set to true, remains true)
+      sinon.assert.notCalled(setContextValueStub);
+    });
+
+    it("Should handle setting to the same resource (partial no-op)", async () => {
+      // As if was focused on something and then set to the same thing
+      const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      provider.resource = resource;
+
+      await provider.setParentResource(resource);
+
+      assert.strictEqual(provider.resource, resource, "resource should be unchanged");
+      sinon.assert.notCalled(setSearchStub); // should not reset search when parent resource is unchanged
+      sinon.assert.calledOnce(refreshStub);
+      sinon.assert.calledOnce(updateTreeViewDescriptionStub);
+      sinon.assert.notCalled(setContextValueStub); // should not change context when parent resource is unchanged
     });
 
     it("Should be called when parentResourceChangedEmitter fires", () => {

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -68,9 +68,9 @@ export abstract class ParentedBaseViewProvider<
     if (this.resource !== resource) {
       this.setSearch(null); // reset search when parent resource changes
 
-      // If we have a boolean context value to adjust, and if the value is changing, adjust it.
-      if (this.parentResourceChangedContextValue && !!resource !== !!this.resource) {
-        promises.push(setContextValue(this.parentResourceChangedContextValue, !!resource));
+      // If we have a boolean context value to adjust, and if the boolean value is changing, adjust it.
+      if (this.parentResourceChangedContextValue && Boolean(resource) !== Boolean(this.resource)) {
+        promises.push(setContextValue(this.parentResourceChangedContextValue, Boolean(resource)));
       }
 
       this.resource = resource;

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -95,10 +95,6 @@ export abstract class ParentedBaseViewProvider<
 
   /** Event handler for when CCloud connection gets logged out: If the view was focused on a ccloud resource, reset the view. */
   ccloudConnectedHandler(connected: boolean): void {
-    this.logger.debug("ccloudConnected event fired", {
-      connected,
-      expression: !connected && this.resource && isCCloud(this.resource),
-    });
     if (!connected && this.resource && isCCloud(this.resource)) {
       // any transition of CCloud connection state should reset the tree view if we're focused on
       // a CCloud parent resource

--- a/src/viewProviders/flinkDatabase.ts
+++ b/src/viewProviders/flinkDatabase.ts
@@ -33,6 +33,7 @@ export class FlinkDatabaseViewProvider extends MultiModeViewProvider<
   ArtifactOrUdf
 > {
   viewId = "confluent-flink-database";
+  kind = "flinkdatabase";
 
   parentResourceChangedEmitter = flinkDatabaseViewResourceChanged;
   parentResourceChangedContextValue = ContextValues.flinkDatabaseSelected;
@@ -135,10 +136,6 @@ export class FlinkDatabaseViewProvider extends MultiModeViewProvider<
 
   get loggerName() {
     return `viewProviders.flink.${this.currentDelegate?.mode ?? "unknown"}`;
-  }
-
-  get kind() {
-    return this.currentDelegate?.mode ?? "unknown";
   }
 
   get database(): CCloudFlinkDbKafkaCluster | null {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- New command / title bar action for force refreshing the Flink Database view.
  - Refreshes only the current modal delegate (at this time).

While here and was clicktesting, happend to wander into clicktest path of 'log in, set the Flink database in the view, then log out from CCloud, and then finally logging back in', then being unhappy with the view states when logged out as well as when logged back in:
  - When logged out after having set the view state, the view title wasn't cleared.
  - When logged back in, the default view state still thought that a database had been selected even though the logout had cleared it.
  
So, this branch also fixes both of those issues (both were due to insufficient / wrong code in `ParentedBaseViewProvider::setParentResource()`) and more thoroughly flesh out its tests.

Closes #2618 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
