### PR TITLE
Rename and reorder Flink extension settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
-- Two Flink enablement settings have updated names for clarity. Users may need to verify or update
-  their settings for Flink Language Server and Flink Artifacts.
-  ([#2684](https://github.com/confluentinc/vscode/pull/2684))
+- Two Flink enablement settings
+  [`confluent.flink.languageServer`](vscode://settings/confluent.flink.languageServer) and
+  [`confluent.flink.artifacts`](vscode://settings/confluent.flink.artifacts) have updated names for
+  clarity. Users may need to verify or update their settings for Flink Language Server and Flink
+  Artifacts. ([#2684](https://github.com/confluentinc/vscode/pull/2684))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+- Two Flink enablement settings have updated names for clarity. Users may need to verify or update
+  their settings for Flink Language Server and Flink Artifacts.
+  ([#2684](https://github.com/confluentinc/vscode/pull/2684))
+
 ### Added
 
 - Date/time picker for message viewer when consuming from a specific point in time.

--- a/package.json
+++ b/package.json
@@ -910,13 +910,13 @@
       {
         "title": "Flink",
         "properties": {
-          "confluent.flink.enableConfluentCloudLanguageServer": {
+          "confluent.flink.languageServer": {
             "type": "boolean",
             "order": 0,
             "default": true,
             "markdownDescription": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents. (Requires [signing in to Confluent Cloud](command:confluent.connections.ccloud.signIn).)"
           },
-          "confluent.flink.enableFlinkArtifacts": {
+          "confluent.flink.artifacts": {
             "type": "boolean",
             "default": false,
             "order": 1,

--- a/package.json
+++ b/package.json
@@ -908,10 +908,11 @@
         }
       },
       {
-        "title": "Flink SQL Defaults",
+        "title": "Flink",
         "properties": {
           "confluent.flink.enableConfluentCloudLanguageServer": {
             "type": "boolean",
+            "order": 0,
             "default": true,
             "markdownDescription": "Enable integration with the Confluent Cloud Flink SQL language server for diagnostics, code completion, and other language features in Flink SQL documents. (Requires [signing in to Confluent Cloud](command:confluent.connections.ccloud.signIn).)"
           },
@@ -927,12 +928,10 @@
           "confluent.flink.computePoolId": {
             "type": "string",
             "default": "",
-            "order": 2,
             "markdownDescription": "ID for the compute pool to use as a default in Confluent Cloud for Apache Flink® SQL operations. The value must be a valid Confluent Cloud compute pool ID. \n\nTo select from the list of available compute pools use the [\"Configure default settings for Flink SQL actions\" command](command:confluent.flink.configureFlinkDefaults)."
           },
           "confluent.flink.database": {
             "type": "string",
-            "order": 3,
             "default": "",
             "markdownDescription": "Name or ID for Apache Kafka® cluster in Confluent to use as the default Confluent Cloud for Apache Flink® SQL database. The value must be a valid Confluent Cloud database (Kafka cluster) name or ID. \n\nTo select from the list of available databases use the [\"Configure default settings for Flink SQL actions\" command](command:confluent.flink.configureFlinkDefaults)."
           },

--- a/src/commands/flinkComputePools.ts
+++ b/src/commands/flinkComputePools.ts
@@ -64,7 +64,7 @@ export async function configureFlinkDefaults(): Promise<void> {
   // Note: we can use name or ID for Language Server, but name used in Cloud UI since what you send is what shows in completions documentation
   await FLINK_CONFIG_DATABASE.update(databaseCluster.id, true);
 
-  window.showInformationMessage("Flink SQL defaults updated.", "View").then((selection) => {
+  window.showInformationMessage("Flink defaults updated.", "View").then((selection) => {
     if (selection === "View") {
       commands.executeCommand(
         "workbench.action.openSettings",

--- a/src/extensionSettings/base.ts
+++ b/src/extensionSettings/base.ts
@@ -16,7 +16,7 @@ export enum SettingsSection {
   CCLOUD = "Confluent Cloud",
   LOCAL = "Local",
   DIRECT_CONNECTIONS = "Connections",
-  FLINK = "Flink SQL Defaults",
+  FLINK = "Flink",
   COPILOT = "Copilot Chat Participant",
 }
 

--- a/src/extensionSettings/constants.ts
+++ b/src/extensionSettings/constants.ts
@@ -107,7 +107,7 @@ export const LOCAL_SCHEMA_REGISTRY_IMAGE_TAG = new ExtensionSetting<string>(
 
 /** Whether or not to enable the Confluent Cloud language client+server integration for Flink SQL documents. */
 export const ENABLE_FLINK_CCLOUD_LANGUAGE_SERVER = new ExtensionSetting<boolean>(
-  "confluent.flink.enableConfluentCloudLanguageServer",
+  "confluent.flink.languageServer",
   SettingsSection.FLINK,
 );
 /** Default Flink compute pool ID. */
@@ -160,7 +160,7 @@ export const STATEMENT_POLLING_CONCURRENCY = new ExtensionSetting<number>(
 
 /** Whether or not to enable Flink Artifacts functionality including the artifacts view. */
 export const ENABLE_FLINK_ARTIFACTS = new ExtensionSetting<boolean>(
-  "confluent.flink.enableFlinkArtifacts",
+  "confluent.flink.artifacts",
   SettingsSection.FLINK,
 );
 


### PR DESCRIPTION
⚠️ Users who previously set a custom value for `confluent.flink.enableConfluentCloudLanguageServer` or `confluent.flink.enableFlinkArtifacts` may need to update their Flink settings for the extension. 
Go to **Preferences > Open Settings (UI) > Extensions > Confluent** to view and access Confluent extension settings. 

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2656
- "Flink SQL Defaults" -> "Flink" : Rename this section of our extension settings since we've expanded beyond FlinkSQL. 
- Reorder the settings so that users see the two "enable" flags first, followed by the rest in ABC order (this is vscode default if there is no "order" property, and it works well imo since Compute Pool and Database defaults come first) 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
| Close up at the top | All settings (outdated titles, see left) |
| -- | -- | 
|  <img width="1233" height="489" alt="Screenshot 2025-09-25 at 1 19 50 PM" src="https://github.com/user-attachments/assets/dfc11d54-1136-4dc6-99af-31747c8380d9" /> | <img width="828" height="811" alt="Screenshot 2025-09-25 at 8 47 46 AM" src="https://github.com/user-attachments/assets/88012e03-54f2-44cf-ba9e-fd53d1d107a7" /> |

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other
### 📝 This PR is linked in the CHANGELOG note, and instructions have been added to the top of this description to facilitate. 

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [X] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
