### PR TITLE
Fix the broken thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+## Fixed
+
+- Fixed automatically refreshing the Topics view when creating or deleting subjects in the
+  corresponding schema registry (re-correlating the new set of schemas to topics)
+  ([#2556](https://github.com/confluentinc/vscode/issues/2556)).
+
 ### Added
 
 - Date/time picker for message viewer when consuming from a specific point in time.

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -574,6 +574,8 @@ describe("TopicViewProvider", () => {
             change,
           } as SubjectChangeEvent);
           sinon.assert.calledOnce(refreshStub);
+          // Must be a deep refresh to do the right thing and re-correlate topics and subjects.
+          sinon.assert.calledWith(refreshStub, true);
         });
       }
     });

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -365,8 +365,8 @@ export class TopicViewProvider
         },
       );
 
-      // Toplevel repaint.
-      this.refresh();
+      // Toplevel (deep) repaint to reevaluate which topics have subjects.
+      this.refresh(true);
     }
   }
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix #2556 by having the very well meaning existing event handler for the Topics view drive a deep-refreshing reload when a schema subject is created or deleted from the viewed cluster's corresponding schema registry. It was only performing a shallow reload previously, which did not drive re-correlating schemas and topics in our newer 'caching' resource loaders.

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

![proper-delete-refresh](https://github.com/user-attachments/assets/1abe8439-12c1-4aed-aaed-93af744114fd)


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
