### PR TITLE
add `getFlinkDatabase[s]` helper methods for the CCloud resource loader

### DIFF
--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -153,6 +153,18 @@ export abstract class CachingResourceLoader<
   }
 
   /**
+   * Get all of the known kafka clusters in the accessible environments.
+   *
+   * Ensures that the coarse resources are loaded before returning the kafka clusters from
+   * the resource manager cache.
+   **/
+  public async getKafkaClusters(filterPredicate?: (cluster: KCT) => boolean): Promise<KCT[]> {
+    await this.ensureCoarseResourcesLoaded(false);
+    const clusters = await getResourceManager().getKafkaClusters<KCT>(this.connectionId);
+    return filterPredicate ? clusters.filter(filterPredicate) : clusters;
+  }
+
+  /**
    * Get all of the known schema registries in the accessible environments.
    *
    * Ensures that the coarse resources are loaded before returning the schema registries from

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -174,6 +174,34 @@ export class CCloudResourceLoader extends CachingResourceLoader<
   }
 
   /**
+   * Get all Flink databases (Flink-enabled Kafka clusters) in all environments.
+   * @returns Array of {@link CCloudFlinkDbKafkaCluster} objects.
+   */
+  public async getFlinkDatabases(
+    environmentId?: EnvironmentId,
+  ): Promise<CCloudFlinkDbKafkaCluster[]> {
+    let databases = await this.getKafkaClusters((cluster) => {
+      return environmentId
+        ? cluster.environmentId === environmentId && cluster.isFlinkable()
+        : cluster.isFlinkable();
+    });
+    return databases as CCloudFlinkDbKafkaCluster[];
+  }
+
+  /**
+   * Get a specific Flink database (Flink-enabled Kafka cluster) by ID.
+   * @param databaseId The database/cluster ID to look for.
+   * @returns The {@link CCloudFlinkDbKafkaCluster} with the given ID, or undefined if not found.
+   */
+  public async getFlinkDatabase(
+    databaseId: string,
+    environmentId?: EnvironmentId,
+  ): Promise<CCloudFlinkDbKafkaCluster | undefined> {
+    const databases: CCloudFlinkDbKafkaCluster[] = await this.getFlinkDatabases(environmentId);
+    return databases.find((db) => db.id === databaseId);
+  }
+
+  /**
    * Convert the given CCloudEnvironment, CCloudFlinkComputePool, or CCloudKafkaCluster
    * into a list of distinct IFlinkQueryable objects. Each object
    * will be for a separate provider-region pair within the environment.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

-

## Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

##### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

##### Other

- [ ] All new disposables (event listeners, views, channels, etc.) collected as  for eventual cleanup?
<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md) or [README](https://github.com/confluentinc/vscode/blob/main/public/README.md)?
- [ ] Have you validated this change locally by [packaging](https://github.com/confluentinc/vscode/blob/main/README.md#packaging-steps) and installing the extension `.vsix` file?
  ```shell
  gulp clicktest
  ```
