### PR TITLE
Fix mystery clearing search filter when submitting a new flink statement

### DIFF
--- a/src/viewProviders/baseModels/parentedBase.test.ts
+++ b/src/viewProviders/baseModels/parentedBase.test.ts
@@ -254,6 +254,25 @@ describe("viewProviders/base.ts ParentedBaseViewProvider", () => {
       sinon.assert.notCalled(setContextValueStub); // should not change context when parent resource is unchanged
     });
 
+    it("Should handle setting to the same resource by id and connection id equality (partial no-op)", async () => {
+      // As if was focused on something and then set to the same thing
+      const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
+      provider.resource = resource;
+
+      // won't be same object reference, but should be considered "same" resource.
+      const equivalentResource = new CCloudFlinkComputePool({
+        ...TEST_CCLOUD_FLINK_COMPUTE_POOL,
+      });
+
+      await provider.setParentResource(equivalentResource);
+
+      assert.strictEqual(provider.resource, resource, "resource should be unchanged");
+      sinon.assert.notCalled(setSearchStub); // should not reset search when parent resource is unchanged
+      sinon.assert.calledOnce(refreshStub);
+      sinon.assert.calledOnce(updateTreeViewDescriptionStub);
+      sinon.assert.notCalled(setContextValueStub); // should not change context when parent resource is unchanged
+    });
+
     it("Should be called when parentResourceChangedEmitter fires", () => {
       const resource = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       const setParentResourceStub = sandbox.stub(provider, "setParentResource");

--- a/src/viewProviders/baseModels/parentedBase.ts
+++ b/src/viewProviders/baseModels/parentedBase.ts
@@ -60,7 +60,10 @@ export abstract class ParentedBaseViewProvider<
 
     const promises: Promise<unknown>[] = [];
 
-    if (this.resource !== resource) {
+    if (
+      this.resource?.id !== resource?.id ||
+      this.resource?.connectionId !== resource?.connectionId
+    ) {
       this.setSearch(null); // reset search when parent resource changes
 
       // If we have a boolean context value to adjust, and if the boolean value is changing, adjust it.

--- a/src/viewProviders/flinkStatements.test.ts
+++ b/src/viewProviders/flinkStatements.test.ts
@@ -302,26 +302,22 @@ describe("FlinkStatementsViewProvider", () => {
       sinon.assert.calledWith(revealStub, statement, { focus: true, select: true });
     });
 
-    it("throws if reveal() fails", async () => {
+    it("does not throw if reveal() fails", async () => {
       const statement = createFlinkStatement();
       resourcesInTreeView.set(statement.id, statement);
+
+      // As would be the case if, oh, the item is not actually visible (e.g. filtered out by search).
       const revealStub = sandbox.stub(viewProvider["treeView"], "reveal").throws();
-      await assert.rejects(
-        async () => {
-          await viewProvider.focus(statement.id);
-        },
-        {
-          name: "Error",
-          message: "Error",
-        },
-      );
+
+      await viewProvider.focus(statement.id);
+
       sinon.assert.calledOnce(revealStub);
       sinon.assert.calledWith(revealStub, statement, { focus: true, select: true });
     });
 
     it("throws error if statement not found", async () => {
       const statementId = "non-existent-statement-id";
-      assert.rejects(
+      await assert.rejects(
         async () => {
           await viewProvider.focus(statementId);
         },

--- a/src/viewProviders/flinkStatements.ts
+++ b/src/viewProviders/flinkStatements.ts
@@ -158,10 +158,10 @@ export class FlinkStatementsViewProvider
       try {
         logger.debug(`Focusing statement ${existingStatement.id} in the view`);
         await this.treeView.reveal(existingStatement, { focus: true, select: true });
-        return;
       } catch (e) {
+        // May fail if the item is not actually visible (e.g. filtered out by search).
+        // Just log the error and move on.
         this.logger.error("Error focusing statement in view", e);
-        throw e;
       }
     } else {
       logger.error("Could not find statement in the view", statementId);


### PR DESCRIPTION

## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Fix the equivalence test used in `setParentResource()` -- it was seduced into 'detecting changed parent' by exact object comparisonusing `===`, when instead it should have been comparing at least the `id` and `connectionId` fields directly (remembering that Kafka cluster ids are assigned by the brokers, but may be from different connections).
- It was that flaw which cause the "submit Flink statement" command path, when it asks to set the parent resource of the view, must be doing so with a nonidentical Flink Compute Pool instance (say, one rehydrated loaded from the resource manager cache), was causing `setParentResource` to believe that a whole new parent resource was being set, when in reality it wasn't.
- While here, and testing while having a search filter set, needed to relax the behavior of `.focus()` so that if we end up with an error when we ask the treeview to focus on a search-filtered-out statement, that we don't altogether fail.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Log into CCloud
2. Set a Flink Compute Pool in the view
3. Filter the statements
4. Submit a new statement to that very pool, whose new name may or may not match the filter.
5. See that the statements view refreshes, but does not clear the search. If the new statement name (or other attrs) have it not match the search criteria, then the attempt to focus on the view will silently fail.

![submit-to-viewed-filtered-pool](https://github.com/user-attachments/assets/86b7ee7d-6758-4aa2-8423-542b8c57e771)

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2832 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
