### PR TITLE
DRAFT: Refactor: Moving funcs from flinkArtifacts -> flinkUDFs 

### DIFF
--- a/src/commands/flinkArtifacts.test.ts
+++ b/src/commands/flinkArtifacts.test.ts
@@ -16,12 +16,8 @@ import { FlinkArtifact } from "../models/flinkArtifact";
 import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "../models/resource";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
-import {
-  createUdfRegistrationDocumentCommand,
-  registerFlinkArtifactCommands,
-  startGuidedUdfCreationCommand,
-  uploadArtifactCommand,
-} from "./flinkArtifacts";
+import { registerFlinkArtifactCommands, uploadArtifactCommand } from "./flinkArtifacts";
+import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } from "./flinkUDFs";
 import * as commands from "./index";
 import * as artifactUploadForm from "./utils/artifactUploadForm";
 import * as uploadArtifact from "./utils/uploadArtifactOrUDF";

--- a/src/commands/flinkArtifacts.test.ts
+++ b/src/commands/flinkArtifacts.test.ts
@@ -2,22 +2,11 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
-import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
-import { createResponseError } from "../../tests/unit/testUtils";
-import { ArtifactV1FlinkArtifactMetadataFromJSON, ResponseError } from "../clients/flinkArtifacts";
 import {
   PresignedUploadUrlArtifactV1PresignedUrl200ResponseApiVersionEnum,
   PresignedUploadUrlArtifactV1PresignedUrl200ResponseKindEnum,
 } from "../clients/flinkArtifacts/models/PresignedUploadUrlArtifactV1PresignedUrl200Response";
-import { ConnectionType } from "../clients/sidecar";
-import { CCloudResourceLoader } from "../loaders/ccloudResourceLoader";
-import { CCloudEnvironment } from "../models/environment";
-import { FlinkArtifact } from "../models/flinkArtifact";
-import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
-import { ConnectionId, EnvironmentId } from "../models/resource";
-import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { registerFlinkArtifactCommands, uploadArtifactCommand } from "./flinkArtifacts";
-import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } from "./flinkUDFs";
 import * as commands from "./index";
 import * as artifactUploadForm from "./utils/artifactUploadForm";
 import * as uploadArtifact from "./utils/uploadArtifactOrUDF";
