### PR TITLE
MINOR: update copilot test instructions for running specific tests via gulp

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,7 @@ clusters within VS Code.
 npx gulp build          # Build for development
 npx gulp build -w       # Watch mode
 npx gulp test          # Unit tests (Mocha/Sinon)
+npx gulp test -t "test name here" # Run specific test(s) by name
 npx gulp e2e           # End-to-end tests (Playwright)
 npx gulp check         # TypeScript type checking
 npx gulp lint          # ESLint with auto-fix: gulp lint -f

--- a/.github/instructions/unit-testing.instructions.md
+++ b/.github/instructions/unit-testing.instructions.md
@@ -5,8 +5,10 @@ description: "Unit testing practices with Mocha, Sinon, and Assert"
 
 # Unit Testing with Mocha, Sinon, and Assert
 
-Tests should be run with `npx gulp test` (use `--coverage` flag for Istanbul reports). When writing
-unit tests for this extension:
+Tests should be run with `npx gulp test` (use `--coverage` flag for Istanbul reports). Specific
+tests can be run by name with `npx gulp test -t "test name here"`.
+
+When writing unit tests for this extension:
 
 ## Test Structure and Naming
 


### PR DESCRIPTION
Prevents suggestions to run `npx gulp test/functional/e2e --grep ___`

Although this does raise a bigger question: should we just allow passing params straight through in `gulp test` (and `gulp functional` and `gulp e2e`) instead of our current arg lookup? https://github.com/confluentinc/vscode/blob/bbeb22313b9efa356ef20648afc59e8c4a0756f1/Gulpfile.js#L725-L727