### PR TITLE
MINOR: update issue template to use Bug type instead of `bug` label [ci skip]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 'Report a bug'
 description: Report a bug with Confluent for VS Code.
+type: Bug
 labels:
-  - 'bug'
   - 'needs triage'
 body:
   - type: markdown


### PR DESCRIPTION
We don't use the `bug` label, and we have Feature/Task/Bug issue types.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#:~:text=String-,type,and%20can%20be%20used%20to%20create%20a%20shared%20syntax%20across%20repos.,-Optional