@@ -42,84 +31,12 @@ describe("flinkArtifacts", () => {
     kind: "kind" as unknown as PresignedUploadUrlArtifactV1PresignedUrl200ResponseKindEnum,
   };
 
-  const artifact = new FlinkArtifact({
-    id: "artifact-id",
-    name: "test-artifact",
-    description: "description",
-    connectionId: "conn-id" as ConnectionId,
-    connectionType: "ccloud" as ConnectionType,
-    environmentId: "env-id" as EnvironmentId,
-    provider: "aws",
-    region: "us-west-2",
-    documentationLink: "https://confluent.io",
-    metadata: ArtifactV1FlinkArtifactMetadataFromJSON({
-      self: {},
-      resource_name: "test-artifact",
-      created_at: new Date(),
-      updated_at: new Date(),
-      deleted_at: new Date(),
-    }),
-  });
-
-  const mockEnvironment = TEST_CCLOUD_ENVIRONMENT;
-
-  const mockCluster = {
-    id: "cluster-123",
-    name: "Flink DB Cluster",
-    connectionId: artifact.connectionId,
-    connectionType: ConnectionType.Ccloud,
-    environmentId: artifact.environmentId,
-    bootstrapServers: "pkc-xyz",
-    provider: "aws",
-    region: "us-west-2",
-    flinkPools: [{ id: "compute-pool-1" }],
-    isFlinkable: true,
-    isSameCloudRegion: () => true,
-    toFlinkSpecProperties: () => ({
-      toProperties: () => ({}),
-    }),
-  } as unknown as CCloudFlinkDbKafkaCluster;
-
   beforeEach(() => {
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
     sandbox.restore();
-  });
-
-  it("should open a new Flink SQL document with placeholder query for valid artifact", async () => {
-    const openTextDocStub = sandbox
-      .stub(vscode.workspace, "openTextDocument")
-      .resolves({} as vscode.TextDocument);
-    const insertSnippetStub = sandbox.stub().resolves();
-    const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument").resolves({
-      insertSnippet: insertSnippetStub,
-    } as unknown as vscode.TextEditor);
-
-    await createUdfRegistrationDocumentCommand(artifact);
-
-    sinon.assert.calledOnce(openTextDocStub);
-    const callArgs = openTextDocStub.getCall(0).args[0];
-    assert.ok(callArgs, "openTextDocStub was not called with any arguments");
-    assert.strictEqual(callArgs.language, "flinksql");
-    sinon.assert.calledOnce(showTextDocStub);
-    sinon.assert.calledOnce(insertSnippetStub);
-    const snippetArg = insertSnippetStub.getCall(0).args[0];
-    assert.ok(
-      typeof snippetArg.value === "string" && snippetArg.value.includes("CREATE FUNCTION"),
-      "insertSnippet should be called with a snippet containing CREATE FUNCTION",
-    );
-  });
-
-  it("should return early if no artifact is provided", async () => {
-    const openTextDocStub = sandbox.stub(vscode.workspace, "openTextDocument");
-    const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument");
-
-    await createUdfRegistrationDocumentCommand(undefined as any);
-
-    sinon.assert.notCalled(openTextDocStub);
-    sinon.assert.notCalled(showTextDocStub);
   });
 
   it("should register the uploadArtifact command", () => {
@@ -210,157 +127,5 @@ describe("flinkArtifacts", () => {
 
     sinon.assert.calledOnce(createArtifactStub);
     sinon.assert.calledWithExactly(createArtifactStub, mockParams, mockUploadId);
-  });
-  it("should return early if no artifact is provided in startGuidedUdfCreationCommand", async () => {
-    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
-    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
-
-    const result = await startGuidedUdfCreationCommand(undefined as any);
-
-    assert.strictEqual(result, undefined);
-    sinon.assert.notCalled(showInfoStub);
-    sinon.assert.notCalled(showErrorStub);
-  });
-  it("should throw an error if flinkDatabases is empty", async () => {
-    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
-    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
-
-    await startGuidedUdfCreationCommand(artifact);
-
-    sinon.assert.notCalled(showInfoStub);
-    sinon.assert.calledOnce(showErrorStub);
-    sinon.assert.calledWith(showErrorStub, "Failed to create UDF function:  No Flink database.");
-  });
-  it("should prompt for function name and classname and show info message on success", async () => {
-    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
-    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
-
-    const promptStub = sandbox.stub(uploadArtifact, "promptForFunctionAndClassName").resolves({
-      functionName: "testFunction",
-      className: "com.test.TestClass",
-    });
-
-    const mockFlinkDatabaseViewProvider = {
-      resource: mockCluster,
-    };
-    sandbox
-      .stub(FlinkDatabaseViewProvider, "getInstance")
-      .returns(mockFlinkDatabaseViewProvider as any);
-
-    const executeStub = sandbox
-      .stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement")
-      .resolves([{ created_at: JSON.stringify(new Date().toISOString()) }]);
-    const withProgressStub = sandbox.stub(vscode.window, "withProgress");
-    withProgressStub.callsFake(async (options, callback) => {
-      return await callback(
-        {
-          report: () => {},
-        },
-        {} as any,
-      );
-    });
-
-    await startGuidedUdfCreationCommand(artifact);
-
-    sinon.assert.calledOnce(promptStub);
-    sinon.assert.calledOnce(executeStub);
-    sinon.assert.calledOnce(withProgressStub);
-    sinon.assert.calledOnce(showInfoStub);
-    sinon.assert.notCalled(showErrorStub);
-  });
-
-  it("should handle ResponseError with string response body in startGuidedUdfCreationCommand", async () => {
-    const showErrorStub = getShowErrorNotificationWithButtonsStub(sandbox);
-    sandbox.stub(uploadArtifact, "promptForFunctionAndClassName").resolves({
-      functionName: "testFunction",
-      className: "com.test.TestClass",
-    });
-
-    const mockEnvironmentNoComputePools: CCloudEnvironment = new CCloudEnvironment({
-      ...TEST_CCLOUD_ENVIRONMENT,
-      flinkComputePools: [],
-    });
-
-    const mockProvider = sandbox.createStubInstance(FlinkDatabaseViewProvider);
-    sandbox.stub(FlinkDatabaseViewProvider, "getInstance").returns(mockProvider);
-    mockProvider.resource = mockCluster;
-
-    sandbox
-      .stub(CCloudResourceLoader.getInstance(), "getEnvironments")
-      .resolves([mockEnvironmentNoComputePools]);
-
-    const responseForNewError = createResponseError(400, "Bad Request", "Plain text error message");
-    const responseError: ResponseError = new ResponseError(
-      responseForNewError.response,
-      responseForNewError.message,
-    );
-    sandbox
-      .stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement")
-      .rejects(responseError);
-
-    await startGuidedUdfCreationCommand(artifact);
-
-    sinon.assert.calledOnce(showErrorStub);
-    sinon.assert.calledWith(
-      showErrorStub,
-      "Failed to create UDF function:  Plain text error message",
-    );
-  });
-
-  it("should handle plain Error objects in startGuidedUdfCreationCommand", async () => {
-    const showErrorStub = getShowErrorNotificationWithButtonsStub(sandbox);
-
-    sandbox.stub(uploadArtifact, "promptForFunctionAndClassName").resolves({
-      functionName: "testFunction",
-      className: "com.test.TestClass",
-    });
-
-    sandbox
-      .stub(FlinkDatabaseViewProvider, "getInstance")
-      .returns({ resource: mockCluster } as any);
-
-    sandbox
-      .stub(CCloudResourceLoader.getInstance(), "getEnvironments")
-      .resolves([mockEnvironment as CCloudEnvironment]);
-
-    const error = new Error("Something went wrong with UDF creation");
-
-    sandbox.stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement").rejects(error);
-
-    await startGuidedUdfCreationCommand(artifact);
-
-    sinon.assert.calledOnce(showErrorStub);
-    sinon.assert.calledWithExactly(
-      showErrorStub,
-      "Failed to create UDF function:  Something went wrong with UDF creation",
-    );
-  });
-
-  it("should exit silently if a user exits the function and class name prompt", async () => {
-    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
-    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
-
-    const promptStub = sandbox
-      .stub(uploadArtifact, "promptForFunctionAndClassName")
-      .resolves(undefined as any);
-
-    const mockFlinkDatabaseViewProvider = {
-      resource: mockCluster,
-    };
-    sandbox
-      .stub(FlinkDatabaseViewProvider, "getInstance")
-      .returns(mockFlinkDatabaseViewProvider as any);
-
-    const executeStub = sandbox.stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement");
-
-    const withProgressStub = sandbox.stub(vscode.window, "withProgress");
-
-    await startGuidedUdfCreationCommand(artifact);
-
-    sinon.assert.calledOnce(promptStub);
-    sinon.assert.notCalled(executeStub);
-    sinon.assert.notCalled(withProgressStub);
-    sinon.assert.notCalled(showInfoStub);
-    sinon.assert.notCalled(showErrorStub);
   });
 });

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -1,28 +1,24 @@
 import * as vscode from "vscode";
