### PR TITLE
MINOR fix: add validation for local Kafka+SR image tags settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -895,7 +895,10 @@
           "confluent.localDocker.kafkaImageTag": {
             "type": "string",
             "default": "7.9.0",
-            "description": "Docker image tag to use when starting a local Kafka container"
+            "description": "Docker image tag to use when starting a local Kafka container",
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_.-]*$",
+            "patternErrorMessage": "Image tag must start with an alphanumeric character or underscore, and can only contain alphanumeric characters, underscores, periods, or hyphens."
           },
           "confluent.localDocker.schemaRegistryImageRepo": {
             "type": "string",
@@ -908,7 +911,10 @@
           "confluent.localDocker.schemaRegistryImageTag": {
             "type": "string",
             "default": "7.9.0",
-            "markdownDescription": "Docker image tag to use when starting a local Schema Registry container"
+            "markdownDescription": "Docker image tag to use when starting a local Schema Registry container",
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_][a-zA-Z0-9_.-]*$",
+            "patternErrorMessage": "Image tag must start with an alphanumeric character or underscore, and can only contain alphanumeric characters, underscores, periods, or hyphens."
           }
         }
       },


### PR DESCRIPTION
Requires at least one character:
<img width="556" height="197" alt="image" src="https://github.com/user-attachments/assets/11c980bd-1621-420c-b3e5-45b68a4cb1b3" />

No invalid characters:
<img width="563" height="206" alt="image" src="https://github.com/user-attachments/assets/7dca5570-077e-4420-abe1-ddd95b1285a3" />

`latest` and other version tag patterns are fine:
<img width="593" height="269" alt="image" src="https://github.com/user-attachments/assets/3a7ec6ce-0e14-47af-b34f-4aab83582ea1" />
