### PR TITLE
Improve error handling for invalid JAR file uploads

### DIFF
--- a/src/commands/flinkArtifacts.ts
+++ b/src/commands/flinkArtifacts.ts
@@ -82,13 +82,24 @@ export async function uploadArtifactCommand(
       },
     );
   } catch (err) {
-    let errorMessage = "Failed to upload artifact: ";
+    let errorMessage = "Failed to upload artifact:";
     if (isResponseError(err)) {
-      const resp = await extractResponseBody(err);
-      try {
-        errorMessage = `${errorMessage} ${resp?.errors?.[0]?.detail}`;
-      } catch {
-        errorMessage = `${errorMessage} ${typeof resp === "string" ? resp : JSON.stringify(resp)}`;
+      const statusCode = err.response.status;
+
+      switch (statusCode) {
+        // Temporary fix to clarify generic error message from invalid JAR files until validation of JAR files is implemented
+        case 500:
+          errorMessage = `${errorMessage} Please make sure that you provided a valid JAR file`;
+          break;
+        default: {
+          const resp = await extractResponseBody(err);
+          try {
+            errorMessage = `${errorMessage} ${resp?.errors?.[0]?.detail}`;
+          } catch {
+            errorMessage = `${errorMessage} ${typeof resp === "string" ? resp : JSON.stringify(resp)}`;
+          }
+          break;
+        }
       }
     } else if (err instanceof Error) {
       errorMessage = `${errorMessage} ${err.message}`;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Adds specific error handling for `500` status codes when uploading invalid JAR files to Flink artifacts. This is a temporary fix to improve user experience until proper JAR validation is implemented client-side.
- Error message now displays `"Failed to upload artifact: Please make sure that you provided a valid JAR file"`
- Added test coverage for error messages

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Upload corrupted / invalid JAR file to Artifacts

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Fixes #2651
- Will require followup to validate JAR file instead of handling all `500` errors to custom message. 

<img width="1443" height="320" alt="Screenshot 2025-09-29 at 3 48 47 PM" src="https://github.com/user-attachments/assets/c3b0a76b-2d00-4978-98be-76ebbcd108b2" />

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [X] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