-import { SnippetString, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { DeleteArtifactV1FlinkArtifactRequest } from "../clients/flinkArtifacts/apis/FlinkArtifactsArtifactV1Api";
 import { PresignedUploadUrlArtifactV1PresignedUrlRequest } from "../clients/flinkArtifacts/models";
 import { ContextValues, setContextValue } from "../context/values";
 import { artifactsChanged, flinkDatabaseViewMode } from "../emitters";
 import { extractResponseBody, isResponseError, logError } from "../errors";
-import { CCloudResourceLoader } from "../loaders";
 import { FlinkArtifact } from "../models/flinkArtifact";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { CCloudKafkaCluster } from "../models/kafkaCluster";
 import {
   showErrorNotificationWithButtons,
-  showInfoNotificationWithButtons,
   showWarningNotificationWithButtons,
 } from "../notifications";
 import { getSidecar } from "../sidecar";
-import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
+import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } from "./flinkUDFs";
 import { artifactUploadQuickPickForm } from "./utils/artifactUploadForm";
 import {
   getPresignedUploadUrl,
   handleUploadToCloudProvider,
-  promptForFunctionAndClassName,
   uploadArtifactToCCloud,
 } from "./utils/uploadArtifactOrUDF";
 
@@ -146,80 +142,6 @@ export async function deleteArtifactCommand(
   void vscode.window.showInformationMessage(
     `Artifact "${selectedArtifact.name}" deleted successfully from Confluent Cloud.`,
   );
-}
-
-export async function createUdfRegistrationDocumentCommand(selectedArtifact: FlinkArtifact) {
-  if (!selectedArtifact) {
-    return;
-  }
-  const snippetString = new SnippetString()
-    .appendText(`-- Register UDF for artifact "${selectedArtifact.name}"\n`)
-    .appendText("CREATE FUNCTION `")
-    .appendPlaceholder("yourFunctionNameHere", 1)
-    .appendText("` AS '")
-    .appendPlaceholder("your.class.NameHere", 2)
-    .appendText(`' USING JAR 'confluent-artifact://${selectedArtifact.id}';\n`)
-    .appendText("-- confirm with 'SHOW USER FUNCTIONS';\n");
-
-  const document = await workspace.openTextDocument({
-    language: "flinksql",
-    // content is initialized as an empty string, we insert the snippet next due to how the Snippets API works
-    content: "",
-  });
-
-  const editor = await window.showTextDocument(document, { preview: false });
-  await editor.insertSnippet(snippetString);
-}
-
-export async function startGuidedUdfCreationCommand(selectedArtifact: FlinkArtifact) {
-  if (!selectedArtifact) {
-    return;
-  }
-  try {
-    const ccloudResourceLoader = CCloudResourceLoader.getInstance();
-    const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
-    const database = flinkDatabaseProvider.resource;
-    if (!database) {
-      throw new Error("No Flink database.");
-    }
-
-    let userInput = await promptForFunctionAndClassName(selectedArtifact);
-    if (!userInput) {
-      return; // User cancelled the input
-    }
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: "Creating UDF function from artifact",
-        cancellable: false,
-      },
-      async (progress) => {
-        progress.report({ message: "Executing statement..." });
-        await ccloudResourceLoader.executeFlinkStatement<{ created_at?: string }>(
-          `CREATE FUNCTION \`${userInput.functionName}\` AS '${userInput.className}' USING JAR 'confluent-artifact://${selectedArtifact.id}';`,
-          database,
-          undefined,
-          60000, // custom timeout of 60 seconds
-        );
-        progress.report({ message: "Processing results..." });
-        const createdMsg = `${userInput.functionName} function created successfully.`;
-        void showInfoNotificationWithButtons(createdMsg);
-      },
-    );
-  } catch (err) {
-    if (!(err instanceof Error && err.message.includes("Failed to create UDF function"))) {
-      let errorMessage = "Failed to create UDF function: ";
-
-      if (isResponseError(err)) {
-        const resp = await err.response.clone().text();
-        errorMessage = `${errorMessage} ${resp}`;
-      } else if (err instanceof Error) {
-        errorMessage = `${errorMessage} ${err.message}`;
-        logError(err, errorMessage);
-      }
-      showErrorNotificationWithButtons(errorMessage);
-    }
-  }
 }
 
 /** Set the Flink Database view to Artifacts mode */

