### PR TITLE
cleanup(tests): update notCalled/calledOnce/calledTwice assertions to use the `sinon.assert` API

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -51,7 +51,7 @@ describe("authz.schemaRegistry", function () {
   // it("canAccessSchemaForTopic() should return true if both key and value access are true", async function () {
   //   const stub = sandbox.stub(schemaRegistry, "canAccessSchemaTypeForTopic").resolves(true);
   //   const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
-  //   assert.ok(stub.calledTwice);
+  //   sinon.assert.calledTwice(stub);
   //   assert.strictEqual(result, true);
   // });
 
@@ -65,14 +65,14 @@ describe("authz.schemaRegistry", function () {
   //     .withArgs(topic, "value")
   //     .resolves(false);
   //   const result = await schemaRegistry.canAccessSchemaForTopic(topic);
-  //   assert.ok(stub.calledTwice);
+  //   sinon.assert.calledTwice(stub);
   //   assert.strictEqual(result, true);
   // });
 
   // it("canAccessSchemaForTopic() should return false if both key and value access are false", async function () {
   //   const stub = sandbox.stub(schemaRegistry, "canAccessSchemaTypeForTopic").resolves(false);
   //   const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
-  //   assert.ok(stub.calledTwice);
+  //   sinon.assert.calledTwice(stub);
   //   assert.strictEqual(result, false);
   // });
 
@@ -142,7 +142,7 @@ describe("authz.schemaRegistry", function () {
 
     const showWarningMessageStub = sandbox.stub(window, "showWarningMessage").resolves(undefined);
     schemaRegistry.showNoSchemaAccessWarningNotification();
-    assert.ok(showWarningMessageStub.calledOnce);
+    sinon.assert.calledOnce(showWarningMessageStub);
   });
 
   it("showNoSchemaAccessWarningNotification() should not show warning if warnings are disabled", function () {
@@ -150,7 +150,7 @@ describe("authz.schemaRegistry", function () {
 
     const showWarningMessageStub = sandbox.stub(window, "showWarningMessage").resolves(undefined);
     schemaRegistry.showNoSchemaAccessWarningNotification();
-    assert.ok(showWarningMessageStub.notCalled);
+    sinon.assert.notCalled(showWarningMessageStub);
   });
 });
 

--- a/src/commands/diffs.test.ts
+++ b/src/commands/diffs.test.ts
@@ -92,7 +92,7 @@ describe("commands/diffs.ts", () => {
 
     await diffs.compareWithSelectedCommand(schema);
 
-    assert.ok(executeCommandStub.notCalled);
+    sinon.assert.notCalled(executeCommandStub);
   });
 
   it("compareWithSelectedCommand() should throw an error when trying to compare unsupported resource type", async () => {

--- a/src/commands/docker.test.ts
+++ b/src/commands/docker.test.ts
@@ -64,9 +64,9 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     await runWorkflowWithProgress();
 
-    assert.ok(localResourcesQuickPickStub.notCalled);
-    assert.ok(getKafkaWorkflowStub.notCalled);
-    assert.ok(getSchemaRegistryWorkflowStub.notCalled);
+    sinon.assert.notCalled(localResourcesQuickPickStub);
+    sinon.assert.notCalled(getKafkaWorkflowStub);
+    sinon.assert.notCalled(getSchemaRegistryWorkflowStub);
   });
 
   it("should skip running a workflow for unsupported Kafka images", async () => {
@@ -75,8 +75,8 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
     await runWorkflowWithProgress();
 
     // `docker/workflows/index.test.ts` tests the error notification for this case
-    assert.ok(stubKafkaWorkflow.start.notCalled);
-    assert.ok(stubKafkaWorkflow.stop.notCalled);
+    sinon.assert.notCalled(stubKafkaWorkflow.start);
+    sinon.assert.notCalled(stubKafkaWorkflow.stop);
   });
 
   it("should skip running a workflow for unsupported Schema Registry images", async () => {
@@ -85,8 +85,8 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
     await runWorkflowWithProgress();
 
     // `docker/workflows/index.test.ts` tests the error notification for this case
-    assert.ok(stubSchemaRegistryWorkflow.start.notCalled);
-    assert.ok(stubSchemaRegistryWorkflow.stop.notCalled);
+    sinon.assert.notCalled(stubSchemaRegistryWorkflow.start);
+    sinon.assert.notCalled(stubSchemaRegistryWorkflow.stop);
   });
 
   it("should show an workflow's error notification for uncaught errors in the workflow .start()", async () => {
@@ -94,9 +94,9 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     await runWorkflowWithProgress();
 
-    assert.ok(stubKafkaWorkflow.start.calledOnce);
-    assert.ok(stubKafkaWorkflow.stop.notCalled);
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.calledOnce(stubKafkaWorkflow.start);
+    sinon.assert.notCalled(stubKafkaWorkflow.stop);
+    sinon.assert.calledOnce(showErrorNotificationStub);
   });
 
   it("should show an workflow's error notification for uncaught errors in the workflow .stop()", async () => {
@@ -104,24 +104,24 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     await runWorkflowWithProgress(false);
 
-    assert.ok(stubKafkaWorkflow.start.notCalled);
-    assert.ok(stubKafkaWorkflow.stop.calledOnce);
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.notCalled(stubKafkaWorkflow.start);
+    sinon.assert.calledOnce(stubKafkaWorkflow.stop);
+    sinon.assert.calledOnce(showErrorNotificationStub);
   });
 
   // once multi-select quickpick is added, update these in follow-on branch.
   it("should call the Kafka workflow's .start() method when start=true", async () => {
     await runWorkflowWithProgress();
 
-    assert.ok(stubKafkaWorkflow.start.calledOnce);
-    assert.ok(stubKafkaWorkflow.stop.notCalled);
+    sinon.assert.calledOnce(stubKafkaWorkflow.start);
+    sinon.assert.notCalled(stubKafkaWorkflow.stop);
   });
 
   it("should call the Kafka workflow's .stop() method when start=false", async () => {
     await runWorkflowWithProgress(false);
 
-    assert.ok(stubKafkaWorkflow.start.notCalled);
-    assert.ok(stubKafkaWorkflow.stop.calledOnce);
+    sinon.assert.notCalled(stubKafkaWorkflow.start);
+    sinon.assert.calledOnce(stubKafkaWorkflow.stop);
   });
 
   it("should call multiple workflows' .start() methods when multiple resources are selected", async () => {
@@ -132,8 +132,8 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     await runWorkflowWithProgress();
 
-    assert.ok(stubKafkaWorkflow.start.calledOnce);
-    assert.ok(stubSchemaRegistryWorkflow.start.calledOnce);
+    sinon.assert.calledOnce(stubKafkaWorkflow.start);
+    sinon.assert.calledOnce(stubSchemaRegistryWorkflow.start);
   });
 
   it("should call multiple workflows' .stop() methods when multiple resources are selected and start=false", async () => {
@@ -144,8 +144,8 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     await runWorkflowWithProgress(false);
 
-    assert.ok(stubKafkaWorkflow.stop.calledOnce);
-    assert.ok(stubSchemaRegistryWorkflow.stop.calledOnce);
+    sinon.assert.calledOnce(stubKafkaWorkflow.stop);
+    sinon.assert.calledOnce(stubSchemaRegistryWorkflow.stop);
   });
 });
 

--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -42,8 +42,8 @@ describe("flinkComputePools.ts", () => {
 
       await commandsModule.configureFlinkDefaults();
 
-      assert.ok(stubbedConfigs.update.notCalled);
-      assert.ok(flinkDatabaseQuickpickStub.notCalled);
+      sinon.assert.notCalled(stubbedConfigs.update);
+      sinon.assert.notCalled(flinkDatabaseQuickpickStub);
     });
 
     it("should return early if no database is selected", async () => {

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -112,7 +112,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
     // see tests in suite below
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(showErrorMessageStub.notCalled);
+    sinon.assert.notCalled(showErrorMessageStub);
   });
 
   it("should show an error notification for an invalid JSON message", async function () {
@@ -120,7 +120,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(showErrorMessageStub.calledOnce);
+    sinon.assert.calledOnce(showErrorMessageStub);
     const callArgs = showErrorMessageStub.getCall(0).args;
     assert.strictEqual(callArgs[0], "Unable to produce message(s): JSON schema validation failed.");
   });
@@ -134,11 +134,11 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(clientStub.produceRecord.calledOnce);
-    assert.ok(showInfoMessageStub.calledOnce);
+    sinon.assert.calledOnce(clientStub.produceRecord);
+    sinon.assert.calledOnce(showInfoMessageStub);
     const successMsg = showInfoMessageStub.firstCall.args[0];
     assert.ok(successMsg.startsWith("Successfully produced 1 message to topic"), successMsg);
-    assert.ok(showErrorMessageStub.notCalled);
+    sinon.assert.notCalled(showErrorMessageStub);
   });
 
   it("should show an error notification for any ResponseErrors", async function () {
@@ -153,7 +153,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(showErrorMessageStub.calledOnce);
+    sinon.assert.calledOnce(showErrorMessageStub);
     const errorMsg = showErrorMessageStub.firstCall.args[0];
     assert.ok(errorMsg.startsWith("Failed to produce 1 message to topic"), errorMsg);
   });
