### PR TITLE
add more logging when CCloud auth fails

### DIFF
--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -22,7 +22,7 @@ import { SecretStorageKeys } from "../storage/constants";
 import { getResourceManager, ResourceManager } from "../storage/resourceManager";
 import { clearWorkspaceState } from "../storage/utils";
 import { getUriHandler, UriEventHandler } from "../uriHandler";
-import { ConfluentCloudAuthProvider, getAuthProvider } from "./ccloudProvider";
+import { ConfluentCloudAuthProvider } from "./ccloudProvider";
 import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
 import { AuthCallbackEvent } from "./types";
 
@@ -65,7 +65,7 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
       .stub(watcher, "waitForConnectionToBeStable")
       .resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
 
-    authProvider = getAuthProvider();
+    authProvider = ConfluentCloudAuthProvider.getInstance();
     // don't handle the progress notification, openExternal, etc in this test suite
     browserAuthFlowStub = sandbox.stub(authProvider, "browserAuthFlow").resolves();
     stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);
@@ -379,7 +379,7 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider URI handling", () =
 
     deleteConnectionStub = sandbox.stub(ccloud, "deleteCCloudConnection").resolves();
 
-    authProvider = getAuthProvider();
+    authProvider = ConfluentCloudAuthProvider.getInstance();
     createSessionStub = sandbox.stub(authProvider, "createSession").resolves();
     // don't handle the progress notification, openExternal, etc in this test suite
     stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -2,371 +2,36 @@ import { chromium } from "@playwright/test";
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
-import { getStubbedSecretStorage, StubbedSecretStorage } from "../../tests/stubs/extensionStorage";
+import {
+  getStubbedResourceManager,
+  getStubbedSecretStorage,
+  StubbedSecretStorage,
+} from "../../tests/stubs/extensionStorage";
 import { TEST_CCLOUD_AUTH_SESSION } from "../../tests/unit/testResources/ccloudAuth";
 import {
   TEST_AUTHENTICATED_CCLOUD_CONNECTION,
   TEST_CCLOUD_CONNECTION,
 } from "../../tests/unit/testResources/connection";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
-import { ConnectedState, Connection } from "../clients/sidecar";
+import { ConnectedState, Connection, ConnectionFromJSON } from "../clients/sidecar";
 import { CCLOUD_AUTH_CALLBACK_URI, CCLOUD_BASE_PATH, CCLOUD_CONNECTION_ID } from "../constants";
