### PR TITLE
cleanup(tests): update calledWith* assertions to use the `sinon.assert` API

### DIFF
--- a/src/commands/flinkComputePools.test.ts
+++ b/src/commands/flinkComputePools.test.ts
@@ -1,4 +1,3 @@
-import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 import { eventEmitterStubs } from "../../tests/stubs/emitters";
@@ -96,11 +95,10 @@ describe("flinkComputePools.ts", () => {
 
       await commandsModule.configureFlinkDefaults();
 
-      assert.ok(
-        executeCommandStub.calledWith(
-          "workbench.action.openSettings",
-          "@ext:confluentinc.vscode-confluent flink",
-        ),
+      sinon.assert.calledWith(
+        executeCommandStub,
+        "workbench.action.openSettings",
+        "@ext:confluentinc.vscode-confluent flink",
       );
     });
   });

--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -102,7 +102,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
     // shouldn't be possible based on the package.json configs, but just in case
     await produceMessagesFromDocument(null as any);
 
-    assert.ok(showErrorMessageStub.calledOnceWith("No topic selected."));
+    sinon.assert.calledOnceWithExactly(showErrorMessageStub, "No topic selected.");
   });
 
   it("should exit early if no file/editor is selected from the URI quickpick", async function () {
@@ -360,13 +360,12 @@ describe("commands/topics.ts produceMessageFromDocument() with schema(s)", funct
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(getSubjectNameStrategyStub.calledOnceWith(TEST_LOCAL_KAFKA_TOPIC, "value"));
-    assert.ok(
-      promptForSchemaStub.calledOnceWith(
-        TEST_LOCAL_KAFKA_TOPIC,
-        "value",
-        SubjectNameStrategy.TOPIC_NAME,
-      ),
+    sinon.assert.calledOnceWithExactly(getSubjectNameStrategyStub, TEST_LOCAL_KAFKA_TOPIC, "value");
+    sinon.assert.calledOnceWithExactly(
+      promptForSchemaStub,
+      TEST_LOCAL_KAFKA_TOPIC,
+      "value",
+      SubjectNameStrategy.TOPIC_NAME,
     );
     sinon.assert.calledOnce(recordsV3ApiStub.produceRecord);
   });
@@ -402,17 +401,19 @@ describe("commands/topics.ts produceMessageFromDocument() with schema(s)", funct
 
     await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
 
-    assert.ok(getSubjectNameStrategyStub.calledWith(TEST_LOCAL_KAFKA_TOPIC, "key"));
-    assert.ok(getSubjectNameStrategyStub.calledWith(TEST_LOCAL_KAFKA_TOPIC, "value"));
-    assert.ok(
-      promptForSchemaStub.calledWith(TEST_LOCAL_KAFKA_TOPIC, "key", SubjectNameStrategy.TOPIC_NAME),
+    sinon.assert.calledWith(getSubjectNameStrategyStub, TEST_LOCAL_KAFKA_TOPIC, "key");
+    sinon.assert.calledWith(getSubjectNameStrategyStub, TEST_LOCAL_KAFKA_TOPIC, "value");
+    sinon.assert.calledWith(
+      promptForSchemaStub,
+      TEST_LOCAL_KAFKA_TOPIC,
+      "key",
+      SubjectNameStrategy.TOPIC_NAME,
     );
-    assert.ok(
-      promptForSchemaStub.calledWith(
-        TEST_LOCAL_KAFKA_TOPIC,
-        "value",
-        SubjectNameStrategy.RECORD_NAME,
-      ),
+    sinon.assert.calledWith(
+      promptForSchemaStub,
+      TEST_LOCAL_KAFKA_TOPIC,
+      "value",
+      SubjectNameStrategy.RECORD_NAME,
     );
     sinon.assert.calledOnce(recordsV3ApiStub.produceRecord);
   });

--- a/src/context/values.test.ts
+++ b/src/context/values.test.ts
@@ -22,7 +22,7 @@ describe("ContextValue functions", () => {
 
     await setContextValue(key, value);
 
-    assert.ok(executeCommandStub.calledWith("setContext", key, value));
+    sinon.assert.calledOnceWithExactly(executeCommandStub, "setContext", key, value);
     assert.deepStrictEqual(getContextValue<boolean>(key), value);
   });
 

--- a/src/docker/configs.test.ts
+++ b/src/docker/configs.test.ts
@@ -99,12 +99,12 @@ describe("docker/configs functions", function () {
     const error = new ResponseError(new Response("uh oh", { status: 400 }));
     await configs.showDockerUnavailableErrorNotification(error);
 
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        "Docker is not available: Error 400: uh oh",
-        "Open Logs",
-        "File Issue",
-      ),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      "Docker is not available: Error 400: uh oh",
+      "Open Logs",
+      "File Issue",
+      "",
     );
   });
 
@@ -116,12 +116,12 @@ describe("docker/configs functions", function () {
     const error = new Error("connect ENOENT /var/run/docker.sock");
     await configs.showDockerUnavailableErrorNotification(error);
 
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        "Docker is not available: Please install Docker and try again once it's running.",
-        "Install Docker",
-        "Open Logs",
-      ),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      "Docker is not available: Please install Docker and try again once it's running.",
+      "Install Docker",
+      "Open Logs",
+      "",
     );
   });
 