@@ -172,7 +172,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(clientStub.produceRecord.calledOnce);
+    sinon.assert.calledOnce(clientStub.produceRecord);
     const requestArg: ProduceRecordRequest = clientStub.produceRecord.firstCall.args[0];
     assert.strictEqual(requestArg.ProduceRequest!.partition_id, partition_id);
     // timestamp should also be converted to a Date object
@@ -186,7 +186,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(clientStub.produceRecord.calledOnce);
+    sinon.assert.calledOnce(clientStub.produceRecord);
     const requestArg: ProduceRecordRequest = clientStub.produceRecord.firstCall.args[0];
     assert.strictEqual(requestArg.ProduceRequest!.partition_id, partition_id);
     assert.strictEqual(requestArg.ProduceRequest!.timestamp, undefined);
@@ -222,7 +222,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
       assert.ok(mvConfig instanceof MessageViewerConfig);
       assert.strictEqual(mvConfig.textFilter, undefined);
 
-      assert.ok(showErrorMessageStub.notCalled);
+      sinon.assert.notCalled(showErrorMessageStub);
     });
   }
 
@@ -255,7 +255,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
       assert.ok(mvConfig instanceof MessageViewerConfig);
       assert.strictEqual(mvConfig.textFilter, String(key));
 
-      assert.ok(showErrorMessageStub.notCalled);
+      sinon.assert.notCalled(showErrorMessageStub);
     });
   }
 });
@@ -368,7 +368,7 @@ describe("commands/topics.ts produceMessageFromDocument() with schema(s)", funct
         SubjectNameStrategy.TOPIC_NAME,
       ),
     );
-    assert.ok(recordsV3ApiStub.produceRecord.calledOnce);
+    sinon.assert.calledOnce(recordsV3ApiStub.produceRecord);
   });
 
   it("should handle both key and value schema selection", async function () {
@@ -414,7 +414,7 @@ describe("commands/topics.ts produceMessageFromDocument() with schema(s)", funct
         SubjectNameStrategy.RECORD_NAME,
       ),
     );
-    assert.ok(recordsV3ApiStub.produceRecord.calledOnce);
+    sinon.assert.calledOnce(recordsV3ApiStub.produceRecord);
   });
 
   it("should handle the deferToDocument option", async function () {
@@ -448,9 +448,9 @@ describe("commands/topics.ts produceMessageFromDocument() with schema(s)", funct
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
     // should not show schema quickpicks to user
-    assert.ok(getSubjectNameStrategyStub.notCalled);
-    assert.ok(promptForSchemaStub.notCalled);
-    assert.ok(recordsV3ApiStub.produceRecord.calledOnce);
+    sinon.assert.notCalled(getSubjectNameStrategyStub);
+    sinon.assert.notCalled(promptForSchemaStub);
+    sinon.assert.calledOnce(recordsV3ApiStub.produceRecord);
   });
 
   it("should handle errors in promptForSchema", async function () {
@@ -956,7 +956,7 @@ describe("commands/topics.ts queryTopicWithFlink()", function () {
 
     await queryTopicWithFlink(TEST_CCLOUD_KAFKA_TOPIC);
 
-    assert.ok(openTextDocumentStub.calledOnce);
+    sinon.assert.calledOnce(openTextDocumentStub);
     const expectedQuery = `-- Query topic "${TEST_CCLOUD_KAFKA_TOPIC.name}" with Flink SQL
 -- Replace this with your actual Flink SQL query
 
@@ -968,7 +968,7 @@ LIMIT 10;`;
       content: expectedQuery,
     });
 
-    assert.ok(showTextDocumentStub.calledOnce);
+    sinon.assert.calledOnce(showTextDocumentStub);
     sinon.assert.calledWithExactly(showTextDocumentStub, mockDocument, { preview: false });
   });
 
@@ -1022,8 +1022,8 @@ LIMIT 10;`;
   it("should return early if topic is null or not a KafkaTopic instance", async function () {
     await queryTopicWithFlink(null as any);
 
-    assert.ok(openTextDocumentStub.notCalled);
-    assert.ok(showTextDocumentStub.notCalled);
+    sinon.assert.notCalled(openTextDocumentStub);
+    sinon.assert.notCalled(showTextDocumentStub);
     sinon.assert.notCalled(ccloudLoader.getEnvironment);
     sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
@@ -1033,8 +1033,8 @@ LIMIT 10;`;
 
     await queryTopicWithFlink(notATopic as any);
 
-    assert.ok(openTextDocumentStub.notCalled);
-    assert.ok(showTextDocumentStub.notCalled);
+    sinon.assert.notCalled(openTextDocumentStub);
+    sinon.assert.notCalled(showTextDocumentStub);
     sinon.assert.notCalled(ccloudLoader.getEnvironment);
     sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
@@ -1046,8 +1046,8 @@ LIMIT 10;`;
     await queryTopicWithFlink(TEST_CCLOUD_KAFKA_TOPIC);
 
     sinon.assert.calledOnce(ccloudLoader.getEnvironment);
-    assert.ok(openTextDocumentStub.notCalled);
-    assert.ok(showTextDocumentStub.notCalled);
+    sinon.assert.notCalled(openTextDocumentStub);
+    sinon.assert.notCalled(showTextDocumentStub);
   });
 
   it("should return early if cluster is missing", async function () {
@@ -1058,15 +1058,15 @@ LIMIT 10;`;
 
     sinon.assert.calledOnce(ccloudLoader.getEnvironment);
     sinon.assert.calledOnce(ccloudLoader.getKafkaClustersForEnvironmentId);
-    assert.ok(openTextDocumentStub.notCalled);
-    assert.ok(showTextDocumentStub.notCalled);
+    sinon.assert.notCalled(openTextDocumentStub);
+    sinon.assert.notCalled(showTextDocumentStub);
   });
 
   it("should return early if topic is a local", async function () {
     await queryTopicWithFlink(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(openTextDocumentStub.notCalled);
-    assert.ok(showTextDocumentStub.notCalled);
+    sinon.assert.notCalled(openTextDocumentStub);
+    sinon.assert.notCalled(showTextDocumentStub);
     sinon.assert.notCalled(ccloudLoader.getEnvironment);
     sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
@@ -1074,8 +1074,8 @@ LIMIT 10;`;
   it("should return early if topic is a direct connection topic", async function () {
     await queryTopicWithFlink(TEST_DIRECT_KAFKA_TOPIC);
 
-    assert.ok(openTextDocumentStub.notCalled);
-    assert.ok(showTextDocumentStub.notCalled);
+    sinon.assert.notCalled(openTextDocumentStub);
+    sinon.assert.notCalled(showTextDocumentStub);
     sinon.assert.notCalled(ccloudLoader.getEnvironment);
     sinon.assert.notCalled(ccloudLoader.getKafkaClustersForEnvironmentId);
   });
@@ -1091,7 +1091,7 @@ LIMIT 10;`;
     await queryTopicWithFlink(TEST_CCLOUD_KAFKA_TOPIC);
 
     // Should still create the document
-    assert.ok(openTextDocumentStub.calledOnce);
+    sinon.assert.calledOnce(openTextDocumentStub);
     // But should not set the metadata since there's no compute pool
     sinon.assert.notCalled(setUriMetadataStub);
   });

--- a/src/commands/utils/schemaManagement/upload.test.ts
+++ b/src/commands/utils/schemaManagement/upload.test.ts
@@ -611,7 +611,7 @@ describe("commands/utils/schemaManagement/upload.ts", function () {
           expectedSchemaType,
           `Expected ${expectedSchemaType} given ${fileExtension}, got ${schemaType} instead`,
         );
-        assert.ok(schemaTypeQuickPickStub.notCalled);
+        sinon.assert.notCalled(schemaTypeQuickPickStub);
       }
     });
 
@@ -619,7 +619,7 @@ describe("commands/utils/schemaManagement/upload.ts", function () {
       const fileUri = Uri.file("some-file.txt");
       await determineSchemaType(fileUri, "plaintext");
 
-      assert.ok(schemaTypeQuickPickStub.calledOnce);
+      sinon.assert.calledOnce(schemaTypeQuickPickStub);
     });
 
     it("should show the schema type quickpick when the provided Uri has a JSON file extension and language ID", async () => {
@@ -628,14 +628,14 @@ describe("commands/utils/schemaManagement/upload.ts", function () {
       const fileUri = Uri.file("some-file.json");
       const result = await determineSchemaType(fileUri, "json");
 
-      assert.ok(schemaTypeQuickPickStub.calledOnce);
+      sinon.assert.calledOnce(schemaTypeQuickPickStub);
       assert.strictEqual(result, undefined);
 
       // next, simulate the user selecting the JSON option
       schemaTypeQuickPickStub.resolves("JSON");
       const nextResult = await determineSchemaType(fileUri, "json");
 
-      assert.ok(schemaTypeQuickPickStub.calledTwice);
+      sinon.assert.calledTwice(schemaTypeQuickPickStub);
       assert.strictEqual(nextResult, SchemaType.Json);
     });
 
@@ -653,7 +653,7 @@ describe("commands/utils/schemaManagement/upload.ts", function () {
           expectedSchemaType,
           `Expected ${expectedSchemaType} given ${languageId}, got ${schemaType} instead`,
         );
-        assert.ok(schemaTypeQuickPickStub.notCalled);
+        sinon.assert.notCalled(schemaTypeQuickPickStub);
       }
     });
 
