### PR TITLE
Update doc metadata for codelens on new CREATE FUNCTION statements

### DIFF
--- a/src/commands/flinkUDFs.test.ts
+++ b/src/commands/flinkUDFs.test.ts
@@ -72,40 +72,6 @@ describe("flinkUDFs command", () => {
     sandbox.restore();
   });
 
-  it("should open a new Flink SQL document with placeholder query for valid artifact", async () => {
-    const openTextDocStub = sandbox
-      .stub(vscode.workspace, "openTextDocument")
-      .resolves({} as vscode.TextDocument);
-    const insertSnippetStub = sandbox.stub().resolves();
-    const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument").resolves({
-      insertSnippet: insertSnippetStub,
-    } as unknown as vscode.TextEditor);
-
-    await createUdfRegistrationDocumentCommand(artifact);
-
-    sinon.assert.calledOnce(openTextDocStub);
-    const callArgs = openTextDocStub.getCall(0).args[0];
-    assert.ok(callArgs, "openTextDocStub was not called with any arguments");
-    assert.strictEqual(callArgs.language, "flinksql");
-    sinon.assert.calledOnce(showTextDocStub);
-    sinon.assert.calledOnce(insertSnippetStub);
-    const snippetArg = insertSnippetStub.getCall(0).args[0];
-    assert.ok(
-      typeof snippetArg.value === "string" && snippetArg.value.includes("CREATE FUNCTION"),
-      "insertSnippet should be called with a snippet containing CREATE FUNCTION",
-    );
-  });
-
-  it("should return early if no artifact is provided in createUdfRegistrationDocumentCommand", async () => {
-    const openTextDocStub = sandbox.stub(vscode.workspace, "openTextDocument");
-    const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument");
-
-    await createUdfRegistrationDocumentCommand(undefined as any);
-
-    sinon.assert.notCalled(openTextDocStub);
-    sinon.assert.notCalled(showTextDocStub);
-  });
-
   it("should register startGuidedUdfCreationCommand and createUdfRegistrationDocumentCommand", () => {
     const registerCommandWithLoggingStub = sandbox
       .stub(commands, "registerCommandWithLogging")
@@ -300,6 +266,40 @@ describe("flinkUDFs command", () => {
 
       flinkDatabaseProviderStub = sandbox.createStubInstance(FlinkDatabaseViewProvider);
       sandbox.stub(FlinkDatabaseViewProvider, "getInstance").returns(flinkDatabaseProviderStub);
+    });
+
+    it("should open a new Flink SQL document with placeholder query for valid artifact", async () => {
+      const openTextDocStub = sandbox
+        .stub(vscode.workspace, "openTextDocument")
+        .resolves({} as vscode.TextDocument);
+      const insertSnippetStub = sandbox.stub().resolves();
+      const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument").resolves({
+        insertSnippet: insertSnippetStub,
+      } as unknown as vscode.TextEditor);
+
+      await createUdfRegistrationDocumentCommand(artifact);
+
+      sinon.assert.calledOnce(openTextDocStub);
+      const callArgs = openTextDocStub.getCall(0).args[0];
+      assert.ok(callArgs, "openTextDocStub was not called with any arguments");
+      assert.strictEqual(callArgs.language, "flinksql");
+      sinon.assert.calledOnce(showTextDocStub);
+      sinon.assert.calledOnce(insertSnippetStub);
+      const snippetArg = insertSnippetStub.getCall(0).args[0];
+      assert.ok(
+        typeof snippetArg.value === "string" && snippetArg.value.includes("CREATE FUNCTION"),
+        "insertSnippet should be called with a snippet containing CREATE FUNCTION",
+      );
+    });
+
+    it("should return early if no artifact is provided", async () => {
+      const openTextDocStub = sandbox.stub(vscode.workspace, "openTextDocument");
+      const showTextDocStub = sandbox.stub(vscode.window, "showTextDocument");
+
+      await createUdfRegistrationDocumentCommand(undefined as any);
+
+      sinon.assert.notCalled(openTextDocStub);
+      sinon.assert.notCalled(showTextDocStub);
     });
 
     it("should set URI metadata when both database and catalog are available", async () => {

--- a/src/commands/flinkUDFs.test.ts
+++ b/src/commands/flinkUDFs.test.ts
@@ -1,7 +1,9 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
+import { getStubbedResourceManager } from "../../tests/stubs/extensionStorage";
 import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
+import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
 import { TEST_CCLOUD_ENVIRONMENT } from "../../tests/unit/testResources";
 import { createResponseError } from "../../tests/unit/testUtils";
 import { ArtifactV1FlinkArtifactMetadataFromJSON, ResponseError } from "../clients/flinkArtifacts";
@@ -261,11 +263,8 @@ describe("flinkUDFs command", () => {
     let insertSnippetStub: sinon.SinonStub;
 
     beforeEach(() => {
-      resourceManagerStub = sandbox.createStubInstance(ResourceManager);
-      sandbox.stub(ResourceManager, "getInstance").returns(resourceManagerStub);
-
-      ccloudLoaderStub = sandbox.createStubInstance(CCloudResourceLoader);
-      sandbox.stub(CCloudResourceLoader, "getInstance").returns(ccloudLoaderStub);
+      resourceManagerStub = getStubbedResourceManager(sandbox);
+      ccloudLoaderStub = getStubbedCCloudResourceLoader(sandbox);
 
       flinkDatabaseProviderStub = sandbox.createStubInstance(FlinkDatabaseViewProvider);
       sandbox.stub(FlinkDatabaseViewProvider, "getInstance").returns(flinkDatabaseProviderStub);

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -5,6 +5,7 @@ import { ContextValues, setContextValue } from "../context/values";
 import { flinkDatabaseViewMode } from "../emitters";
 import { isResponseError, logError } from "../errors";
 import { CCloudResourceLoader } from "../loaders";
+import { Logger } from "../logging";
 import { FlinkArtifact } from "../models/flinkArtifact";
 import {
   showErrorNotificationWithButtons,
@@ -16,6 +17,7 @@ import { UriMetadata } from "../storage/types";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 import { promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
+const logger = new Logger("flinkUDFs");
 
 export async function setFlinkUDFViewModeCommand() {
   flinkDatabaseViewMode.fire(FlinkDatabaseViewProviderMode.UDFs);
@@ -56,21 +58,25 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
     // content is initialized as an empty string, we insert the snippet next due to how the Snippets API works
     content: "",
   });
-  // We'll gather all the metadata we can and attach it to the document
-  // In the future some of this could be handled by the codelens provider getting a little smarter about defaults
-  const loader = CCloudResourceLoader.getInstance();
-  const catalog = await loader.getEnvironment(selectedArtifact.environmentId);
-  const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
-  const database = flinkDatabaseProvider.database; // selected database in Artifacts view
-  if (database && catalog) {
-    const metadata: UriMetadata = {
-      [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: database.flinkPools[0]?.id || null,
-      [UriMetadataKeys.FLINK_CATALOG_ID]: catalog.id,
-      [UriMetadataKeys.FLINK_CATALOG_NAME]: catalog.name,
-      [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
-      [UriMetadataKeys.FLINK_DATABASE_NAME]: database.name,
-    };
-    await ResourceManager.getInstance().setUriMetadata(document.uri, metadata);
+  try {
+    // We'll gather all the metadata we can and attach it to the document
+    // In the future some of this could be handled by the codelens provider
+    const loader = CCloudResourceLoader.getInstance();
+    const catalog = await loader.getEnvironment(selectedArtifact.environmentId);
+    const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
+    const database = flinkDatabaseProvider.database; // selected database in Artifacts view
+    if (database && catalog) {
+      const metadata: UriMetadata = {
+        [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: database.flinkPools[0]?.id || null,
+        [UriMetadataKeys.FLINK_CATALOG_ID]: catalog.id,
+        [UriMetadataKeys.FLINK_CATALOG_NAME]: catalog.name,
+        [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
+        [UriMetadataKeys.FLINK_DATABASE_NAME]: database.name,
+      };
+      await ResourceManager.getInstance().setUriMetadata(document.uri, metadata);
+    }
+  } catch (err) {
+    logger.error("failed to set metadata for UDF registration doc", err);
   }
   const editor = await window.showTextDocument(document, { preview: false });
   await editor.insertSnippet(snippetString);

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -10,6 +10,9 @@ import {
   showErrorNotificationWithButtons,
   showInfoNotificationWithButtons,
 } from "../notifications";
+import { UriMetadataKeys } from "../storage/constants";
+import { ResourceManager } from "../storage/resourceManager";
+import { UriMetadata } from "../storage/types";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 import { promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
@@ -53,7 +56,22 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
     // content is initialized as an empty string, we insert the snippet next due to how the Snippets API works
     content: "",
   });
-
+  // We'll gather all the metadata we can and attach it to the document
+  // In the future some of this could be handled by the codelens provider getting a little smarter about defaults
+  const loader = CCloudResourceLoader.getInstance();
+  const catalog = await loader.getEnvironment(selectedArtifact.environmentId);
+  const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
+  const database = flinkDatabaseProvider.database; // selected database in Artifacts view
+  if (database && catalog) {
+    const metadata: UriMetadata = {
+      [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: database.flinkPools[0]?.id || null,
+      [UriMetadataKeys.FLINK_CATALOG_ID]: catalog.id,
+      [UriMetadataKeys.FLINK_CATALOG_NAME]: catalog.name,
+      [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
+      [UriMetadataKeys.FLINK_DATABASE_NAME]: database.name,
+    };
+    await ResourceManager.getInstance().setUriMetadata(document.uri, metadata);
+  }
   const editor = await window.showTextDocument(document, { preview: false });
   await editor.insertSnippet(snippetString);
 }

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -67,6 +67,8 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
     const database = flinkDatabaseProvider.database; // selected database in Artifacts view
     if (database && catalog) {
       const metadata: UriMetadata = {
+        // FLINK_COMPUTE_POOL_ID will fallback to `null` so the user has to pick a pool to run the statement,
+        // to avoid conflicts between any default pool settings and the artifact-related catalog/database
         [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: database.flinkPools[0]?.id || null,
         [UriMetadataKeys.FLINK_CATALOG_ID]: catalog.id,
         [UriMetadataKeys.FLINK_CATALOG_NAME]: catalog.name,


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2662 
- Sets the Flink URI metadata for the new document that we open when running the "register UDF with Editor" flow
- Adds imports and uses the results from `flinkDatabaseProvider.database` and `CCloudResourceLoader.getEnvironment`

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Make sure your settings have Flink Artifacts `enabled` 
2. Log in to Confluent Cloud in the extension
3. Choose a database that has artifacts in the Flink Artifacts view panel (or upload a new artifact). To verify defaults don't get picked up, choose a database that is in a different region/provider than your Default Flink Database setting
4. Right-click on an artifact and choose Register with Flink SQL option to open a new sql code editor document.

**Verify that**: 
- ... you see the option to Submit the statement right away. 
- ... you do **not** see codelens prompts to select a database or compute pool. 
- ... you see the info for your selected database, not your defaults (if they differ). 
- After you submit the statement, you do **not** get an error message that says `artifact id $id version id latest does not belong to org $uuid or environment $id`

### Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Background: If the correct metadata isn't set, the codelens provider will go by default settings or offer a picker, both of which can cause unexpected errors when the region or env don't match the artifact. 
- Future optimization: We may be able to update the Codelens Provider so that it picks up the selected Flink database or other resources. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
