### PR TITLE
minor: remove test `jar` inspector command

### DIFF
--- a/package.json
+++ b/package.json
@@ -715,12 +715,6 @@
         "category": "Confluent: Support"
       },
       {
-        "command": "confluent.testInspectJar",
-        "icon": "$(file-binary)",
-        "title": "Inspect JAR File",
-        "category": "Confluent: Flink Artifacts"
-      },
-      {
         "command": "confluent.topic.consume",
         "icon": "$(confluent-view-messages)",
         "title": "View Messages",
@@ -1593,10 +1587,6 @@
           "when": "true"
         },
         {
-          "command": "confluent.testInspectJar",
-          "when": "false"
-        },
-        {
           "command": "confluent.topic.consume",
           "when": "true"
         },
@@ -2124,11 +2114,6 @@
           "command": "confluent.uploadArtifact",
           "group": "confluent@1",
           "when": "config.confluent.flink.artifacts && confluent.ccloudConnectionAvailable && resourceExtname == .jar"
-        },
-        {
-          "command": "confluent.testInspectJar",
-          "group": "confluent@2",
-          "when": "isDevelopment && resourceExtname == .jar"
         }
       ],
       "confluent.flinkdatabase.viewMode": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,7 +91,6 @@ import { sendTelemetryIdentifyEvent } from "./telemetry/telemetry";
 import { getTelemetryLogger } from "./telemetry/telemetryLogger";
 import { UriEventHandler } from "./uriHandler";
 import { WriteableTmpDir } from "./utils/file";
-import { inspectJarClasses } from "./utils/jarInspector";
 import { RefreshableTreeViewProvider } from "./viewProviders/baseModels/base";
 import { FlinkDatabaseViewProvider } from "./viewProviders/flinkDatabase";
 import { FlinkStatementsViewProvider } from "./viewProviders/flinkStatements";
@@ -268,7 +267,6 @@ async function _activateExtension(
     ...registerFlinkArtifactCommands(),
     ...registerNewResourceViewCommands(),
     ...registerUriCommands(),
-    registerCommandWithLogging("confluent.testInspectJar", inspectJarClasses), // TEMP DO NOT MERGE
   ];
   logger.info("Commands registered");
 


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- At the [end of development](https://github.com/confluentinc/vscode/pull/2861) for quick-registration after upload, so this command is no longer needed. 