### PR TITLE
Delete Flink Statement functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -646,6 +646,11 @@
         "category": "Confluent: Flink Statements"
       },
       {
+        "command": "confluent.statements.delete",
+        "title": "Delete Statement",
+        "category": "Confluent: Flink Statements"
+      },
+      {
         "command": "confluent.statements.flink-compute-pool.select",
         "icon": "$(confluent-flink-compute-pool)",
         "title": "Select Flink Compute Pool",
@@ -660,11 +665,6 @@
       {
         "command": "confluent.statements.viewstatementsql",
         "title": "View Statement SQL",
-        "category": "Confluent: Flink Statements"
-      },
-      {
-        "command": "confluent.statements.delete",
-        "title": "Delete Statement",
         "category": "Confluent: Flink Statements"
       },
       {
@@ -1477,6 +1477,10 @@
           "when": "false"
         },
         {
+          "command": "confluent.statements.delete",
+          "when": "false"
+        },
+        {
           "command": "confluent.statements.flink-compute-pool.select",
           "when": "confluent.ccloudConnectionAvailable"
         },
@@ -1486,10 +1490,6 @@
         },
         {
           "command": "confluent.statements.viewstatementsql",
-          "when": "false"
-        },
-        {
-          "command": "confluent.statements.delete",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -663,6 +663,11 @@
         "category": "Confluent: Flink Statements"
       },
       {
+        "command": "confluent.statements.delete",
+        "title": "Delete Statement",
+        "category": "Confluent: Flink Statements"
+      },
+      {
         "command": "confluent.support.confluent-walkthrough.launch",
         "title": "Get Started with Kafka",
         "category": "Confluent: Support"
@@ -1484,6 +1489,10 @@
           "when": "false"
         },
         {
+          "command": "confluent.statements.delete",
+          "when": "false"
+        },
+        {
           "command": "confluent.support.confluent-walkthrough.launch",
           "when": "true"
         },
@@ -2014,8 +2023,14 @@
         },
         {
           "command": "confluent.flinkStatementResults",
+          "comment": "statements whose results are not viewable will have context value of '...flink-statement-not-viewable', so note the $ at the end of the regex to exclude those",
           "when": "view == confluent-flink-statements && viewItem =~ /.*flink-statement$/",
           "group": "inline@1"
+        },
+        {
+          "command": "confluent.statements.delete",
+          "when": "view == confluent-flink-statements && viewItem =~ /.*flink-statement.*/",
+          "group": "3_statements_crudl@1"
         }
       ],
       "explorer/context": [

--- a/src/commands/flinkStatements.ts
+++ b/src/commands/flinkStatements.ts
@@ -375,11 +375,31 @@ async function openFlinkStatementResultsView(statement: FlinkStatement | undefin
   });
 }
 
+export async function deleteFlinkStatementCommand(statement: FlinkStatement): Promise<void> {
+  if (!statement || !(statement instanceof FlinkStatement)) {
+    logger.error("deleteFlinkStatementCommand", "statement is invalid");
+    return;
+  }
+  const ccloudLoader = CCloudResourceLoader.getInstance();
+
+  try {
+    await ccloudLoader.deleteFlinkStatement(statement);
+  } catch (err) {
+    logger.error("deleteFlinkStatementCommand", `Error deleting statement: ${err}`);
+    await showErrorNotificationWithButtons(`Error deleting statement: ${err}`);
+    return;
+  }
+
+  // Show a notification that the statement was deleted.
+  void vscode.window.showInformationMessage(`Deleted statement ${statement.name}`);
+}
+
 export function registerFlinkStatementCommands(): vscode.Disposable[] {
   return [
     registerCommandWithLogging("confluent.statements.viewstatementsql", viewStatementSqlCommand),
     registerCommandWithLogging("confluent.statements.create", submitFlinkStatementCommand),
     // Different naming scheme due to legacy telemetry reasons.
     registerCommandWithLogging("confluent.flinkStatementResults", openFlinkStatementResultsView),
+    registerCommandWithLogging("confluent.statements.delete", deleteFlinkStatementCommand),
   ];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -375,6 +375,7 @@ async function setupContextValues() {
     "ccloud-schema-registry",
     "ccloud-flink-compute-pool",
     "ccloud-flink-statement",
+    "ccloud-flink-statement-not-viewable",
   ]);
   // allow for easier matching using "in" clauses for our Resources/Topics/Schemas views
   const viewsWithResources = setContextValue(ContextValues.VIEWS_WITH_RESOURCES, [
@@ -408,6 +409,7 @@ async function setupContextValues() {
     "ccloud-flinkable-kafka-cluster",
     "ccloud-flink-compute-pool",
     "ccloud-flink-statement",
+    "ccloud-flink-statement-not-viewable",
     "ccloud-flink-artifact",
     "ccloud-flink-udf",
     "local-kafka-cluster",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Infrastructure and context menu command to delete a Flink statement.
- Also automatically invoke after having run a background statement and consumed its results. Frees up the statement name within the compute cluster, somewhat useful for if the user might manage to be able to submit a statement with the same name (implying within the same second).
- While here, I noticed that a couple of context menu items ("Copy name", "View in Confluent Cloud") were not showing up properly if a statement was not the sort that may have viewable results. Issue was that those statements context value end with '-not-viewable', and the constants backing the command when clauses were not updated when that extension was created.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Submit a statement, or find an existing not-useful-anymore statement in our compute clusters.
2. Right click, invoke "Delete Statement"
3. See it disappear from the view and a notification raised saying that you deleted the statement.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2597

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