--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -14,7 +14,6 @@ import {
 } from "../notifications";
 import { getSidecar } from "../sidecar";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
-import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } from "./flinkUDFs";
 import { artifactUploadQuickPickForm } from "./utils/artifactUploadForm";
 import {
   getPresignedUploadUrl,
@@ -163,14 +162,6 @@ export function registerFlinkArtifactCommands(): vscode.Disposable[] {
     registerCommandWithLogging(
       "confluent.flinkdatabase.setArtifactsViewMode",
       setFlinkArtifactsViewModeCommand,
-    ),
-    registerCommandWithLogging(
-      "confluent.artifacts.createUdfRegistrationDocument",
-      createUdfRegistrationDocumentCommand,
-    ),
-    registerCommandWithLogging(
-      "confluent.artifacts.startGuidedUdfCreation",
-      startGuidedUdfCreationCommand,
     ),
   ];
 }

--- a/src/commands/flinkUDFs.test.ts
+++ b/src/commands/flinkUDFs.test.ts
@@ -1,0 +1,270 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
+import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
+import { createResponseError } from "../../tests/unit/testUtils";
+import { ArtifactV1FlinkArtifactMetadataFromJSON, ResponseError } from "../clients/flinkArtifacts";
+import { ConnectionType } from "../clients/sidecar";
+import { CCloudResourceLoader } from "../loaders/ccloudResourceLoader";
+import { CCloudEnvironment } from "../models/environment";
+import { FlinkArtifact } from "../models/flinkArtifact";
+import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
+import { ConnectionId, EnvironmentId } from "../models/resource";
+import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
+import { registerFlinkArtifactCommands, uploadArtifactCommand } from "./flinkArtifacts";
+import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } from "./flinkUDFs";
+import * as commands from "./index";
+import * as uploadArtifact from "./utils/uploadArtifactOrUDF";
+
+describe("flinkUDFs", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  const artifact = new FlinkArtifact({
+    id: "artifact-id",
+    name: "test-artifact",
+    description: "description",
+    connectionId: "conn-id" as ConnectionId,
+    connectionType: "ccloud" as ConnectionType,
+    environmentId: "env-id" as EnvironmentId,
+    provider: "aws",
+    region: "us-west-2",
+    documentationLink: "https://confluent.io",
+    metadata: ArtifactV1FlinkArtifactMetadataFromJSON({
+      self: {},
+      resource_name: "test-artifact",
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: new Date(),
+    }),
+  });
+
+  const mockEnvironment = TEST_CCLOUD_ENVIRONMENT;
+
+  const mockCluster = {
+    id: "cluster-123",
+    name: "Flink DB Cluster",
+    connectionId: artifact.connectionId,
+    connectionType: ConnectionType.Ccloud,
+    environmentId: artifact.environmentId,
+    bootstrapServers: "pkc-xyz",
+    provider: "aws",
+    region: "us-west-2",
+    flinkPools: [{ id: "compute-pool-1" }],
+    isFlinkable: true,
+    isSameCloudRegion: () => true,
+    toFlinkSpecProperties: () => ({
+      toProperties: () => ({}),
+    }),
+  } as unknown as CCloudFlinkDbKafkaCluster;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should open a new Flink SQL document with placeholder query for valid artifact", async () => {
+    const openTextDocStub = sandbox
+      .stub(vscode.workspace, "openTextDocument")
+      .resolves({} as vscode.TextDocument);
+    const insertSnippetStub = sandbox.stub().resolves();
+    const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument").resolves({
+      insertSnippet: insertSnippetStub,
+    } as unknown as vscode.TextEditor);
+
+    await createUdfRegistrationDocumentCommand(artifact);
+
+    sinon.assert.calledOnce(openTextDocStub);
+    const callArgs = openTextDocStub.getCall(0).args[0];
+    assert.ok(callArgs, "openTextDocStub was not called with any arguments");
+    assert.strictEqual(callArgs.language, "flinksql");
+    sinon.assert.calledOnce(showTextDocStub);
+    sinon.assert.calledOnce(insertSnippetStub);
+    const snippetArg = insertSnippetStub.getCall(0).args[0];
+    assert.ok(
+      typeof snippetArg.value === "string" && snippetArg.value.includes("CREATE FUNCTION"),
+      "insertSnippet should be called with a snippet containing CREATE FUNCTION",
+    );
+  });
+
+  it("should return early if no artifact is provided", async () => {
+    const openTextDocStub = sandbox.stub(vscode.workspace, "openTextDocument");
+    const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument");
+
+    await createUdfRegistrationDocumentCommand(undefined as any);
+
+    sinon.assert.notCalled(openTextDocStub);
+    sinon.assert.notCalled(showTextDocStub);
+  });
+
+  it("should register the uploadArtifact command", () => {
+    const registerCommandWithLoggingStub = sandbox
+      .stub(commands, "registerCommandWithLogging")
+      .returns({} as vscode.Disposable);
+
+    registerFlinkArtifactCommands();
+
+    sinon.assert.calledWithExactly(
+      registerCommandWithLoggingStub,
+      "confluent.uploadArtifact",
+      uploadArtifactCommand,
+    );
+  });
+
+  it("should return early if no artifact is provided in startGuidedUdfCreationCommand", async () => {
+    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
+    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
+
+    const result = await startGuidedUdfCreationCommand(undefined as any);
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.notCalled(showInfoStub);
+    sinon.assert.notCalled(showErrorStub);
+  });
+  it("should throw an error if flinkDatabases is empty", async () => {
+    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
+    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
+
+    await startGuidedUdfCreationCommand(artifact);
+
+    sinon.assert.notCalled(showInfoStub);
+    sinon.assert.calledOnce(showErrorStub);
+    sinon.assert.calledWith(showErrorStub, "Failed to create UDF function:  No Flink database.");
+  });
+
+  it("should prompt for function name and classname and show info message on success", async () => {
+    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
+    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
+
+    const promptStub = sandbox.stub(uploadArtifact, "promptForFunctionAndClassName").resolves({
+      functionName: "testFunction",
+      className: "com.test.TestClass",
+    });
+
+    const mockFlinkDatabaseViewProvider = {
+      resource: mockCluster,
+    };
+    sandbox
+      .stub(FlinkDatabaseViewProvider, "getInstance")
+      .returns(mockFlinkDatabaseViewProvider as any);
+
+    const executeStub = sandbox
+      .stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement")
+      .resolves([{ created_at: JSON.stringify(new Date().toISOString()) }]);
+    const withProgressStub = sandbox.stub(vscode.window, "withProgress");
+    withProgressStub.callsFake(async (options, callback) => {
+      return await callback(
+        {
+          report: () => {},
+        },
+        {} as any,
+      );
+    });
+
+    await startGuidedUdfCreationCommand(artifact);
+
+    sinon.assert.calledOnce(promptStub);
+    sinon.assert.calledOnce(executeStub);
+    sinon.assert.calledOnce(withProgressStub);
+    sinon.assert.calledOnce(showInfoStub);
+    sinon.assert.notCalled(showErrorStub);
+  });
+
+  it("should handle ResponseError with string response body in startGuidedUdfCreationCommand", async () => {
+    const showErrorStub = getShowErrorNotificationWithButtonsStub(sandbox);
+    sandbox.stub(uploadArtifact, "promptForFunctionAndClassName").resolves({
+      functionName: "testFunction",
+      className: "com.test.TestClass",
+    });
+
+    const mockEnvironmentNoComputePools: CCloudEnvironment = new CCloudEnvironment({
+      ...TEST_CCLOUD_ENVIRONMENT,
+      flinkComputePools: [],
+    });
+
+    const mockProvider = sandbox.createStubInstance(FlinkDatabaseViewProvider);
+    sandbox.stub(FlinkDatabaseViewProvider, "getInstance").returns(mockProvider);
+    mockProvider.resource = mockCluster;
+
+    sandbox
+      .stub(CCloudResourceLoader.getInstance(), "getEnvironments")
+      .resolves([mockEnvironmentNoComputePools]);
+
+    const responseForNewError = createResponseError(400, "Bad Request", "Plain text error message");
+    const responseError: ResponseError = new ResponseError(
+      responseForNewError.response,
+      responseForNewError.message,
+    );
+    sandbox
+      .stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement")
+      .rejects(responseError);
+
+    await startGuidedUdfCreationCommand(artifact);
+
+    sinon.assert.calledOnce(showErrorStub);
+    sinon.assert.calledWith(
+      showErrorStub,
+      "Failed to create UDF function:  Plain text error message",
+    );
+  });
+
+  it("should handle plain Error objects in startGuidedUdfCreationCommand", async () => {
+    const showErrorStub = getShowErrorNotificationWithButtonsStub(sandbox);
+
+    sandbox.stub(uploadArtifact, "promptForFunctionAndClassName").resolves({
+      functionName: "testFunction",
+      className: "com.test.TestClass",
+    });
+
+    sandbox
+      .stub(FlinkDatabaseViewProvider, "getInstance")
+      .returns({ resource: mockCluster } as any);
+
+    sandbox
+      .stub(CCloudResourceLoader.getInstance(), "getEnvironments")
+      .resolves([mockEnvironment as CCloudEnvironment]);
+
+    const error = new Error("Something went wrong with UDF creation");
+
+    sandbox.stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement").rejects(error);
+
+    await startGuidedUdfCreationCommand(artifact);
+
+    sinon.assert.calledOnce(showErrorStub);
+    sinon.assert.calledWithExactly(
+      showErrorStub,
+      "Failed to create UDF function:  Something went wrong with UDF creation",
+    );
+  });
+
+  it("should exit silently if a user exits the function and class name prompt", async () => {
+    const showInfoStub = sandbox.stub(vscode.window, "showInformationMessage");
+    const showErrorStub = sandbox.stub(vscode.window, "showErrorMessage");
+
+    const promptStub = sandbox
+      .stub(uploadArtifact, "promptForFunctionAndClassName")
+      .resolves(undefined as any);
+
+    const mockFlinkDatabaseViewProvider = {
+      resource: mockCluster,
+    };
+    sandbox
+      .stub(FlinkDatabaseViewProvider, "getInstance")
+      .returns(mockFlinkDatabaseViewProvider as any);
+
+    const executeStub = sandbox.stub(CCloudResourceLoader.getInstance(), "executeFlinkStatement");
+
+    const withProgressStub = sandbox.stub(vscode.window, "withProgress");
+
+    await startGuidedUdfCreationCommand(artifact);
+
+    sinon.assert.calledOnce(promptStub);
+    sinon.assert.notCalled(executeStub);
+    sinon.assert.notCalled(withProgressStub);
+    sinon.assert.notCalled(showInfoStub);
+    sinon.assert.notCalled(showErrorStub);
+  });
+});

