### PR TITLE
[main] add udfsChanged emitter upon deletion

### DIFF
--- a/src/commands/flinkUDFs.test.ts
+++ b/src/commands/flinkUDFs.test.ts
@@ -3,12 +3,14 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { eventEmitterStubs } from "../../tests/stubs/emitters";
 import { getStubbedResourceManager } from "../../tests/stubs/extensionStorage";
+import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
 import {
   createFlinkArtifact,
   TEST_CCLOUD_ENVIRONMENT,
   TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER,
 } from "../../tests/unit/testResources";
+import { createFlinkUDF } from "../../tests/unit/testResources/flinkUDF";
 import { createResponseError, ResponseErrorSource } from "../../tests/unit/testUtils";
 import { ResponseError as FlinkArtifactsResponseError } from "../clients/flinkArtifacts";
 import { CCloudResourceLoader } from "../loaders/ccloudResourceLoader";
@@ -28,8 +30,6 @@ import {
 } from "./flinkUDFs";
 import * as commands from "./index";
 import * as uploadArtifact from "./utils/uploadArtifactOrUDF";
-import { createFlinkUDF } from "../../tests/unit/testResources/flinkUDF";
-import { getShowErrorNotificationWithButtonsStub } from "../../tests/stubs/notifications";
 
 describe("commands/flinkUDFs.ts", () => {
   let sandbox: sinon.SinonSandbox;
@@ -38,10 +38,15 @@ describe("commands/flinkUDFs.ts", () => {
   const mockEnvironment: CCloudEnvironment = TEST_CCLOUD_ENVIRONMENT;
   const mockDatabase: CCloudFlinkDbKafkaCluster = TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER;
 
+  let stubbedUDFsChangedEmitter: sinon.SinonStubbedInstance<
+    vscode.EventEmitter<CCloudFlinkDbKafkaCluster>
+  >;
+
   let withProgressStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    stubbedUDFsChangedEmitter = eventEmitterStubs(sandbox).udfsChanged!;
     withProgressStub = sandbox.stub(vscode.window, "withProgress").callsFake((_, callback) => {
       const mockProgress = {
         report: sandbox.stub(),
@@ -168,8 +173,7 @@ describe("commands/flinkUDFs.ts", () => {
       await deleteFlinkUDFCommand(mockUDF);
 
       sinon.assert.calledThrice(progressReportStub);
-      sinon.assert.calledOnce(mockFlinkDatabaseViewProvider.refresh);
-      sinon.assert.calledWith(mockFlinkDatabaseViewProvider.refresh, true);
+      sinon.assert.calledOnceWithExactly(stubbedUDFsChangedEmitter.fire, mockDatabase);
       sinon.assert.calledOnce(showInfoStub);
     });
   });
@@ -290,9 +294,6 @@ describe("commands/flinkUDFs.ts", () => {
     let fakeViewProvider: sinon.SinonStubbedInstance<FlinkDatabaseViewProvider>;
     let promptStub: sinon.SinonStub;
     let executeCreateFunctionStub: sinon.SinonStub;
-    let stubbedUDFsChangedEmitter: sinon.SinonStubbedInstance<
-      vscode.EventEmitter<CCloudFlinkDbKafkaCluster>
-    >;
     let showErrorStub: sinon.SinonStub;
 
     const functionName = "testFunction";
@@ -309,7 +310,6 @@ describe("commands/flinkUDFs.ts", () => {
         className,
       });
       executeCreateFunctionStub = sandbox.stub(uploadArtifact, "executeCreateFunction").resolves();
-      stubbedUDFsChangedEmitter = eventEmitterStubs(sandbox).udfsChanged!;
 
       showErrorStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");
     });

--- a/src/commands/flinkUDFs.ts
+++ b/src/commands/flinkUDFs.ts
@@ -3,10 +3,11 @@ import { registerCommandWithLogging } from ".";
 import { ContextValues, setContextValue } from "../context/values";
 import { flinkDatabaseViewMode, udfsChanged } from "../emitters";
 import { isResponseError, logError } from "../errors";
+import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import { FlinkArtifact } from "../models/flinkArtifact";
-import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
 import { FlinkUdf } from "../models/flinkUDF";
+import { CCloudFlinkDbKafkaCluster } from "../models/kafkaCluster";
 import {
   showErrorNotificationWithButtons,
   showInfoNotificationWithButtons,
@@ -17,7 +18,6 @@ import { UriMetadata } from "../storage/types";
 import { FlinkDatabaseViewProvider } from "../viewProviders/flinkDatabase";
 import { FlinkDatabaseViewProviderMode } from "../viewProviders/multiViewDelegates/constants";
 import { executeCreateFunction, promptForFunctionAndClassName } from "./utils/uploadArtifactOrUDF";
-import { CCloudResourceLoader } from "../loaders";
 
 const logger = new Logger("commands.flinkUDFs");
 
@@ -73,7 +73,7 @@ export async function deleteFlinkUDFCommand(selectedUdf: FlinkUdf): Promise<void
 
         progress.report({ message: "Updating cache..." });
 
-        flinkDatabaseProvider.refresh(true);
+        udfsChanged.fire(database);
 
         progress.report({ message: "UDF deleted successfully." });
       },


### PR DESCRIPTION
## Summary of Changes

Updates the delete command to use the `udfsChanged` emitter to be more consistent with the pattern established in the artifacts list. 

### Optional: Click-testing instructions

1. Open the dev host, log in to CCloud, open the UDFs view.
2. Click delete. List should instantly update.
3. Try with another, this time `esc` out of delete once you get a warning. Relevant UDF should persist. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