@@ -134,13 +134,12 @@ describe("docker/configs functions", function () {
     const error = new Error("ECONNREFUSED: fetch failed, AggregateError");
     await configs.showDockerUnavailableErrorNotification(error);
 
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        `Docker is not available: If Docker is currently running, please disable the "http.fetchAdditionalSupport" setting and try again.`,
-        "Install Docker",
-        "Open Logs",
-        "Update Settings",
-      ),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      `Docker is not available: If Docker is currently running, please disable the "http.fetchAdditionalSupport" setting and try again.`,
+      "Install Docker",
+      "Open Logs",
+      "Update Settings",
     );
   });
 });

--- a/src/docker/containers.test.ts
+++ b/src/docker/containers.test.ts
@@ -98,15 +98,13 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     await createContainer("repo", "tag", { body: {} });
 
     sinon.assert.calledOnce(containerCreateStub);
-    assert.ok(
-      containerCreateStub.calledWithMatch({
-        body: {
-          Labels: {
-            [MANAGED_CONTAINER_LABEL]: "true",
-          },
+    sinon.assert.calledOnceWithMatch(containerCreateStub, {
+      body: {
+        Labels: {
+          [MANAGED_CONTAINER_LABEL]: "true",
         },
-      }),
-    );
+      },
+    });
   });
 
   it("createContainer() should re-throw any error from .containerCreate", async () => {

--- a/src/docker/eventListener.test.ts
+++ b/src/docker/eventListener.test.ts
@@ -132,48 +132,27 @@ describe("docker/eventListener.ts EventListener methods", function () {
     await clock.tickAsync(100);
 
     // we should have called these, then bailed until the next poll
-    assert.ok(
-      getContextValueStub.calledOnceWith(contextValues.ContextValues.dockerServiceAvailable),
-      "getContextValue(ContextValues.dockerServiceAvailable) not called as expected",
+    sinon.assert.calledOnceWithExactly(
+      getContextValueStub,
+      contextValues.ContextValues.dockerServiceAvailable,
     );
 
-    assert.ok(
-      setContextValueStub.calledOnceWith(contextValues.ContextValues.dockerServiceAvailable, false),
-      "setContextValue(ContextValues.dockerServiceAvailable, false) not called as expected",
+    sinon.assert.calledOnceWithExactly(
+      setContextValueStub,
+      contextValues.ContextValues.dockerServiceAvailable,
+      false,
     );
 
-    assert.ok(
-      dockerServiceAvailableFireStub.calledOnceWith(false),
-      "dockerServiceAvailable.fire(false) not called as expected",
-    );
+    sinon.assert.calledOnceWithExactly(dockerServiceAvailableFireStub, false);
 
-    assert.ok(
-      isDockerAvailableStub.calledOnce,
-      `isDockerAvailable() called ${isDockerAvailableStub.callCount} times`,
-    );
-    assert.equal(
-      eventListener.dockerAvailable,
-      dockerAvailable,
-      `dockerAvailable should be ${dockerAvailable}, but is ${eventListener.dockerAvailable}`,
-    );
-    assert.ok(
-      useSlowFrequencySpy.calledOnce,
-      `useSlowFrequency() called ${useSlowFrequencySpy.callCount} times`,
-    );
+    sinon.assert.calledOnce(isDockerAvailableStub);
+    assert.equal(eventListener.dockerAvailable, dockerAvailable);
+    sinon.assert.calledOnce(useSlowFrequencySpy);
     // and we shouldn't have reached any of these
-    assert.ok(
-      useFastFrequencySpy.notCalled,
-      `useFastFrequency() called ${useFastFrequencySpy.callCount} times`,
-    );
-    assert.ok(
-      systemEventsRawStub.notCalled,
-      `systemEventsRaw() called ${systemEventsRawStub.callCount} time(s)`,
-    );
-    assert.ok(
-      readValuesFromStreamStub.notCalled,
-      `readValuesFromStream() called ${readValuesFromStreamStub.callCount} time(s)`,
-    );
-    assert.ok(handleEventStub.notCalled, `handleEvent() called ${handleEventStub.callCount} times`);
+    sinon.assert.notCalled(useFastFrequencySpy);
+    sinon.assert.notCalled(systemEventsRawStub);
+    sinon.assert.notCalled(readValuesFromStreamStub);
+    sinon.assert.notCalled(handleEventStub);
   });
 
   it("listenForEvents() should poll more frequently and make a request for system events if Docker is available", async function () {
@@ -213,35 +192,13 @@ describe("docker/eventListener.ts EventListener methods", function () {
     // advance the clock to allow the event listener logic to execute
     await clock.tickAsync(100);
 
-    assert.ok(
-      isDockerAvailableStub.calledOnce,
-      `isDockerAvailable() called ${isDockerAvailableStub.callCount} times`,
-    );
-    assert.equal(
-      eventListener.dockerAvailable,
-      dockerAvailable,
-      `dockerAvailable should be ${dockerAvailable}, but is ${eventListener.dockerAvailable}`,
-    );
-    assert.ok(
-      useSlowFrequencySpy.notCalled,
-      `useSlowFrequency() called ${useSlowFrequencySpy.callCount} times`,
-    );
-    assert.ok(
-      useFastFrequencySpy.calledOnce,
-      `useFastFrequency() called ${useFastFrequencySpy.callCount} times`,
-    );
-    assert.ok(
-      systemEventsRawStub.calledOnce,
-      `systemEventsRaw() called ${systemEventsRawStub.callCount} times`,
-    );
-    assert.ok(
-      readValuesFromStreamStub.calledOnceWith(stream),
-      `readValuesFromStream() called ${readValuesFromStreamStub.callCount} times with ${JSON.stringify(readValuesFromStreamStub.args)}`,
-    );
-    assert.ok(
-      handleEventStub.calledOnceWith(TEST_CONTAINER_EVENT),
-      `handleEvent() called ${handleEventStub.callCount} times with ${JSON.stringify(handleEventStub.args)}`,
-    );
+    sinon.assert.calledOnce(isDockerAvailableStub);
+    assert.equal(eventListener.dockerAvailable, dockerAvailable);
+    sinon.assert.notCalled(useSlowFrequencySpy);
+    sinon.assert.calledOnce(useFastFrequencySpy);
+    sinon.assert.calledOnce(systemEventsRawStub);
+    sinon.assert.calledOnceWithExactly(readValuesFromStreamStub, stream);
+    sinon.assert.calledOnceWithExactly(handleEventStub, TEST_CONTAINER_EVENT);
   });
 
   it("listenForEvents() should update context values and fire events if the connection to Docker is lost and an error with cause 'other side closed' is thrown while reading from the event stream", async function () {
@@ -289,36 +246,13 @@ describe("docker/eventListener.ts EventListener methods", function () {
     // advance the clock to allow the event listener logic to execute
     await clock.tickAsync(100);
 
-    assert.ok(
-      isDockerAvailableStub.calledOnce,
-      `isDockerAvailable() called ${isDockerAvailableStub.callCount} times`,
-    );
-    assert.equal(
-      eventListener.dockerAvailable,
-      dockerAvailable,
-      `dockerAvailable should be ${dockerAvailable}, but is ${eventListener.dockerAvailable}`,
-    );
-    assert.ok(
-      useSlowFrequencySpy.notCalled,
-      `useSlowFrequency() called ${useSlowFrequencySpy.callCount} times`,
-    );
-    assert.ok(
-      useFastFrequencySpy.calledOnce,
-      `useFastFrequency() called ${useFastFrequencySpy.callCount} times`,
-    );
-
-    assert.ok(
-      systemEventsRawStub.calledOnce,
-      `systemEventsRaw() called ${systemEventsRawStub.callCount} times`,
-    );
-    assert.ok(
-      readValuesFromStreamStub.calledOnceWith(stream),
-      `readValuesFromStream() called ${readValuesFromStreamStub.callCount} times with ${JSON.stringify(readValuesFromStreamStub.args)}`,
-    );
-    assert.ok(
-      handleEventStub.calledOnceWith(TEST_CONTAINER_EVENT),
-      `handleEvent() called ${handleEventStub.callCount} times`,
-    );
+    sinon.assert.calledOnce(isDockerAvailableStub);
+    assert.equal(eventListener.dockerAvailable, dockerAvailable);
+    sinon.assert.notCalled(useSlowFrequencySpy);
+    sinon.assert.calledOnce(useFastFrequencySpy);
+    sinon.assert.calledOnce(systemEventsRawStub);
+    sinon.assert.calledOnceWithExactly(readValuesFromStreamStub, stream);
+    sinon.assert.calledOnceWithExactly(handleEventStub, TEST_CONTAINER_EVENT);
     for (const contextValue of [
       contextValues.ContextValues.localKafkaClusterAvailable,
       contextValues.ContextValues.dockerServiceAvailable,
@@ -430,7 +364,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     };
     await eventListener.handleEvent(eventWithStatus);
 
-    assert.ok(handleContainerEventStub.calledOnceWith(eventWithStatus));
+    sinon.assert.calledOnceWithExactly(handleContainerEventStub, eventWithStatus);
   });
 
   it("handleEvent() should exit early if the event is missing 'status'", async function () {
@@ -471,7 +405,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     };
     await eventListener.handleContainerEvent(startEvent);
 
-    assert.ok(handleContainerStartEventStub.calledOnceWith(startEvent));
+    sinon.assert.calledOnceWithExactly(handleContainerStartEventStub, startEvent);
     sinon.assert.notCalled(handleContainerDieEventStub);
   });
 
@@ -490,7 +424,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     await eventListener.handleEvent(dieEvent);
 
     sinon.assert.notCalled(handleContainerStartEventStub);
-    assert.ok(handleContainerDieEventStub.calledOnceWith(dieEvent));
+    sinon.assert.calledOnceWithExactly(handleContainerDieEventStub, dieEvent);
   });
 
   it("handleContainerEvent() should exit early if 'status' is something other than 'start' or 'die'", async function () {
@@ -529,13 +463,12 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     sinon.assert.calledOnce(waitForContainerRunningStub);
     sinon.assert.calledOnce(waitForServerStartedLogStub);
-    assert.ok(
-      setContextValueStub.calledOnceWith(
-        contextValues.ContextValues.localKafkaClusterAvailable,
-        true,
-      ),
+    sinon.assert.calledOnceWithExactly(
+      setContextValueStub,
+      contextValues.ContextValues.localKafkaClusterAvailable,
+      true,
     );
-    assert.ok(localKafkaConnectedFireStub.calledOnceWith(true));
+    sinon.assert.calledOnceWithExactly(localKafkaConnectedFireStub, true);
   });
 
   it("handleContainerStartEvent() should exit early for containers from non-'confluent-local' images", async function () {
@@ -591,13 +524,12 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     await eventListener.handleContainerDieEvent(event);
 
-    assert.ok(
-      setContextValueStub.calledOnceWith(
-        contextValues.ContextValues.localKafkaClusterAvailable,
-        false,
-      ),
+    sinon.assert.calledOnceWithExactly(
+      setContextValueStub,
+      contextValues.ContextValues.localKafkaClusterAvailable,
+      false,
     );
-    assert.ok(localKafkaConnectedFireStub.calledOnceWith(false));
+    sinon.assert.calledOnceWithExactly(localKafkaConnectedFireStub, false);
   });
 
   it("handleContainerDieEvent() should exit early for containers from non-'confluent-local' images", async function () {
@@ -644,7 +576,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     );
 
     assert.strictEqual(result, true);
-    assert.ok(containerInspectStub.calledOnceWith({ id: containerId }));
+    sinon.assert.calledOnceWithMatch(containerInspectStub, { id: containerId });
   });
 
   it("matchContainerStatus() should return false if the container status is not matched", async function () {
@@ -661,7 +593,7 @@ describe("docker/eventListener.ts EventListener methods", function () {
     );
 
     assert.strictEqual(result, false);
-    assert.ok(containerInspectStub.calledOnceWith({ id: containerId }));
+    sinon.assert.calledOnceWithMatch(containerInspectStub, { id: containerId });
   });
 
   it("waitForContainerLog() should return true if the container logs contain the expected string", async function () {
@@ -683,7 +615,12 @@ describe("docker/eventListener.ts EventListener methods", function () {
     const result: boolean = await eventListener.waitForContainerLog(id, stringToMatch, Date.now());
 
     assert.strictEqual(result, true);
-    assert.ok(containerLogsRawStub.calledOnceWith({ id, since, follow: true, stdout: true }));
+    sinon.assert.calledOnceWithMatch(containerLogsRawStub, {
+      id,
+      since,
+      follow: true,
+      stdout: true,
+    });
   });
 
   it("waitForContainerLog() should return false if the container logs do not contain the expected string", async function () {
@@ -706,6 +643,11 @@ describe("docker/eventListener.ts EventListener methods", function () {
 
     assert.strictEqual(result, false);
     sinon.assert.calledOnce(containerLogsRawStub);
-    assert.ok(containerLogsRawStub.calledOnceWith({ id, since, follow: true, stdout: true }));
+    sinon.assert.calledOnceWithMatch(containerLogsRawStub, {
+      id,
+      since,
+      follow: true,
+      stdout: true,
+    });
   });
 });

--- a/src/docker/images.test.ts
+++ b/src/docker/images.test.ts
@@ -85,7 +85,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
 
     assert.strictEqual(result, undefined);
     sinon.assert.calledOnce(imageCreateRawStub);
-    assert.ok(imageCreateRawStub.calledWithMatch({ fromImage: fakeImageRepoTag }));
+    sinon.assert.calledOnceWithMatch(imageCreateRawStub, { fromImage: fakeImageRepoTag });
   });
 
   it("pullImage() should re-throw any error from .imageCreate", async () => {

--- a/src/docker/networks.test.ts
+++ b/src/docker/networks.test.ts
@@ -28,11 +28,9 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
     await createNetwork("test-network", "bridge");
 
     sinon.assert.calledOnce(networkCreateStub);
-    assert.ok(
-      networkCreateStub.calledWithMatch({
-        networkConfig: { Name: "test-network", Driver: "bridge" },
-      }),
-    );
+    sinon.assert.calledWithMatch(networkCreateStub, {
+      networkConfig: { Name: "test-network", Driver: "bridge" },
+    });
   });
 
   it("createNetwork() should return nothing, but handle 'already exists' 409 ResponseErrors and not re-throw", async () => {

--- a/src/docker/workflows/base.test.ts
+++ b/src/docker/workflows/base.test.ts
@@ -66,8 +66,8 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     await workflow["checkForImage"]("repo", "tag");
 
-    assert.ok(imageExistsStub.calledOnceWith("repo", "tag"));
-    assert.ok(pullImageStub.calledOnceWith("repo", "tag"));
+    sinon.assert.calledOnceWithExactly(imageExistsStub, "repo", "tag");
+    sinon.assert.calledOnceWithExactly(pullImageStub, "repo", "tag");
   });
 
   it("checkForImage() should not pull image if it already exists", async () => {
@@ -75,7 +75,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     await workflow["checkForImage"]("repo", "tag");
 
-    assert.ok(imageExistsStub.calledOnceWith("repo", "tag"));
+    sinon.assert.calledOnceWithExactly(imageExistsStub, "repo", "tag");
     sinon.assert.notCalled(pullImageStub);
   });
 
@@ -87,12 +87,10 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     await workflow.handleExistingContainers(fakeContainers);
 
-    assert.ok(
-      workflowStartContainerStub.calledOnceWith({
-        id: fakeContainers[0].Id!,
-        name: fakeContainers[0].Names![0],
-      }),
-    );
+    sinon.assert.calledOnceWithExactly(workflowStartContainerStub, {
+      id: fakeContainers[0].Id!,
+      name: fakeContainers[0].Names![0],
+    });
   });
 
   it("handleExistingContainers() should handle multiple existing containers and automatically start them all", async () => {
@@ -104,22 +102,15 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     await workflow.handleExistingContainers(fakeContainers);
 
-    assert.ok(
-      workflowStartContainerStub.calledTwice,
-      `workflow startContainer() called ${workflowStartContainerStub.callCount} time(s) with args: ${JSON.stringify(workflowStartContainerStub.args, null, 2)}`,
-    );
-    assert.ok(
-      workflowStartContainerStub.calledWith({
-        id: fakeContainers[0].Id!,
-        name: fakeContainers[0].Names![0],
-      }),
-    );
-    assert.ok(
-      workflowStartContainerStub.calledWith({
-        id: fakeContainers[1].Id!,
-        name: fakeContainers[1].Names![0],
-      }),
-    );
+    sinon.assert.calledTwice(workflowStartContainerStub);
+    sinon.assert.calledWith(workflowStartContainerStub, {
+      id: fakeContainers[0].Id!,
+      name: fakeContainers[0].Names![0],
+    });
+    sinon.assert.calledWith(workflowStartContainerStub, {
+      id: fakeContainers[1].Id!,
+      name: fakeContainers[1].Names![0],
+    });
   });
 
   it("handleExistingContainers() should handle 'running' containers auto-restart them", async () => {
@@ -129,7 +120,7 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
 
     await workflow.handleExistingContainers(fakeContainers);
 
-    assert.ok(restartContainerStub.calledOnceWith(fakeContainers[0].Id!));
+    sinon.assert.calledOnceWithExactly(restartContainerStub, fakeContainers[0].Id!);
   });
 
   it("startContainer() should start a container and return its inspect response", async () => {
@@ -141,8 +132,8 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
     const result = await workflow.startContainer(fakeContainer);
 
     assert.strictEqual(result, fakeResponse);
-    assert.ok(startContainerStub.calledOnceWith(fakeContainer.id));
-    assert.ok(getContainerStub.calledOnceWith(fakeContainer.id));
+    sinon.assert.calledOnceWithExactly(startContainerStub, fakeContainer.id);
+    sinon.assert.calledOnceWithExactly(getContainerStub, fakeContainer.id);
     sinon.assert.notCalled(showErrorMessageStub);
   });
 
@@ -162,13 +153,13 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
     const result = await workflow.startContainer(fakeContainer);
 
     assert.strictEqual(result, undefined);
-    assert.ok(startContainerStub.calledOnceWith(fakeContainer.id));
+    sinon.assert.calledOnceWithExactly(startContainerStub, fakeContainer.id);
     sinon.assert.notCalled(getContainerStub);
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        'Failed to start test container "test-container": Port 8082 is already in use.',
-      ),
-      `showErrorMessageStub.args: ${showErrorMessageStub.args}`,
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      'Failed to start test container "test-container": Port 8082 is already in use.',
+      "Open Logs",
+      "File Issue",
     );
   });
 
@@ -180,10 +171,13 @@ describe("docker/workflows/base.ts LocalResourceWorkflow base methods/properties
     const result = await workflow.startContainer(fakeContainer);
 
     assert.strictEqual(result, undefined);
-    assert.ok(startContainerStub.calledOnceWith(fakeContainer.id));
+    sinon.assert.calledOnceWithExactly(startContainerStub, fakeContainer.id);
     sinon.assert.notCalled(getContainerStub);
-    assert.ok(
-      showErrorMessageStub.calledOnceWith('Failed to start test container "test-container": uh oh'),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      'Failed to start test container "test-container": uh oh',
+      "Open Logs",
+      "File Issue",
     );
   });
 });

