### PR TITLE
Rename  ccloudResourceLoaderUtils -> udfSystemCatalogQuery

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -63,7 +63,7 @@ import {
   loadArtifactsForProviderRegion,
   loadProviderRegions,
 } from "./ccloudResourceLoader";
-import { RawUdfSystemCatalogRow } from "./utils/ccloudResourceLoaderUtils";
+import { RawUdfSystemCatalogRow } from "./utils/udfSystemCatalogQuery";
 
 describe("CCloudResourceLoader", () => {
   let sandbox: sinon.SinonSandbox;

--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -31,12 +31,12 @@ import { getResourceManager } from "../storage/resourceManager";
 import { ObjectSet } from "../utils/objectset";
 import { executeInWorkerPool, ExecutionResult, extract } from "../utils/workerPool";
 import { CachingResourceLoader } from "./cachingResourceLoader";
+import { generateFlinkStatementKey } from "./utils/loaderUtils";
 import {
   getUdfSystemCatalogQuery,
   RawUdfSystemCatalogRow,
   transformUdfSystemCatalogRows,
-} from "./utils/ccloudResourceLoaderUtils";
-import { generateFlinkStatementKey } from "./utils/loaderUtils";
+} from "./utils/udfSystemCatalogQuery";
 
 const logger = new Logger("storage.ccloudResourceLoader");
 

--- a/src/loaders/utils/udfSystemCatalogQuery.test.ts
+++ b/src/loaders/utils/udfSystemCatalogQuery.test.ts
@@ -10,9 +10,9 @@ import {
   RawUdfSystemCatalogRow,
   sortUdfSystemCatalogRows,
   transformUdfSystemCatalogRows,
-} from "./ccloudResourceLoaderUtils";
+} from "./udfSystemCatalogQuery";
 
-describe("ccloudResourceLoaderUtils.ts", () => {
+describe("udfSystemCatalogQuery.ts", () => {
   describe("getUdfSystemCatalogQuery()", () => {
     // This function is trivial, just returns a constant string with the cluster ID filled in twice.
     // Ensure is mentioned twice. Only E2E / clicktesting can prove that the query is otherwise sound.

--- a/src/loaders/utils/udfSystemCatalogQuery.ts
+++ b/src/loaders/utils/udfSystemCatalogQuery.ts
@@ -5,7 +5,7 @@ import { CCloudFlinkDbKafkaCluster } from "../../models/kafkaCluster";
 
 import { Logger } from "../../logging";
 
-const logger = new Logger("ccloudResourceLoaderUtils");
+const logger = new Logger("udfSystemCatalogQuery");
 
 /**
  * Instantiate the UDF system catalog query for a given database (cluster) as the limiting "Flink Schema ID".

--- a/tests/unit/testResources/makeUdfRow.ts
+++ b/tests/unit/testResources/makeUdfRow.ts
@@ -1,4 +1,4 @@
-import { RawUdfSystemCatalogRow } from "../../../src/loaders/utils/ccloudResourceLoaderUtils";
+import { RawUdfSystemCatalogRow } from "../../../src/loaders/utils/udfSystemCatalogQuery";
 
 /**
  * Make a function-describing row as if from UDF_SYSTEM_CATALOG_QUERY.


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- The utilities within `src/loaders/utils/ccloudResourceLoaderUtils.ts` are specific to the UDFs `INFORMATION_SCHEMA` query processing. Name it accordingly.
- Paves the way for a peer module specific to doing the same for the tables / views `INFORMATION_SCHEMA` query.
- Zero functionality change. Just rename in prep for future feature merging.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
