### PR TITLE
[main] update `when` clauses for selecting Flink database from the Resources view and right-clicking a Kafka cluster or compute pool to be based off of `confluent.flink.artifacts` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1860,12 +1860,12 @@
         },
         {
           "command": "confluent.flinkdatabase.kafka-cluster.select",
-          "when": "view == confluent-resources && viewItem =~ /.*-flinkable.*-kafka-cluster/",
+          "when": "view == confluent-resources && viewItem =~ /.*-flinkable.*-kafka-cluster/ && config.confluent.flink.artifacts",
           "group": "4_flink@1"
         },
         {
           "command": "confluent.uploadArtifact",
-          "when": "view in confluent.viewsWithResources && (viewItem =~ /.*-kafka-cluster.*/ || viewItem =~ /.*compute-pool*/)",
+          "when": "view in confluent.viewsWithResources && (viewItem =~ /.*-kafka-cluster.*/ || viewItem =~ /.*compute-pool*/) && config.confluent.flink.artifacts",
           "group": "4_flink@1"
         },
         {


### PR DESCRIPTION
Same as https://github.com/confluentinc/vscode/pull/2753