--- a/src/docker/workflows/confluent-local.test.ts
+++ b/src/docker/workflows/confluent-local.test.ts
@@ -143,7 +143,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
     sinon.assert.calledOnce(checkForImageStub);
 
     sinon.assert.calledOnce(getContainersForImageStub);
-    assert.ok(handleExistingContainersStub.calledOnceWith(fakeContainers));
+    sinon.assert.calledOnceWithExactly(handleExistingContainersStub, fakeContainers);
 
     sinon.assert.notCalled(createNetworkStub);
 
@@ -233,7 +233,7 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
     await workflow.stop(TEST_CANCELLATION_TOKEN);
 
     sinon.assert.calledOnce(getContainersForImageStub);
-    assert.ok(stopContainerStub.calledOnceWith({ id: containerId, name: containerName }));
+    sinon.assert.calledOnceWithExactly(stopContainerStub, { id: containerId, name: containerName });
     sinon.assert.calledOnce(waitForLocalResourceEventChangeStub);
   });
 
@@ -244,11 +244,10 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
 
     sinon.assert.calledOnce(getContainersForImageStub);
     // not the usual "Open Logs"+"File Issue" notification, just a basic error message with a button to open settings
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        `No ${workflow.resourceKind} containers found to stop. Please ensure your Kafka image repo+tag settings match currently running containers and try again.`,
-        "Open Settings",
-      ),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      `No ${workflow.resourceKind} containers found to stop. Please ensure your Kafka image repo+tag settings match currently running containers and try again.`,
+      "Open Settings",
     );
     sinon.assert.notCalled(stopContainerStub);
     sinon.assert.notCalled(waitForLocalResourceEventChangeStub);