@@ -671,7 +671,7 @@ describe("commands/utils/schemaManagement/upload.ts", function () {
           expectedSchemaType,
           `Expected ${expectedSchemaType} given .txt and ${languageId}, got ${schemaType} instead`,
         );
-        assert.ok(schemaTypeQuickPickStub.notCalled);
+        sinon.assert.notCalled(schemaTypeQuickPickStub);
       }
     });
 

--- a/src/directConnectManager.test.ts
+++ b/src/directConnectManager.test.ts
@@ -109,7 +109,7 @@ describe("DirectConnectionManager behavior", () => {
     });
 
     assert.ok(result.connection, JSON.stringify(result));
-    assert.ok(tryToCreateConnectionStub.calledOnce);
+    sinon.assert.calledOnce(tryToCreateConnectionStub);
     const specArg: ConnectionSpec = tryToCreateConnectionStub.firstCall.args[0];
     assert.strictEqual(specArg.kafka_cluster, undefined);
     assert.deepStrictEqual(specArg.schema_registry, testSpec.schema_registry);
@@ -130,7 +130,7 @@ describe("DirectConnectionManager behavior", () => {
     });
     assert.ok(result.connection);
     // don't use .calledOnceWith(testSpec) because the `id` will change
-    assert.ok(tryToCreateConnectionStub.calledOnce);
+    sinon.assert.calledOnce(tryToCreateConnectionStub);
     const specArg: ConnectionSpec = tryToCreateConnectionStub.firstCall.args[0];
     assert.strictEqual(specArg.schema_registry, undefined);
     assert.deepStrictEqual(specArg.kafka_cluster, testSpec.kafka_cluster);
