### PR TITLE
update FlinkSqlCodelensProvider to allow going off of just catalog/database ID metadata (without names)

### DIFF
--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -521,7 +521,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       const databaseName = "cluster_0";
 
       // two Kafka clusters/databases, both of which share a common name but are in different
-      // catalogs/environments and have different provider/region values
+      // catalogs/environments and have different IDs and provider/region values
       const correctDatabase: CCloudKafkaCluster = CCloudKafkaCluster.create({
         ...TEST_CCLOUD_KAFKA_CLUSTER,
         name: databaseName,

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import { CodeLens, Position, Range, TextDocument, Uri } from "vscode";
 import { eventEmitterStubs, StubbedEventEmitters } from "../../tests/stubs/emitters";
+import { getStubbedResourceManager } from "../../tests/stubs/extensionStorage";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
 import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
 import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
@@ -73,8 +74,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
     beforeEach(async () => {
       // reset any stored metadata
       await getResourceManager().deleteAllUriMetadata();
-      resourceManagerStub = sandbox.createStubInstance(ResourceManager);
-      sandbox.stub(ResourceManager, "getInstance").returns(resourceManagerStub);
+      resourceManagerStub = getStubbedResourceManager(sandbox);
 
       provider = FlinkSqlCodelensProvider.getInstance();
     });
@@ -520,7 +520,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       const catalogName = "env_0";
       const databaseName = "cluster_0";
 
-      // two Kafka clusters/databases, both of which share a common name/ID but are in different
+      // two Kafka clusters/databases, both of which share a common name but are in different
       // catalogs/environments and have different provider/region values
       const correctDatabase: CCloudKafkaCluster = CCloudKafkaCluster.create({
         ...TEST_CCLOUD_KAFKA_CLUSTER,
@@ -529,6 +529,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       const incorrectDatabase: CCloudKafkaCluster = CCloudKafkaCluster.create({
         ...TEST_CCLOUD_KAFKA_CLUSTER,
         name: databaseName,
+        id: "other-cluster-id",
         provider: "other-provider",
         region: "other-region",
       });
@@ -831,6 +832,61 @@ describe("codelens/flinkSqlProvider.ts", () => {
       assert.deepStrictEqual(catalogDb.catalog, correctCatalog);
       assert.deepStrictEqual(catalogDb.database, correctDatabase);
     });
+
+    it("should look up catalog/database names if only IDs are provided", async () => {
+      const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      const correctDatabase: CCloudKafkaCluster = CCloudKafkaCluster.create({
+        ...TEST_CCLOUD_KAFKA_CLUSTER,
+        provider: pool.provider,
+        region: pool.region,
+      });
+      const correctCatalog: CCloudEnvironment = new CCloudEnvironment({
+        ...TEST_CCLOUD_ENVIRONMENT,
+        kafkaClusters: [correctDatabase],
+      });
+      ccloudLoaderStub.getEnvironments.resolves([correctCatalog]);
+
+      const metadata = {
+        [UriMetadataKeys.FLINK_CATALOG_ID]: correctCatalog.id,
+        // no FLINK_CATALOG_NAME
+        [UriMetadataKeys.FLINK_DATABASE_ID]: correctDatabase.id,
+        // no FLINK_DATABASE_NAME
+      };
+      const catalogDb: CatalogDatabase = await getCatalogDatabaseFromMetadata(metadata, pool);
+
+      // should correctly look up resources based on IDs alone
+      assert.deepStrictEqual(catalogDb.catalog, correctCatalog);
+      assert.deepStrictEqual(catalogDb.database, correctDatabase);
+    });
+
+    for (const badCatalogId of [undefined, "old-or-invalid-catalog-id"]) {
+      it(`should use the database's environment/catalog ID if database ID metadata is available (catalogId=${badCatalogId})`, async () => {
+        const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+        const correctDatabase: CCloudKafkaCluster = CCloudKafkaCluster.create({
+          ...TEST_CCLOUD_KAFKA_CLUSTER,
+          provider: pool.provider,
+          region: pool.region,
+        });
+        const correctCatalog: CCloudEnvironment = new CCloudEnvironment({
+          ...TEST_CCLOUD_ENVIRONMENT,
+          kafkaClusters: [correctDatabase],
+        });
+        ccloudLoaderStub.getEnvironments.resolves([correctCatalog]);
+
+        const metadata = {
+          [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: pool.id,
+          [UriMetadataKeys.FLINK_CATALOG_ID]: badCatalogId,
+          // no FLINK_CATALOG_NAME
+          [UriMetadataKeys.FLINK_DATABASE_ID]: correctDatabase.id,
+          // no FLINK_DATABASE_NAME
+        };
+        const catalogDb: CatalogDatabase = await getCatalogDatabaseFromMetadata(metadata, pool);
+
+        // should use the database's environment/catalog ID to find the catalog
+        assert.deepStrictEqual(catalogDb.catalog, correctCatalog);
+        assert.deepStrictEqual(catalogDb.database, correctDatabase);
+      });
+    }
   });
 
   describe("getDefaultCatalogDatabase()", () => {

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -131,13 +131,13 @@ export async function startGuidedUdfCreationCommand(selectedArtifact: FlinkArtif
     );
   } catch (err) {
     if (!(err instanceof Error && err.message.includes("Failed to create UDF function"))) {
-      let errorMessage = "Failed to create UDF function: ";
+      let errorMessage = "Failed to create UDF function";
 
       if (isResponseError(err)) {
         const resp = await err.response.clone().text();
-        errorMessage = `${errorMessage} ${resp}`;
+        errorMessage = `${errorMessage}: ${resp}`;
       } else if (err instanceof Error) {
-        errorMessage = `${errorMessage} ${err.message}`;
+        errorMessage = `${errorMessage}: ${err.message}`;
         logError(err, errorMessage);
       }
       showErrorNotificationWithButtons(errorMessage);

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -4,20 +4,16 @@ import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
 import { flinkDatabaseViewMode, udfsChanged } from "../emitters";
 import { isResponseError, logError } from "../errors";
-import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { FlinkArtifact } from "../models/flinkArtifact";
 import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
-import {
-  showErrorNotificationWithButtons,
-  showInfoNotificationWithButtons,
-} from "../notifications";
+import { showErrorNotificationWithButtons } from "../notifications";
 import { UriMetadataKeys } from "../storage/constants";
 import { ResourceManager } from "../storage/resourceManager";
 import { UriMetadata } from "../storage/types";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
-import { promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
+import { executeCreateFunction, promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
 
 const logger = new Logger("commands.flinkUDFs");
 
@@ -80,26 +76,6 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
   }
   const editor = await window.showTextDocument(document, { preview: false });
   await editor.insertSnippet(snippetString);
-}
-
-export async function executeCreateFunction(
-  selectedArtifact: FlinkArtifact,
-  userInput: {
-    functionName: string;
-    className: string;
-  },
-  database: CCloudFlinkDbKafkaCluster,
-) {
-  const ccloudResourceLoader = CCloudResourceLoader.getInstance();
-  await ccloudResourceLoader.executeFlinkStatement<{ created_at?: string }>(
-    `CREATE FUNCTION \`${userInput.functionName}\` AS '${userInput.className}' USING JAR 'confluent-artifact://${selectedArtifact.id}';`,
-    database,
-    {
-      timeout: 60000, // custom timeout of 60 seconds
-    },
-  );
-  const createdMsg = `${userInput.functionName} function created successfully.`;
-  void showInfoNotificationWithButtons(createdMsg);
 }
 
 export async function startGuidedUdfCreationCommand(selectedArtifact: FlinkArtifact) {

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -18,12 +18,8 @@ import { UriMetadata } from "../storage/types";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 import { promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
-const logger = new Logger("flinkUDFs");
 
-export async function setFlinkUDFViewModeCommand() {
-  flinkDatabaseViewMode.fire(FlinkDatabaseViewProviderMode.UDFs);
-  await setContextValue(ContextValues.flinkDatabaseViewMode, FlinkDatabaseViewProviderMode.UDFs);
-}
+const logger = new Logger("commands.flinkUDFs");
 
 export function registerFlinkUDFCommands(): Disposable[] {
   return [
@@ -41,6 +37,12 @@ export function registerFlinkUDFCommands(): Disposable[] {
     ),
   ];
 }
+
+export async function setFlinkUDFViewModeCommand() {
+  flinkDatabaseViewMode.fire(FlinkDatabaseViewProviderMode.UDFs);
+  await setContextValue(ContextValues.flinkDatabaseViewMode, FlinkDatabaseViewProviderMode.UDFs);
+}
+
 export async function createUdfRegistrationDocumentCommand(selectedArtifact: FlinkArtifact) {
   if (!selectedArtifact) {
     return;
@@ -60,19 +62,14 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
     content: "",
   });
   try {
-    // We'll gather all the metadata we can and attach it to the document
-    // In the future some of this could be handled by the codelens provider
-    const loader = CCloudResourceLoader.getInstance();
-    const catalog = await loader.getEnvironment(selectedArtifact.environmentId);
     const flinkDatabaseProvider = FlinkDatabaseViewProvider.getInstance();
-    const database = flinkDatabaseProvider.database; // selected database in Artifacts view
-    if (database && catalog) {
+    const database: CCloudFlinkDbKafkaCluster | null = flinkDatabaseProvider.database; // selected database in Artifacts view
+    if (database) {
       const metadata: UriMetadata = {
         // FLINK_COMPUTE_POOL_ID will fallback to `null` so the user has to pick a pool to run the statement,
         // to avoid conflicts between any default pool settings and the artifact-related catalog/database
         [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: database.flinkPools[0]?.id || null,
-        [UriMetadataKeys.FLINK_CATALOG_ID]: catalog.id,
-        [UriMetadataKeys.FLINK_CATALOG_NAME]: catalog.name,
+        [UriMetadataKeys.FLINK_CATALOG_ID]: database.environmentId,
         [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
         [UriMetadataKeys.FLINK_DATABASE_NAME]: database.name,
       };

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -34,7 +34,7 @@ export abstract class ParentedBaseViewProvider<
    * - Topics view: `KafkaCluster`
    * - Schemas view: `SchemaRegistry`
    * - Flink Statements view: `FlinkComputePool`
-   * - Flink Artifacts view: `FlinkComputePool`
+   * - Flink Databases view: `KafkaCluster` (as Flink database)
    */
   resource: P | null = null;
   /**


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

This is mostly follow-up work to allow the codelens helper functions to look up catalog/database metadata just based off of the IDs alone (which is all we have at the time we use a Flink artifact to create a UDF without using the loader to look up parent resource names):
https://github.com/confluentinc/vscode/blob/fdd12d21a1391b821d571726ac03a6a74da62afe/src/commands/flinkUDFs.ts#L62-L68

Closes #2707

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Sign into CCloud
2. Select a Flink database while in the artifacts view mode
3. Right-click an artifact and select `Register Flink Artifact with Flink SQL` to open the `CREATE FUNCTION` statement editor
4. Expect the Flink view provider's focused database (and parent catalog) to be pre-filled in the codelens (which is the existing behavior, so this is just making sure it isn't broken)

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Most of the line changes here is overall cleanup of `commands/flinkUDFs.test.ts` to reuse some existing patterns and stub behavior, and reorganizing to set up per-function `describe` blocks more easily
  - While handling merge conflicts from https://github.com/confluentinc/vscode/pull/2717, I realized `executeCreateFunction()` should go in `src/commands/utils/`, so it was moved to help more accurately test `startGuidedUdfCreationCommand()`

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
