### PR TITLE
MINOR test cleanup: standardize `getSidecarStub()` usage

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { window } from "vscode";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
+import { getSidecarStub } from "../../tests/stubs/sidecar";
 import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
 import {
   TEST_CCLOUD_KAFKA_TOPIC,
@@ -14,7 +15,7 @@ import { ResponseError, SubjectsV1Api } from "../clients/schemaRegistryRest";
 import { CCLOUD_BASE_PATH, UTM_SOURCE_VSCODE } from "../constants";
 import { SCHEMA_RBAC_WARNINGS_ENABLED } from "../extensionSettings/constants";
 import { CCloudResourceLoader } from "../loaders";
-import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import * as schemaRegistry from "./schemaRegistry";
 
 describe("authz.schemaRegistry", function () {
@@ -29,12 +30,9 @@ describe("authz.schemaRegistry", function () {
 
     sandbox = sinon.createSandbox();
     // create the stubs for the sidecar + service client
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     mockClient = sandbox.createStubInstance(SubjectsV1Api);
-    mockSidecarHandle.getSubjectsV1Api.returns(mockClient);
-    // stub the getSidecar function to return the mock sidecar handle
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+    stubbedSidecar.getSubjectsV1Api.returns(mockClient);
 
     stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
 

--- a/src/authz/topics.test.ts
+++ b/src/authz/topics.test.ts
@@ -1,9 +1,10 @@
 import * as assert from "assert";
 import sinon from "sinon";
+import { getSidecarStub } from "../../tests/stubs/sidecar";
 import { TEST_CCLOUD_KAFKA_TOPIC, TEST_LOCAL_KAFKA_TOPIC } from "../../tests/unit/testResources";
 import { createTestTopicData } from "../../tests/unit/testUtils";
 import { TopicData, TopicV3Api } from "../clients/kafkaRest";
-import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import { KAFKA_TOPIC_OPERATIONS } from "./constants";
 import { fetchTopicAuthorizedOperations } from "./topics";
 
@@ -14,12 +15,9 @@ describe("authz.topics", function () {
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     // create the stubs for the sidecar + service client
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     mockClient = sandbox.createStubInstance(TopicV3Api);
-    mockSidecarHandle.getTopicV3Api.returns(mockClient);
-    // stub the getSidecar function to return the mock sidecar handle
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+    stubbedSidecar.getTopicV3Api.returns(mockClient);
   });
 
   afterEach(function () {

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import sinon from "sinon";
 import * as vscode from "vscode";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
+import { getSidecarStub } from "../../tests/stubs/sidecar";
 import {
   TEST_CCLOUD_ENVIRONMENT,
   TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER,
@@ -31,7 +32,7 @@ import {
   ProduceMessage,
   SubjectNameStrategy,
 } from "../schemas/produceMessageSchema";
-import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import * as fileUtils from "../utils/file";
@@ -88,12 +89,9 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
     sandbox.stub(schemaQuickPicks, "schemaKindMultiSelect").resolves(schemaLess);
 
     // create the stubs for the sidecar + service client
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     clientStub = sandbox.createStubInstance(RecordsV3Api);
-    mockSidecarHandle.getRecordsV3Api.returns(clientStub);
-    // stub the getSidecar function to return the mock sidecar handle
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+    stubbedSidecar.getRecordsV3Api.returns(clientStub);
   });
 
   afterEach(function () {
@@ -290,16 +288,13 @@ describe("commands/topics.ts produceMessageFromDocument() with schema(s)", funct
     promptForSchemaStub = sandbox.stub(schemaUtils, "promptForSchema");
 
     // create the stubs for the sidecar + service clients
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     // non-CCloud:
     recordsV3ApiStub = sandbox.createStubInstance(RecordsV3Api);
-    mockSidecarHandle.getRecordsV3Api.returns(recordsV3ApiStub);
+    stubbedSidecar.getRecordsV3Api.returns(recordsV3ApiStub);
     // CCloud:
     ccloudProduceApiStub = sandbox.createStubInstance(ConfluentCloudProduceRecordsResourceApi);
-    mockSidecarHandle.getConfluentCloudProduceRecordsResourceApi.returns(ccloudProduceApiStub);
-
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+    stubbedSidecar.getConfluentCloudProduceRecordsResourceApi.returns(ccloudProduceApiStub);
   });
 
   afterEach(function () {
@@ -741,16 +736,13 @@ describe("commands/topics.ts produceMessage()", function () {
     sandbox = sinon.createSandbox();
 
     // create the stubs for the sidecar + service clients
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     // non-CCloud:
     recordsV3ApiStub = sandbox.createStubInstance(RecordsV3Api);
-    mockSidecarHandle.getRecordsV3Api.returns(recordsV3ApiStub);
+    stubbedSidecar.getRecordsV3Api.returns(recordsV3ApiStub);
     // CCloud:
     ccloudProduceApiStub = sandbox.createStubInstance(ConfluentCloudProduceRecordsResourceApi);
-    mockSidecarHandle.getConfluentCloudProduceRecordsResourceApi.returns(ccloudProduceApiStub);
-
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+    stubbedSidecar.getConfluentCloudProduceRecordsResourceApi.returns(ccloudProduceApiStub);
   });
 
   afterEach(function () {

--- a/src/commands/utils/uploadArtifactOrUDF.test.ts
+++ b/src/commands/utils/uploadArtifactOrUDF.test.ts
@@ -20,7 +20,7 @@ import { ConnectionType } from "../../clients/sidecar";
 import { FlinkArtifact } from "../../models/flinkArtifact";
 import { ConnectionId, EnvironmentId } from "../../models/resource";
 import * as notifications from "../../notifications";
-import * as sidecar from "../../sidecar";
+import { SidecarHandle } from "../../sidecar";
 import * as fsWrappers from "../../utils/fsWrappers";
 import * as uploadArtifactModule from "./uploadArtifactOrUDF";
 import {
@@ -128,7 +128,6 @@ describe("commands/utils/uploadArtifact", () => {
 
   describe("getPresignedUploadUrl", () => {
     it("should return a presigned upload URL", async () => {
-      const mockSidecarHandle = sandbox.createStubInstance(sidecar.SidecarHandle);
       const mockResponse = {
         upload_url: "https://example.com/presigned-url",
         api_version: PresignedUploadUrlArtifactV1PresignedUrl200ResponseApiVersionEnum.ArtifactV1,
@@ -138,9 +137,8 @@ describe("commands/utils/uploadArtifact", () => {
       const mockPresignedClient = sandbox.createStubInstance(PresignedUrlsArtifactV1Api);
       mockPresignedClient.presignedUploadUrlArtifactV1PresignedUrl.resolves(mockResponse);
 
-      mockSidecarHandle.getFlinkPresignedUrlsApi.returns(mockPresignedClient);
-
-      sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+      const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
+      stubbedSidecar.getFlinkPresignedUrlsApi.returns(mockPresignedClient);
 
       const mockPresignedUploadUrlRequest: PresignedUploadUrlArtifactV1PresignedUrlRequest = {
         content_format: "application/java-archive",

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import sinon from "sinon";
+import { getSidecarStub } from "../tests/stubs/sidecar";
 import { TEST_LOCAL_KAFKA_CLUSTER, TEST_LOCAL_SCHEMA_REGISTRY } from "../tests/unit/testResources";
 import {
   TEST_DIRECT_CONNECTION,
@@ -16,7 +17,7 @@ import {
 import { DirectConnectionManager } from "./directConnectManager";
 import { ResourceLoader } from "./loaders";
 import { ConnectionId } from "./models/resource";
-import * as sidecar from "./sidecar";
+import { SidecarHandle } from "./sidecar";
 import * as connections from "./sidecar/connections";
 import * as watcher from "./sidecar/connections/watcher";
 import {
@@ -63,11 +64,9 @@ describe("DirectConnectionManager behavior", () => {
     sandbox = sinon.createSandbox();
 
     // stub the sidecar Connections API
-    const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     stubbedConnectionsResourceApi = sandbox.createStubInstance(ConnectionsResourceApi);
-    mockSidecarHandle.getConnectionsResourceApi.returns(stubbedConnectionsResourceApi);
-    sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+    stubbedSidecar.getConnectionsResourceApi.returns(stubbedConnectionsResourceApi);
 
     // don't return a Connection type since the IDs are randomly generated - handle in specific tests
     tryToCreateConnectionStub = sandbox

--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -53,6 +53,7 @@ import { FlinkStatement, Phase, restFlinkStatementToModel } from "../models/flin
 import { FlinkUdf } from "../models/flinkUDF";
 import { EnvironmentId } from "../models/resource";
 import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import { ResourceManager } from "../storage/resourceManager";
 import { CachingResourceLoader } from "./cachingResourceLoader";
 import {
@@ -445,11 +446,9 @@ describe("CCloudResourceLoader", () => {
 
     beforeEach(() => {
       // stub the sidecar getFlinkSqlStatementsApi API
-      const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-        sandbox.createStubInstance(sidecar.SidecarHandle);
+      const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
       flinkStatementsApiStub = sandbox.createStubInstance(StatementsSqlV1Api);
-      mockSidecarHandle.getFlinkSqlStatementsApi.returns(flinkStatementsApiStub);
-      sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
+      stubbedSidecar.getFlinkSqlStatementsApi.returns(flinkStatementsApiStub);
 
       sandbox.stub(loader, "getOrganization").resolves(TEST_CCLOUD_ORGANIZATION);
     });
@@ -593,12 +592,9 @@ describe("CCloudResourceLoader", () => {
 
     beforeEach(() => {
       // stub the sidecar getFlinkSqlStatementsApi API
-      const mockSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-        sandbox.createStubInstance(sidecar.SidecarHandle);
-      sandbox.stub(sidecar, "getSidecar").resolves(mockSidecarHandle);
-
+      const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
       flinkSqlStatementsApi = sandbox.createStubInstance(StatementsSqlV1Api);
-      mockSidecarHandle.getFlinkSqlStatementsApi.returns(flinkSqlStatementsApi);
+      stubbedSidecar.getFlinkSqlStatementsApi.returns(flinkSqlStatementsApi);
     });
 
     it("should return the statement if found", async () => {

--- a/src/loaders/loaderUtils.test.ts
+++ b/src/loaders/loaderUtils.test.ts
@@ -21,6 +21,7 @@ import { IFlinkStatementSubmitParameters } from "../flinkSql/statementUtils";
 import * as loaderUtils from "../loaders/loaderUtils";
 import { Schema, SchemaType, Subject } from "../models/schema";
 import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import * as privateNetworking from "../utils/privateNetworking";
 
 // as from fetchTopics() result.
@@ -75,16 +76,9 @@ describe("loaderUtils.ts", () => {
     let stubbedSubjectsV1Api: sinon.SinonStubbedInstance<SubjectsV1Api>;
 
     beforeEach(() => {
+      const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
       stubbedSubjectsV1Api = sandbox.createStubInstance(SubjectsV1Api);
-
-      const getSidecarStub: sinon.SinonStub = sandbox.stub(sidecar, "getSidecar");
-
-      const mockHandle = {
-        getSubjectsV1Api: () => {
-          return stubbedSubjectsV1Api;
-        },
-      };
-      getSidecarStub.resolves(mockHandle);
+      stubbedSidecar.getSubjectsV1Api.returns(stubbedSubjectsV1Api);
     });
 
     it("fetchSubjects() should return subjects sorted", async () => {

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import * as sinon from "sinon";
 import { getStubbedLocalResourceLoader } from "../../tests/stubs/resourceLoaders";
+import { getSidecarStub } from "../../tests/stubs/sidecar";
 import {
   TEST_CCLOUD_KAFKA_CLUSTER,
   TEST_CCLOUD_KAFKA_TOPIC,
@@ -27,7 +28,7 @@ import * as errors from "../errors";
 import { ConnectionId } from "../models/resource";
 import { Schema, Subject } from "../models/schema";
 import * as notifications from "../notifications";
-import * as sidecar from "../sidecar";
+import { SidecarHandle } from "../sidecar";
 import { getResourceManager, ResourceManager } from "../storage/resourceManager";
 import { clearWorkspaceState } from "../storage/utils";
 import { CCloudResourceLoader } from "./ccloudResourceLoader";
@@ -584,17 +585,10 @@ describe("ResourceLoader::deleteSchemaVersion()", () => {
     sandbox = sinon.createSandbox();
     loaderInstance = LocalResourceLoader.getInstance();
 
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     stubbedSubjectsV1Api = sandbox.createStubInstance(SubjectsV1Api);
+    stubbedSidecar.getSubjectsV1Api.returns(stubbedSubjectsV1Api);
 
-    const mockHandle = {
-      getSubjectsV1Api: () => {
-        return stubbedSubjectsV1Api;
-      },
-    };
-
-    const getSidecarStub: sinon.SinonStub = sandbox.stub(sidecar, "getSidecar");
-
-    getSidecarStub.resolves(mockHandle);
     clearCacheStub = sandbox.stub(loaderInstance, "clearCache");
   });
 
@@ -695,16 +689,9 @@ describe("ResourceLoader::deleteSchemaSubject()", () => {
     sandbox = sinon.createSandbox();
     loaderInstance = LocalResourceLoader.getInstance();
 
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     stubbedSubjectsV1Api = sandbox.createStubInstance(SubjectsV1Api);
-
-    const mockHandle = {
-      getSubjectsV1Api: () => {
-        return stubbedSubjectsV1Api;
-      },
-    };
-
-    const getSidecarStub: sinon.SinonStub = sandbox.stub(sidecar, "getSidecar");
-    getSidecarStub.resolves(mockHandle);
+    stubbedSidecar.getSubjectsV1Api.returns(stubbedSubjectsV1Api);
 
     sandbox
       .stub(loaderInstance, "getSchemaRegistryForEnvironmentId")

--- a/src/sidecar/connections/index.test.ts
+++ b/src/sidecar/connections/index.test.ts
@@ -1,6 +1,5 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import * as sidecar from "..";
 import {
   TEST_CCLOUD_CONNECTION,
   TEST_DIRECT_CONNECTION,
@@ -20,6 +19,8 @@ import {
   tryToGetConnection,
   tryToUpdateConnection,
 } from ".";
+import { SidecarHandle } from "..";
+import { getSidecarStub } from "../../../tests/stubs/sidecar";
 
 describe("sidecar/connections/index.ts", () => {
   let sandbox: sinon.SinonSandbox;
@@ -28,12 +29,9 @@ describe("sidecar/connections/index.ts", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     // create the stubs for the sidecar + service client
-    const stubSidecarHandle: sinon.SinonStubbedInstance<sidecar.SidecarHandle> =
-      sandbox.createStubInstance(sidecar.SidecarHandle);
+    const stubbedSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
     stubConnectionsResourceApi = sandbox.createStubInstance(ConnectionsResourceApi);
-    stubSidecarHandle.getConnectionsResourceApi.returns(stubConnectionsResourceApi);
-    // stub the getSidecar function to return the stub sidecar handle
-    sandbox.stub(sidecar, "getSidecar").resolves(stubSidecarHandle);
+    stubbedSidecar.getConnectionsResourceApi.returns(stubConnectionsResourceApi);
   });
 
   afterEach(() => {

--- a/tests/createResultsManager.ts
+++ b/tests/createResultsManager.ts
@@ -9,6 +9,7 @@ import {
 import { CCloudResourceLoader } from "../src/loaders/ccloudResourceLoader";
 import { FlinkStatement } from "../src/models/flinkStatement";
 import * as sidecar from "../src/sidecar";
+import { SidecarHandle } from "../src/sidecar";
 import { WebviewStorage } from "../src/webview/comms/comms";
 import {
   FlinkStatementResultsViewModel,
@@ -16,6 +17,7 @@ import {
 } from "../src/webview/flink-statement-results";
 import { eventually } from "./eventually";
 import { loadFixtureFromFile } from "./fixtures/utils";
+import { getSidecarStub } from "./stubs/sidecar";
 
 class FakeWebviewStorage<T> implements WebviewStorage<T> {
   private storage: T | undefined;
@@ -68,8 +70,7 @@ export async function createTestResultsManagerContext(
   vm: FlinkStatementResultsViewModel;
 }> {
   // Create sidecar and API mocks
-  const mockSidecar = sandbox.createStubInstance(sidecar.SidecarHandle);
-  sandbox.stub(sidecar, "getSidecar").resolves(mockSidecar);
+  const mockSidecar: sinon.SinonStubbedInstance<SidecarHandle> = getSidecarStub(sandbox);
 
   const flinkSqlStatementsApi = sandbox.createStubInstance(StatementsSqlV1Api);
   mockSidecar.getFlinkSqlStatementsApi.returns(flinkSqlStatementsApi);


### PR DESCRIPTION
Replaces (hopefully all) old methods of stubbing the `SidecarHandle`.
Closes #2233