### PR TITLE
Rename event emitter currentSchemaRegistryChanged to schemasViewResourceChanged

### DIFF
--- a/src/commands/schemaRegistry.ts
+++ b/src/commands/schemaRegistry.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
-import { currentSchemaRegistryChanged } from "../emitters";
+import { schemasViewResourceChanged } from "../emitters";
 import { SchemaRegistry } from "../models/schemaRegistry";
 import { schemaRegistryQuickPickWithViewProgress } from "../quickpicks/schemaRegistries";
 
@@ -13,7 +13,7 @@ export async function selectSchemaRegistryCommand(item?: SchemaRegistry) {
   }
   // only called when clicking a Schema Registry in the Resources view; not a dedicated view
   // action or command palette option
-  currentSchemaRegistryChanged.fire(schemaRegistry);
+  schemasViewResourceChanged.fire(schemaRegistry);
   vscode.commands.executeCommand("confluent-schemas.focus");
 }
 

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -106,7 +106,7 @@ export const topicsViewResourceChanged = new vscode.EventEmitter<KafkaCluster | 
  * "Select Schema Registry" action from the Schemas view, or cleared out from a connection
  * (or CCloud organization) change.
  */
-export const currentSchemaRegistryChanged = new vscode.EventEmitter<SchemaRegistry | null>();
+export const schemasViewResourceChanged = new vscode.EventEmitter<SchemaRegistry | null>();
 /**
  * Fired whenever a Flink compute pool is selected from the Resources view or the Flink Statements
  * view, chosen from the "Select Flink Compute Pool" action from the Flink Statements view or

--- a/src/sidecar/connections/ccloud.test.ts
+++ b/src/sidecar/connections/ccloud.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../tests/unit/testResources";
 import { getTestExtensionContext } from "../../../tests/unit/testUtils";
 import { ContextValues, setContextValue } from "../../context/values";
-import { currentSchemaRegistryChanged, topicsViewResourceChanged } from "../../emitters";
+import { schemasViewResourceChanged, topicsViewResourceChanged } from "../../emitters";
 import { SchemasViewProvider } from "../../viewProviders/schemas";
 import { TopicViewProvider } from "../../viewProviders/topics";
 import { clearCurrentCCloudResources, hasCCloudAuthSession } from "./ccloud";
@@ -30,7 +30,7 @@ describe("sidecar/connections/ccloud.ts", () => {
     const mockedCCLoudLoader = getStubbedCCloudResourceLoader(sandbox);
 
     const currentKafkaClusterChangedFireStub = sandbox.stub(topicsViewResourceChanged, "fire");
-    const currentSchemaRegistryChangedFireStub = sandbox.stub(currentSchemaRegistryChanged, "fire");
+    const schemasViewResourceChangedFireStub = sandbox.stub(schemasViewResourceChanged, "fire");
 
     // Set the view controllers to be focused on CCloud resources
     const topicViewProvider = TopicViewProvider.getInstance();
@@ -42,12 +42,12 @@ describe("sidecar/connections/ccloud.ts", () => {
 
     assert.ok(mockedCCLoudLoader.reset.calledOnce);
     assert.ok(currentKafkaClusterChangedFireStub.calledOnceWith(null));
-    assert.ok(currentSchemaRegistryChangedFireStub.calledOnceWith(null));
+    assert.ok(schemasViewResourceChangedFireStub.calledOnceWith(null));
 
     // Reset the stubs
     mockedCCLoudLoader.reset.resetHistory();
     currentKafkaClusterChangedFireStub.resetHistory();
-    currentSchemaRegistryChangedFireStub.resetHistory();
+    schemasViewResourceChangedFireStub.resetHistory();
 
     // Now set the view controllers to be focused on non-CCloud resources.
     // This should not fire any events, but still clear the resources.
@@ -58,7 +58,7 @@ describe("sidecar/connections/ccloud.ts", () => {
 
     assert.ok(mockedCCLoudLoader.reset.calledOnce);
     assert.ok(currentKafkaClusterChangedFireStub.notCalled);
-    assert.ok(currentSchemaRegistryChangedFireStub.notCalled);
+    assert.ok(schemasViewResourceChangedFireStub.notCalled);
   });
 
   for (const value of [false, undefined]) {

--- a/src/sidecar/connections/ccloud.ts
+++ b/src/sidecar/connections/ccloud.ts
@@ -3,8 +3,8 @@ import { Connection } from "../../clients/sidecar";
 import { CCLOUD_CONNECTION_ID, CCLOUD_CONNECTION_SPEC } from "../../constants";
 import { ContextValues, getContextValue } from "../../context/values";
 import {
-  currentSchemaRegistryChanged,
   flinkDatabaseViewResourceChanged,
+  schemasViewResourceChanged,
   topicsViewResourceChanged,
 } from "../../emitters";
 import { CCloudResourceLoader } from "../../loaders";
@@ -48,7 +48,7 @@ export async function clearCurrentCCloudResources() {
   // Likewise for the Schema Registry view.
   const schemasViewProvider = SchemasViewProvider.getInstance();
   if (schemasViewProvider.isFocusedOnCCloud()) {
-    currentSchemaRegistryChanged.fire(null);
+    schemasViewResourceChanged.fire(null);
   }
 
   // Likewise for the Flink Database view, which can only

--- a/src/viewProviders/schemas.test.ts
+++ b/src/viewProviders/schemas.test.ts
@@ -348,13 +348,13 @@ describe("SchemasViewProvider", () => {
       }
     });
 
-    describe("currentSchemaRegistryChangedHandler", () => {
+    describe("schemasViewResourceChangedHandler", () => {
       for (const newRegistry of [null, TEST_LOCAL_SCHEMA_REGISTRY]) {
         it(`should call setSchemaRegistry() with new registry: ${newRegistry?.id}`, async () => {
           const setSchemaRegistryStub = sandbox.stub(provider, "setSchemaRegistry");
 
           // Call the handler with the new registry
-          await provider.currentSchemaRegistryChangedHandler(newRegistry);
+          await provider.schemasViewResourceChangedHandler(newRegistry);
 
           // Should have called .setSchemaRegistry() with the new registry
           assert.ok(setSchemaRegistryStub.calledOnce);
@@ -572,7 +572,7 @@ describe("SchemasViewProvider", () => {
       ["environmentChanged", "environmentChangedHandler"],
       ["ccloudConnected", "ccloudConnectedHandler"],
       ["localSchemaRegistryConnected", "localSchemaRegistryConnectedHandler"],
-      ["currentSchemaRegistryChanged", "currentSchemaRegistryChangedHandler"],
+      ["schemasViewResourceChanged", "schemasViewResourceChangedHandler"],
       ["schemaSearchSet", "schemaSearchSetHandler"],
       ["schemaSubjectChanged", "schemaSubjectChangedHandler"],
       ["schemaVersionsChanged", "schemaVersionsChangedHandler"],

--- a/src/viewProviders/schemas.ts
+++ b/src/viewProviders/schemas.ts
@@ -12,12 +12,12 @@ import { getExtensionContext } from "../context/extension";
 import { ContextValues, setContextValue } from "../context/values";
 import {
   ccloudConnected,
-  currentSchemaRegistryChanged,
   environmentChanged,
   EnvironmentChangeEvent,
   localSchemaRegistryConnected,
   schemaSearchSet,
   schemaSubjectChanged,
+  schemasViewResourceChanged,
   SchemaVersionChangeEvent,
   schemaVersionsChanged,
   SubjectChangeEvent,
@@ -342,7 +342,7 @@ export class SchemasViewProvider
       environmentChanged.event(this.environmentChangedHandler.bind(this)),
       ccloudConnected.event(this.ccloudConnectedHandler.bind(this)),
       localSchemaRegistryConnected.event(this.localSchemaRegistryConnectedHandler.bind(this)),
-      currentSchemaRegistryChanged.event(this.currentSchemaRegistryChangedHandler.bind(this)),
+      schemasViewResourceChanged.event(this.schemasViewResourceChangedHandler.bind(this)),
       schemaSearchSet.event(this.schemaSearchSetHandler.bind(this)),
       schemaSubjectChanged.event(this.schemaSubjectChangedHandler.bind(this)),
       schemaVersionsChanged.event(this.schemaVersionsChangedHandler.bind(this)),
@@ -394,10 +394,10 @@ export class SchemasViewProvider
     }
   }
 
-  async currentSchemaRegistryChangedHandler(schemaRegistry: SchemaRegistry | null): Promise<void> {
+  async schemasViewResourceChangedHandler(schemaRegistry: SchemaRegistry | null): Promise<void> {
     // User has either selected a (probably different) SR to view, or has closed
     // a connection to a SR (null). React accordingly.
-    logger.debug("currentSchemaRegistryChanged event fired");
+    logger.debug("schemasViewResourceChanged event fired");
     await this.setSchemaRegistry(schemaRegistry);
   }
 


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Rename this event emitter to better match its use.
- No functionality changes.
- Closes #2546