### PR TITLE
swap promise kickoff vs data member assignment ordering

### DIFF
--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -63,13 +63,16 @@ export abstract class ParentedBaseViewProvider<
     if (this.resource !== resource) {
       this.setSearch(null); // reset search when parent resource changes
 
+      this.resource = resource;
+
       // If we have a boolean context value to adjust, and if the boolean value is changing, adjust it.
       if (this.parentResourceChangedContextValue && Boolean(resource) !== Boolean(this.resource)) {
         promises.push(setContextValue(this.parentResourceChangedContextValue, Boolean(resource)));
       }
-
-      this.resource = resource;
     }
+
+    // Be sure to only kick off the awaitables _after_ we've assigned this.resource,
+    // since they depend on it.
 
     promises.push(
       // Always refresh the view when parent resource changes.

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -58,12 +58,7 @@ export abstract class ParentedBaseViewProvider<
       resource,
     });
 
-    const promises: Promise<unknown>[] = [
-      // Always refresh the view when parent resource changes.
-      this.refresh(),
-      // Update the tree view description to show the parent environment name and resource ID.
-      this.updateTreeViewDescription(),
-    ];
+    const promises: Promise<unknown>[] = [];
 
     if (this.resource !== resource) {
       this.setSearch(null); // reset search when parent resource changes
@@ -75,6 +70,13 @@ export abstract class ParentedBaseViewProvider<
 
       this.resource = resource;
     }
+
+    promises.push(
+      // Always refresh the view when parent resource changes.
+      this.refresh(),
+      // Update the tree view description to show the parent environment name and resource ID.
+      this.updateTreeViewDescription(),
+    );
 
     await Promise.all(promises);
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix #2687 through being sure to make the data member assignment prior to kicking off async functions that will observe the data member, in that execution of those awaitables will start immediately at function call time. They're just not guaranteed to _complete_ until their returned Promise resolves.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
