### PR TITLE
MINOR cleanup: remove top-level Resources view refresh command 

### DIFF
--- a/package.json
+++ b/package.json
@@ -504,12 +504,6 @@
         "category": "Confluent: Kafka Clusters"
       },
       {
-        "command": "confluent.resources.refresh",
-        "icon": "$(sync)",
-        "title": "Refresh",
-        "category": "Confluent: Resources"
-      },
-      {
         "command": "confluent.resources.refreshConnection",
         "icon": "$(sync)",
         "title": "Refresh Connection",
@@ -1370,10 +1364,6 @@
         {
           "command": "confluent.resources.kafka-cluster.copyBootstrapServers",
           "when": "false"
-        },
-        {
-          "command": "confluent.resources.refresh",
-          "when": "true"
         },
         {
           "command": "confluent.resources.refreshConnection",

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -10,8 +10,6 @@ import {
 import { ExtensionContextNotSetError } from "./errors";
 import { getRefreshableViewProviders } from "./extension";
 import { ResourceManager } from "./storage/resourceManager";
-import { BaseViewProvider } from "./viewProviders/baseModels/base";
-import { ResourceViewProvider } from "./viewProviders/resources";
 import { SchemasViewProvider } from "./viewProviders/schemas";
 import { TopicViewProvider } from "./viewProviders/topics";
 
@@ -39,11 +37,6 @@ describe("ExtensionContext", () => {
 
   it("should not allow ExtensionContext-dependent singletons to be created before extension activation", async () => {
     const extensionContextSingletons = [
-      {
-        callable: () => ResourceViewProvider.getInstance(),
-        source: "ResourceViewProvider",
-        clear: () => BaseViewProvider["instanceMap"].delete("ResourceViewProvider"),
-      },
       {
         callable: () => TopicViewProvider.getInstance(),
         source: "TopicViewProvider",
@@ -101,7 +94,7 @@ describe("Refreshable views tests", () => {
    *
    * When a new one is added, its `kind` attribute value should be added to this list.
    */
-  const expectedKinds = ["resources", "topics", "schemas", "statements", "flinkdatabase"];
+  const expectedKinds = ["topics", "schemas", "statements", "flinkdatabase"];
 
   before(async () => {
     await getTestExtensionContext();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -496,7 +496,6 @@ export function getRefreshableViewProviders(): RefreshableTreeViewProvider[] {
   // When adding a new refreshable view, also update the test block
   // "Refreshable views tests" in extension.test.ts.
   const refreshables = [
-    ResourceViewProvider.getInstance(),
     TopicViewProvider.getInstance(),
     SchemasViewProvider.getInstance(),
     FlinkStatementsViewProvider.getInstance(),

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -81,7 +81,7 @@ test.describe("Direct Connection CRUD Lifecycle", { tag: [Tag.DirectConnectionCR
         schemaRegistryConfig = undefined;
       });
 
-      test.describe.only("CCloud API key+secret", { tag: [Tag.Direct] }, () => {
+      test.describe("CCloud API key+secret", { tag: [Tag.Direct] }, () => {
         const name = "CCloud API key+secret";
         const formConnectionType = FormConnectionType.ConfluentCloud;
 

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -81,7 +81,7 @@ test.describe("Direct Connection CRUD Lifecycle", { tag: [Tag.DirectConnectionCR
         schemaRegistryConfig = undefined;
       });
 
-      test.describe("CCloud API key+secret", { tag: [Tag.Direct] }, () => {
+      test.describe.only("CCloud API key+secret", { tag: [Tag.Direct] }, () => {
         const name = "CCloud API key+secret";
         const formConnectionType = FormConnectionType.ConfluentCloud;
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up to https://github.com/confluentinc/vscode/pull/2743 now that there is no old Resource view provider, which implemented the top-level refresh. The new provider has connection-row-level refreshes.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [x] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