@@ -353,29 +352,26 @@ describe("docker/workflows/confluent-local.ts ConfluentLocalWorkflow", () => {
     assert.equal(result.id, "1");
     assert.equal(result.name, containerName);
     sinon.assert.calledOnce(createContainerStub);
-    assert.ok(
-      createContainerStub.calledWith(workflow.imageRepo, workflow.imageTag, {
-        body: {
-          Image: workflow.imageRepoTag,
-          Hostname: containerName,
-          ExposedPorts: { [`${plainTextPort}/tcp`]: {} },
-          HostConfig: {
-            NetworkMode: workflow.networkName,
-            PortBindings: {
-              [`${plainTextPort}/tcp`]: [{ HostIp: "0.0.0.0", HostPort: plainTextPort.toString() }],
-              [`${LOCAL_KAFKA_REST_PORT}/tcp`]: [
-                { HostIp: "0.0.0.0", HostPort: LOCAL_KAFKA_REST_PORT.toString() },
-              ],
-            },
+    sinon.assert.calledOnceWithExactly(createContainerStub, workflow.imageRepo, workflow.imageTag, {
+      body: {
+        Image: workflow.imageRepoTag,
+        Hostname: containerName,
+        ExposedPorts: { [`${plainTextPort}/tcp`]: {} },
+        HostConfig: {
+          NetworkMode: workflow.networkName,
+          PortBindings: {
+            [`${plainTextPort}/tcp`]: [{ HostIp: "0.0.0.0", HostPort: plainTextPort.toString() }],
+            [`${LOCAL_KAFKA_REST_PORT}/tcp`]: [
+              { HostIp: "0.0.0.0", HostPort: LOCAL_KAFKA_REST_PORT.toString() },
+            ],
           },
-          Cmd: ["bash", "-c", "'/etc/confluent/docker/run'"],
-          Env: envVars,
-          Tty: false,
         },
-        name: containerName,
-      }),
-      `createContainerStub called with: ${JSON.stringify(createContainerStub.args, null, 2)}`,
-    );
+        Cmd: ["bash", "-c", "'/etc/confluent/docker/run'"],
+        Env: envVars,
+        Tty: false,
+      },
+      name: containerName,
+    });
   });
 });
 