-import { ccloudAuthSessionInvalidated } from "../emitters";
+import { ccloudAuthCallback, ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
 import * as errors from "../errors";
+import * as notifications from "../notifications";
 import { getSidecar } from "../sidecar";
 import * as ccloud from "../sidecar/connections/ccloud";
 import * as watcher from "../sidecar/connections/watcher";
 import * as sidecarLogging from "../sidecar/logging";
-import { SidecarOutputs } from "../sidecar/types";
 import { SecretStorageKeys } from "../storage/constants";
-import { getResourceManager, ResourceManager } from "../storage/resourceManager";
+import { ResourceManager } from "../storage/resourceManager";
 import { clearWorkspaceState } from "../storage/utils";
-import { getUriHandler, UriEventHandler } from "../uriHandler";
-import { ConfluentCloudAuthProvider } from "./ccloudProvider";
+import { ConfluentCloudAuthProvider, convertToAuthSession } from "./ccloudProvider";
 import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
+import { CCloudSignInError } from "./errors";
 import { AuthCallbackEvent } from "./types";
 
-describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider methods", () => {
-  let authProvider: ConfluentCloudAuthProvider;
-  let uriHandler: UriEventHandler;
-
+describe("authn/ccloudProvider.ts", () => {
   let sandbox: sinon.SinonSandbox;
-  // vscode stubs
-  let showErrorMessageStub: sinon.SinonStub;
-  let showInfoMessageStub: sinon.SinonStub;
-  // helper function stubs
-  let getCCloudConnectionStub: sinon.SinonStub;
-  let createCCloudConnectionStub: sinon.SinonStub;
-  let deleteConnectionStub: sinon.SinonStub;
-  let logErrorStub: sinon.SinonStub;
-  let gatherSidecarOutputsStub: sinon.SinonStub;
-  // auth provider stubs
-  let browserAuthFlowStub: sinon.SinonStub;
-  let stubOnDidChangeSessions: sinon.SinonStubbedInstance<
-    vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>
-  >;
-
-  before(async () => {
-    await getTestExtensionContext();
-
-    uriHandler = getUriHandler();
-  });
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-
-    getCCloudConnectionStub = sandbox.stub(ccloud, "getCCloudConnection").resolves(null);
-    // stub the connection creation and deletion methods
-    createCCloudConnectionStub = sandbox.stub(ccloud, "createCCloudConnection").resolves();
-    deleteConnectionStub = sandbox.stub(ccloud, "deleteCCloudConnection").resolves();
-
-    // assume the connection is immediately usable for most tests
-    sandbox
-      .stub(watcher, "waitForConnectionToBeStable")
-      .resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-
-    authProvider = ConfluentCloudAuthProvider.getInstance();
-    // don't handle the progress notification, openExternal, etc in this test suite
-    browserAuthFlowStub = sandbox.stub(authProvider, "browserAuthFlow").resolves();
-    stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);
-    authProvider["_onDidChangeSessions"] = stubOnDidChangeSessions;
-
-    showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage").resolves();
-    showInfoMessageStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
-
-    logErrorStub = sandbox.stub(errors, "logError").resolves();
-    gatherSidecarOutputsStub = sandbox.stub(sidecarLogging, "gatherSidecarOutputs").resolves({
-      logLines: [],
-      parsedLogLines: [],
-      stderrLines: [],
-    } satisfies SidecarOutputs);
-  });
-
-  afterEach(() => {
-    authProvider.dispose();
-    // reset the singleton instance between tests
-    ConfluentCloudAuthProvider["instance"] = null;
-    sandbox.restore();
-  });
-
-  it("createSession() should create a new CCloud connection when one doesn't exist", async () => {
-    // first call doesn't return a Connection, second call returns the connection from createCCloudConnection()
-    getCCloudConnectionStub.onFirstCall().resolves(null);
-    createCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    getCCloudConnectionStub.onSecondCall().resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // authentication completes successfully
-    browserAuthFlowStub.resolves({ success: true, resetPassword: false });
-
-    await authProvider.createSession();
-
-    sinon.assert.calledOnce(createCCloudConnectionStub);
-    sinon.assert.calledOnce(browserAuthFlowStub);
-  });
-
-  it("createSession() should reuse an existing CCloud connection", async () => {
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // authentication completes successfully
-    browserAuthFlowStub.resolves({ success: true, resetPassword: false });
-
-    await authProvider.createSession();
-
-    sinon.assert.notCalled(createCCloudConnectionStub);
-    sinon.assert.calledOnce(browserAuthFlowStub);
-  });
-
-  it("createSession() should update the connected state secret on successful authentication", async () => {
-    const setCCloudAuthStatusStub = sandbox
-      .stub(ResourceManager.getInstance(), "setCCloudState")
-      .resolves();
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // authentication completes successfully
-    browserAuthFlowStub.resolves({ success: true, resetPassword: false });
-
-    await authProvider.createSession();
-
-    sinon.assert.calledWith(
-      setCCloudAuthStatusStub,
-      TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud!.state,
-    );
-  });
-
-  it("createSession() should handle authentication failure and send sidecar logs to Sentry", async () => {
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // authentication fails
-    browserAuthFlowStub.resolves({ success: false, resetPassword: false });
-    // stub the sidecar logs so we don't pull in the real logs and blow up test output
-    const fakeSidecarLogs = {
-      logLines: ["oh no", "something went wrong"],
-      parsedLogLines: [],
-      stderrLines: [],
-    } satisfies SidecarOutputs;
-    gatherSidecarOutputsStub.resolves(fakeSidecarLogs);
-
-    const authFailedMsg = "Confluent Cloud authentication failed. See browser for details.";
-    await assert.rejects(authProvider.createSession(), {
-      message: authFailedMsg,
-    });
-
-    sinon.assert.calledWith(showErrorMessageStub, authFailedMsg);
-    sinon.assert.calledOnce(gatherSidecarOutputsStub);
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      sinon.match.instanceOf(Error),
-      "CCloud authentication failed",
-      { extra: { sidecarLogs: fakeSidecarLogs.logLines.join("\n") } },
-    );
-  });
-
-  it("createSession() should handle authentication failure when gathering sidecar logs fails", async () => {
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // authentication fails
-    browserAuthFlowStub.resolves({ success: false, resetPassword: false });
-    // stub sidecar log gathering failure
-    const sidecarLogError = new Error("Failed to read log file");
-    gatherSidecarOutputsStub.rejects(sidecarLogError);
-
-    const authFailedMsg = "Confluent Cloud authentication failed. See browser for details.";
-    await assert.rejects(authProvider.createSession(), {
-      message: authFailedMsg,
-    });
-
-    sinon.assert.calledWith(showErrorMessageStub, authFailedMsg);
-    sinon.assert.calledOnce(gatherSidecarOutputsStub);
-    sinon.assert.calledWithExactly(
-      logErrorStub,
-      sinon.match.instanceOf(Error),
-      "CCloud authentication failed",
-      { extra: { sidecarLogs: `Failed to gather sidecar logs:\n${sidecarLogError.stack}` } },
-    );
-  });
-
-  it("createSession() should handle password reset scenario", async () => {
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // password reset occurred
-    browserAuthFlowStub.resolves({ success: false, resetPassword: true });
-
-    await assert.rejects(authProvider.createSession(), {
-      message: "User reset their password.",
-    });
-
-    sinon.assert.calledWith(
-      showInfoMessageStub,
-      "Your password has been reset. Please sign in again to Confluent Cloud.",
-      sinon.match(CCLOUD_SIGN_IN_BUTTON_LABEL),
-    );
-    sinon.assert.notCalled(gatherSidecarOutputsStub);
-    sinon.assert.notCalled(logErrorStub);
-  });
-
-  it("createSession() should handle user cancellation", async () => {
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    // user cancels the operation
-    browserAuthFlowStub.resolves(undefined);
-
-    await assert.rejects(authProvider.createSession(), {
-      message: "User cancelled the authentication flow.",
-    });
-
-    sinon.assert.notCalled(deleteConnectionStub);
-    sinon.assert.notCalled(showInfoMessageStub);
-    sinon.assert.notCalled(showErrorMessageStub);
-    sinon.assert.notCalled(gatherSidecarOutputsStub);
-    sinon.assert.notCalled(logErrorStub);
-  });
-
-  it(`getSessions() should treat connections with a ${ConnectedState.None}/${ConnectedState.Failed} state as nonexistent`, async () => {
-    getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
-
-    const sessions = await authProvider.getSessions();
-
-    assert.deepStrictEqual(sessions, []);
-  });
-
-  it("getSessions() should return an empty array when no connection exists", async () => {
-    getCCloudConnectionStub.resolves(null);
-
-    const sessions = await authProvider.getSessions();
-
-    assert.deepStrictEqual(sessions, []);
-  });
-
-  it("getSessions() should return an AuthenticationSession when a valid connection exists", async () => {
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-
-    const sessions = await authProvider.getSessions();
-
-    assert.strictEqual(sessions.length, 1);
-    assert.deepStrictEqual(sessions[0], TEST_CCLOUD_AUTH_SESSION);
-  });
-
-  it("removeSession() should delete an existing connection and the connected state secret", async () => {
-    const handleSessionRemovedStub = sandbox.stub().resolves();
-    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
-    getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
-    const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
-
-    await authProvider.removeSession("sessionId");
-
-    assert.ok(deleteConnectionStub.called);
-    assert.ok(stubbedSecretStorage.delete.calledWith(SecretStorageKeys.CCLOUD_STATE));
-    assert.ok(handleSessionRemovedStub.calledWith(true));
-  });
-
-  it("removeSession() should only update the provider's internal state when no connection exists", async () => {
-    const handleSessionRemovedStub = sandbox.stub().resolves();
-    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
-    getCCloudConnectionStub.resolves(null);
-
-    authProvider["_session"] = null;
-    await authProvider.removeSession("sessionId");
-
-    assert.ok(deleteConnectionStub.notCalled);
-    assert.ok(handleSessionRemovedStub.notCalled);
-  });
-
-  it("removeSession() should only update the provider's internal state when no connection exists but the provider is still tracking a session internally", async () => {
-    const handleSessionRemovedStub = sandbox.stub().resolves();
-    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
-    getCCloudConnectionStub.resolves(null);
-
-    authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
-    await authProvider.removeSession("sessionId");
-
-    assert.ok(deleteConnectionStub.notCalled);
-    assert.ok(handleSessionRemovedStub.calledWith(true));
-  });
-
-  it("handleSessionCreated() should update the provider's internal state, fire the _onDidChangeSessions event.", async () => {
-    const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
-
-    await authProvider["handleSessionCreated"](TEST_CCLOUD_AUTH_SESSION, true);
-
-    assert.strictEqual(authProvider["_session"], TEST_CCLOUD_AUTH_SESSION);
-    sinon.assert.calledWith(
-      stubbedSecretStorage.store,
-      SecretStorageKeys.AUTH_SESSION_EXISTS,
-      "true",
-    );
-    sinon.assert.called(stubOnDidChangeSessions.fire);
-    sinon.assert.calledWith(stubOnDidChangeSessions.fire, {
-      added: [TEST_CCLOUD_AUTH_SESSION],
-      removed: [],
-      changed: [],
-    });
-  });
-
-  it("handleSessionRemoved() should update the provider's internal state, fire the _onDidChangeSessions event.", async () => {
-    const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
-
-    authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
-    await authProvider["handleSessionRemoved"](true);
-
-    assert.strictEqual(authProvider["_session"], null);
-    sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.AUTH_SESSION_EXISTS);
-    sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.AUTH_COMPLETED);
-    sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.AUTH_PASSWORD_RESET);
-    sinon.assert.called(stubOnDidChangeSessions.fire);
-    sinon.assert.calledWith(stubOnDidChangeSessions.fire, {
-      added: [],
-      removed: [TEST_CCLOUD_AUTH_SESSION],
-      changed: [],
-    });
-  });
-
-  it("handleSessionSecretChange() should call handleSessionCreated() when a session is available", async () => {
-    const handleSessionCreatedStub = sandbox.stub().resolves();
-    authProvider["handleSessionCreated"] = handleSessionCreatedStub;
-    const handleSessionRemovedStub = sandbox.stub().resolves();
-    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
-    sandbox.stub(vscode.authentication, "getSession").resolves(TEST_CCLOUD_AUTH_SESSION);
-
-    await authProvider["handleSessionSecretChange"]();
-
-    assert.ok(handleSessionCreatedStub.calledOnceWith(TEST_CCLOUD_AUTH_SESSION));
-    assert.ok(handleSessionRemovedStub.notCalled);
-  });
-
-  it("handleSessionSecretChange() should call handleSessionRemoved() when no session is available", async () => {
-    const handleSessionCreatedStub = sandbox.stub().resolves();
-    authProvider["handleSessionCreated"] = handleSessionCreatedStub;
-    const handleSessionRemovedStub = sandbox.stub().resolves();
-    authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
-
-    sandbox.stub(vscode.authentication, "getSession").resolves(undefined);
-
-    authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
-    await authProvider["handleSessionSecretChange"]();
-
-    assert.ok(handleSessionCreatedStub.notCalled);
-    assert.ok(handleSessionRemovedStub.called);
-  });
-
-  for (const success of [true, false] as const) {
-    it(`should return '${success}' from waitForUriHandling when the URI query contains 'success=${success}'`, async () => {
-      const promise: Promise<AuthCallbackEvent> = authProvider.waitForUriHandling();
-
-      const uri = vscode.Uri.parse(CCLOUD_AUTH_CALLBACK_URI).with({ query: `success=${success}` });
-      uriHandler.handleUri(uri);
-
-      const result: AuthCallbackEvent = await promise;
-      assert.strictEqual(result.success, success);
-    });
-  }
-});
-
-describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider URI handling", () => {
-  let authProvider: ConfluentCloudAuthProvider;
-
-  let sandbox: sinon.SinonSandbox;
-  // vscode stubs
-  let showInfoMessageStub: sinon.SinonStub;
-  // helper function stubs
-  let deleteConnectionStub: sinon.SinonStub;
-  // auth provider stubs
-  let createSessionStub: sinon.SinonStub;
-  let stubOnDidChangeSessions: sinon.SinonStubbedInstance<
-    vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>
-  >;
 
   before(async () => {
     await getTestExtensionContext();
@@ -374,103 +39,577 @@ describe("authn/ccloudProvider.ts ConfluentCloudAuthProvider URI handling", () =
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-
-    showInfoMessageStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
-
-    deleteConnectionStub = sandbox.stub(ccloud, "deleteCCloudConnection").resolves();
-
-    authProvider = ConfluentCloudAuthProvider.getInstance();
-    createSessionStub = sandbox.stub(authProvider, "createSession").resolves();
-    // don't handle the progress notification, openExternal, etc in this test suite
-    stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);
-    authProvider["_onDidChangeSessions"] = stubOnDidChangeSessions;
-
-    // assume the connection is immediately usable for most tests
-    sandbox
-      .stub(watcher, "waitForConnectionToBeStable")
-      .resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
   });
 
   afterEach(() => {
-    authProvider.dispose();
-    // reset the singleton instance between tests
-    ConfluentCloudAuthProvider["instance"] = null;
     sandbox.restore();
   });
 
