### PR TITLE
Fix gap when searchMatches could hold items no longer in the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this extension will be documented in this file.
   its description and tooltip, and the "Start Local Resources" action will not be offered if the
   extension cannot ping the local Docker Engine.
 
+### Fixed
+
+- Issue with sometimes reporting the wrong number of "matching elements" when searching some views.
+
 ## 1.7.0
 
 ### Added

--- a/src/viewProviders/baseModels/base.ts
+++ b/src/viewProviders/baseModels/base.ts
@@ -152,8 +152,6 @@ export abstract class BaseViewProvider<T extends BaseViewProviderData>
       // set context value to toggle between "search" and "clear search" actions
       setContextValue(this.searchContextValue, searchString !== null);
     }
-    // clear from any previous search filter
-    this.searchMatches.clear();
 
     if (searchString) {
       // Increment the count of how many times the user has set a search string
@@ -169,8 +167,9 @@ export abstract class BaseViewProvider<T extends BaseViewProviderData>
   filterChildren(element: T | undefined, children: T[]): T[] {
     if (!element) {
       // if no parent element, we're at the root, so reset the total item count
-      // for this pass through the children
+      // and the searchMatches set for this pass through all the children
       this.totalItemCount = 0;
+      this.searchMatches.clear();
     }
     // Always increment the total item count with this amount of children
     this.totalItemCount += children.length;


### PR DESCRIPTION


## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- baseViewProvider's `this.searchMatches` maintenance had a gap, and wasn't being cleared at the most opportune moment, leading to edge cases such as when a Flink Statement was manually deleted when a search was in play.
- Fix is to realize to clear `searchMatches` when starting a filtering run against the toplevel children, the same place when we reset `totalItemCount`.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Log into CCloud
2. Select a Flink compute pool
3. Search for a subset of the statements.
4. Delete one of the matching statements.
5. Note that the treeview's description of the number of matching items is updated accordingly.

![delete+filter-count](https://github.com/user-attachments/assets/6eef99c6-6446-4a34-aeb7-e1fa2a236fbf)


### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Topics view might also be susceptible to this issue, not being derived from BaseViewProvider, but the better fix would be to bring it under the fold here this release cycle, then it would be fixed 'for free.' 
- Closes #2821

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [x] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
