### PR TITLE
Fix parented view empty state when had been viewing a ccloud resource and user logged out of ccloud.

### DIFF
--- a/src/viewProviders/baseModels/parentedBase.test.ts
+++ b/src/viewProviders/baseModels/parentedBase.test.ts
@@ -73,21 +73,22 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
     sandbox.restore();
   });
 
-  describe("event listeners", () => {
-    it("handleCCloudConnectionChange() should call reset() when the `ccloudConnected` event fires and a CCloud resource is focused", () => {
-      const resetSpy = sandbox.spy(provider, "reset");
+  describe("handleCCloudConnectionChange()", () => {
+    let setParentResourceStub: sinon.SinonStub;
 
-      // simulate CCloud connection state change
+    beforeEach(() => {
+      setParentResourceStub = sandbox.stub(provider, "setParentResource");
+    });
+    it("should call setParentResource(null) when the `ccloudConnected` event fires disconnected and a CCloud resource was focused", () => {
+      // simulate CCloud connection logout when a compute pool was focused
       provider.resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       provider["ccloudConnectedHandler"](false);
 
-      sinon.assert.calledOnce(resetSpy);
-      assert.strictEqual(provider.resource, null);
+      sinon.assert.calledOnce(setParentResourceStub);
+      sinon.assert.calledWith(setParentResourceStub, null);
     });
 
-    it("handleCCloudConnectionChange() should not call reset() when the `ccloudConnected` event fires and a non-CCloud resource is focused", () => {
-      const resetSpy = sandbox.spy(provider, "reset");
-
+    it("should not call setParentResource() when the `ccloudConnected` event fires and a non-CCloud resource is focused", () => {
       // simulate a non-CCloud resource
       const fakeResource = {
         ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
@@ -96,8 +97,7 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
       provider.resource = fakeResource;
       provider.ccloudConnectedHandler(false);
 
-      sinon.assert.notCalled(resetSpy);
-      assert.strictEqual(provider.resource, fakeResource);
+      sinon.assert.notCalled(setParentResourceStub);
     });
   });
 

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -104,7 +104,8 @@ export abstract class ParentedBaseViewProvider<
       // any transition of CCloud connection state should reset the tree view if we're focused on
       // a CCloud parent resource
       this.logger.debug("ccloudConnected event fired, resetting view", { connected });
-      void this.reset();
+      // Use setParentResource so all the right things happen, including context value adjustment.
+      void this.setParentResource(null);
     }
   }
 


### PR DESCRIPTION
…

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix #2642 through making use of the logic already in `setParentResource(null)` instead of `reset()` (implemented in base class ignorant of the context value). It handles resetting the `parentResourceChangedContextValue` value, fixing the issue.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Log into CCloud
2. Select a Flink Compute pool, see the statements view populate.
3. Select a ccloud-based schema registry, see the schemas view populate
4. Log out of CCloud
5. Now see the Flink Statements view empty state invite the user to log back into CCloud, instead of just being empty.
6. See the schemas view also go to good empty state also (both of these views are subclasses of ParentedBaseViewProvider, where the fix was).

![logout-better-end-state](https://github.com/user-attachments/assets/341622e5-2074-4c0c-8819-500dcd4049ca)


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
