### PR TITLE
demo: add `codiconDecoration` proposed api for read-only schemes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "workspaceContains:**/*.confluent.*",
     "onUri"
   ],
+  "enabledApiProposals": ["codiconDecoration"],
   "main": "./out/extension.js",
   "contributes": {
     "authentication": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,10 @@ import { DirectConnectionManager } from "./directConnectManager";
 import { EventListener } from "./docker/eventListener";
 import { registerLocalResourceWorkflows } from "./docker/workflows/workflowInitialization";
 import { DocumentMetadataManager } from "./documentMetadataManager";
-import { FlinkStatementDocumentProvider } from "./documentProviders/flinkStatement";
+import {
+  FLINKSTATEMENT_URI_SCHEME,
+  FlinkStatementDocumentProvider,
+} from "./documentProviders/flinkStatement";
 import { MESSAGE_URI_SCHEME, MessageDocumentProvider } from "./documentProviders/message";
 import { SCHEMA_URI_SCHEME, SchemaDocumentProvider } from "./documentProviders/schema";
 import { logError } from "./errors";
@@ -326,6 +329,21 @@ async function _activateExtension(
   // with a dot to the right of the item label+description area
   context.subscriptions.push(
     vscode.window.registerFileDecorationProvider(SEARCH_DECORATION_PROVIDER),
+    vscode.window.registerFileDecorationProvider({
+      provideFileDecoration: (uri: vscode.Uri): vscode.FileDecoration | undefined => {
+        if (
+          [SCHEMA_URI_SCHEME, MESSAGE_URI_SCHEME, FLINKSTATEMENT_URI_SCHEME].includes(uri.scheme)
+        ) {
+          // enabled with the `codiconDecoration` proposed API
+          const decoration: vscode.FileDecoration2 = {
+            propagate: false,
+            tooltip: "Read-only",
+            badge: new vscode.ThemeIcon("lock"),
+          };
+          return decoration as vscode.FileDecoration;
+        }
+      },
+    }),
   );
 
   // register the Copilot chat participant

--- a/src/vscode.proposed.codiconDecoration.d.ts
+++ b/src/vscode.proposed.codiconDecoration.d.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module "vscode" {
+  // https://github.com/microsoft/vscode/issues/135591 @alexr00
+
+  // export interface FileDecorationProvider {
+  // 	provideFileDecoration(uri: Uri, token: CancellationToken): ProviderResult<FileDecoration | FileDecoration1>;
+  // }
+
+  /**
+   * A file decoration represents metadata that can be rendered with a file.
+   */
+  export class FileDecoration2 {
+    /**
+     * A very short string that represents this decoration.
+     */
+    badge?: string | ThemeIcon;
+
+    /**
+     * A human-readable tooltip for this decoration.
+     */
+    tooltip?: string;
+
+    /**
+     * The color of this decoration.
+     */
+    color?: ThemeColor;
+
+    /**
+     * A flag expressing that this decoration should be
+     * propagated to its parents.
+     */
+    propagate?: boolean;
+
+    /**
+     * Creates a new decoration.
+     *
+     * @param badge A letter that represents the decoration.
+     * @param tooltip The tooltip of the decoration.
+     * @param color The color of the decoration.
+     */
+    constructor(badge?: string | ThemeIcon, tooltip?: string, color?: ThemeColor);
+  }
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- https://code.visualstudio.com/api/advanced-topics/using-proposed-api

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Open VS Code Insiders and run this extension in normal dev mode
2. Open one of our read-only document types (message preview, schema, Flink statement)
3. Note the document tabs now show a `lock` codicon with a `Read-only` tooltip suffix
<img width="3656" height="1742" alt="image" src="https://github.com/user-attachments/assets/5423b77b-8e00-4b01-9f72-335a65f44612" />


### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
