### PR TITLE
prototype: make submenu for switching Flink database view modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -458,13 +458,15 @@
         "command": "confluent.flinkdatabase.setArtifactsViewMode",
         "title": "Switch to Flink Artifacts",
         "icon": "$(confluent-code)",
-        "category": "Confluent: Flink Database View"
+        "category": "Confluent: Flink Database View",
+        "enablement": "confluent.flinkDatabaseViewMode != 'artifacts'"
       },
       {
         "command": "confluent.flinkdatabase.setUDFsViewMode",
         "title": "Switch to Flink UDFs",
         "icon": "$(confluent-function)",
-        "category": "Confluent: Flink Database View"
+        "category": "Confluent: Flink Database View",
+        "enablement": "confluent.flinkDatabaseViewMode != 'UDFs'"
       },
       {
         "command": "confluent.flinkStatementResults",
@@ -1362,11 +1364,11 @@
         },
         {
           "command": "confluent.flinkdatabase.setArtifactsViewMode",
-          "when": "confluent.flinkDatabaseViewMode == 'UDFs'"
+          "when": "false"
         },
         {
           "command": "confluent.flinkdatabase.setUDFsViewMode",
-          "when": "confluent.flinkDatabaseViewMode == 'artifacts'"
+          "when": "false"
         },
         {
           "command": "confluent.flinkStatementResults",
@@ -1806,13 +1808,8 @@
           "group": "navigation@998"
         },
         {
-          "command": "confluent.flinkdatabase.setArtifactsViewMode",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.artifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'UDFs'",
-          "group": "navigation@999"
-        },
-        {
-          "command": "confluent.flinkdatabase.setUDFsViewMode",
-          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.artifacts && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'artifacts'",
+          "submenu": "confluent.flinkdatabase.viewMode",
+          "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.artifacts && confluent.flinkDatabaseSelected",
           "group": "navigation@999"
         }
       ],
@@ -2068,8 +2065,25 @@
           "group": "confluent@1",
           "when": "config.confluent.flink.artifacts && confluent.ccloudConnectionAvailable && resourceExtname == .jar"
         }
+      ],
+      "confluent.flinkdatabase.viewMode": [
+        {
+          "command": "confluent.flinkdatabase.setArtifactsViewMode",
+          "group": "viewMode@1"
+        },
+        {
+          "command": "confluent.flinkdatabase.setUDFsViewMode",
+          "group": "viewMode@2"
+        }
       ]
     },
+    "submenus": [
+      {
+        "id": "confluent.flinkdatabase.viewMode",
+        "label": "Switch View Mode",
+        "icon": "$(list-tree)"
+      }
+    ],
     "colors": [],
     "icons": {
       "apache-kafka": {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Replaces our existing Flink database view's `view/title` actions to expose a single submenu rather than alternate between:
- showing the "switch to UDFs mode" when in artifacts mode
- showing the "switch to artifacts mode" when in UDFs mode

Having a single submenu could help extend it if we want to use multiple view modes, but it's effectively the same as the `...` context menu actions, so this really boils down to whether we want to use a submenu or set a custom `group` so these actions don't show up inline in the view title.


https://github.com/user-attachments/assets/9fcb3284-59bd-4aea-9905-7953edbfe1ec



### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Sign in to CCloud
2. Select a Flink database
3. Click the new view/title action and set the view mode
4. Artifacts view mode should be disabled since it's active by default
5. Switching to UDFs mode should disable that submenu option

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
