### PR TITLE
[1.7] Add proper WHERE clauses to the UDFs system catalog query

### DIFF
--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -32,9 +32,9 @@ import { ObjectSet } from "../utils/objectset";
 import { executeInWorkerPool, ExecutionResult, extract } from "../utils/workerPool";
 import { CachingResourceLoader } from "./cachingResourceLoader";
 import {
+  getUdfSystemCatalogQuery,
   RawUdfSystemCatalogRow,
   transformUdfSystemCatalogRows,
-  UDF_SYSTEM_CATALOG_QUERY,
 } from "./ccloudResourceLoaderUtils";
 import { generateFlinkStatementKey } from "./loaderUtils";
 
@@ -368,11 +368,14 @@ export class CCloudResourceLoader extends CachingResourceLoader<
     if (udfs === undefined || forceDeepRefresh) {
       // Run the statement to list UDFs.
 
+      // Get the query to run, limiting by the given cluster's ID.
+      const udfSystemCatalogQuery = getUdfSystemCatalogQuery(cluster);
+
       // Will raise Error if the cluster isn't Flinkable or if the statement
       // execution fails. Will use the first compute pool in the cluster's
       // flinkPools array to execute the statement.
       const rawResults = await this.executeFlinkStatement<RawUdfSystemCatalogRow>(
-        UDF_SYSTEM_CATALOG_QUERY,
+        udfSystemCatalogQuery,
         cluster,
         { nameSpice: "list-udfs" },
       );

--- a/src/loaders/ccloudResourceLoaderUtils.test.ts
+++ b/src/loaders/ccloudResourceLoaderUtils.test.ts
@@ -3,12 +3,24 @@ import * as assert from "assert";
 import { TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { makeUdfFunctionRow, makeUdfParameterRow } from "../../tests/unit/testResources/makeUdfRow";
 import {
+  getUdfSystemCatalogQuery,
   RawUdfSystemCatalogRow,
   sortUdfSystemCatalogRows,
   transformUdfSystemCatalogRows,
 } from "./ccloudResourceLoaderUtils";
 
 describe("loaders/ccloudResourceLoaderUtils.ts", () => {
+  describe("getUdfSystemCatalogQuery()", () => {
+    // This function is trivial, just returns a constant string with the cluster ID filled in twice.
+    // Ensure is mentioned twice. Only E2E / clicktesting can prove that the query is otherwise sound.
+    it("should return string with cluster's id mixed in 2x", () => {
+      const query = getUdfSystemCatalogQuery(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
+      const occurrences = query.match(new RegExp(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER.id, "g"));
+      assert.ok(occurrences);
+      assert.strictEqual(occurrences.length, 2);
+    });
+  });
+
   describe("transformUDFSystemCatalogRows()", () => {
     it("should balk if encounters repeated function rows describing same functionSpecificName", () => {
       const rows: RawUdfSystemCatalogRow[] = [

--- a/src/loaders/ccloudResourceLoaderUtils.ts
+++ b/src/loaders/ccloudResourceLoaderUtils.ts
@@ -38,7 +38,7 @@ export function getUdfSystemCatalogQuery(database: CCloudFlinkDbKafkaCluster): s
     cast(null as string)  as \`parameterTraits\`
   from \`INFORMATION_SCHEMA\`.\`ROUTINES\`
   where ROUTINE_TYPE = 'FUNCTION'
-    and ROUTINE_SCHEMA_ID = '${database.id}')
+    and SPECIFIC_SCHEMA_ID = '${database.id}')
 
   union all
 

--- a/src/loaders/ccloudResourceLoaderUtils.ts
+++ b/src/loaders/ccloudResourceLoaderUtils.ts
@@ -38,7 +38,7 @@ export function getUdfSystemCatalogQuery(database: CCloudFlinkDbKafkaCluster): s
     cast(null as string)  as \`parameterTraits\`
   from \`INFORMATION_SCHEMA\`.\`ROUTINES\`
   where ROUTINE_TYPE = 'FUNCTION'
-    and SPECIFIC_SCHEMA_ID = '${database.id}')
+    and \`SPECIFIC_SCHEMA_ID\` = '${database.id}')
 
   union all
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Refine the SQL used to query for UDFs and their parameters by limiting both halves of the query to a single Flink database (by its id, via `INFORMATION_SCHEMA.ROUTINES` and `PARAMETERS` views's common column `SPECIFIC_SCHEMA_ID` , doc'd as "The ID of the database").
- I missed including that filter previously, so were getting ... perhaps all of the UDFs in the cloud/region/environment, yet claiming were just for a single Flink database.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Select one of our Flink databases as a Flink database, then switch to the UDFs view. Should now only see fewer UDFs, and they should match the list offered by Flink Workspace's 'Functions' schema browser subset for the same database, then nothing to hang a bad 'delete UDF' action from.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2765 in v1.7.x timeline.
- Also preemptively fixes "failing to delete a UDF that does not exist", because we're not showing UDFs from other databases any more.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
