### PR TITLE
Add deleteFlinkUDFCommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -361,6 +361,11 @@
         "category": "Confluent: Flink Artifacts"
       },
       {
+        "command": "confluent.deleteFlinkUDF",
+        "title": "Delete UDF",
+        "category": "Confluent: Flink UDFs"
+      },
+      {
         "command": "confluent.diff.compareWithSelected",
         "icon": "$(diff)",
         "title": "Compare with Selected",
@@ -1273,6 +1278,10 @@
           "when": "false"
         },
         {
+          "command": "confluent.deleteFlinkUDF",
+          "when": "false"
+        },
+        {
           "command": "confluent.diff.compareWithSelected",
           "when": "false"
         },
@@ -1914,6 +1923,11 @@
           "command": "confluent.deleteArtifact",
           "when": "view == confluent-flink-database && viewItem =~ /.*-flink-artifact$/",
           "group": "artifacts"
+        },
+        {
+          "command": "confluent.deleteFlinkUDF",
+          "when": "view == confluent-flink-database && viewItem =~ /.*-flink-udf$/",
+          "group": "udfs"
         },
         {
           "command": "confluent.schemas.upload",

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -1,7 +1,15 @@
-import { Disposable } from "vscode";
+import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
 import { flinkDatabaseViewMode } from "../emitters";
+import { isResponseError, logError } from "../errors";
+import { CCloudResourceLoader } from "../loaders";
+import { FlinkUdf } from "../models/flinkUDF";
+import {
+  showErrorNotificationWithButtons,
+  showInfoNotificationWithButtons,
+} from "../notifications";
+import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 
 export async function setFlinkUDFViewModeCommand() {
@@ -9,8 +17,88 @@ export async function setFlinkUDFViewModeCommand() {
   await setContextValue(ContextValues.flinkDatabaseViewMode, FlinkDatabaseViewProviderMode.UDFs);
 }
 
-export function registerFlinkUDFCommands(): Disposable[] {
+/**
+ * Delete a Flink UDF by executing a DROP FUNCTION statement.
+ *
+ * @param selectedUdf The UDF to delete
+ */
+export async function deleteFlinkUDFCommand(selectedUdf: FlinkUdf): Promise<void> {
+  if (!selectedUdf) {
+    return;
+  }
+
+  const confirmButton = "Yes, delete";
+  const confirmResult = await vscode.window.showWarningMessage(
+    `Are you sure you want to delete the UDF "${selectedUdf.name}"?`,
+    { modal: true },
+    confirmButton,
+  );
+
+  if (confirmResult !== confirmButton) {
+    return;
+  }
+
+  try {
+    const ccloudResourceLoader = CCloudResourceLoader.getInstance();
+    const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
+    const database = flinkDatabaseProvider.resource;
+
+    if (!database) {
+      throw new Error("No Flink database.");
+    }
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Deleting Flink UDF",
+        cancellable: false,
+      },
+      async (progress) => {
+        progress.report({ message: "Executing DROP FUNCTION statement..." });
+        await ccloudResourceLoader.executeFlinkStatement<{ dropped_at?: string }>(
+          `DROP FUNCTION \`${selectedUdf.name}\`;`,
+          database,
+          {
+            nameSpice: "delete-udf",
+            timeout: 30000, // 30 second timeout
+          },
+        );
+
+        progress.report({ message: "Updating cache..." });
+
+        flinkDatabaseProvider.refresh(true);
+
+        progress.report({ message: "UDF deleted successfully." });
+      },
+    );
+
+    showInfoNotificationWithButtons(
+      `UDF "${selectedUdf.name}" deleted successfully from Confluent Cloud.`,
+    );
+  } catch (err) {
+    let errorMessage = "Failed to delete UDF: ";
+
+    if (isResponseError(err)) {
+      const resp = await err.response.clone().text();
+      errorMessage = `${errorMessage} ${resp}`;
+    } else if (err instanceof Error) {
+      // extract the error detail from the error message for better error notification
+      const flinkDetail = err.message.split("Error detail:")[1]?.trim();
+      if (flinkDetail) {
+        errorMessage = `${errorMessage} ${flinkDetail}`;
+      } else {
+        // fall back to regular error message
+        errorMessage = `${errorMessage} ${err.message}`;
+      }
+    }
+    logError(err, errorMessage);
+    showErrorNotificationWithButtons(errorMessage);
+  }
+}
+
+export function registerFlinkUDFCommands(): vscode.Disposable[] {
   return [
+    registerCommandWithLogging("confluent.deleteFlinkUDF", deleteFlinkUDFCommand),
     registerCommandWithLogging(
       "confluent.flinkdatabase.setUDFsViewMode",
       setFlinkUDFViewModeCommand,

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -340,6 +340,7 @@ export class CCloudResourceLoader extends CachingResourceLoader<
       const rawResults = await this.executeFlinkStatement<FunctionNameRow>(
         "SHOW USER FUNCTIONS",
         cluster,
+        { nameSpice: "list-udfs" },
       );
 
       udfs = rawResults.map((row) => {
@@ -385,7 +386,7 @@ export class CCloudResourceLoader extends CachingResourceLoader<
    * @param options Optional parameters for statement execution
    * @param options.computePool The compute pool to use for execution, defaults to the first compute pool in the database's flinkPools array
    * @param options.timeout Custom timeout for the statement execution
-   * @param options.spice Additional spice parameter for extending statement name
+   * @param options.nameSpice Additional spice parameter for extending statement name
    * @returns Array of results, each of type RT (generic type parameter) corresponding to the result row structure from the query.
    *
    */
@@ -395,7 +396,7 @@ export class CCloudResourceLoader extends CachingResourceLoader<
     options: {
       computePool?: CCloudFlinkComputePool;
       timeout?: number;
-      spice?: string;
+      nameSpice?: string;
     } = {},
   ): Promise<Array<RT>> {
     const organization = await this.getOrganization();
@@ -414,7 +415,7 @@ export class CCloudResourceLoader extends CachingResourceLoader<
 
     const statementParams: IFlinkStatementSubmitParameters = {
       statement: sqlStatement,
-      statementName: await determineFlinkStatementName(options.spice),
+      statementName: await determineFlinkStatementName(options.nameSpice),
       organizationId: organization.id,
       computePool: options.computePool,
       hidden: true, // Hidden statement, user didn't author it.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Added `confluent.deleteFlinkUDF` command registration and menu items
- Created `deleteFlinkUDFCommand()` that executes `DROP FUNCTION SQL` statements with user confirmation to delete UDFs from right click option
- Renamed optional arg `spice` to `nameSpice` in `executeFlinkStatement()` for clarity
- Add name spice `list-udf' to `executeFlinkStatment` call in `getFlinkArtifacts()`

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Open `Flink UDFs` list tree view
2. Right click on UDF to delete
3. Click `Delete UDF`

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2541

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