--- a/src/docker/workflows/cp-schema-registry.test.ts
+++ b/src/docker/workflows/cp-schema-registry.test.ts
@@ -163,7 +163,7 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     sinon.assert.calledOnce(checkForImageStub);
 
     sinon.assert.calledOnce(getContainersForImageStub);
-    assert.ok(handleExistingContainersStub.calledOnceWith(fakeContainers));
+    sinon.assert.calledOnceWithExactly(handleExistingContainersStub, fakeContainers);
     // bailing here
 
     sinon.assert.notCalled(fetchAndFilterKafkaContainersStub);
@@ -207,18 +207,15 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     sinon.assert.notCalled(handleExistingContainersStub);
 
     sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        `No running Kafka containers found for image "${LOCAL_KAFKA_IMAGE.defaultValue}:${LOCAL_KAFKA_IMAGE_TAG.defaultValue}". Please start Kafka and try again.`,
-        START_KAFKA_BUTTON,
-        IMAGE_SETTINGS_BUTTON,
-      ),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      `No running Kafka containers found for image "${LOCAL_KAFKA_IMAGE.defaultValue}:${LOCAL_KAFKA_IMAGE_TAG.defaultValue}". Please start Kafka and try again.`,
+      START_KAFKA_BUTTON,
+      IMAGE_SETTINGS_BUTTON,
     );
