### PR TITLE
Try to harden / gather more information in strange Resources View case: err on not showing strange state direct connections instead of going completely blank

### DIFF
--- a/src/viewProviders/newResources.test.ts
+++ b/src/viewProviders/newResources.test.ts
@@ -781,8 +781,8 @@ describe("viewProviders/newResources.ts", () => {
           sandbox.assert.calledOnce(repaintStub);
           sandbox.assert.calledOnceWithExactly(storeConnectionSpy, localConnectionRow);
 
-          // ensure that store is called before refresh and repaint, since is an immediately
-          // usable ConnectionRow (LocalConnectionRow)
+          // ensure that store is called before refresh and repaint, since a LocalConnectionRow is
+          // immediately usable.
           sinon.assert.callOrder(storeConnectionSpy, localRowRefreshStub, repaintStub);
         });
 
@@ -791,8 +791,8 @@ describe("viewProviders/newResources.ts", () => {
           await provider.loadAndStoreConnection(ccloudConnectionRow);
           sandbox.assert.calledOnce(repaintStub);
           sandbox.assert.calledOnceWithExactly(storeConnectionSpy, ccloudConnectionRow);
-          // ensure that store is called before refresh and repaint, since is an immediately
-          // usable ConnectionRow (CCloudConnectionRow)
+          // ensure that store is called before refresh and repaint, since a CCloudConnectionRow is
+          // immediately usable.
           sinon.assert.callOrder(storeConnectionSpy, ccloudRowRefreshStub, repaintStub);
         });
 
@@ -801,8 +801,8 @@ describe("viewProviders/newResources.ts", () => {
           await provider.loadAndStoreConnection(directConnectionRow);
           sandbox.assert.calledOnce(repaintStub);
           sandbox.assert.calledOnceWithExactly(storeConnectionSpy, directConnectionRow);
-          // ensure that store is called AFTER refresh and repaint, since is an immediately
-          // usable ConnectionRow (DirectConnectionRow)
+          // ensure that store is called AFTER refresh and repaint, since a DirectConnectionRow is
+          // NOW immediately usable (not until after the initial refresh).
           sinon.assert.callOrder(directRowRefreshStub, storeConnectionSpy, repaintStub);
         });
       });

--- a/src/viewProviders/newResources.ts
+++ b/src/viewProviders/newResources.ts
@@ -85,9 +85,9 @@ export abstract class ConnectionRow<ET extends ConcreteEnvironment, LT extends R
   readonly environments: ET[];
 
   /**
-   * Is this row useable yet (and properties like `name` and so forth can be referenced?
+   * Is this row usable yet (and properties like `name` and so forth can be referenced?
    *
-   * CCloud and Local connectino rows will always be, but DirectConnectionRows won't be until they complete
+   * CCloud and Local connection rows will always be, but DirectConnectionRows won't be until they complete
    * their first loading
    **/
   abstract usable: boolean;
@@ -400,7 +400,7 @@ export class LocalConnectionRow extends SingleEnvironmentConnectionRow<
   LocalSchemaRegistry,
   LocalResourceLoader
 > {
-  // Local connection row is always immediately useable.
+  // Local connection row is always immediately usable.
   usable = true;
 
   constructor() {
@@ -723,7 +723,7 @@ export class NewResourceViewProvider
     connectionRow: AnyConnectionRow,
   ): Promise<void> {
     // We can eagerly insert the row *before* the initial refresh if it is
-    // already useable (i.e. CCloud or Local connection rows).
+    // already usable (i.e. CCloud or Local connection rows).
     // If it is a DirectConnectionRow, we must wait until after the initial refresh
     // completes, because only then will we know the name, icon, and so forth.
     // (And if we try to make a TreeItem before that, an error will be raised.)
@@ -780,14 +780,14 @@ export class NewResourceViewProvider
     const usableConnections = allConnections.filter((row) => row.usable);
 
     // Triple guard against making TreeItems for connections that aren't
-    // yet useable (i.e. DirectConnectionRows that haven't yet completed
+    // yet usable (i.e. DirectConnectionRows that haven't yet completed
     // their initial refresh, whose name, iconPath, and tooltip cannot
     // be referenced yet).
     if (usableConnections.length !== allConnections.length) {
       const unusableConnectionIds = allConnections
         .filter((row) => !row.usable)
         .map((row) => row.connectionId);
-      this.logger.debug("Some connection rows not yet useable, omitting from toplevel children", {
+      this.logger.debug("Some connection rows not yet usable, omitting from toplevel children", {
         unusableConnectionIds,
       });
     }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Try to prevent (or at least log more information) if / when new resources view provider tries to make a treeitem out of a not-yet-initially-loaded DirectEnvironmentRow (fails due to properties like name, etc. not being available yet until the GQL completes), ending up with a completely empty Resources view:

  - New boolean `usable` property on `ConnectionRow` instances, statically true for ccloud and local connection row instances, variable based on underlying environment presence for DirectConnectionRow instances.
  - Use that property to determine 'insert into main map before or after the load completes' behavior in `loadAndStoreConnection`, removing needing to pass in an extra boolean parameter to control that behavior. There should be no overall net change in behavior from these two changes, AFAICS. Just a little cleaner. In doing this, I could not find a codepath where it was obvious how a 'not loaded yet' DirectConnectionRow ends up in the view provider's main map, in that the insert happens only after successful rowwise `refresh()`.
  - When collecting toplevel children in `getToplevelChildren`, explicitly filter out any `ConnectionRow` instance added to the main map but somehow still smelling `usable = false`. Log if there are any such rows being filtered out, because the order of events producing this rare outcome is unknown.  This will at least leave us a better logging trail instead of a completely empty Resources view (due to ultimately converting those `DirectConnectionRow`s into treeitems will raise Error when trying to reference as-yet-unknown properties like the connection's 'name', etc.). 


### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Gathers more information and perhaps prevents the worst of side effects of bug #2682, but I do not believe will prevent it. Is quite rare / hard to reproduce in any event.
- Re-nests the three blocks of tests over the individual ConnectionRow classes into a parent 'ConnectionRow' block, so the line diff is bloated. Sorry.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
