### PR TITLE
MINOR fix(E2E): wrap sidecar log download expect+attach into try/catch

### DIFF
--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -338,14 +338,21 @@ async function globalAfterEach(
   const formatQuickPick = new Quickpick(page);
   await expect(formatQuickPick.locator).toBeVisible({ timeout: 5000 });
   await formatQuickPick.selectItemByText("Human-readable format");
-  // wait for info notification indicating sidecar log file was saved
-  const sidecarLogSuccess = notificationArea.infoNotifications.filter({
-    hasText: "Confluent extension sidecar log file saved successfully.",
-  });
-  await expect(sidecarLogSuccess).toHaveCount(1, { timeout: 5000 });
-  // attach the sidecar log to the test results
-  await testInfo.attach("vscode-confluent-sidecar.log", {
-    path: sidecarLogPath,
-    contentType: "text/plain",
-  });
+  // NOTE: this occasionally times out on macOS or Windows for unknown reasons even after clearing
+  // any existing sidecar log file, but we don't want this to count as a test failure and these logs
+  // are more nice-to-have
+  try {
+    // wait for info notification indicating sidecar log file was saved
+    const sidecarLogSuccess = notificationArea.infoNotifications.filter({
+      hasText: "Confluent extension sidecar log file saved successfully.",
+    });
+    await expect(sidecarLogSuccess).toHaveCount(1, { timeout: 5000 });
+    // attach the sidecar log to the test results
+    await testInfo.attach("vscode-confluent-sidecar.log", {
+      path: sidecarLogPath,
+      contentType: "text/plain",
+    });
+  } catch (error) {
+    console.warn("Error saving sidecar logs:", error);
+  }
 }


### PR DESCRIPTION
We'll occasionally see E2E test timeouts waiting to get the info notification that saving the sidecar log succeeded, but the reasoning isn't clear.

There aren't any issues running the save-sidecar-logs command normally, and this only seems to happen on occasion when running E2E tests locally on macOS, as well as locally and in CI on Windows.

Until we can determine the cause of the timeouts in these test environments, we'll just wrap this past part of the `after` behavior in a try/catch and move on without sidecar logs saved/attached to the playwright report.

Closes #2835