@@ -154,7 +154,7 @@ describe("DirectConnectionManager behavior", () => {
 
     assert.ok(result.connection);
     // don't use .calledOnceWith(testSpec) because the `id` will change
-    assert.ok(tryToCreateConnectionStub.calledOnce);
+    sinon.assert.calledOnce(tryToCreateConnectionStub);
     const storedConnections: DirectConnectionsById =
       await getResourceManager().getDirectConnections();
     assert.equal(storedConnections.size, 1);
@@ -215,7 +215,7 @@ describe("DirectConnectionManager behavior", () => {
 
     await manager.updateConnection(updatedSpec);
 
-    assert.ok(tryToUpdateConnectionStub.calledOnce);
+    sinon.assert.calledOnce(tryToUpdateConnectionStub);
     const storedConnections: DirectConnectionsById =
       await getResourceManager().getDirectConnections();
     assert.equal(storedConnections.size, 1);
@@ -257,7 +257,7 @@ describe("DirectConnectionManager behavior", () => {
 
     await manager.rehydrateConnections();
 
-    assert.ok(tryToCreateConnectionStub.calledOnce);
+    sinon.assert.calledOnce(tryToCreateConnectionStub);
     const args = tryToCreateConnectionStub.getCall(0).args;
     assert.deepStrictEqual(
       ConnectionSpecFromJSON(args[0]),
@@ -283,7 +283,7 @@ describe("DirectConnectionManager behavior", () => {
 
     await manager.rehydrateConnections();
 
-    assert.ok(tryToCreateConnectionStub.notCalled);
+    sinon.assert.notCalled(tryToCreateConnectionStub);
   });
 
   describe("deleteConnection()", () => {

--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -69,8 +69,8 @@ describe("docker/configs functions", function () {
     const result = await configs.isDockerAvailable();
 
     assert.strictEqual(result, true);
-    assert.ok(systemPingStub.calledOnce);
-    assert.ok(showErrorMessageStub.notCalled);
+    sinon.assert.calledOnce(systemPingStub);
+    sinon.assert.notCalled(showErrorMessageStub);
   });
 
   it("isDockerAvailable() should return false when Docker is not available", async function () {
@@ -81,7 +81,7 @@ describe("docker/configs functions", function () {
     const result = await configs.isDockerAvailable();
 
     assert.strictEqual(result, false);
-    assert.ok(systemPingStub.calledOnce);
+    sinon.assert.calledOnce(systemPingStub);
   });
 
   it("isDockerAvailable() should show a notification if `showNotification` is set to true and Docker is not available", async function () {
@@ -91,8 +91,8 @@ describe("docker/configs functions", function () {
 
     await configs.isDockerAvailable(true);
 
-    assert.ok(systemPingStub.calledOnce);
-    assert.ok(showErrorMessageStub.calledOnce);
+    sinon.assert.calledOnce(systemPingStub);
+    sinon.assert.calledOnce(showErrorMessageStub);
   });
 
   it("showDockerUnavailableErrorNotification() should show ResponseError content in the error notification", async () => {

--- a/src/docker/containers.test.ts
+++ b/src/docker/containers.test.ts
@@ -53,7 +53,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     const result = await getContainersForImage({});
 
     assert.deepStrictEqual(result, fakeResponse);
-    assert.ok(containerListStub.calledOnce);
+    sinon.assert.calledOnce(containerListStub);
   });
 
   it("getContainersForImage() should re-throw any error from .containerList", async () => {
@@ -61,7 +61,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     containerListStub.rejects(fakeError);
 
     await assert.rejects(getContainersForImage({}), fakeError);
-    assert.ok(containerListStub.calledOnce);
+    sinon.assert.calledOnce(containerListStub);
   });
 
   it("createContainer() should return a ContainerCreateResponse after successfully creating a container", async () => {
@@ -72,7 +72,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     const result = await createContainer("repo", "tag", { body: {} });
 
     assert.deepStrictEqual(result, fakeResponse);
-    assert.ok(containerCreateStub.calledOnce);
+    sinon.assert.calledOnce(containerCreateStub);
   });
 
   // TODO: determine if we want to keep this behavior+test
@@ -85,9 +85,9 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     const result = await createContainer("repo", "tag", { body: {} });
 
     assert.deepStrictEqual(result, fakeResponse);
-    assert.ok(imageExistsStub.calledOnce);
-    assert.ok(pullImageStub.calledOnce);
-    assert.ok(containerCreateStub.calledOnce);
+    sinon.assert.calledOnce(imageExistsStub);
+    sinon.assert.calledOnce(pullImageStub);
+    sinon.assert.calledOnce(containerCreateStub);
   });
 
   it(`createContainer() should always add the "${MANAGED_CONTAINER_LABEL}" label to .containerCreate calls`, async () => {
@@ -97,7 +97,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
 
     await createContainer("repo", "tag", { body: {} });
 
-    assert.ok(containerCreateStub.calledOnce);
+    sinon.assert.calledOnce(containerCreateStub);
     assert.ok(
       containerCreateStub.calledWithMatch({
         body: {
@@ -115,7 +115,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     containerCreateStub.rejects(fakeError);
 
     await assert.rejects(createContainer("repo", "tag", { body: {} }), fakeError);
-    assert.ok(containerCreateStub.calledOnce);
+    sinon.assert.calledOnce(containerCreateStub);
   });
 
   it("startContainer() should return nothing after successfully starting a container", async () => {
@@ -124,7 +124,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     const result = await startContainer("1");
 
     assert.strictEqual(result, undefined);
-    assert.ok(containerStartStub.calledOnce);
+    sinon.assert.calledOnce(containerStartStub);
   });
 
   it("startContainer() should re-throw any error from .containerStart", async () => {
@@ -132,7 +132,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     containerStartStub.rejects(fakeError);
 
     await assert.rejects(startContainer("1"), fakeError);
-    assert.ok(containerStartStub.calledOnce);
+    sinon.assert.calledOnce(containerStartStub);
   });
 
   it("getContainer() should return a ContainerInspectResponse from a successful request", async () => {
@@ -142,7 +142,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     const result = await getContainer("1");
 
     assert.deepStrictEqual(result, fakeResponse);
-    assert.ok(containerInspectStub.calledOnce);
+    sinon.assert.calledOnce(containerInspectStub);
   });
 
   it("stopContainer() should return nothing after successfully stopping a container", async () => {
@@ -151,7 +151,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     const result = await stopContainer("1");
 
     assert.strictEqual(result, undefined);
-    assert.ok(containerStopStub.calledOnce);
+    sinon.assert.calledOnce(containerStopStub);
   });
 
   it("stopContainer() should re-throw any error from .containerStop", async () => {
@@ -159,7 +159,7 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     containerStopStub.rejects(fakeError);
 
     await assert.rejects(stopContainer("1"), fakeError);
-    assert.ok(containerStopStub.calledOnce);
+    sinon.assert.calledOnce(containerStopStub);
   });
 
   it("getContainer() should re-throw any error from .containerInspect", async () => {
@@ -167,6 +167,6 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     containerInspectStub.rejects(fakeError);
 
     await assert.rejects(getContainer("1"), fakeError);
-    assert.ok(containerInspectStub.calledOnce);
+    sinon.assert.calledOnce(containerInspectStub);
   });
 });

--- a/src/docker/eventListener.test.ts
+++ b/src/docker/eventListener.test.ts
@@ -64,7 +64,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     eventListener.start();
 
     assert.strictEqual(eventListener["stopped"], false);
-    assert.ok(pollStartSpy.calledOnce);
+    sinon.assert.calledOnce(pollStartSpy);
   });
 
   it("stop() should stop the poller", function () {
@@ -73,7 +73,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     eventListener.stop();
 
     assert.strictEqual(eventListener["stopped"], true);
-    assert.ok(pollStopSpy.calledOnce);
+    sinon.assert.calledOnce(pollStopSpy);
   });
 
   it("listenForEvents() should exit early if already handling the event stream", async function () {
@@ -83,7 +83,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     await eventListener.listenForEvents();
 
     // should not have called isDockerAvailable() since we exited early
-    assert.ok(isDockerAvailableStub.notCalled);
+    sinon.assert.notCalled(isDockerAvailableStub);
   });
 
   it("listenForEvents() should poll slowly if Docker is not available", async function () {
@@ -362,7 +362,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     });
     await eventListener.readValuesFromStream(stream);
 
-    assert.ok(handleEventStub.notCalled);
+    sinon.assert.notCalled(handleEventStub);
   });
 
   it("readValuesFromStream() should exit early if the event listener is stopped", async function () {
@@ -442,7 +442,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     };
     await eventListener.handleEvent(missingStatusEvent);
 
-    assert.ok(handleContainerEventStub.notCalled);
+    sinon.assert.notCalled(handleContainerEventStub);
   });
 
   it("handleEvent() should exit early if the event is not a container event", async function () {
@@ -454,7 +454,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     };
     await eventListener.handleEvent(imageEvent);
 
-    assert.ok(handleContainerEventStub.notCalled);
+    sinon.assert.notCalled(handleContainerEventStub);
   });
 
   it("handleContainerEvent() should pass a container 'start' event to handleContainerStartEvent()", async function () {
@@ -472,7 +472,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     await eventListener.handleContainerEvent(startEvent);
 
     assert.ok(handleContainerStartEventStub.calledOnceWith(startEvent));
-    assert.ok(handleContainerDieEventStub.notCalled);
+    sinon.assert.notCalled(handleContainerDieEventStub);
   });
 
   it("handleContainerEvent() should pass a container 'die' event to handleContainerDieEvent()", async function () {
@@ -489,7 +489,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     };
     await eventListener.handleEvent(dieEvent);
 
-    assert.ok(handleContainerStartEventStub.notCalled);
+    sinon.assert.notCalled(handleContainerStartEventStub);
     assert.ok(handleContainerDieEventStub.calledOnceWith(dieEvent));
   });
 
@@ -507,8 +507,8 @@ describe("docker/eventListener.ts EventListener methods", function () {
     };
     await eventListener.handleEvent(event);
 
-    assert.ok(handleContainerStartEventStub.notCalled);
-    assert.ok(handleContainerDieEventStub.notCalled);
+    sinon.assert.notCalled(handleContainerStartEventStub);
+    sinon.assert.notCalled(handleContainerDieEventStub);
   });
 
   it("handleContainerStartEvent() should set the 'localKafkaClusterAvailable' context value and cause the 'localKafkaConnected' event emitter to fire if a container from the 'confluent-local' image starts successfully", async function () {
@@ -527,8 +527,8 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     await eventListener.handleContainerStartEvent(TEST_CONTAINER_EVENT);
 
-    assert.ok(waitForContainerRunningStub.calledOnce);
-    assert.ok(waitForServerStartedLogStub.calledOnce);
+    sinon.assert.calledOnce(waitForContainerRunningStub);
+    sinon.assert.calledOnce(waitForServerStartedLogStub);
     assert.ok(
       setContextValueStub.calledOnceWith(
         contextValues.ContextValues.localKafkaClusterAvailable,
@@ -556,10 +556,10 @@ describe("docker/eventListener.ts EventListener methods", function () {
       Actor: { Attributes: { image: "not-confluent-local" } },
     });
 
-    assert.ok(waitForContainerRunningStub.notCalled);
-    assert.ok(waitForServerStartedLogStub.notCalled);
-    assert.ok(setContextValueStub.notCalled);
-    assert.ok(localKafkaConnectedFireStub.notCalled);
+    sinon.assert.notCalled(waitForContainerRunningStub);
+    sinon.assert.notCalled(waitForServerStartedLogStub);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(localKafkaConnectedFireStub);
   });
 
   it("handleContainerStartEvent() should exit early if the event is missing an id or image name", async function () {
@@ -575,10 +575,10 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     await eventListener.handleContainerStartEvent({ ...TEST_CONTAINER_EVENT, id: undefined });
 
-    assert.ok(waitForContainerRunningStub.notCalled);
-    assert.ok(waitForServerStartedLogStub.notCalled);
-    assert.ok(setContextValueStub.notCalled);
-    assert.ok(localKafkaConnectedFireStub.notCalled);
+    sinon.assert.notCalled(waitForContainerRunningStub);
+    sinon.assert.notCalled(waitForServerStartedLogStub);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(localKafkaConnectedFireStub);
   });
 
   it("handleContainerDieEvent() should set the 'localKafkaClusterAvailable' context value and cause the 'localKafkaConnected' event emitter to fire if a container from the 'confluent-local' image dies", async function () {
@@ -611,8 +611,8 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     await eventListener.handleContainerDieEvent(event);
 
-    assert.ok(setContextValueStub.notCalled);
-    assert.ok(localKafkaConnectedFireStub.notCalled);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(localKafkaConnectedFireStub);
   });
 
   it("handleContainerDieEvent() should exit early if the event is missing an image name", async function () {
@@ -626,8 +626,8 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     await eventListener.handleContainerDieEvent(event);
 
-    assert.ok(setContextValueStub.notCalled);
-    assert.ok(localKafkaConnectedFireStub.notCalled);
+    sinon.assert.notCalled(setContextValueStub);
+    sinon.assert.notCalled(localKafkaConnectedFireStub);
   });
 
   it("matchContainerStatus() should return true if the container status is matched", async function () {
@@ -705,7 +705,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     const result: boolean = await eventListener.waitForContainerLog(id, stringToMatch, since);
 
     assert.strictEqual(result, false);
-    assert.ok(containerLogsRawStub.calledOnce);
+    sinon.assert.calledOnce(containerLogsRawStub);
     assert.ok(containerLogsRawStub.calledOnceWith({ id, since, follow: true, stdout: true }));
   });
 });

--- a/src/docker/images.test.ts
+++ b/src/docker/images.test.ts
@@ -48,7 +48,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
     const result = await imageExists(fakeImageRepo, fakeImageTag);
 
     assert.strictEqual(result, true);
-    assert.ok(imageListStub.calledOnce);
+    sinon.assert.calledOnce(imageListStub);
   });
 
   it("imageExists() should return false if the image repo+tag does not exist in the image listing", async () => {
@@ -59,7 +59,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
     const result = await imageExists(fakeImageRepo, fakeImageTag);
 
     assert.strictEqual(result, false);
-    assert.ok(imageListStub.calledOnce);
+    sinon.assert.calledOnce(imageListStub);
   });
 
   it("imageExists() should return false if there is a non-ResponseError error", async () => {
@@ -69,7 +69,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
     const result = await imageExists(fakeImageRepo, fakeImageTag);
 
     assert.strictEqual(result, false);
-    assert.ok(imageListStub.calledOnce);
+    sinon.assert.calledOnce(imageListStub);
   });
 
   it("pullImage() should return nothing after successfully pulling an image", async () => {
@@ -84,7 +84,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
     const result = await pullImage(fakeImageRepo, fakeImageTag);
 
     assert.strictEqual(result, undefined);
-    assert.ok(imageCreateRawStub.calledOnce);
+    sinon.assert.calledOnce(imageCreateRawStub);
     assert.ok(imageCreateRawStub.calledWithMatch({ fromImage: fakeImageRepoTag }));
   });
 
@@ -93,6 +93,6 @@ describe("docker/images.ts ImageApi wrappers", () => {
     imageCreateRawStub.rejects(fakeError);
 
     await assert.rejects(pullImage(fakeImageRepo, fakeImageTag), fakeError);
-    assert.ok(imageCreateRawStub.calledOnce);
+    sinon.assert.calledOnce(imageCreateRawStub);
   });
 });

--- a/src/docker/networks.test.ts
+++ b/src/docker/networks.test.ts
@@ -27,7 +27,7 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
 
     await createNetwork("test-network", "bridge");
 
-    assert.ok(networkCreateStub.calledOnce);
+    sinon.assert.calledOnce(networkCreateStub);
     assert.ok(
       networkCreateStub.calledWithMatch({
         networkConfig: { Name: "test-network", Driver: "bridge" },
@@ -47,7 +47,7 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
     const result = await createNetwork("test-network", "bridge");
 
     assert.strictEqual(result, undefined);
-    assert.ok(networkCreateStub.calledOnce);
+    sinon.assert.calledOnce(networkCreateStub);
   });
 
   it("createNetwork() should re-throw any ResponseError that doesn't contain 'already exists' in the message", async () => {
@@ -60,7 +60,7 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
     networkCreateStub.rejects(fakeError);
 
     await assert.rejects(createNetwork("test-network", "bridge"), fakeError);
-    assert.ok(networkCreateStub.calledOnce);
+    sinon.assert.calledOnce(networkCreateStub);
   });
 
   it("createNetwork() should re-throw any non-ResponseError error", async () => {
@@ -68,6 +68,6 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
     networkCreateStub.rejects(fakeError);
 
     await assert.rejects(createNetwork("test-network", "bridge"), fakeError);
-    assert.ok(networkCreateStub.calledOnce);
+    sinon.assert.calledOnce(networkCreateStub);
   });
 });

