### PR TITLE
Minor (UDFs): update copy to indicate fully classified name needed

### DIFF
--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -47,7 +47,7 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
   }
   const snippetString = new SnippetString()
     .appendText(`-- Register UDF for artifact "${selectedArtifact.name}"\n`)
-    .appendText(`-- Class name must be a fully qualified class name (e.g. "com.example.MyUDF")\n`)
+    .appendText(`-- Class name must be fully qualified (e.g. "com.example.MyUDF")\n`)
     .appendText("CREATE FUNCTION `")
     .appendPlaceholder("yourFunctionNameHere", 1)
     .appendText("` AS '")

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -47,7 +47,7 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
   }
   const snippetString = new SnippetString()
     .appendText(`-- Register UDF for artifact "${selectedArtifact.name}"\n`)
-    .appendText(`Class name must be a fully qualified class name (e.g. "com.example.MyUDF")\n`)
+    .appendText(`-- Class name must be a fully qualified class name (e.g. "com.example.MyUDF")\n`)
     .appendText("CREATE FUNCTION `")
     .appendPlaceholder("yourFunctionNameHere", 1)
     .appendText("` AS '")

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -49,9 +49,9 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
     .appendText(`-- Register UDF for artifact "${selectedArtifact.name}"\n`)
     .appendText(`-- Class name must be fully qualified (e.g. "com.example.MyUDF")\n`)
     .appendText("CREATE FUNCTION `")
-    .appendPlaceholder("yourFunctionNameHere", 1)
+    .appendPlaceholder("registeredFunctionName", 1)
     .appendText("` AS '")
-    .appendPlaceholder("your.class.NameHere", 2)
+    .appendPlaceholder("your.package.ClassName", 2)
     .appendText(`' USING JAR 'confluent-artifact://${selectedArtifact.id}';\n`)
     .appendText("-- confirm with 'SHOW USER FUNCTIONS';\n");
 

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -47,6 +47,7 @@ export async function createUdfRegistrationDocumentCommand(selectedArtifact: Fli
   }
   const snippetString = new SnippetString()
     .appendText(`-- Register UDF for artifact "${selectedArtifact.name}"\n`)
+    .appendText(`Class name must be a fully qualified class name (e.g. "com.example.MyUDF")\n`)
     .appendText("CREATE FUNCTION `")
     .appendPlaceholder("yourFunctionNameHere", 1)
     .appendText("` AS '")

--- a/src/commands/utils/uploadArtifactOrUDF.ts
+++ b/src/commands/utils/uploadArtifactOrUDF.ts
@@ -272,8 +272,8 @@ export async function promptForFunctionAndClassName(
   }
 
   const className = await vscode.window.showInputBox({
-    prompt: "Enter the fully qualified class name",
-    placeHolder: `your.class.NameHere`,
+    prompt: 'Enter the fully qualified class name, e.g. "com.example.MyUDF"',
+    placeHolder: `your.package.ClassName`,
     validateInput: (value) => validateUdfInput(value, classNameRegex),
     ignoreFocusOut: true,
   });

--- a/src/commands/utils/uploadArtifactOrUDF.ts
+++ b/src/commands/utils/uploadArtifactOrUDF.ts
@@ -261,7 +261,7 @@ export async function promptForFunctionAndClassName(
   const functionNameRegex = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
   const classNameRegex = /^[a-zA-Z_][a-zA-Z0-9_.]*$/;
   const functionName = await vscode.window.showInputBox({
-    prompt: "Enter a name for the new UDF function",
+    prompt: "Enter a name for the new UDF",
     placeHolder: defaultFunctionName,
     validateInput: (value) => validateUdfInput(value, functionNameRegex),
     ignoreFocusOut: true,
@@ -272,7 +272,7 @@ export async function promptForFunctionAndClassName(
   }
 
   const className = await vscode.window.showInputBox({
-    prompt: "Enter the fully qualified class name for the new UDF",
+    prompt: "Enter the fully qualified class name",
     placeHolder: `your.class.NameHere`,
     validateInput: (value) => validateUdfInput(value, classNameRegex),
     ignoreFocusOut: true,

--- a/src/commands/utils/uploadArtifactOrUDF.ts
+++ b/src/commands/utils/uploadArtifactOrUDF.ts
@@ -272,7 +272,7 @@ export async function promptForFunctionAndClassName(
   }
 
   const className = await vscode.window.showInputBox({
-    prompt: "Enter the class name for the new UDF",
+    prompt: "Enter the fully qualified class name for the new UDF",
     placeHolder: `your.class.NameHere`,
     validateInput: (value) => validateUdfInput(value, classNameRegex),
     ignoreFocusOut: true,


### PR DESCRIPTION
## Summary of Changes

Fixes #2652 

Updates the copy in both UDF flows (editor and guided user input) to hint that the user will need to enter the fully qualified class name. 

### Click-testing instructions

1. Open extension dev host
2. Connect to Confluent Cloud and select a cluster with artifactsw
3. Right-click on an Artifact and select a UDF registration path
4. Confirm that there is copy to indicate that user needs fully qualified classname like the screenshots below 

<img width="500" alt="Screenshot 2025-09-29 at 6 47 20 PM" src="https://github.com/user-attachments/assets/412a08da-6832-4f19-adc7-eb7c11e03230" />

_______________________________________________________________________________________


<img width="500" alt="Screenshot 2025-09-29 at 6 52 07 PM" src="https://github.com/user-attachments/assets/32713292-8cf1-49df-b455-bbe9a0232319" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
