### PR TITLE
Add E2E test covering generating project from Flink compute pool

### DIFF
--- a/tests/e2e/objects/views/viewItems/FlinkComputePoolItem.ts
+++ b/tests/e2e/objects/views/viewItems/FlinkComputePoolItem.ts
@@ -1,0 +1,8 @@
+import { ViewItem } from "./ViewItem";
+
+export class FlinkComputePoolItem extends ViewItem {
+  /** Start the "Generate project from resource" workflow from the right-click context menu of the Flink compute pool item. */
+  async generateProject(): Promise<void> {
+    await this.rightClickContextMenuAction("Generate project from resource");
+  }
+}

--- a/tests/e2e/objects/webviews/ProjectScaffoldWebview.ts
+++ b/tests/e2e/objects/webviews/ProjectScaffoldWebview.ts
@@ -21,6 +21,10 @@ export class ProjectScaffoldWebview extends Webview {
     return this.form.locator('[name="cc_topic"]');
   }
 
+  get computePoolIdField(): Locator {
+    return this.form.locator('[name="cc_compute_pool_id"]');
+  }
+
   async submitForm(): Promise<void> {
     return this.form.locator('input[type="submit"]').click();
   }

--- a/tests/e2e/specs/scaffold.spec.ts
+++ b/tests/e2e/specs/scaffold.spec.ts
@@ -23,6 +23,10 @@ import { Tag } from "../tags";
 import { openGeneratedProjectInCurrentWindow, verifyGeneratedProject } from "../utils/scaffold";
 import { openConfluentSidebar } from "../utils/sidebarNavigation";
 
