### PR TITLE
MINOR: Set accessibility information based on whether cluster is Flinkable

### DIFF
--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -23,11 +23,6 @@ import {
 } from "./resource";
 import { KafkaTopic } from "./topic";
 
-export enum clusterLabel {
-  KafkaCluster = "Kafka Cluster",
-  FlinkableKafkaCluster = "Flinkable Kafka Cluster",
-}
-
 /** Base class for all KafkaClusters */
 export abstract class KafkaCluster extends Data implements IResourceBase, ISearchable {
   abstract connectionId: ConnectionId;

--- a/tests/e2e/objects/views/ResourcesView.ts
+++ b/tests/e2e/objects/views/ResourcesView.ts
@@ -9,7 +9,6 @@ import { View } from "./View";
  * {@link https://code.visualstudio.com/api/ux-guidelines/views#tree-views view} in the "Confluent"
  * {@link https://code.visualstudio.com/api/ux-guidelines/views#view-containers view container}.
  */
-
 export class ResourcesView extends View {
   constructor(page: Page) {
     // we don't need a regex pattern here because we don't update the tree view title/description


### PR DESCRIPTION
## Summary of Changes

Set accessibility info based on whether cluster is flinkable, and add a convenience method to find flinkable clusters for e2e tests. This will unblock  my work on #2481 

### Optional: Any additional details or context that should be provided?

E2E promotion job in semaphore should also pass in order for this PR to merge

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