-    assert.ok(
-      executeCommandStub.calledOnceWith("confluent.docker.startLocalResources", [
-        LocalResourceKind.Kafka,
-      ]),
-    );
+    sinon.assert.calledOnceWithExactly(executeCommandStub, "confluent.docker.startLocalResources", [
+      LocalResourceKind.Kafka,
+    ]);
     // bailing here
 
     sinon.assert.notCalled(createContainerStub);
@@ -240,18 +237,16 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
     sinon.assert.notCalled(handleExistingContainersStub);
 
     sinon.assert.calledOnce(fetchAndFilterKafkaContainersStub);
-    assert.ok(
-      showErrorMessageStub.calledOnceWith(
-        `No running Kafka containers found for image "${LOCAL_KAFKA_IMAGE.defaultValue}:${LOCAL_KAFKA_IMAGE_TAG.defaultValue}". Please start Kafka and try again.`,
-        START_KAFKA_BUTTON,
-        IMAGE_SETTINGS_BUTTON,
-      ),
+    sinon.assert.calledOnceWithExactly(
+      showErrorMessageStub,
+      `No running Kafka containers found for image "${LOCAL_KAFKA_IMAGE.defaultValue}:${LOCAL_KAFKA_IMAGE_TAG.defaultValue}". Please start Kafka and try again.`,
+      START_KAFKA_BUTTON,
+      IMAGE_SETTINGS_BUTTON,
     );
-    assert.ok(
-      executeCommandStub.calledOnceWith(
-        "workbench.action.openSettings",
-        `@id:${LOCAL_KAFKA_IMAGE.id} @id:${LOCAL_KAFKA_IMAGE_TAG.id}`,
-      ),
+    sinon.assert.calledOnceWithExactly(
+      executeCommandStub,
+      "workbench.action.openSettings",
+      `@id:${LOCAL_KAFKA_IMAGE.id} @id:${LOCAL_KAFKA_IMAGE_TAG.id}`,
     );
     // bailing here
 
@@ -392,9 +387,11 @@ describe("docker/workflows/cp-schema-registry.ts ConfluentPlatformSchemaRegistry
       },
       name: CONTAINER_NAME,
     };
-    assert.ok(
-      createContainerStub.calledWith(workflow.imageRepo, workflow.imageTag, createBody),
-      `createContainerStub called with: ${JSON.stringify(createContainerStub.args, null, 2)}\n\nand not ${JSON.stringify([workflow.imageRepo, workflow.imageTag, createBody], null, 2)}`,
+    sinon.assert.calledOnceWithExactly(
+      createContainerStub,
+      workflow.imageRepo,
+      workflow.imageTag,
+      createBody,
     );
   });
 });

