### PR TITLE
MINOR: refactor tests for Flink Artifacts

### DIFF
--- a/src/commands/flinkArtifacts.test.ts
+++ b/src/commands/flinkArtifacts.test.ts
@@ -65,13 +65,10 @@ describe("flinkArtifacts", () => {
       cloud: "Azure",
     };
 
-    const params = { ...mockParams };
-    const uploadUrl = { ...mockPresignedUrlResponse };
-
     let showErrorStub: sinon.SinonStub;
 
     beforeEach(() => {
-      sandbox.stub(vscode.window, "showOpenDialog").resolves([params.selectedFile]);
+      sandbox.stub(vscode.window, "showOpenDialog").resolves([mockParams.selectedFile]);
       showErrorStub = getShowErrorNotificationWithButtonsStub(sandbox);
     });
 
@@ -97,8 +94,8 @@ describe("flinkArtifacts", () => {
     });
 
     it("should show error notification with custom error message when Error has message property", async () => {
-      sandbox.stub(artifactUploadForm, "artifactUploadQuickPickForm").resolves(params);
-      sandbox.stub(uploadArtifact, "getPresignedUploadUrl").resolves(uploadUrl);
+      sandbox.stub(artifactUploadForm, "artifactUploadQuickPickForm").resolves(mockParams);
+      sandbox.stub(uploadArtifact, "getPresignedUploadUrl").resolves(mockPresignedUrlResponse);
       sandbox.stub(uploadArtifact, "handleUploadToCloudProvider").resolves();
 
       const customErrorMessage = "Custom error message from Error instance";
@@ -113,8 +110,8 @@ describe("flinkArtifacts", () => {
     });
 
     it("should show custom clarification error when 500 status code is returned for invalid JAR file", async () => {
-      sandbox.stub(artifactUploadForm, "artifactUploadQuickPickForm").resolves(params);
-      sandbox.stub(uploadArtifact, "getPresignedUploadUrl").resolves(uploadUrl);
+      sandbox.stub(artifactUploadForm, "artifactUploadQuickPickForm").resolves(mockParams);
+      sandbox.stub(uploadArtifact, "getPresignedUploadUrl").resolves(mockPresignedUrlResponse);
       sandbox.stub(uploadArtifact, "handleUploadToCloudProvider").resolves();
 
       sandbox
@@ -131,8 +128,8 @@ describe("flinkArtifacts", () => {
     });
 
     it("should error for other status codes", async () => {
-      sandbox.stub(artifactUploadForm, "artifactUploadQuickPickForm").resolves(params);
-      sandbox.stub(uploadArtifact, "getPresignedUploadUrl").resolves(uploadUrl);
+      sandbox.stub(artifactUploadForm, "artifactUploadQuickPickForm").resolves(mockParams);
+      sandbox.stub(uploadArtifact, "getPresignedUploadUrl").resolves(mockPresignedUrlResponse);
       sandbox.stub(uploadArtifact, "handleUploadToCloudProvider").resolves();
 
       sandbox.stub(uploadArtifact, "uploadArtifactToCCloud").rejects(


### PR DESCRIPTION
## Summary of Changes

fixes: https://github.com/confluentinc/vscode/issues/2875

Due to bad describe blocks, `flinkArtifacts` was registering as having **0** test coverage. This test fixes that. Coverage as listed by gulp now: 

```
  flinkArtifacts.ts                   |   59.09 |    41.66 |   57.14 |   59.52 | 71,123,145-190   
```

I also moved some constants out into describe blocks to reduce the overall lines of code and make the tests easy to read.

Hint: easier to review test diffs when whitespace is turned off in review settings:
  
<img width="554" height="433" alt="Screenshot 2025-10-15 at 12 34 19 PM" src="https://github.com/user-attachments/assets/c1b90788-4fbe-459b-9944-ffcf8649978b" />

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
