### PR TITLE
MINOR: move `DEFAULT_RESULT_LIMIT` to `flinkSql/constants.ts` to fix circular dependency

### DIFF
--- a/src/commands/utils/statements.ts
+++ b/src/commands/utils/statements.ts
@@ -1,6 +1,7 @@
 import { ObservableScope } from "inertial";
 import * as vscode from "vscode";
 import { STATEMENT_RESULTS_LOCATION } from "../../extensionSettings/constants";
+import { DEFAULT_RESULT_LIMIT } from "../../flinkSql/constants";
 import { FlinkStatementResultsManager } from "../../flinkSql/flinkStatementResultsManager";
 import { FlinkStatementWebviewPanelCache } from "../../flinkSql/statementUtils";
 import { Logger } from "../../logging";
@@ -9,8 +10,6 @@ import { FlinkStatementResultsPanelProvider } from "../../panelProviders/flinkSt
 import { getSidecar } from "../../sidecar";
 import { handleWebviewMessage } from "../../webview/comms/comms";
 
-/** Max number of statement results rows to display. */
-export const DEFAULT_RESULT_LIMIT = 100_000;
 /** Cache of statement result webviews by env/statement name. */
 export const statementResultsViewCache = new FlinkStatementWebviewPanelCache();
 

--- a/src/flinkSql/constants.ts
+++ b/src/flinkSql/constants.ts
@@ -6,3 +6,6 @@ export const FLINK_SQL_FILE_EXTENSIONS = [".flink.sql"];
 
 /** Primary/default file extension supporting the {@linkcode FLINK_SQL_LANGUAGE_ID} document language. */
 export const DEFAULT_FLINK_SQL_FILE_EXTENSION = FLINK_SQL_FILE_EXTENSIONS[0];
+
+/** Max number of statement results rows to display. */
+export const DEFAULT_RESULT_LIMIT = 100_000;

--- a/src/panelProviders/flinkStatementResults.ts
+++ b/src/panelProviders/flinkStatementResults.ts
@@ -10,10 +10,10 @@ import {
   type WebviewViewProvider,
   window,
 } from "vscode";
-import { DEFAULT_RESULT_LIMIT } from "../commands/utils/statements";
 import { getExtensionContext } from "../context/extension";
 import { ContextValues, setContextValue } from "../context/values";
 import { ExtensionContextNotSetError } from "../errors";
+import { DEFAULT_RESULT_LIMIT } from "../flinkSql/constants";
 import { FlinkStatementResultsManager } from "../flinkSql/flinkStatementResultsManager";
 import { Logger } from "../logging";
 import { type FlinkStatement } from "../models/flinkStatement";


### PR DESCRIPTION
No more circular dependency warning:
<img width="760" height="116" alt="image" src="https://github.com/user-attachments/assets/7e45aba7-9fe2-4d1f-96e3-9b803dc61fcb" />