--- a/src/extensionSettings/listener.test.ts
+++ b/src/extensionSettings/listener.test.ts
@@ -133,7 +133,7 @@ describe("extensionSettings/listener.ts", function () {
         // simulate the setting being changed by the user
         await onDidChangeConfigurationStub.firstCall.args[0](mockEvent);
 
-        assert.ok(setContextValueStub.calledWith(previewContextValue, enabled));
+        sinon.assert.calledWith(setContextValueStub, previewContextValue, enabled);
       });
     }
   }

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -104,8 +104,10 @@ describe("ResourceLoader::getSubjects()", () => {
         // will have asked for the subjects from the resource manager, but none returned, so deep fetched.
         sinon.assert.calledOnce(rmGetSubjectsStub);
         /// will have stored the deep fetched subjects in the resource manager.
-        assert.ok(
-          rmSetSubjectsStub.calledWithExactly(TEST_LOCAL_SCHEMA_REGISTRY, fetchSubjectsStubReturns),
+        sinon.assert.calledOnceWithExactly(
+          rmSetSubjectsStub,
+          TEST_LOCAL_SCHEMA_REGISTRY,
+          fetchSubjectsStubReturns,
         );
 
         // reset the resource manager stubs for next iteration.
@@ -154,8 +156,10 @@ describe("ResourceLoader::getSubjects()", () => {
       // will not have asked resource manager for subjects, since deep fetch is forced.
       sinon.assert.notCalled(rmGetSubjectsStub);
       /// will have stored the deep fetched subjects in the resource manager.
-      assert.ok(
-        rmSetSubjectsStub.calledWithExactly(TEST_LOCAL_SCHEMA_REGISTRY, fetchSubjectsStubReturns),
+      sinon.assert.calledOnceWithExactly(
+        rmSetSubjectsStub,
+        TEST_LOCAL_SCHEMA_REGISTRY,
+        fetchSubjectsStubReturns,
       );
 
       // reset the resource manager stubs for next iteration.
@@ -361,7 +365,7 @@ describe("ResourceLoader::clearCache()", () => {
     await loaderInstance.clearCache(schemaRegistry);
     sinon.assert.calledOnce(rmSetSubjectsStub);
     // calling with undefined will clear out just this single schema registry's subjects.
-    assert.ok(rmSetSubjectsStub.calledWithExactly(schemaRegistry, undefined));
+    sinon.assert.calledOnceWithExactly(rmSetSubjectsStub, schemaRegistry, undefined);
   });
 });
 
@@ -621,7 +625,7 @@ describe("ResourceLoader::deleteSchemaVersion()", () => {
 
       if (shouldClearSubjects) {
         sinon.assert.calledOnce(clearCacheStub);
-        assert.ok(clearCacheStub.calledWithExactly(schema.subjectObject()));
+        sinon.assert.calledOnceWithExactly(clearCacheStub, schema.subjectObject());
       } else {
         sinon.assert.notCalled(clearCacheStub);
       }

--- a/src/sidecar/connections/ccloud.test.ts
+++ b/src/sidecar/connections/ccloud.test.ts
@@ -41,8 +41,8 @@ describe("sidecar/connections/ccloud.ts", () => {
     await clearCurrentCCloudResources();
 
     sinon.assert.calledOnce(mockedCCLoudLoader.reset);
-    assert.ok(currentKafkaClusterChangedFireStub.calledOnceWith(null));
-    assert.ok(schemasViewResourceChangedFireStub.calledOnceWith(null));
+    sinon.assert.calledOnceWithExactly(currentKafkaClusterChangedFireStub, null);
+    sinon.assert.calledOnceWithExactly(schemasViewResourceChangedFireStub, null);
 
     // Reset the stubs
     mockedCCLoudLoader.reset.resetHistory();

--- a/src/sidecar/connections/watcherUtils.test.ts
+++ b/src/sidecar/connections/watcherUtils.test.ts
@@ -64,10 +64,7 @@ describe("connectionEventHandler", () => {
         "handleUpdatedConnection called",
       );
 
-      assert.ok(
-        handleUpdatedConnectionStub.calledWith(TEST_CCLOUD_CONNECTION),
-        `handleUpdatedConnection called with ${handleUpdatedConnectionStub.getCall(0).args[0]}`,
-      );
+      sinon.assert.calledOnceWithExactly(handleUpdatedConnectionStub, TEST_CCLOUD_CONNECTION);
 
       // ccloud events should never fire directConnectionCreatedStub
       sinon.assert.notCalled(directConnectionCreatedStub);

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -74,7 +74,7 @@ describe("getEditorOrFileContents", () => {
 
     assert.strictEqual(result.content, fakeDocumentContents);
     assert.strictEqual(result.openDocument, fakeDocument);
-    assert.ok(readFileStub.notCalled, "readFile should not be called if editor is open");
+    sinon.assert.notCalled(readFileStub);
   });
 
   it("should return file contents if editor is not open", async () => {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

**No functional changes, no test-logic changes. Just like https://github.com/confluentinc/vscode/pull/2850, the main idea here is consistency within our codebase so any new test writers (human or bot) will have a single pattern to go off of.**

Some slight adjustments were made to convert more general `calledWith()` to use more specific `calledOnceWithExactly`/`calledOnceWithMatch`, but some (especially with multiple calls) were left as `calledWith`.

Part 2 of 2:
- https://github.com/confluentinc/vscode/pull/2850
  - https://github.com/confluentinc/vscode/pull/2851 👈 

Closes #1936.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