-  it("showResetPasswordNotification() should display a message with sign-in button", async () => {
-    // user dismissed the notification
-    showInfoMessageStub.resolves(undefined);
+  describe("ConfluentCloudAuthProvider", () => {
+    let authProvider: ConfluentCloudAuthProvider;
+    let stubbedResourceManager: sinon.SinonStubbedInstance<ResourceManager>;
 
-    authProvider.showResetPasswordNotification();
+    // used by createSession, getSessions, and deleteSession tests
+    let getCCloudConnectionStub: sinon.SinonStub;
 
-    sinon.assert.calledWith(
-      showInfoMessageStub,
-      "Your password has been reset. Please sign in again to Confluent Cloud.",
-      CCLOUD_SIGN_IN_BUTTON_LABEL,
-    );
-    sinon.assert.notCalled(createSessionStub);
-  });
+    let clearCurrentCCloudResourcesStub: sinon.SinonStub;
+    let ccloudConnectedFireStub: sinon.SinonStub;
 
-  it("showResetPasswordNotification() should call createSession when the sign-in button is clicked", async () => {
-    const clock = sandbox.useFakeTimers(Date.now());
-    // user clicked the sign-in button
-    showInfoMessageStub.resolves(CCLOUD_SIGN_IN_BUTTON_LABEL);
+    beforeEach(() => {
+      stubbedResourceManager = getStubbedResourceManager(sandbox);
+      // tests need to define whether or not a connection exists
+      getCCloudConnectionStub = sandbox.stub(ccloud, "getCCloudConnection").resolves(null);
 
-    authProvider.showResetPasswordNotification();
-    // simulate the passage of time to allow the notification to be shown + button clicked
-    await clock.tickAsync(100);
-
-    sinon.assert.calledWith(
-      showInfoMessageStub,
-      "Your password has been reset. Please sign in again to Confluent Cloud.",
-      CCLOUD_SIGN_IN_BUTTON_LABEL,
-    );
-    sinon.assert.calledOnce(createSessionStub);
-  });
-
-  for (const success of [true, false] as const) {
-    it(`handleUri() should not invalidate the current CCloud auth session for non-reset-password URI callbacks (success=${success})`, async () => {
-      const setAuthFlowCompletedStub = sandbox
-        .stub(getResourceManager(), "setAuthFlowCompleted")
+      clearCurrentCCloudResourcesStub = sandbox
+        .stub(ccloud, "clearCurrentCCloudResources")
         .resolves();
-      const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
-      const showResetPasswordNotificationStub = sandbox.stub(
-        authProvider,
-        "showResetPasswordNotification",
+
+      authProvider = ConfluentCloudAuthProvider.getInstance();
+
+      // ensure any firing of this event doesn't affect other parts of the codebase unrelated to the
+      // auth provider tests
+      ccloudConnectedFireStub = sandbox.stub(ccloudConnected, "fire").resolves();
+    });
+
+    afterEach(() => {
+      authProvider.dispose();
+      // reset the singleton instance between tests
+      ConfluentCloudAuthProvider["instance"] = null;
+    });
+
+    describe("createSession()", () => {
+      let createCCloudConnectionStub: sinon.SinonStub;
+      let browserAuthFlowStub: sinon.SinonStub;
+      let signInErrorStub: sinon.SinonStub;
+      let deleteCCloudConnectionStub: sinon.SinonStub;
+      let waitForConnectionToBeStableStub: sinon.SinonStub;
+      let showErrorMessageStub: sinon.SinonStub;
+      let showInfoNotificationWithButtonsStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        createCCloudConnectionStub = sandbox.stub(ccloud, "createCCloudConnection").resolves();
+
+        // don't handle the progress notification, openExternal, etc in this test suite
+        browserAuthFlowStub = sandbox.stub(authProvider, "browserAuthFlow").resolves();
+        signInErrorStub = sandbox.stub(authProvider, "signInError").resolves();
+        deleteCCloudConnectionStub = sandbox.stub(ccloud, "deleteCCloudConnection").resolves();
+
+        // assume the connection is immediately usable for most tests
+        waitForConnectionToBeStableStub = sandbox
+          .stub(watcher, "waitForConnectionToBeStable")
+          .resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+
+        showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage").resolves();
+        showInfoNotificationWithButtonsStub = sandbox
+          .stub(notifications, "showInfoNotificationWithButtons")
+          .resolves();
+      });
+
+      it("should create a new CCloud connection when one doesn't exist", async () => {
+        // first call doesn't return a Connection, second call returns the connection from createCCloudConnection()
+        getCCloudConnectionStub.onFirstCall().resolves(null);
+        createCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        getCCloudConnectionStub.onSecondCall().resolves(TEST_CCLOUD_CONNECTION);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+
+        await authProvider.createSession();
+
+        sinon.assert.calledOnce(createCCloudConnectionStub);
+        sinon.assert.calledOnce(browserAuthFlowStub);
+      });
+
+      it("should reuse an existing CCloud connection", async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+
+        await authProvider.createSession();
+
+        sinon.assert.notCalled(createCCloudConnectionStub);
+        sinon.assert.calledOnce(browserAuthFlowStub);
+      });
+
+      it("should update the connected state secret on successful authentication", async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+
+        await authProvider.createSession();
+
+        sinon.assert.calledWith(
+          stubbedResourceManager.setCCloudState,
+          TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud!.state,
+        );
+      });
+
+      it("should throw a CCloudSignInError if no sign-in URI is available", async () => {
+        getCCloudConnectionStub.resolves({
+          ...TEST_CCLOUD_CONNECTION,
+          metadata: { ...TEST_CCLOUD_CONNECTION.metadata, sign_in_uri: undefined },
+        });
+        const noSignInUriError = new CCloudSignInError(
+          "Failed to create new connection. Please try again.",
+        );
+        signInErrorStub.resolves(noSignInUriError);
+
+        await assert.rejects(authProvider.createSession(), noSignInUriError);
+
+        sinon.assert.notCalled(createCCloudConnectionStub);
+        sinon.assert.calledOnceWithExactly(signInErrorStub, noSignInUriError.message);
+        sinon.assert.notCalled(browserAuthFlowStub);
+      });
+
+      it("should handle user cancellation", async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        // user cancels the operation
+        browserAuthFlowStub.resolves(undefined);
+        // not returned from signInError() for this scenario
+        const cancellationError = new CCloudSignInError("User cancelled the authentication flow.");
+
+        await assert.rejects(authProvider.createSession(), cancellationError);
+
+        sinon.assert.notCalled(deleteCCloudConnectionStub);
+        sinon.assert.notCalled(showInfoNotificationWithButtonsStub);
+        sinon.assert.notCalled(showErrorMessageStub);
+      });
+
+      it("should handle password resets", async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        // password reset occurred
+        browserAuthFlowStub.resolves({ success: false, resetPassword: true });
+        // not returned from signInError() for this scenario
+        const passwordResetError = new CCloudSignInError("User reset their password.");
+
+        await assert.rejects(authProvider.createSession(), passwordResetError);
+
+        sinon.assert.calledWith(
+          showInfoNotificationWithButtonsStub,
+          "Your password has been reset. Please sign in again to Confluent Cloud.",
+          { [CCLOUD_SIGN_IN_BUTTON_LABEL]: sinon.match.func },
+        );
+      });
+
+      it("should handle authentication failure (success=false)", async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        // authentication fails
+        browserAuthFlowStub.resolves({ success: false, resetPassword: false });
+        const authFailedMsg = "Confluent Cloud authentication failed. See browser for details.";
+        // this does not throw, only returns the error to be thrown by createSession()
+        const signInError = new CCloudSignInError(authFailedMsg);
+        signInErrorStub.resolves(signInError);
+
+        await assert.rejects(authProvider.createSession(), signInError);
+
+        sinon.assert.calledWith(showErrorMessageStub, authFailedMsg);
+        sinon.assert.calledOnceWithExactly(signInErrorStub, authFailedMsg);
+      });
+
+      it("should throw a CCloudSignInError if no connection is returned from waitForConnectionToBeStable()", async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        waitForConnectionToBeStableStub.resolves(null);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+        const noConnectionError = new CCloudSignInError(
+          "CCloud connection failed to become usable after authentication.",
+        );
+        signInErrorStub.resolves(noConnectionError);
+
+        await assert.rejects(authProvider.createSession(), noConnectionError);
+
+        sinon.assert.notCalled(createCCloudConnectionStub);
+        sinon.assert.calledOnceWithExactly(signInErrorStub, noConnectionError.message);
+        sinon.assert.calledOnce(browserAuthFlowStub);
+      });
+
+      it("should throw a CCloudSignInError if no status.ccloud is available after authentication", async () => {
+        const missingStatusConnection = ConnectionFromJSON({
+          ...TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+          status: {
+            ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status,
+            ccloud: undefined,
+          },
+        } satisfies Connection);
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+        waitForConnectionToBeStableStub.resolves(missingStatusConnection);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+        const noStatusError = new CCloudSignInError(
+          "Authenticated connection has no status information.",
+        );
+        signInErrorStub.resolves(noStatusError);
+
+        await assert.rejects(authProvider.createSession(), noStatusError);
+
+        sinon.assert.notCalled(createCCloudConnectionStub);
+        sinon.assert.calledOnceWithExactly(signInErrorStub, noStatusError.message);
+        sinon.assert.calledOnce(browserAuthFlowStub);
+      });
+
+      it("should throw a CCloudSignInError when no UserInfo is available after authentication", async () => {
+        const missingUserInfoConnection = ConnectionFromJSON({
+          ...TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+          status: {
+            ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status,
+            ccloud: {
+              ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud!,
+              user: undefined,
+            },
+          },
+        } satisfies Connection);
+        getCCloudConnectionStub.resolves(missingUserInfoConnection);
+        waitForConnectionToBeStableStub.resolves(missingUserInfoConnection);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+        const noUserInfoError = new CCloudSignInError(
+          "Authenticated connection has no CCloud user.",
+        );
+        signInErrorStub.resolves(noUserInfoError);
+
+        await assert.rejects(authProvider.createSession(), noUserInfoError);
+
+        sinon.assert.notCalled(createCCloudConnectionStub);
+        sinon.assert.calledOnceWithExactly(signInErrorStub, noUserInfoError.message);
+        sinon.assert.calledOnce(browserAuthFlowStub);
+      });
+
+      it("should show an info notification and fire ccloudConnected after successful sign-in", async () => {
+        // plain info notification, not showInfoNotificationWithButtons
+        const showInfoMessageStub = sandbox.stub(vscode.window, "showInformationMessage");
+        getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+        // authentication completes successfully
+        browserAuthFlowStub.resolves({ success: true, resetPassword: false });
+
+        await authProvider.createSession();
+
+        sinon.assert.calledWith(
+          showInfoMessageStub,
+          `Successfully signed in to Confluent Cloud as ${TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud?.user?.username}`,
+        );
+        sinon.assert.calledOnce(ccloudConnectedFireStub);
+      });
+    });
+
+    describe("getSessions()", () => {
+      it(`should treat connections with a ${ConnectedState.None}/${ConnectedState.Failed} state as nonexistent`, async () => {
+        getCCloudConnectionStub.resolves(TEST_CCLOUD_CONNECTION);
+
+        const sessions = await authProvider.getSessions();
+
+        assert.deepStrictEqual(sessions, []);
+      });
+
+      it("should return an empty array when no connection exists", async () => {
+        getCCloudConnectionStub.resolves(null);
+
+        const sessions = await authProvider.getSessions();
+
+        assert.deepStrictEqual(sessions, []);
+      });
+
+      it("should return an AuthenticationSession when a valid connection exists", async () => {
+        getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+
+        const sessions = await authProvider.getSessions();
+
+        assert.strictEqual(sessions.length, 1);
+        assert.deepStrictEqual(sessions[0], TEST_CCLOUD_AUTH_SESSION);
+      });
+    });
+
+    describe("removeSession()", () => {
+      let deleteCCloudConnectionStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        deleteCCloudConnectionStub = sandbox.stub(ccloud, "deleteCCloudConnection").resolves();
+      });
+
+      it("should delete an existing connection and the connected state secret", async () => {
+        const handleSessionRemovedStub = sandbox.stub().resolves();
+        authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+        getCCloudConnectionStub.resolves(TEST_AUTHENTICATED_CCLOUD_CONNECTION);
+        const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
+
+        await authProvider.removeSession("sessionId");
+
+        sinon.assert.calledOnce(deleteCCloudConnectionStub);
+        sinon.assert.calledOnceWithExactly(
+          stubbedSecretStorage.delete,
+          SecretStorageKeys.CCLOUD_STATE,
+        );
+        sinon.assert.calledOnceWithExactly(handleSessionRemovedStub, true);
+      });
+
+      it("should only update the provider's internal state when no connection exists", async () => {
+        const handleSessionRemovedStub = sandbox.stub().resolves();
+        authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+        getCCloudConnectionStub.resolves(null);
+
+        authProvider["_session"] = null;
+        await authProvider.removeSession("sessionId");
+
+        sinon.assert.notCalled(deleteCCloudConnectionStub);
+        sinon.assert.notCalled(handleSessionRemovedStub);
+      });
+
+      it("should only update the provider's internal state when no connection exists but the provider is still tracking a session internally", async () => {
+        const handleSessionRemovedStub = sandbox.stub().resolves();
+        authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+        getCCloudConnectionStub.resolves(null);
+
+        authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
+        await authProvider.removeSession("sessionId");
+
+        sinon.assert.notCalled(deleteCCloudConnectionStub);
+        sinon.assert.calledOnceWithExactly(handleSessionRemovedStub, true);
+      });
+    });
+
+    describe("handleSessionCreated()", () => {
+      let stubOnDidChangeSessions: sinon.SinonStubbedInstance<
+        vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>
+      >;
+
+      beforeEach(() => {
+        stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);
+        authProvider["_onDidChangeSessions"] = stubOnDidChangeSessions;
+      });
+
+      it("should update the provider's internal state, fire the _onDidChangeSessions event.", async () => {
+        const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
+
+        await authProvider["handleSessionCreated"](TEST_CCLOUD_AUTH_SESSION, true);
+
+        assert.strictEqual(authProvider["_session"], TEST_CCLOUD_AUTH_SESSION);
+        sinon.assert.calledWith(
+          stubbedSecretStorage.store,
+          SecretStorageKeys.AUTH_SESSION_EXISTS,
+          "true",
+        );
+        sinon.assert.called(stubOnDidChangeSessions.fire);
+        sinon.assert.calledWith(stubOnDidChangeSessions.fire, {
+          added: [TEST_CCLOUD_AUTH_SESSION],
+          removed: [],
+          changed: [],
+        });
+      });
+    });
+
+    describe("handleSessionRemoved()", () => {
+      let stubOnDidChangeSessions: sinon.SinonStubbedInstance<
+        vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>
+      >;
+
+      beforeEach(() => {
+        stubOnDidChangeSessions = sandbox.createStubInstance(vscode.EventEmitter);
+        authProvider["_onDidChangeSessions"] = stubOnDidChangeSessions;
+      });
+
+      it("should update the provider's internal state, fire the _onDidChangeSessions event.", async () => {
+        const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
+
+        authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
+        await authProvider["handleSessionRemoved"](true);
+
+        assert.strictEqual(authProvider["_session"], null);
+        sinon.assert.calledOnce(clearCurrentCCloudResourcesStub);
+        sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.AUTH_SESSION_EXISTS);
+        sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.AUTH_COMPLETED);
+        sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.AUTH_PASSWORD_RESET);
+        sinon.assert.called(stubOnDidChangeSessions.fire);
+        sinon.assert.calledWith(stubOnDidChangeSessions.fire, {
+          added: [],
+          removed: [TEST_CCLOUD_AUTH_SESSION],
+          changed: [],
+        });
+      });
+    });
+
+    describe("handleSessionSecretChange()", () => {
+      let handleSessionCreatedStub: sinon.SinonStub;
+      let handleSessionRemovedStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        handleSessionCreatedStub = sandbox.stub().resolves();
+        authProvider["handleSessionCreated"] = handleSessionCreatedStub;
+        handleSessionRemovedStub = sandbox.stub().resolves();
+        authProvider["handleSessionRemoved"] = handleSessionRemovedStub;
+      });
+
+      it("should call handleSessionCreated() when a session is available", async () => {
+        sandbox.stub(vscode.authentication, "getSession").resolves(TEST_CCLOUD_AUTH_SESSION);
+
+        await authProvider["handleSessionSecretChange"]();
+
+        sinon.assert.calledOnceWithExactly(handleSessionCreatedStub, TEST_CCLOUD_AUTH_SESSION);
+        sinon.assert.notCalled(handleSessionRemovedStub);
+      });
+
+      it("should call handleSessionRemoved() when no session is available", async () => {
+        sandbox.stub(vscode.authentication, "getSession").resolves(undefined);
+
+        authProvider["_session"] = TEST_CCLOUD_AUTH_SESSION;
+        await authProvider["handleSessionSecretChange"]();
+
+        sinon.assert.notCalled(handleSessionCreatedStub);
+        sinon.assert.calledOnce(handleSessionRemovedStub);
+      });
+    });
+
+    describe("waitForUriHandling()", () => {
+      for (const success of [true, false] as const) {
+        it(`should return '${success}' when the URI query contains 'success=${success}'`, async () => {
+          const promise: Promise<AuthCallbackEvent> = authProvider.waitForUriHandling();
+          const uri = vscode.Uri.parse(CCLOUD_AUTH_CALLBACK_URI).with({
+            query: `success=${success}`,
+          });
+          ccloudAuthCallback.fire(uri);
+          authProvider["_onAuthFlowCompletedSuccessfully"].fire({ success, resetPassword: false });
+          const result: AuthCallbackEvent = await promise;
+
+          assert.strictEqual(result.success, success);
+        });
+      }
+    });
+
+    describe("handleCCloudAuthCallback()", () => {
+      let deleteCCloudConnectionStub: sinon.SinonStub;
+      let showInfoNotificationWithButtonsStub: sinon.SinonStub;
+      let ccloudAuthSessionInvalidatedFireStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        deleteCCloudConnectionStub = sandbox.stub(ccloud, "deleteCCloudConnection").resolves();
+        showInfoNotificationWithButtonsStub = sandbox
+          .stub(notifications, "showInfoNotificationWithButtons")
+          .resolves();
+        ccloudAuthSessionInvalidatedFireStub = sandbox.stub(ccloudAuthSessionInvalidated, "fire");
+      });
+
+      for (const success of [true, false] as const) {
+        it(`should not invalidate the current CCloud auth session for non-reset-password URI callbacks (success=${success})`, async () => {
+          const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
+
+          const uri = vscode.Uri.parse(CCLOUD_AUTH_CALLBACK_URI).with({
+            query: `success=${success}`,
+          });
+          await authProvider.handleCCloudAuthCallback(uri);
+
+          sinon.assert.calledWith(stubbedResourceManager.setAuthFlowCompleted, {
+            success,
+            resetPassword: false,
+          });
+          sinon.assert.notCalled(deleteCCloudConnectionStub);
+          sinon.assert.notCalled(stubbedSecretStorage.delete);
+          sinon.assert.notCalled(showInfoNotificationWithButtonsStub);
+          sinon.assert.notCalled(ccloudAuthSessionInvalidatedFireStub);
+        });
+      }
+
+      it("should invalidate the current CCloud auth session for reset-password URI callbacks", async () => {
+        const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
+
+        const uri = vscode.Uri.parse(CCLOUD_AUTH_CALLBACK_URI).with({
+          query: "success=false&reset_password=true",
+        });
+        await authProvider.handleCCloudAuthCallback(uri);
+
+        sinon.assert.calledWith(stubbedResourceManager.setAuthFlowCompleted, {
+          success: false,
+          resetPassword: true,
+        });
+        sinon.assert.calledOnce(deleteCCloudConnectionStub);
+        sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.CCLOUD_STATE);
+        sinon.assert.calledOnce(ccloudAuthSessionInvalidatedFireStub);
+        sinon.assert.calledOnceWithExactly(
+          showInfoNotificationWithButtonsStub,
+          "Your password has been reset. Please sign in again to Confluent Cloud.",
+          { [CCLOUD_SIGN_IN_BUTTON_LABEL]: sinon.match.func },
+        );
+      });
+    });
+
+    describe("signInError()", () => {
+      let getLastSidecarLogLinesStub: sinon.SinonStub;
+      let logErrorStub: sinon.SinonStub;
+
+      const fakeErrorMsg = "uh oh, something went wrong";
+
+      beforeEach(() => {
+        getLastSidecarLogLinesStub = sandbox
+          .stub(sidecarLogging, "getLastSidecarLogLines")
+          .resolves([]);
+        logErrorStub = sandbox.stub(errors, "logError").resolves();
+      });
+
+      it("should return a CCloudSignInError", async () => {
+        const signInError: CCloudSignInError = await authProvider.signInError(fakeErrorMsg);
+
+        assert.ok(signInError instanceof CCloudSignInError);
+        assert.strictEqual(signInError.message, fakeErrorMsg);
+      });
+
+      it("should call logError() with the provided message and recent sidecar logs", async () => {
+        const sidecarLogs = ["log line 1", "log line 2"];
+        getLastSidecarLogLinesStub.resolves(sidecarLogs);
+
+        await authProvider.signInError(fakeErrorMsg);
+
+        sinon.assert.calledOnce(getLastSidecarLogLinesStub);
+        sinon.assert.calledOnce(logErrorStub);
+        sinon.assert.calledOnceWithExactly(
+          logErrorStub,
+          sinon.match(
+            (error: Error) => error.name === "CCloudSignInError" && error.message === fakeErrorMsg,
+          ),
+          fakeErrorMsg,
+          { extra: { sidecarLogs } },
+        );
+      });
+    });
+  });
+
+  describe("convertToAuthSession()", () => {
+    it("should throw if the Connection is missing .user", () => {
+      // has status.ccloud, but no status.ccloud.user
+      const connection = TEST_CCLOUD_CONNECTION;
+
+      assert.throws(
+        () => convertToAuthSession(connection),
+        Error("Connection has no CCloud user."),
       );
-
-      const uri = vscode.Uri.parse(CCLOUD_AUTH_CALLBACK_URI).with({ query: `success=${success}` });
-      await authProvider.handleUri(uri);
-
-      sinon.assert.calledWith(setAuthFlowCompletedStub, { success, resetPassword: false });
-      sinon.assert.notCalled(deleteConnectionStub);
-      sinon.assert.notCalled(stubbedSecretStorage.delete);
-      sinon.assert.notCalled(showResetPasswordNotificationStub);
     });
-  }
 
-  it("handleUri() should invalidate the current CCloud auth session for reset-password URI callbacks", async () => {
-    const setAuthFlowCompletedStub = sandbox
-      .stub(getResourceManager(), "setAuthFlowCompleted")
-      .resolves();
-    const ccloudAuthSessionInvalidatedFireStub = sandbox.stub(ccloudAuthSessionInvalidated, "fire");
-    const stubbedSecretStorage: StubbedSecretStorage = getStubbedSecretStorage(sandbox);
-    const showResetPasswordNotificationStub = sandbox.stub(
-      authProvider,
-      "showResetPasswordNotification",
-    );
+    for (const missingField of ["id", "username"]) {
+      it(`should throw if the Connection's UserInfo is missing '${missingField}'`, () => {
+        const connection = ConnectionFromJSON({
+          ...TEST_AUTHENTICATED_CCLOUD_CONNECTION,
+          status: {
+            ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status,
+            ccloud: {
+              ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud!,
+              user: {
+                ...TEST_AUTHENTICATED_CCLOUD_CONNECTION.status.ccloud!.user!,
+                [missingField]: undefined,
+              },
+            },
+          },
+        } satisfies Connection);
 
-    const uri = vscode.Uri.parse(CCLOUD_AUTH_CALLBACK_URI).with({
-      query: "success=false&reset_password=true",
+        assert.throws(
+          () => convertToAuthSession(connection),
+          Error("Connection has CCloud user with no id or username."),
+        );
+      });
+    }
+
+    it("should convert a Connection to an AuthenticationSession", () => {
+      // has valid status.ccloud.user data
+      const connection = TEST_AUTHENTICATED_CCLOUD_CONNECTION;
+
+      const session: vscode.AuthenticationSession = convertToAuthSession(connection);
+
+      assert.deepStrictEqual(session, TEST_CCLOUD_AUTH_SESSION);
     });
-    await authProvider.handleUri(uri);
-
-    sinon.assert.calledWith(setAuthFlowCompletedStub, { success: false, resetPassword: true });
-    sinon.assert.calledOnce(deleteConnectionStub);
-    sinon.assert.calledWith(stubbedSecretStorage.delete, SecretStorageKeys.CCLOUD_STATE);
-    sinon.assert.calledOnce(ccloudAuthSessionInvalidatedFireStub);
-    sinon.assert.calledOnce(showResetPasswordNotificationStub);
   });
 });
 

--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -529,15 +529,17 @@ describe("authn/ccloudProvider.ts", () => {
     });
 
     describe("signInError()", () => {
-      let getLastSidecarLogLinesStub: sinon.SinonStub;
+      let gatherSidecarOutputsStub: sinon.SinonStub;
       let logErrorStub: sinon.SinonStub;
 
       const fakeErrorMsg = "uh oh, something went wrong";
 
       beforeEach(() => {
-        getLastSidecarLogLinesStub = sandbox
-          .stub(sidecarLogging, "getLastSidecarLogLines")
-          .resolves([]);
+        gatherSidecarOutputsStub = sandbox.stub(sidecarLogging, "gatherSidecarOutputs").resolves({
+          logLines: [],
+          parsedLogLines: [],
+          stderrLines: [],
+        });
         logErrorStub = sandbox.stub(errors, "logError").resolves();
       });
 
@@ -550,11 +552,15 @@ describe("authn/ccloudProvider.ts", () => {
 
       it("should call logError() with the provided message and recent sidecar logs", async () => {
         const sidecarLogs = ["log line 1", "log line 2"];
-        getLastSidecarLogLinesStub.resolves(sidecarLogs);
+        gatherSidecarOutputsStub.resolves({
+          logLines: sidecarLogs,
+          parsedLogLines: [],
+          stderrLines: [],
+        });
 
         await authProvider.signInError(fakeErrorMsg);
 
-        sinon.assert.calledOnce(getLastSidecarLogLinesStub);
+        sinon.assert.calledOnce(gatherSidecarOutputsStub);
         sinon.assert.calledOnce(logErrorStub);
         sinon.assert.calledOnceWithExactly(
           logErrorStub,

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -708,7 +708,3 @@ function convertToAuthSession(connection: Connection): vscode.AuthenticationSess
   };
   return session;
 }
-
-export function getAuthProvider(): ConfluentCloudAuthProvider {
-  return ConfluentCloudAuthProvider.getInstance();
-}

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -129,8 +129,8 @@ export class ConfluentCloudAuthProvider
 
     // NOTE: for any of the branches below, if there's an error scenario we need to gather more info
     // about for internal debugging/troubleshooting, we need to create a CCloudSignInError with
-    // `handleSignInError()`. This also captures the last few lines of sidecar logs to send to
-    // Sentry along with the error.
+    // `signInError()`. This also captures the last few lines of sidecar logs to send to Sentry
+    // along with the error.
     // If we need to escape this flow without creating an AuthenticationSession, we still need to
     // throw an error but don't necessarily need to gather sidecar logs, so we can throw a
     // CCloudSignInError directly if we don't want it to appear as an error notification.

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -25,7 +25,7 @@ import { getResourceManager } from "../storage/resourceManager";
 import { getSecretStorage } from "../storage/utils";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { sendTelemetryIdentifyEvent } from "../telemetry/telemetry";
-import { getUriHandler } from "../uriHandler";
+import { UriEventHandler } from "../uriHandler";
 import { DisposableCollection } from "../utils/disposables";
 import { CCLOUD_SIGN_IN_BUTTON_LABEL } from "./constants";
 import { CCloudSignInError } from "./errors";
@@ -433,7 +433,7 @@ export class ConfluentCloudAuthProvider
 
     // general listener for the URI handling event, which is used to resolve any auth flow promises
     // and will trigger the secrets.onDidChange event described above
-    const uriHandlerSub: vscode.Disposable = getUriHandler().event(
+    const uriHandlerSub: vscode.Disposable = UriEventHandler.getInstance().event(
       async (uri) => await this.handleUri(uri),
     );
 

--- a/src/authn/ccloudProvider.ts
+++ b/src/authn/ccloudProvider.ts
@@ -20,7 +20,7 @@ import {
   getCCloudConnection,
 } from "../sidecar/connections/ccloud";
 import { waitForConnectionToBeStable } from "../sidecar/connections/watcher";
-import { getLastSidecarLogLines } from "../sidecar/logging";
+import { gatherSidecarOutputs } from "../sidecar/logging";
 import { SecretStorageKeys } from "../storage/constants";
 import { getResourceManager } from "../storage/resourceManager";
 import { getSecretStorage } from "../storage/utils";
@@ -663,8 +663,8 @@ export class ConfluentCloudAuthProvider
    */
   async signInError(message: string): Promise<CCloudSignInError> {
     const error = new CCloudSignInError(message);
-    const sidecarLogs: string[] = await getLastSidecarLogLines();
-    await logError(error, message, { extra: { sidecarLogs } });
+    const { logLines } = await gatherSidecarOutputs();
+    await logError(error, message, { extra: { sidecarLogs: logLines } });
     return error;
   }
 }

--- a/src/authn/ccloudStateHandling.ts
+++ b/src/authn/ccloudStateHandling.ts
@@ -78,7 +78,8 @@ export async function handleUpdatedConnection(connection: Connection): Promise<v
       void showErrorNotificationWithButtons(
         "Error authenticating with Confluent Cloud. Please try again.",
         {
-          [CCLOUD_SIGN_IN_BUTTON_LABEL]: async () => await getCCloudAuthSession(true),
+          [CCLOUD_SIGN_IN_BUTTON_LABEL]: async () =>
+            await getCCloudAuthSession({ createIfNone: true }),
         },
       );
       break;
@@ -92,7 +93,7 @@ export async function handleUpdatedConnection(connection: Connection): Promise<v
         void showInfoNotificationWithButtons(
           "Your Confluent Cloud session has expired. Please sign in again to continue.",
           {
-            [REAUTH_BUTTON_TEXT]: async () => await getCCloudAuthSession(true),
+            [REAUTH_BUTTON_TEXT]: async () => await getCCloudAuthSession({ createIfNone: true }),
           },
         );
       } else if (previousState !== ConnectedState.None) {
@@ -137,7 +138,8 @@ export async function handleUpdatedConnection(connection: Connection): Promise<v
       void showErrorNotificationWithButtons(
         "Error authenticating with Confluent Cloud. Please try again.",
         {
-          [CCLOUD_SIGN_IN_BUTTON_LABEL]: async () => await getCCloudAuthSession(true),
+          [CCLOUD_SIGN_IN_BUTTON_LABEL]: async () =>
+            await getCCloudAuthSession({ createIfNone: true }),
         },
       );
     } else if (hasTransientErrors) {

--- a/src/authn/errors.ts
+++ b/src/authn/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Error representing a handled unhappy path during the Confluent Cloud sign-in flow through the
+ * authentication provider.
+ */
+export class CCloudSignInError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CCloudSignInError";
+  }
+}

--- a/src/authn/utils.ts
+++ b/src/authn/utils.ts
@@ -1,18 +1,18 @@
-import { authentication, AuthenticationSession } from "vscode";
+import { authentication, AuthenticationGetSessionOptions, AuthenticationSession } from "vscode";
 import { AUTH_PROVIDER_ID } from "../constants";
 
-/** Convenience function to check with the authentication API and get a CCloud auth session, if
+/**
+ * Convenience function to check with the authentication API and get a CCloud auth session, if
  * one exists.
  *
- * NOTE: If any callers need to check for general CCloud connection status, they should do it here.
- * Any reactions to CCloud connection change should also use an event listener for the
- * `ccloudConnected` event emitter.
+ * NOTE: Use this to check for CCloud authentication status. Any change in CCloud connection status
+ * will be fired through the `ccloudConnected` event emitter.
  *
- * @param createIfNone If `true`, create a new session if one doesn't exist. This starts the
- * browser-based sign-in flow to CCloud. (default: `false`)
+ * @param options Optional {@link AuthenticationGetSessionOptions}. If not provided, defaults to
+ * {@linkcode AuthenticationGetSessionOptions.createIfNone createIfNone}:`false`.
  */
 export async function getCCloudAuthSession(
-  createIfNone: boolean = false,
+  options?: AuthenticationGetSessionOptions,
 ): Promise<AuthenticationSession | undefined> {
-  return await authentication.getSession(AUTH_PROVIDER_ID, [], { createIfNone: createIfNone });
+  return await authentication.getSession(AUTH_PROVIDER_ID, [], options ?? { createIfNone: false });
 }

--- a/src/commands/connections.test.ts
+++ b/src/commands/connections.test.ts
@@ -51,7 +51,7 @@ describe("commands/connections.ts", function () {
 
       await connections.ccloudSignInCommand();
 
-      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, true);
+      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, { createIfNone: true });
     });
 
     it("should not re-throw 'User did not consent to login' errors", async function () {
@@ -59,7 +59,7 @@ describe("commands/connections.ts", function () {
 
       await connections.ccloudSignInCommand();
 
-      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, true);
+      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, { createIfNone: true });
     });
 
     it("should not re-throw CCloudSignInErrors", async function () {
@@ -67,7 +67,7 @@ describe("commands/connections.ts", function () {
 
       await connections.ccloudSignInCommand();
 
-      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, true);
+      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, { createIfNone: true });
     });
 
     it("should re-throw unexpected errors", async function () {
@@ -76,7 +76,7 @@ describe("commands/connections.ts", function () {
 
       await assert.rejects(connections.ccloudSignInCommand(), unexpectedError);
 
-      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, true);
+      sinon.assert.calledOnceWithExactly(getCCloudAuthSessionStub, { createIfNone: true });
     });
   });
 

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -27,7 +27,7 @@ const logger = new Logger("commands.connections");
 /** Allow CCloud sign-in via the auth provider outside of the Accounts section of the VS Code UI. */
 export async function ccloudSignInCommand() {
   try {
-    await getCCloudAuthSession(true);
+    await getCCloudAuthSession({ createIfNone: true });
   } catch (error) {
     // we don't need to do anything if:
     // - the user clicks "Cancel" on the modal before the sign-in process, or on the progress

--- a/src/commands/connections.ts
+++ b/src/commands/connections.ts
@@ -1,6 +1,5 @@
 import { Disposable, Uri, window } from "vscode";
 import { registerCommandWithLogging } from ".";
-import { CCloudSignInError } from "../authn/errors";
 import { getCCloudAuthSession } from "../authn/utils";
 import { EXTENSION_VERSION } from "../constants";
 import { openDirectConnectionForm } from "../directConnect";
@@ -35,8 +34,8 @@ export async function ccloudSignInCommand() {
     //  notification after the sign-in process has started
     // - the auth provider handles a sign-in failure (which shows its own error notification)
     if (
-      error instanceof CCloudSignInError ||
-      (error instanceof Error && error.name === "CCloudSignInError")
+      error instanceof Error &&
+      (error.message === "User did not consent to login." || error.name === "CCloudSignInError")
     ) {
       return;
     }

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -11,6 +11,8 @@ import { FlinkDatabaseViewProviderMode } from "./viewProviders/multiViewDelegate
 // NOTE: these are kept at the global level to allow for easy access from any file and track where
 // we .fire() events and where we react to them via .event()
 
+/** Fires when we get a `vscode://confluentinc.vscode-confluent/authCallback` URI to handle. */
+export const ccloudAuthCallback = new vscode.EventEmitter<vscode.Uri>();
 /**
  * Indicate whether or not we have a CCloud connection (controlled by our auth provider).
  *

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ import { migrateStorageIfNeeded } from "./storage/migrationManager";
 import { logUsage, UserEvent } from "./telemetry/events";
 import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
-import { getUriHandler } from "./uriHandler";
+import { UriEventHandler } from "./uriHandler";
 import { WriteableTmpDir } from "./utils/file";
 import { RefreshableTreeViewProvider } from "./viewProviders/baseModels/base";
 import { FlinkDatabaseViewProvider } from "./viewProviders/flinkDatabase";
@@ -286,7 +286,9 @@ async function _activateExtension(
     context.subscriptions.push(flinkLanguageClientManager);
   }
 
-  const uriHandler: vscode.Disposable = vscode.window.registerUriHandler(getUriHandler());
+  const uriHandler: vscode.Disposable = vscode.window.registerUriHandler(
+    UriEventHandler.getInstance(),
+  );
 
   // If the user is already authenticated to ccloud (this being not the first
   // workspace activated), this will eventually cause ccloudConnected to be fired.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ if (process.env.SENTRY_DSN) {
 }
 
 import { handleNewOrUpdatedExtensionInstallation } from "./activation/compareVersions";
-import { ConfluentCloudAuthProvider, getAuthProvider } from "./authn/ccloudProvider";
+import { ConfluentCloudAuthProvider } from "./authn/ccloudProvider";
 import { getCCloudAuthSession } from "./authn/utils";
 import { disableCCloudStatusPolling, enableCCloudStatusPolling } from "./ccloudStatus/polling";
 import { PARTICIPANT_ID } from "./chat/constants";
@@ -532,7 +532,7 @@ async function setupStorage(): Promise<void> {
  * @returns A {@link vscode.Disposable} for the auth provider
  */
 async function setupAuthProvider(): Promise<vscode.Disposable[]> {
-  const provider: ConfluentCloudAuthProvider = getAuthProvider();
+  const provider = ConfluentCloudAuthProvider.getInstance();
   const providerDisposable = vscode.authentication.registerAuthenticationProvider(
     AUTH_PROVIDER_ID,
     AUTH_PROVIDER_LABEL,

--- a/src/sidecar/sidecarManager.test.ts
+++ b/src/sidecar/sidecarManager.test.ts
@@ -219,7 +219,7 @@ describe("sidecarManager.ts", () => {
       it("Happy when process is running", async () => {
         isProcessRunningStub.returns(true);
         // does not throw.
-        await manager.confirmSidecarProcessIsRunning(1234, "", "");
+        await manager.confirmSidecarProcessIsRunning(1234, "");
       });
 
       it("Does proper things when process is not running", async () => {
@@ -242,7 +242,7 @@ describe("sidecarManager.ts", () => {
           .returns(SidecarStartupFailureReason.PORT_IN_USE);
 
         try {
-          await manager.confirmSidecarProcessIsRunning(2345, "prefix", "");
+          await manager.confirmSidecarProcessIsRunning(2345, "prefix");
         } catch (e) {
           if (e instanceof SidecarFatalError) {
             assert.strictEqual(

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -41,7 +41,3 @@ export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements 
     }
   }
 }
-
-export function getUriHandler(): UriEventHandler {
-  return UriEventHandler.getInstance();
-}

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { projectScaffoldUri } from "./emitters";
+import { ccloudAuthCallback, projectScaffoldUri } from "./emitters";
 import { Logger } from "./logging";
 
 const logger = new Logger("uriHandler");
@@ -29,8 +29,7 @@ export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements 
     const { path } = uri;
     switch (path) {
       case "/authCallback":
-        logger.debug("Got authCallback URI, firing as Event", uri);
-        this.fire(uri);
+        ccloudAuthCallback.fire(uri);
         break;
       case "/consume":
         vscode.commands.executeCommand("confluent.topic.consume.fromUri", uri);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We wanted easier ways of gathering sidecar logs while handling different CCloud sign-in issues, so I:
- updated `gatherSidecarOutputs()` to use a single `options` param with some defaults for the log path, stderr path, and number of log lines to work with
- set up the error scenarios while signing in (before converting to a VS Code `AuthenticationSession`) to use a new `.signInError()` method which creates (new) `CCloudSignInError`s while also gathering and sending sidecar logs to Sentry for our team to investigate for follow-up fixing
  - all of that to say that that cases like this just mean "grab the sidecar logs, send to sentry, and prep a `CCloudSignInError` to throw":
    <img width="668" height="407" alt="image" src="https://github.com/user-attachments/assets/323f5ff0-4210-4db8-9486-3f606650df00" />


> [!TIP]
> The majority of lines changed here are from updating `authn/ccloudProvider.test.ts` so it fit our `file->function->test` describe-hierarchy. Updating tests and trying to manage stubs in the old structure was awful, but should be much easier to follow/maintain in the new structure.
> (There were also some functions that were missing stubs, so changes in secret storage or other events being fired would show logs from the (new) resource view provider, `clearCurrentCCloudResources()`, and others, which indicated some test state leaking.)

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Unfortunately, as far as I can tell there isn't an easy way to reproduce missing `status` or `user` info when we finish the auth flow and get an authenticated connection back from CCloud / the sidecar. However, you can start the CCloud sign-in flow and open the following URIs in a browser to make fake auth callbacks and watch the Confluent output channel and notifications area to make sure nothing strange is happening:
  - `vscode://confluentinc.vscode-confluent/authCallback?success=false`
  - `vscode://confluentinc.vscode-confluent/authCallback?success=false&reset_password=true`

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- `getAuthProvider()` and `getUriHandler()` were bothering me since they were pretty worthless one-line wrappers, so I removed them in favor of their respective classes' `.getInstance()` method calls.
- `ccloudAuthCallback` is a new emitter used when the UriEventHandler is handling the `/authCallback` URI from the browser-based auth flow, which closes #1477 
- `getCCloudAuthSession()`'s optional argument is being expanded to match the VS Code Authentication API's `getSession()` call (see [`AuthenticationGetSessionOptions`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8e137dc522c346de09c25af256e26afb26a94ef1/types/vscode/index.d.ts#L17745-L17748)), which is mainly setup for digging into https://github.com/confluentinc/vscode/issues/2669

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
