### PR TITLE
[bug fix] Direct connect form: send auth update to host after override

### DIFF
--- a/src/webview/direct-connect-form.ts
+++ b/src/webview/direct-connect-form.ts
@@ -218,6 +218,10 @@ class DirectConnectFormViewModel extends ViewModel {
         ).map((option) => option.value);
         if (!validAuthTypes.includes(this.kafkaAuthType())) {
           this.kafkaAuthType(validAuthTypes[0]);
+          await post("SaveFormAuthType", {
+            inputName: "kafka_cluster.auth_type",
+            inputValue: validAuthTypes[0],
+          });
         }
         break;
       }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Closes #2767 
- Added a call to save the auth type in VSCode host when we manually override it, so it persists in form state

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Open a new direct connection webview form and choose "Confluent Cloud" as type of connection - API key auth type will be auto selected.
2. Fill in API key for Kafka cluster
3. Open or click to another editor tab in vscode so the form is hidden from view but still open
4. On return to the form, expect the API fields to remain and still contain the key you entered. (with the bug, the fields for API auth were hidden).

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- We send an update from the webform to the vscode host env for each input (form field) change by default. In this case we're overriding the value of `auth_type` input when the `platform_type` input changes, but were missing the corresponding update for `auth_type`. You can see related host updates happening for overrides in the same switch handler, e.g. if the user enters a `localhost` value, or updates `warpStreamPortForwardingEnabled`. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