+const TEST_ENV_NAME = "main-test-env";
+const TEST_COMPUTE_POOL_NAME = "main-test-pool";
+const TEST_COMPUTE_POOL_ID = "lfcp-5ovn9q";
+
 /**
  * E2E test suite for testing the Project Scaffolding functionality.
  * {@see https://github.com/confluentinc/vscode/issues/1840}
@@ -73,12 +77,12 @@ test.describe("Project Scaffolding", () => {
       const resourcesView = new ResourcesView(page);
       // First, expand the CCloud env
       await expect(resourcesView.ccloudEnvironments).not.toHaveCount(0);
-      await resourcesView.ccloudEnvironments.getByText("main-test-env").click();
+      await resourcesView.ccloudEnvironments.getByText(TEST_ENV_NAME).click();
       // Then click on a Flink compute pool
       await expect(resourcesView.ccloudFlinkComputePools).not.toHaveCount(0);
       const computePool = new FlinkComputePoolItem(
         page,
-        resourcesView.ccloudFlinkComputePools.getByText("main-test-pool"),
+        resourcesView.ccloudFlinkComputePools.getByText(TEST_COMPUTE_POOL_NAME),
       );
 
       // If we start the generate project flow from the right-click context menu
@@ -96,7 +100,7 @@ test.describe("Project Scaffolding", () => {
       // and we should see that the configuration file cloud.properties holds the correct values
       const configFileName = "cloud.properties";
       const explorerView = new View(page, "Explorer");
-      for (var name of ["src", "resources", configFileName]) {
+      for (const name of ["src", "resources", configFileName]) {
         const item = explorerView.treeItems.filter({
           hasText: name,
         });
@@ -107,7 +111,7 @@ test.describe("Project Scaffolding", () => {
       await expect(configFileDocument.tab).toBeVisible();
       await expect(configFileDocument.editorContent).toBeVisible();
       await expect(configFileDocument.editorContent).toContainText(
-        "client.compute-pool-id=lfcp-5ovn9q",
+        `client.compute-pool-id=${TEST_COMPUTE_POOL_ID}`,
       );
     });
   });

--- a/tests/e2e/specs/scaffold.spec.ts
+++ b/tests/e2e/specs/scaffold.spec.ts
@@ -78,7 +78,7 @@ test.describe("Project Scaffolding", () => {
       // First, expand the CCloud env
       await expect(resourcesView.ccloudEnvironments).not.toHaveCount(0);
       await resourcesView.ccloudEnvironments.getByText(TEST_ENV_NAME).click();
-      // Then click on a Flink compute pool
+      // Then verify we can see the Flink compute pool
       await expect(resourcesView.ccloudFlinkComputePools).not.toHaveCount(0);
       const computePool = new FlinkComputePoolItem(
         page,
@@ -89,6 +89,7 @@ test.describe("Project Scaffolding", () => {
       await computePool.generateProject();
       // and we choose a project template from the quickpick
       const projectQuickpick = new Quickpick(page);
+      await expect(projectQuickpick.locator).toBeVisible();
       await projectQuickpick.selectItemByText("Flink Table API In Java For Confluent Cloud");
       // and we submit the form using the pre-filled configuration
       const scaffoldForm = new ProjectScaffoldWebview(page);

--- a/tests/e2e/specs/scaffold.spec.ts
+++ b/tests/e2e/specs/scaffold.spec.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import path from "path";
 import { test } from "../baseTest";
 import { ConnectionType } from "../connectionTypes";
+import { TextDocument } from "../objects/editor/TextDocument";
 import { Quickpick } from "../objects/quickInputs/Quickpick";
 import { ResourcesView } from "../objects/views/ResourcesView";
 import { SupportView } from "../objects/views/SupportView";
@@ -13,11 +14,13 @@ import {
   SelectKafkaCluster,
   TopicsView,
 } from "../objects/views/TopicsView";
+import { View } from "../objects/views/View";
+import { FlinkComputePoolItem } from "../objects/views/viewItems/FlinkComputePoolItem";
 import { KafkaClusterItem } from "../objects/views/viewItems/KafkaClusterItem";
 import { TopicItem } from "../objects/views/viewItems/TopicItem";
 import { ProjectScaffoldWebview } from "../objects/webviews/ProjectScaffoldWebview";
 import { Tag } from "../tags";
-import { verifyGeneratedProject } from "../utils/scaffold";
+import { openGeneratedProjectInCurrentWindow, verifyGeneratedProject } from "../utils/scaffold";
 import { openConfluentSidebar } from "../utils/sidebarNavigation";
 
 /**
@@ -55,6 +58,59 @@ test.describe("Project Scaffolding", () => {
     [ConnectionType.Direct, Tag.Direct, DEFAULT_CCLOUD_TOPIC_REPLICATION_FACTOR],
     [ConnectionType.Local, Tag.Local, 1],
   ];
+
+  test.describe("CCloud connection", { tag: [Tag.CCloud] }, () => {
+    test.use({ connectionType: ConnectionType.Ccloud });
+
+    test.beforeEach(async ({ connectionItem }) => {
+      // ensure connection tree item has resources available to work with
+      await expect(connectionItem.locator).toHaveAttribute("aria-expanded", "true");
+    });
+
+    test(`should apply Flink Table API In Java For Confluent Cloud template from Flink compute pool`, async ({
+      page,
+    }) => {
+      const resourcesView = new ResourcesView(page);
+      // First, expand the CCloud env
+      await expect(resourcesView.ccloudEnvironments).not.toHaveCount(0);
+      await resourcesView.ccloudEnvironments.getByText("main-test-env").click();
+      // Then click on a Flink compute pool
+      await expect(resourcesView.ccloudFlinkComputePools).not.toHaveCount(0);
+      const computePool = new FlinkComputePoolItem(
+        page,
+        resourcesView.ccloudFlinkComputePools.getByText("main-test-pool"),
+      );
+
+      // If we start the generate project flow from the right-click context menu
+      await computePool.generateProject();
+      // and we choose a project template from the quickpick
+      const projectQuickpick = new Quickpick(page);
+      await projectQuickpick.selectItemByText("Flink Table API In Java For Confluent Cloud");
+      // and we submit the form using the pre-filled configuration
+      const scaffoldForm = new ProjectScaffoldWebview(page);
+      await expect(scaffoldForm.computePoolIdField).not.toBeEmpty();
+      await scaffoldForm.submitForm();
+
+      // Then we should see that the project was generated successfully
+      await openGeneratedProjectInCurrentWindow(page);
+      // and we should see that the configuration file cloud.properties holds the correct values
+      const configFileName = "cloud.properties";
+      const explorerView = new View(page, "Explorer");
+      for (var name of ["src", "resources", configFileName]) {
+        const item = explorerView.treeItems.filter({
+          hasText: name,
+        });
+        await expect(item).toBeVisible();
+        await item.click();
+      }
+      const configFileDocument = new TextDocument(page, configFileName);
+      await expect(configFileDocument.tab).toBeVisible();
+      await expect(configFileDocument.editorContent).toBeVisible();
+      await expect(configFileDocument.editorContent).toContainText(
+        "client.compute-pool-id=lfcp-5ovn9q",
+      );
+    });
+  });
 
   for (const [templateDisplayName, templateName] of templates) {
     test(`should apply ${templateDisplayName} template from Support view`, async ({ page }) => {

--- a/tests/e2e/utils/scaffold.ts
+++ b/tests/e2e/utils/scaffold.ts
@@ -5,6 +5,24 @@ import { NotificationArea } from "../objects/notifications/NotificationArea";
 import { View } from "../objects/views/View";
 
 /**
+ * Opens the generated project in the current window.
+ *
+ * @param page - The Playwright page object.
+ */
+export async function openGeneratedProjectInCurrentWindow(page: Page) {
+  // We should see that the project was generated successfully
+  const notificationArea = new NotificationArea(page);
+  const infoNotifications = notificationArea.infoNotifications.filter({
+    hasText: "Project Generated",
+  });
+  await expect(infoNotifications).not.toHaveCount(0);
+
+  // Open the generated project in the current window
+  const successNotification = new Notification(page, infoNotifications.first());
+  await successNotification.clickActionButton("Open in Current Window");
+}
+
+/**
  * Verifies that the project was generated successfully and that its .env file holds
  * the expected configuration.
  *
@@ -19,16 +37,7 @@ export async function verifyGeneratedProject(
   bootstrapServers: string,
   topic?: string,
 ) {
-  // We should see that the project was generated successfully
-  const notificationArea = new NotificationArea(page);
-  const infoNotifications = notificationArea.infoNotifications.filter({
-    hasText: "Project Generated",
-  });
-  await expect(infoNotifications).not.toHaveCount(0);
-
-  // Open the generated project in the current window
-  const successNotification = new Notification(page, infoNotifications.first());
-  await successNotification.clickActionButton("Open in Current Window");
+  await openGeneratedProjectInCurrentWindow(page);
 
   // Open the configuration file .env
   const envFileName = ".env";

--- a/tests/e2e/utils/scaffold.ts
+++ b/tests/e2e/utils/scaffold.ts
@@ -5,7 +5,7 @@ import { NotificationArea } from "../objects/notifications/NotificationArea";
 import { View } from "../objects/views/View";
 
 /**
- * Opens the generated project in the current window.
+ * Verifies that the project was generated successfully and opens it in the current window.
  *
  * @param page - The Playwright page object.
  */


### PR DESCRIPTION
## Summary of Changes

This change introduces a new E2E test that makes sure we can generate a new project from the right-click context menu of a Flink compute pool item in the Resources view.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