--- a/src/commands/flinkUDFs.test.ts
+++ b/src/commands/flinkUDFs.test.ts
@@ -12,8 +12,12 @@ import { FlinkArtifact } from "../models/flinkArtifact";
 import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
 import { ConnectionId, EnvironmentId } from "../models/resource";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
-import { registerFlinkArtifactCommands, uploadArtifactCommand } from "./flinkArtifacts";
-import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } from "./flinkUDFs";
+import {
+  createUdfRegistrationDocumentCommand,
+  registerFlinkUDFCommands,
+  setFlinkUDFViewModeCommand,
+  startGuidedUdfCreationCommand,
+} from "./flinkUDFs";
 import * as commands from "./index";
 import * as uploadArtifact from "./utils/uploadArtifactOrUDF";
 
@@ -100,17 +104,29 @@ describe("flinkUDFs command", () => {
     sinon.assert.notCalled(showTextDocStub);
   });
 
-  it("should register the uploadArtifact command", () => {
+  it("should register startGuidedUdfCreationCommand and createUdfRegistrationDocumentCommand", () => {
     const registerCommandWithLoggingStub = sandbox
       .stub(commands, "registerCommandWithLogging")
       .returns({} as vscode.Disposable);
 
-    registerFlinkArtifactCommands();
+    registerFlinkUDFCommands();
+
+    sinon.assert.calledThrice(registerCommandWithLoggingStub);
 
     sinon.assert.calledWithExactly(
-      registerCommandWithLoggingStub,
-      "confluent.uploadArtifact",
-      uploadArtifactCommand,
+      registerCommandWithLoggingStub.getCall(0),
+      "confluent.flinkdatabase.setUDFsViewMode",
+      setFlinkUDFViewModeCommand,
+    );
+    sinon.assert.calledWithExactly(
+      registerCommandWithLoggingStub.getCall(1),
+      "confluent.artifacts.createUdfRegistrationDocument",
+      createUdfRegistrationDocumentCommand,
+    );
+    sinon.assert.calledWithExactly(
+      registerCommandWithLoggingStub.getCall(2),
+      "confluent.artifacts.startGuidedUdfCreation",
+      startGuidedUdfCreationCommand,
     );
   });
 

--- a/src/commands/flinkUDFs.test.ts
+++ b/src/commands/flinkUDFs.test.ts
@@ -17,7 +17,7 @@ import { createUdfRegistrationDocumentCommand, startGuidedUdfCreationCommand } f
 import * as commands from "./index";
 import * as uploadArtifact from "./utils/uploadArtifactOrUDF";
 
-describe("flinkUDFs", () => {
+describe("flinkUDFs command", () => {
   let sandbox: sinon.SinonSandbox;
 
   const artifact = new FlinkArtifact({

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -1,8 +1,18 @@
-import { Disposable } from "vscode";
+import * as vscode from "vscode";
+import { Disposable, SnippetString, window, workspace } from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
 import { flinkDatabaseViewMode } from "../emitters";
+import { isResponseError, logError } from "../errors";
+import { CCloudResourceLoader } from "../loaders";
+import { FlinkArtifact } from "../models/flinkArtifact";
+import {
+  showErrorNotificationWithButtons,
+  showInfoNotificationWithButtons,
+} from "../notifications";
+import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
+import { promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
 
 export async function setFlinkUDFViewModeCommand() {
   flinkDatabaseViewMode.fire(FlinkDatabaseViewProviderMode.UDFs);
@@ -16,4 +26,76 @@ export function registerFlinkUDFCommands(): Disposable[] {
       setFlinkUDFViewModeCommand,
     ),
   ];
+}
+export async function createUdfRegistrationDocumentCommand(selectedArtifact: FlinkArtifact) {
+  if (!selectedArtifact) {
+    return;
+  }
+  const snippetString = new SnippetString()
+    .appendText(`-- Register UDF for artifact "${selectedArtifact.name}"\n`)
+    .appendText("CREATE FUNCTION `")
+    .appendPlaceholder("yourFunctionNameHere", 1)
+    .appendText("` AS '")
+    .appendPlaceholder("your.class.NameHere", 2)
+    .appendText(`' USING JAR 'confluent-artifact://${selectedArtifact.id}';\n`)
+    .appendText("-- confirm with 'SHOW USER FUNCTIONS';\n");
+
+  const document = await workspace.openTextDocument({
+    language: "flinksql",
+    // content is initialized as an empty string, we insert the snippet next due to how the Snippets API works
+    content: "",
+  });
+
+  const editor = await window.showTextDocument(document, { preview: false });
+  await editor.insertSnippet(snippetString);
+}
+export async function startGuidedUdfCreationCommand(selectedArtifact: FlinkArtifact) {
+  if (!selectedArtifact) {
+    return;
+  }
+  try {
+    const ccloudResourceLoader = CCloudResourceLoader.getInstance();
+    const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
+    const database = flinkDatabaseProvider.resource;
+    if (!database) {
+      throw new Error("No Flink database.");
+    }
+
+    let userInput = await promptForFunctionAndClassName(selectedArtifact);
+    if (!userInput) {
+      return; // User cancelled the input
+    }
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Creating UDF function from artifact",
+        cancellable: false,
+      },
+      async (progress) => {
+        progress.report({ message: "Executing statement..." });
+        await ccloudResourceLoader.executeFlinkStatement<{ created_at?: string }>(
+          `CREATE FUNCTION \`${userInput.functionName}\` AS '${userInput.className}' USING JAR 'confluent-artifact://${selectedArtifact.id}';`,
+          database,
+          undefined,
+          60000,
+        );
+        progress.report({ message: "Processing results..." });
+        const createdMsg = `${userInput.functionName} function created successfully.`;
+        void showInfoNotificationWithButtons(createdMsg);
+      },
+    );
+  } catch (err) {
+    if (!(err instanceof Error && err.message.includes("Failed to create UDF function"))) {
+      let errorMessage = "Failed to create UDF function: ";
+
+      if (isResponseError(err)) {
+        const resp = await err.response.clone().text();
+        errorMessage = `${errorMessage} ${resp}`;
+      } else if (err instanceof Error) {
+        errorMessage = `${errorMessage} ${err.message}`;
+        logError(err, errorMessage);
+      }
+      showErrorNotificationWithButtons(errorMessage);
+    }
+  }
 }

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -25,6 +25,14 @@ export function registerFlinkUDFCommands(): Disposable[] {
       "confluent.flinkdatabase.setUDFsViewMode",
       setFlinkUDFViewModeCommand,
     ),
+    registerCommandWithLogging(
+      "confluent.artifacts.createUdfRegistrationDocument",
+      createUdfRegistrationDocumentCommand,
+    ),
+    registerCommandWithLogging(
+      "confluent.artifacts.startGuidedUdfCreation",
+      startGuidedUdfCreationCommand,
+    ),
   ];
 }
 export async function createUdfRegistrationDocumentCommand(selectedArtifact: FlinkArtifact) {


### PR DESCRIPTION
## Summary of Changes

Fixes https://github.com/confluentinc/vscode/issues/2691

I discovered need for this refactor while [reading the code to add event emitters to UDFs](https://github.com/confluentinc/vscode/issues/2588), so that PR will follow this one. 

Two functions, `createUdfRegistrationDocumentCommand` and `startGuidedUdfCreationCommand`, moved:
- from `commands/flinkArtifacts`
- to `commands/flinkUDF`

Consequently, some tests also had to move. There was no `flinkUDF.test.ts` so I added it. Also, the registration code for `createUdfRegistrationDocumentCommand` and `startGuidedUdfCreationCommand` moved from `flinkArtifacts` to `commands/flinkUDF` as well, and the related test there needed updating. Otherwise, I didn't change the code itself much, just moved it around. 


If you're interested, here is the effect on test coverage from `gulp` 

| Branch Name | File Name | Stmts column  %| Line count %
| :------- | :------: | -------: | -------: |
| main | flinkArtifacts.ts |   70.83  % | 70.42%
| main | flinkUDFs.ts |  33.33 % |  33.33 %
| refactor-udf-artifact-commands | flinkArtifacts.ts | 47.5% | 46.15%
| refactor-udf-artifact-commands | flinkUDFs.ts | 94.28% |   94.28% 


> [!NOTE]
> I noticed some opportunities to improve testing as well. Some not _strictly_ necessary `as any`s, as well as some places where we could use `createFlinkArtifact` instead of mocking the whole thing out. However, in the interest of making this PR readable, I may file an issue or do a follow-on here. 

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