--- a/src/docker/workflows/base.test.ts
+++ b/src/docker/workflows/base.test.ts
@@ -76,7 +76,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
     await workflow["checkForImage"]("repo", "tag");
 
     assert.ok(imageExistsStub.calledOnceWith("repo", "tag"));
-    assert.ok(pullImageStub.notCalled);
+    sinon.assert.notCalled(pullImageStub);
   });
 
   it("handleExistingContainers() should handle an existing container and automatically start it if it isn't running", async () => {
@@ -143,7 +143,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
     assert.strictEqual(result, fakeResponse);
     assert.ok(startContainerStub.calledOnceWith(fakeContainer.id));
     assert.ok(getContainerStub.calledOnceWith(fakeContainer.id));
-    assert.ok(showErrorMessageStub.notCalled);
+    sinon.assert.notCalled(showErrorMessageStub);
   });
 
   it("startContainer() should return nothing and show an error notification for port-in-use ResponseErrors", async () => {
@@ -163,7 +163,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     assert.strictEqual(result, undefined);
     assert.ok(startContainerStub.calledOnceWith(fakeContainer.id));
-    assert.ok(getContainerStub.notCalled);
+    sinon.assert.notCalled(getContainerStub);
     assert.ok(
       showErrorMessageStub.calledOnceWith(
         'Failed to start test container "test-container": Port 8082 is already in use.',
@@ -181,7 +181,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     assert.strictEqual(result, undefined);
     assert.ok(startContainerStub.calledOnceWith(fakeContainer.id));
-    assert.ok(getContainerStub.notCalled);
+    sinon.assert.notCalled(getContainerStub);
     assert.ok(
       showErrorMessageStub.calledOnceWith('Failed to start test container "test-container": uh oh'),
     );
@@ -218,7 +218,7 @@ describe("docker/workflows/index.ts LocalResourceWorkflow registry", () => {
       LocalResourceWorkflow.getKafkaWorkflow,
       new Error(`Unsupported Kafka image repo: ${unsupportedImageRepo}`),
     );
-    assert.ok(showErrorMessageStub.calledOnce);
+    sinon.assert.calledOnce(showErrorMessageStub);
   });
 
   it(`getKafkaWorkflow() should return a ConfluentLocalWorkflow instance for the correct "${LOCAL_KAFKA_IMAGE.id}" setting`, async () => {
@@ -237,7 +237,7 @@ describe("docker/workflows/index.ts LocalResourceWorkflow registry", () => {
       LocalResourceWorkflow.getSchemaRegistryWorkflow,
       new Error(`Unsupported Schema Registry image repo: ${unsupportedImageRepo}`),
     );
-    assert.ok(showErrorMessageStub.calledOnce);
+    sinon.assert.calledOnce(showErrorMessageStub);
   });
 
   it(`getSchemaRegistryWorkflow() should return a ConfluentLocalWorkflow instance for the correct "${LOCAL_SCHEMA_REGISTRY_IMAGE.id}" setting`, async () => {

--- a/src/docker/workflows/confluent-local.test.ts
+++ b/src/docker/workflows/confluent-local.test.ts
@@ -120,18 +120,18 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
     // happy path: no existing containers, user selects 1 broker
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(createNetworkStub.calledOnce);
+    sinon.assert.calledOnce(createNetworkStub);
 
-    assert.ok(showInputBoxStub.calledOnce);
-    assert.ok(createContainerStub.calledOnce);
-    assert.ok(startContainerStub.calledOnce);
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledOnce(createContainerStub);
+    sinon.assert.calledOnce(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
+    sinon.assert.calledOnce(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should handle existing containers and not create new ones", async () => {
@@ -140,18 +140,18 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
+    sinon.assert.calledOnce(getContainersForImageStub);
     assert.ok(handleExistingContainersStub.calledOnceWith(fakeContainers));
 
-    assert.ok(createNetworkStub.notCalled);
+    sinon.assert.notCalled(createNetworkStub);
 
-    assert.ok(showInputBoxStub.notCalled);
-    assert.ok(createContainerStub.notCalled);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.notCalled(showInputBoxStub);
+    sinon.assert.notCalled(createContainerStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should exit early when the user exits the broker container input box", async () => {
@@ -159,18 +159,18 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(createNetworkStub.calledOnce);
+    sinon.assert.calledOnce(createNetworkStub);
 
-    assert.ok(showInputBoxStub.calledOnce);
-    assert.ok(createContainerStub.notCalled);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.notCalled(createContainerStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should exit early and show an error notification if a container fails to be created", async () => {
@@ -178,19 +178,19 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(createNetworkStub.calledOnce);
+    sinon.assert.calledOnce(createNetworkStub);
 
-    assert.ok(showInputBoxStub.calledOnce);
-    assert.ok(createContainerStub.calledOnce);
-    assert.ok(showErrorNotificationStub.calledOnce);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledOnce(createContainerStub);
+    sinon.assert.calledOnce(showErrorNotificationStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should exit early and if a container fails to start", async () => {
@@ -198,19 +198,19 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(createNetworkStub.calledOnce);
+    sinon.assert.calledOnce(createNetworkStub);
 
-    assert.ok(showInputBoxStub.calledOnce);
-    assert.ok(createContainerStub.calledOnce);
-    assert.ok(startContainerStub.calledOnce);
+    sinon.assert.calledOnce(showInputBoxStub);
+    sinon.assert.calledOnce(createContainerStub);
+    sinon.assert.calledOnce(startContainerStub);
     // notification tested in base.test.ts as part of .startContainer() tests
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("stop() should get the imageTag from workspace configuration", async () => {
@@ -232,9 +232,9 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     await workflow.stop(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(getContainersForImageStub.calledOnce);
+    sinon.assert.calledOnce(getContainersForImageStub);
     assert.ok(stopContainerStub.calledOnceWith({ id: containerId, name: containerName }));
-    assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
+    sinon.assert.calledOnce(waitForLocalResourceEventChangeStub);
   });
 
   it("stop() should exit early if there are no running Kafka containers", async () => {
@@ -242,7 +242,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     await workflow.stop(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(getContainersForImageStub.calledOnce);
+    sinon.assert.calledOnce(getContainersForImageStub);
     // not the usual "Open Logs"+"File Issue" notification, just a basic error message with a button to open settings
     assert.ok(
       showErrorMessageStub.calledOnceWith(
@@ -250,8 +250,8 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
         "Open Settings",
       ),
     );
-    assert.ok(stopContainerStub.notCalled);
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(stopContainerStub);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("waitForLocalResourceEventChange() should resolve when the localKafkaConnected event is emitted", async () => {
@@ -352,7 +352,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
     assert.ok(result);
     assert.equal(result.id, "1");
     assert.equal(result.name, containerName);
-    assert.ok(createContainerStub.calledOnce);
+    sinon.assert.calledOnce(createContainerStub);
     assert.ok(
       createContainerStub.calledWith(workflow.imageRepo, workflow.imageTag, {
         body: {

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -138,20 +138,20 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
     // happy path: no existing containers, Kafka container(s) exist to work off of
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce); // twice if fetchAndFilterKafkaContainersStub is not stubbed
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub); // twice if fetchAndFilterKafkaContainersStub is not stubbed
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
 
-    assert.ok(createContainerStub.calledOnce);
-    assert.ok(startContainerStub.calledOnce);
-    assert.ok(showErrorNotificationStub.notCalled);
+    sinon.assert.calledOnce(createContainerStub);
+    sinon.assert.calledOnce(startContainerStub);
+    sinon.assert.notCalled(showErrorNotificationStub);
 
-    assert.ok(updateLocalConnectionStub.calledOnce);
+    sinon.assert.calledOnce(updateLocalConnectionStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
+    sinon.assert.calledOnce(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should handle existing containers and not create new ones", async () => {
@@ -160,18 +160,18 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
+    sinon.assert.calledOnce(getContainersForImageStub);
     assert.ok(handleExistingContainersStub.calledOnceWith(fakeContainers));
     // bailing here
 
-    assert.ok(fetchAndFilterKafkaContainersStub.notCalled);
+    sinon.assert.notCalled(fetchAndFilterKafkaContainersStub);
 
-    assert.ok(createContainerStub.notCalled);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.notCalled(createContainerStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should exit early when no Kafka containers are found", async () => {
@@ -179,19 +179,19 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
-    assert.ok(showErrorMessageStub.calledOnce);
+    sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
+    sinon.assert.calledOnce(showErrorMessageStub);
     // bailing here
 
-    assert.ok(createContainerStub.notCalled);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.notCalled(createContainerStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should allow users to start Kafka resources via the notification buttons if no Kafka containers are available", async () => {
@@ -201,12 +201,12 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
     assert.ok(
       showErrorMessageStub.calledOnceWith(
         `No running Kafka containers found for image "${LOCAL_KAFKA_IMAGE.defaultValue}:${LOCAL_KAFKA_IMAGE_TAG.defaultValue}". Please start Kafka and try again.`,
@@ -221,10 +221,10 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     );
     // bailing here
 
-    assert.ok(createContainerStub.notCalled);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.notCalled(createContainerStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should allow users to access Docker image settings via the notification buttons if no Kafka containers are available", async () => {
@@ -234,12 +234,12 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
     assert.ok(
       showErrorMessageStub.calledOnceWith(
         `No running Kafka containers found for image "${LOCAL_KAFKA_IMAGE.defaultValue}:${LOCAL_KAFKA_IMAGE_TAG.defaultValue}". Please start Kafka and try again.`,
@@ -255,10 +255,10 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     );
     // bailing here
 
-    assert.ok(createContainerStub.notCalled);
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.notCalled(createContainerStub);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should exit early and show an error notification if a container fails to be created", async () => {
@@ -266,20 +266,20 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
-    assert.ok(showErrorMessageStub.notCalled);
+    sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
+    sinon.assert.notCalled(showErrorMessageStub);
 
-    assert.ok(createContainerStub.calledOnce);
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.calledOnce(createContainerStub);
+    sinon.assert.calledOnce(showErrorNotificationStub);
     // bailing here
-    assert.ok(startContainerStub.notCalled);
+    sinon.assert.notCalled(startContainerStub);
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("start() should exit early and if a container fails to start", async () => {
@@ -287,18 +287,18 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.start(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(checkForImageStub.calledOnce);
+    sinon.assert.calledOnce(checkForImageStub);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(handleExistingContainersStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(handleExistingContainersStub);
 
-    assert.ok(fetchAndFilterKafkaContainersStub.calledOnce);
+    sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
 
-    assert.ok(createContainerStub.calledOnce);
-    assert.ok(startContainerStub.calledOnce);
+    sinon.assert.calledOnce(createContainerStub);
+    sinon.assert.calledOnce(startContainerStub);
     // notification tested in base.test.ts as part of .startContainer() tests
 
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("stop() should get the imageTag from workspace configuration", async () => {
@@ -317,9 +317,9 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.stop(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(stopContainerStub.calledOnce);
-    assert.ok(waitForLocalResourceEventChangeStub.calledOnce);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.calledOnce(stopContainerStub);
+    sinon.assert.calledOnce(waitForLocalResourceEventChangeStub);
   });
 
   it("stop() should exit early if there are no running Schema Registry containers", async () => {
@@ -327,9 +327,9 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
 
     await workflow.stop(TEST_CANCELLATION_TOKEN);
 
-    assert.ok(getContainersForImageStub.calledOnce);
-    assert.ok(stopContainerStub.notCalled);
-    assert.ok(waitForLocalResourceEventChangeStub.notCalled);
+    sinon.assert.calledOnce(getContainersForImageStub);
+    sinon.assert.notCalled(stopContainerStub);
+    sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
   });
 
   it("fetchAndFilterKafkaContainers() should return Kafka containers", async () => {
@@ -368,7 +368,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
       kafkaNetworks,
     );
 
-    assert.ok(createContainerStub.calledOnce);
+    sinon.assert.calledOnce(createContainerStub);
     assert.ok(container);
 
     const createBody: ContainerCreateOperationRequest = {

--- a/src/documentMetadataManager.test.ts
+++ b/src/documentMetadataManager.test.ts
@@ -46,9 +46,9 @@ describe("documentMetadataManager.ts", () => {
     DocumentMetadataManager["instance"] = null;
     DocumentMetadataManager.getInstance();
 
-    assert.ok(onDidOpenTextDocumentSpy.calledOnce);
-    assert.ok(onDidSaveTextDocumentSpy.calledOnce);
-    assert.ok(onDidCloseTextDocumentSpy.calledOnce);
+    sinon.assert.calledOnce(onDidOpenTextDocumentSpy);
+    sinon.assert.calledOnce(onDidSaveTextDocumentSpy);
+    sinon.assert.calledOnce(onDidCloseTextDocumentSpy);
   });
 
   it("handleDocumentSave() should exit early for 'untitled' documents", async () => {

--- a/src/extensionSettings/listener.test.ts
+++ b/src/extensionSettings/listener.test.ts
@@ -114,7 +114,7 @@ describe("extensionSettings/listener.ts", function () {
     createConfigChangeListener();
     await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
 
-    assert.ok(updatePreferencesStub.notCalled);
+    sinon.assert.notCalled(updatePreferencesStub);
   });
 
   const previewSettings: [ExtensionSetting<any>, contextValues.ContextValues][] = [

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -362,7 +362,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
 
       // Wait for the request to actually start
       await eventually(() => {
-        assert.ok(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.calledOnce);
+        sinon.assert.calledOnce(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult);
       });
 
       // While that's in flight, start stopping the statement

--- a/src/loaders/loaderUtils.test.ts
+++ b/src/loaders/loaderUtils.test.ts
@@ -238,7 +238,7 @@ describe("loaderUtils.ts", () => {
         const results = await loaderUtils.fetchTopics(TEST_CCLOUD_KAFKA_CLUSTER);
         assert.deepStrictEqual(results, []);
 
-        assert.ok(showPrivateNetworkingHelpNotificationStub.calledOnce);
+        sinon.assert.calledOnce(showPrivateNetworkingHelpNotificationStub);
       });
 
       it("fetchTopics should throw TopicFetchError when not private networking symptom ResponseError", async () => {
@@ -249,7 +249,7 @@ describe("loaderUtils.ts", () => {
           loaderUtils.TopicFetchError,
         );
 
-        assert.ok(showPrivateNetworkingHelpNotificationStub.notCalled);
+        sinon.assert.notCalled(showPrivateNetworkingHelpNotificationStub);
       });
 
       it("fetchTopics should throw TopicFetchError when not a ResponseError", async () => {
@@ -260,7 +260,7 @@ describe("loaderUtils.ts", () => {
           loaderUtils.TopicFetchError,
         );
 
-        assert.ok(showPrivateNetworkingHelpNotificationStub.notCalled);
+        sinon.assert.notCalled(showPrivateNetworkingHelpNotificationStub);
       });
     });
   });

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -102,7 +102,7 @@ describe("ResourceLoader::getSubjects()", () => {
 
         assert.deepStrictEqual(subjects, fetchSubjectsStubReturns);
         // will have asked for the subjects from the resource manager, but none returned, so deep fetched.
-        assert.ok(rmGetSubjectsStub.calledOnce);
+        sinon.assert.calledOnce(rmGetSubjectsStub);
         /// will have stored the deep fetched subjects in the resource manager.
         assert.ok(
           rmSetSubjectsStub.calledWithExactly(TEST_LOCAL_SCHEMA_REGISTRY, fetchSubjectsStubReturns),
@@ -128,11 +128,11 @@ describe("ResourceLoader::getSubjects()", () => {
         assert.deepStrictEqual(subjects, rmGetSubjectsStubReturns);
 
         // will have asked for the subjects from the resource manager, and found them.
-        assert.ok(rmGetSubjectsStub.calledOnce);
+        sinon.assert.calledOnce(rmGetSubjectsStub);
         // Not deep fetched 'cause of resource manager cache hit.
-        assert.ok(fetchSubjectsStub.notCalled);
+        sinon.assert.notCalled(fetchSubjectsStub);
         // will not call setSubjects() because of cache hit.
-        assert.ok(rmSetSubjectsStub.notCalled);
+        sinon.assert.notCalled(rmSetSubjectsStub);
 
         // reset the resource manager stub for next iteration.
         rmGetSubjectsStub.resetHistory();
@@ -152,7 +152,7 @@ describe("ResourceLoader::getSubjects()", () => {
 
       assert.deepStrictEqual(subjects, fetchSubjectsStubReturns);
       // will not have asked resource manager for subjects, since deep fetch is forced.
-      assert.ok(rmGetSubjectsStub.notCalled);
+      sinon.assert.notCalled(rmGetSubjectsStub);
       /// will have stored the deep fetched subjects in the resource manager.
       assert.ok(
         rmSetSubjectsStub.calledWithExactly(TEST_LOCAL_SCHEMA_REGISTRY, fetchSubjectsStubReturns),
@@ -177,11 +177,11 @@ describe("ResourceLoader::getSubjects()", () => {
       assert.deepStrictEqual(subjects, []);
 
       // will have asked for the subjects from the resource manager, and found them.
-      assert.ok(rmGetSubjectsStub.calledOnce);
+      sinon.assert.calledOnce(rmGetSubjectsStub);
       // Not deep fetched 'cause of resource manager cache hit.
-      assert.ok(fetchSubjectsStub.notCalled);
+      sinon.assert.notCalled(fetchSubjectsStub);
       // will not call setSubjects() because of cache hit.
-      assert.ok(rmSetSubjectsStub.notCalled);
+      sinon.assert.notCalled(rmSetSubjectsStub);
 
       // reset the resource manager stub for next iteration.
       rmGetSubjectsStub.resetHistory();
@@ -234,8 +234,8 @@ describe("ResourceLoader::checkedGetSubjects()", () => {
 
     const result = await loaderInstance.checkedGetSubjects(TEST_LOCAL_SCHEMA_REGISTRY);
     assert.deepStrictEqual(result, []);
-    assert.ok(isResponseErrorStub.calledOnce);
-    assert.ok(showWarningNotificationWithButtonsStub.calledOnce);
+    sinon.assert.calledOnce(isResponseErrorStub);
+    sinon.assert.calledOnce(showWarningNotificationWithButtonsStub);
     assert.ok(
       showWarningNotificationWithButtonsStub
         .getCall(0)
@@ -249,7 +249,7 @@ describe("ResourceLoader::checkedGetSubjects()", () => {
 
     await assert.rejects(loaderInstance.checkedGetSubjects(TEST_LOCAL_SCHEMA_REGISTRY), (err) => {
       assert.strictEqual((err as Error).message, "Test error");
-      assert.ok(isResponseErrorStub.calledOnce);
+      sinon.assert.calledOnce(isResponseErrorStub);
       return true;
     });
   });
@@ -359,7 +359,7 @@ describe("ResourceLoader::clearCache()", () => {
   it("clearCache(schemaRegistry) side effects", async () => {
     const schemaRegistry = TEST_LOCAL_SCHEMA_REGISTRY;
     await loaderInstance.clearCache(schemaRegistry);
-    assert.ok(rmSetSubjectsStub.calledOnce);
+    sinon.assert.calledOnce(rmSetSubjectsStub);
     // calling with undefined will clear out just this single schema registry's subjects.
     assert.ok(rmSetSubjectsStub.calledWithExactly(schemaRegistry, undefined));
   });
@@ -405,10 +405,10 @@ describe("ResourceLoader::getTopicsForCluster()", () => {
     const topics = await loaderInstance.getTopicsForCluster(TEST_LOCAL_KAFKA_CLUSTER);
     assert.deepStrictEqual(topics, cachedTopics);
     // Should not have called fetchTopics() or getSubjects() since cache hit.
-    assert.ok(fetchTopicsStub.notCalled);
-    assert.ok(getSubjectsStub.notCalled);
+    sinon.assert.notCalled(fetchTopicsStub);
+    sinon.assert.notCalled(getSubjectsStub);
     // Should have called getTopicsForCluster() on the resource manager.
-    assert.ok(rmGetTopicsStub.calledOnce);
+    sinon.assert.calledOnce(rmGetTopicsStub);
   });
 
   it("Returns correlated topics with schema subjects", async () => {
@@ -431,8 +431,8 @@ describe("ResourceLoader::getTopicsForCluster()", () => {
     assert.ok(topics[1].hasSchema);
     assert.ok(!topics[2].hasSchema);
 
-    assert.ok(getSubjectsStub.calledOnce);
-    assert.ok(fetchTopicsStub.calledOnce);
+    sinon.assert.calledOnce(getSubjectsStub);
+    sinon.assert.calledOnce(fetchTopicsStub);
   });
 
   it("Returns topics without schemas if getSubjects() returns empty array", async () => {
@@ -453,8 +453,8 @@ describe("ResourceLoader::getTopicsForCluster()", () => {
     assert.ok(!topics[1].hasSchema);
     assert.ok(!topics[2].hasSchema);
 
-    assert.ok(getSubjectsStub.calledOnce);
-    assert.ok(fetchTopicsStub.calledOnce);
+    sinon.assert.calledOnce(getSubjectsStub);
+    sinon.assert.calledOnce(fetchTopicsStub);
   });
 
   it("Gracefully handles error from getSubjects()", async () => {
@@ -479,7 +479,7 @@ describe("ResourceLoader::getTopicsForCluster()", () => {
     // Returned topics def won't have schemas.
     assert.ok(!topics[0].hasSchema);
 
-    assert.ok(showWarningNotificationWithButtonsStub.calledOnce);
+    sinon.assert.calledOnce(showWarningNotificationWithButtonsStub);
   });
 });
 
@@ -507,7 +507,7 @@ describe("ResourceLoader::getSchemasForSubject()", () => {
       TEST_LOCAL_SUBJECT_WITH_SCHEMAS.name,
     );
     assert.deepStrictEqual(schemas, TEST_LOCAL_SUBJECT_WITH_SCHEMAS.schemas);
-    assert.ok(fetchSchemasForSubjectStub.calledOnce);
+    sinon.assert.calledOnce(fetchSchemasForSubjectStub);
   });
 });
 
@@ -606,7 +606,7 @@ describe("ResourceLoader::deleteSchemaVersion()", () => {
         shouldClearSubjects,
       );
 
-      assert.ok(stubbedSubjectsV1Api.deleteSchemaVersion.calledOnce);
+      sinon.assert.calledOnce(stubbedSubjectsV1Api.deleteSchemaVersion);
 
       const expectedRequest = {
         subject: schema.subject,
@@ -620,10 +620,10 @@ describe("ResourceLoader::deleteSchemaVersion()", () => {
       );
 
       if (shouldClearSubjects) {
-        assert.ok(clearCacheStub.calledOnce);
+        sinon.assert.calledOnce(clearCacheStub);
         assert.ok(clearCacheStub.calledWithExactly(schema.subjectObject()));
       } else {
-        assert.ok(clearCacheStub.notCalled);
+        sinon.assert.notCalled(clearCacheStub);
       }
     });
   }
@@ -726,7 +726,7 @@ describe("ResourceLoader::deleteSchemaSubject()", () => {
         );
       }
 
-      assert.ok(clearCacheStub.calledOnce);
+      sinon.assert.calledOnce(clearCacheStub);
     });
   }
 });

--- a/src/quickpicks/utils/schemas.test.ts
+++ b/src/quickpicks/utils/schemas.test.ts
@@ -142,6 +142,6 @@ describe("quickpicks/utils/schemas.ts promptForSchema()", () => {
       async () => promptForSchema(TEST_LOCAL_KAFKA_TOPIC, "value", SubjectNameStrategy.TOPIC_NAME),
       { message: `No schema versions found for subject "${TEST_LOCAL_SCHEMA.subject}".` },
     );
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.calledOnce(showErrorNotificationStub);
   });
 });

--- a/src/sidecar/connections/ccloud.test.ts
+++ b/src/sidecar/connections/ccloud.test.ts
@@ -40,7 +40,7 @@ describe("sidecar/connections/ccloud.ts", () => {
 
     await clearCurrentCCloudResources();
 
-    assert.ok(mockedCCLoudLoader.reset.calledOnce);
+    sinon.assert.calledOnce(mockedCCLoudLoader.reset);
     assert.ok(currentKafkaClusterChangedFireStub.calledOnceWith(null));
     assert.ok(schemasViewResourceChangedFireStub.calledOnceWith(null));
 
@@ -56,9 +56,9 @@ describe("sidecar/connections/ccloud.ts", () => {
 
     await clearCurrentCCloudResources();
 
-    assert.ok(mockedCCLoudLoader.reset.calledOnce);
-    assert.ok(currentKafkaClusterChangedFireStub.notCalled);
-    assert.ok(schemasViewResourceChangedFireStub.notCalled);
+    sinon.assert.calledOnce(mockedCCLoudLoader.reset);
+    sinon.assert.notCalled(currentKafkaClusterChangedFireStub);
+    sinon.assert.notCalled(schemasViewResourceChangedFireStub);
   });
 
   for (const value of [false, undefined]) {

--- a/src/sidecar/connections/watcher.test.ts
+++ b/src/sidecar/connections/watcher.test.ts
@@ -71,8 +71,8 @@ describe("sidecar/connections/watcher.ts ConnectionStateWatcher handleConnection
 
     await connectionStateWatcher.handleConnectionUpdateEvent(message);
 
-    assert.ok(connectionEventHandlerStub.calledOnce);
-    assert.ok(logErrorStub.notCalled);
+    sinon.assert.calledOnce(connectionEventHandlerStub);
+    sinon.assert.notCalled(logErrorStub);
     const cachedEvent = connectionStateWatcher.getLatestConnectionEvent(
       TEST_AUTHENTICATED_CCLOUD_CONNECTION.id as ConnectionId,
     );
@@ -192,7 +192,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
       const result = await connectionPromise;
       assert.strictEqual(result, null);
       // even if we hit a timeout, we need to stop the "loading" state
-      assert.ok(connectionStableFireStub.calledOnce);
+      sinon.assert.calledOnce(connectionStableFireStub);
     });
 
     it(`${baseConnection.spec.type}: waitForConnectionToBeStable() should wait for websocket event if the connection is not found initially`, async () => {
@@ -219,13 +219,13 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
         await clock.tickAsync(100);
 
         // isConnectionStableSpy should not have been called yet.
-        assert.ok(isConnectionStableSpy.notCalled);
+        sinon.assert.notCalled(isConnectionStableSpy);
 
         // simulate a websocket event that updates the connection state to this new stable state.
         await announceConnectionState(testConnection);
 
         // And now isConnectionStable should have been called.
-        assert.ok(isConnectionStableSpy.calledOnce);
+        sinon.assert.calledOnce(isConnectionStableSpy);
         // and it should have returned true
         assert.ok(isConnectionStableSpy.returned(true));
       }
@@ -240,7 +240,7 @@ describe("sidecar/connections/watcher.ts waitForConnectionToBeStable()", () => {
       assert.deepStrictEqual(results[1], testConnection);
       // and that isDirectConnectionStable was called (after the websocket event)
       // log number of calls.
-      assert.ok(isConnectionStableSpy.calledOnce);
+      sinon.assert.calledOnce(isConnectionStableSpy);
     });
   }
 });
@@ -285,7 +285,7 @@ describe("sidecar/connections/watcher.ts SingleConnectionEntry", () => {
     singleConnectionEntry.handleUpdate(firstEvent);
 
     assert.deepEqual(firstEvent, singleConnectionEntry.mostRecentEvent);
-    assert.ok(eventEmitterFireSub.calledOnce);
+    sinon.assert.calledOnce(eventEmitterFireSub);
     // Now assigned.
     assert.deepEqual(firstEvent.connection, singleConnectionEntry.connection);
 
@@ -304,7 +304,7 @@ describe("sidecar/connections/watcher.ts SingleConnectionEntry", () => {
     };
 
     singleConnectionEntry.handleUpdate(secondEvent);
-    assert.ok(eventEmitterFireSub.calledOnce);
+    sinon.assert.calledOnce(eventEmitterFireSub);
     // reassigned.
     assert.deepEqual(secondEvent.connection, singleConnectionEntry.connection);
   });
@@ -391,7 +391,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.calledOnce(showErrorNotificationStub);
     const callArgs = showErrorNotificationStub.getCall(0).args;
     assert.strictEqual(
       callArgs[0],
@@ -411,7 +411,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.calledOnce(showErrorNotificationStub);
     const callArgs = showErrorNotificationStub.getCall(0).args;
     assert.strictEqual(
       callArgs[0],
@@ -431,7 +431,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.notCalled);
+    sinon.assert.notCalled(showErrorNotificationStub);
   });
 
   it("should not show a notification if a CCLOUD connection does not have a FAILED `ccloud` state", async () => {
@@ -444,7 +444,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.notCalled);
+    sinon.assert.notCalled(showErrorNotificationStub);
   });
 
   it("should show a notification if a CCLOUD connection has a FAILED `ccloud` state", async () => {
@@ -457,7 +457,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.calledOnce);
+    sinon.assert.calledOnce(showErrorNotificationStub);
     const callArgs = showErrorNotificationStub.getCall(0).args;
     assert.strictEqual(
       callArgs[0],
@@ -478,7 +478,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.notCalled);
+    sinon.assert.notCalled(showErrorNotificationStub);
   });
 
   // TODO(shoup): remove this after the LOCAL connection migrates to a DIRECT connection
@@ -496,7 +496,7 @@ describe("sidecar/connections/watcher.ts reportUsableState() notifications", () 
 
     await reportUsableState(connection);
 
-    assert.ok(showErrorNotificationStub.notCalled);
+    sinon.assert.notCalled(showErrorNotificationStub);
   });
 });
 

--- a/src/sidecar/middlewares.test.ts
+++ b/src/sidecar/middlewares.test.ts
@@ -1,4 +1,3 @@
-import * as assert from "assert";
 import sinon from "sinon";
 import { getTestExtensionContext } from "../../tests/unit/testUtils";
 import { ConnectedState, RequestContext } from "../clients/sidecar";
@@ -60,8 +59,8 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
 
     await middleware.pre(requestContext);
 
-    assert.ok(handleCCloudAuthStatusSpy.calledOnce);
-    assert.ok(handleProblematicStatusStub.notCalled);
+    sinon.assert.calledOnce(handleCCloudAuthStatusSpy);
+    sinon.assert.notCalled(handleProblematicStatusStub);
   });
 
   it("should not call handleCCloudAuthStatus() when the CCloud connection header is missing", async () => {
@@ -73,8 +72,8 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
     await middleware.pre(requestContext2);
     await middleware.pre(requestContext3);
 
-    assert.ok(handleCCloudAuthStatusSpy.notCalled);
-    assert.ok(handleProblematicStatusStub.notCalled);
+    sinon.assert.notCalled(handleCCloudAuthStatusSpy);
+    sinon.assert.notCalled(handleProblematicStatusStub);
   });
 
   it(`should call handleProblematicStatus() from the ${ConnectedState.Expired} state`, async () => {
@@ -86,8 +85,8 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
 
     await middleware.pre(requestContext);
 
-    assert.ok(handleCCloudAuthStatusSpy.calledOnce);
-    assert.ok(handleProblematicStatusStub.calledOnce);
+    sinon.assert.calledOnce(handleCCloudAuthStatusSpy);
+    sinon.assert.calledOnce(handleProblematicStatusStub);
   });
 
   it(`should fire ccloudAuthSessionInvalidated from a ${ConnectedState.None} or ${ConnectedState.Failed} state`, async () => {
@@ -99,7 +98,7 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
 
     await middleware.pre(requestContext);
 
-    assert.ok(ccloudAuthSessionInvalidatedStub.calledOnce);
+    sinon.assert.calledOnce(ccloudAuthSessionInvalidatedStub);
 
     // isn't easy to get into this state since we should delete the CCloud connection and reset the
     // associated resources for the (previous) connection, but just in case:
@@ -107,7 +106,7 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
 
     await middleware.pre(requestContext);
 
-    assert.ok(ccloudAuthSessionInvalidatedStub.calledTwice);
+    sinon.assert.calledTwice(ccloudAuthSessionInvalidatedStub);
   });
 
   it(`should not block requests from the ${ConnectedState.Success} state`, async () => {
@@ -119,8 +118,8 @@ describe("CCloudAuthStatusMiddleware behavior", () => {
 
     await middleware.pre(requestContext);
 
-    assert.ok(handleCCloudAuthStatusSpy.calledOnce);
-    assert.ok(handleProblematicStatusStub.notCalled);
-    assert.ok(ccloudAuthSessionInvalidatedStub.notCalled);
+    sinon.assert.calledOnce(handleCCloudAuthStatusSpy);
+    sinon.assert.notCalled(handleProblematicStatusStub);
+    sinon.assert.notCalled(ccloudAuthSessionInvalidatedStub);
   });
 });

--- a/src/storage/migrations/v2.test.ts
+++ b/src/storage/migrations/v2.test.ts
@@ -119,7 +119,7 @@ describe("storage/migrations/v2", () => {
 
     await migration.upgradeSecretStorage();
 
-    assert.ok(secretsStoreStub.notCalled);
+    sinon.assert.notCalled(secretsStoreStub);
   });
 
   it("downgradeSecretStorage() should remove 'ssl' configs from connection specs", async () => {
@@ -174,7 +174,7 @@ describe("storage/migrations/v2", () => {
     await migration.downgradeSecretStorage();
 
     // secrets.store() should be called once during a downgrade
-    assert.ok(secretsStoreStub.calledOnce);
+    sinon.assert.calledOnce(secretsStoreStub);
     // and now we have to pull out the stringified Map that was used for the call
     const mapStringArg = JSON.parse(secretsStoreStub.args[0][1]);
     const secretsStoreCallArgs: any = Object.values(mapStringArg)[0];
@@ -193,6 +193,6 @@ describe("storage/migrations/v2", () => {
 
     await migration.downgradeSecretStorage();
 
-    assert.ok(secretsStoreStub.notCalled);
+    sinon.assert.notCalled(secretsStoreStub);
   });
 });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

**No functional changes, no test-logic changes. The main idea here is consistency within our codebase so any new test writers (human or bot) will have a single pattern to go off of.**

This is part 1 that handles the "easy" fixes, and the next branch handles the `calledWith*` cases.
- https://github.com/confluentinc/vscode/pull/2850 👈 
  - https://github.com/confluentinc/vscode/pull/2851

Docs: https://sinonjs.org/releases/v20/assertions/

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
