### PR TITLE
[main] Add proper WHERE clauses to the UDFs system catalog query

### DIFF
--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -32,9 +32,9 @@ import { ObjectSet } from "../utils/objectset";
 import { executeInWorkerPool, ExecutionResult, extract } from "../utils/workerPool";
 import { CachingResourceLoader } from "./cachingResourceLoader";
 import {
+  getUdfSystemCatalogQuery,
   RawUdfSystemCatalogRow,
   transformUdfSystemCatalogRows,
-  UDF_SYSTEM_CATALOG_QUERY,
 } from "./ccloudResourceLoaderUtils";
 import { generateFlinkStatementKey } from "./loaderUtils";
 
@@ -368,11 +368,14 @@ export class CCloudResourceLoader extends CachingResourceLoader<
     if (udfs === undefined || forceDeepRefresh) {
       // Run the statement to list UDFs.
 
+      // Get the query to run, limiting by the given cluster's ID.
+      const udfSystemCatalogQuery = getUdfSystemCatalogQuery(cluster);
+
       // Will raise Error if the cluster isn't Flinkable or if the statement
       // execution fails. Will use the first compute pool in the cluster's
       // flinkPools array to execute the statement.
       const rawResults = await this.executeFlinkStatement<RawUdfSystemCatalogRow>(
-        UDF_SYSTEM_CATALOG_QUERY,
+        udfSystemCatalogQuery,
         cluster,
         { nameSpice: "list-udfs" },
       );

--- a/src/loaders/ccloudResourceLoaderUtils.test.ts
+++ b/src/loaders/ccloudResourceLoaderUtils.test.ts
@@ -3,12 +3,24 @@ import * as assert from "assert";
 import { TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { makeUdfFunctionRow, makeUdfParameterRow } from "../../tests/unit/testResources/makeUdfRow";
 import {
+  getUdfSystemCatalogQuery,
   RawUdfSystemCatalogRow,
   sortUdfSystemCatalogRows,
   transformUdfSystemCatalogRows,
 } from "./ccloudResourceLoaderUtils";
 
 describe("loaders/ccloudResourceLoaderUtils.ts", () => {
+  describe("getUdfSystemCatalogQuery()", () => {
+    // This function is trivial, just returns a constant string with the cluster ID filled in twice.
+    // Ensure is mentioned twice. Only E2E / clicktesting can prove that the query is otherwise sound.
+    it("should return string with cluster's id mixed in 2x", () => {
+      const query = getUdfSystemCatalogQuery(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
+      const occurrences = query.match(new RegExp(TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER.id, "g"));
+      assert.ok(occurrences);
+      assert.strictEqual(occurrences.length, 2);
+    });
+  });
+
   describe("transformUDFSystemCatalogRows()", () => {
     it("should balk if encounters repeated function rows describing same functionSpecificName", () => {
       const rows: RawUdfSystemCatalogRow[] = [

--- a/src/loaders/ccloudResourceLoaderUtils.ts
+++ b/src/loaders/ccloudResourceLoaderUtils.ts
@@ -8,48 +8,58 @@ import { Logger } from "../logging";
 const logger = new Logger("ccloudResourceLoaderUtils");
 
 /**
- * Query that unions together bits describing user-supplied functions and their parameters. The rows
- * will be of two types: those describing a function and those describing a parameter.  The two types
- * can be distinguished by the parameterOrdinalPosition being null (for function rows) or a number (for parameter rows).
- * The function rows will have details about the function itself, while the parameter rows will have details
- * about each parameter. The two can be joined on functionSpecificName.
+ * Instantiate the UDF system catalog query for a given database (cluster) as the limiting "Flink Schema ID".
+ *
+ * @param database The database (cluster) to get UDFs for
+ * @returns The SQL query string
  */
-export const UDF_SYSTEM_CATALOG_QUERY = `
-(select
-  SPECIFIC_NAME as \`functionSpecificName\`,
-  ROUTINE_NAME as \`functionRoutineName\`,
-  cast(null as int) as \`parameterOrdinalPosition\`,
-  cast(null as string) as \`parameterName\`,
-  FULL_DATA_TYPE as \`fullDataType\`,
-  EXTERNAL_NAME as \`functionExternalName\`,
-  EXTERNAL_LANGUAGE as \`functionExternalLanguage\`,
-  EXTERNAL_ARTIFACTS as \`functionExternalArtifacts\`,
-  IS_DETERMINISTIC as \`isDeterministic\`,
-  cast(CREATED as string) as \`functionCreatedTs\`,
-  FUNCTION_KIND as \`functionKind\`,
-  cast(false as string) as \`isParameterOptional\`,
-  cast(null as string)  as \`parameterTraits\`
-from \`INFORMATION_SCHEMA\`.\`ROUTINES\`
-where ROUTINE_TYPE = 'FUNCTION')
+export function getUdfSystemCatalogQuery(database: CCloudFlinkDbKafkaCluster): string {
+  /**
+   * Query that unions together bits describing user-supplied functions and their parameters. The rows
+   * will be of two types: those describing a function and those describing a parameter.  The two types
+   * can be distinguished by the parameterOrdinalPosition being null (for function rows) or a number (for parameter rows).
+   * The function rows will have details about the function itself, while the parameter rows will have details
+   * about each parameter. The two can be joined on functionSpecificName.
+   */
+  return `
+  (select
+    SPECIFIC_NAME as \`functionSpecificName\`,
+    ROUTINE_NAME as \`functionRoutineName\`,
+    cast(null as int) as \`parameterOrdinalPosition\`,
+    cast(null as string) as \`parameterName\`,
+    FULL_DATA_TYPE as \`fullDataType\`,
+    EXTERNAL_NAME as \`functionExternalName\`,
+    EXTERNAL_LANGUAGE as \`functionExternalLanguage\`,
+    EXTERNAL_ARTIFACTS as \`functionExternalArtifacts\`,
+    IS_DETERMINISTIC as \`isDeterministic\`,
+    cast(CREATED as string) as \`functionCreatedTs\`,
+    FUNCTION_KIND as \`functionKind\`,
+    cast(false as string) as \`isParameterOptional\`,
+    cast(null as string)  as \`parameterTraits\`
+  from \`INFORMATION_SCHEMA\`.\`ROUTINES\`
+  where ROUTINE_TYPE = 'FUNCTION'
+    and \`SPECIFIC_SCHEMA_ID\` = '${database.id}')
 
-union all
+  union all
 
-(select
-  SPECIFIC_NAME as \`functionSpecificName\`,
-  ROUTINE_NAME as \`functionRoutineName\`,
-  ORDINAL_POSITION as \`parameterOrdinalPosition\`,
-  PARAMETER_NAME as \`parameterName\`,
-  FULL_DATA_TYPE as \`fullDataType\`,
-  cast(null as string) as \`functionExternalName\`,
-  cast(null as string) as \`functionExternalLanguage\`,
-  cast(null as string) as \`functionExternalArtifacts\`,
-  cast(null as string) as \`isDeterministic\`,
-  cast(null as string) as \`functionCreatedTs\`,
-  cast(null as string) as \`functionKind\`,
-  IS_OPTIONAL as \`isParameterOptional\`,
-  TRAITS as \`parameterTraits\`
-from \`INFORMATION_SCHEMA\`.\`PARAMETERS\`)
-`;
+  (select
+    SPECIFIC_NAME as \`functionSpecificName\`,
+    ROUTINE_NAME as \`functionRoutineName\`,
+    ORDINAL_POSITION as \`parameterOrdinalPosition\`,
+    PARAMETER_NAME as \`parameterName\`,
+    FULL_DATA_TYPE as \`fullDataType\`,
+    cast(null as string) as \`functionExternalName\`,
+    cast(null as string) as \`functionExternalLanguage\`,
+    cast(null as string) as \`functionExternalArtifacts\`,
+    cast(null as string) as \`isDeterministic\`,
+    cast(null as string) as \`functionCreatedTs\`,
+    cast(null as string) as \`functionKind\`,
+    IS_OPTIONAL as \`isParameterOptional\`,
+    TRAITS as \`parameterTraits\`
+  from \`INFORMATION_SCHEMA\`.\`PARAMETERS\`
+  WHERE \`SPECIFIC_SCHEMA_ID\` = '${database.id}')
+  `;
+}
 
 /** Raw results type corresponding to UDF_SYSTEM_CATALOG_QUERY */
 export type RawUdfSystemCatalogRow =


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Bring #2772 forward into main.
- Refine the system catalog query used for gathering UDF information to limit to a single Flink database id