### PR TITLE
Degraded statement links

### DIFF
--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -273,13 +273,13 @@ describe("FlinkStatement", () => {
         expected: false,
       },
       {
-        name: "should not be viewable when statement is DEGRADED",
+        name: "should be viewable when statement is DEGRADED",
         statement: {
           phase: Phase.DEGRADED,
           sqlKind: "SELECT",
           createdAt: today,
         },
-        expected: false,
+        expected: true,
       },
     ];
 
@@ -406,6 +406,27 @@ describe("FlinkStatementTreeItem", () => {
     const treeItem = new FlinkStatementTreeItem(oldStatement);
     // ensure 'viewable' is not in the context value
     assert.ok(!treeItem.contextValue!.includes("viewable"));
+  });
+
+  it("tooltip when DEGRADED phase includes diagnose link", () => {
+    const statement = createFlinkStatement({
+      name: "statement0",
+      phase: Phase.DEGRADED,
+      detail: "Statement is degraded",
+      sqlKind: "SELECT",
+      environmentId: "env0" as EnvironmentId,
+      computePoolId: "pool0",
+    });
+
+    const treeItem = new FlinkStatementTreeItem(statement);
+    const tooltip = treeItem.tooltip as CustomMarkdownString;
+
+    assert.ok(
+      tooltip.value.includes(
+        "(Learn more)](https://docs.confluent.io/cloud/current/flink/how-to-guides/resolve-common-query-problems.html#statement-enters-degraded-state)",
+      ),
+      `Expected tooltip to include diagnose link for DEGRADED phase\n${tooltip.value}`,
+    );
   });
 
   it("tooltip hits the major properties", () => {

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -44,12 +44,7 @@ export const FAILED_PHASES = [Phase.FAILED, Phase.FAILING];
 /**  List of terminal phases. Statements in terminal phase won't ever change on their own. */
 export const TERMINAL_PHASES = [Phase.COMPLETED, Phase.STOPPED, Phase.FAILED];
 
-const EXECUTION_STARTED_PHASES = [
-  Phase.PENDING,
-  Phase.RUNNING,
-  Phase.COMPLETED,
-  // Phase.DEGRADED,??
-];
+const EXECUTION_STARTED_PHASES = [Phase.PENDING, Phase.RUNNING, Phase.COMPLETED, Phase.DEGRADED];
 
 /** Phases which cannot be stopped. */
 export const UNSTOPPABLE_PHASES = [
@@ -409,7 +404,15 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
   const tooltip = new CustomMarkdownString()
     .addHeader("Flink Statement", getFlinkStatementThemeIcon(resource.phase).id as IconNames)
     .addField("Kind", resource.sqlKindDisplay)
-    .addField("Status", resource.phase)
+    .addField("Status", resource.phase);
+
+  if (resource.phase === Phase.DEGRADED) {
+    tooltip.appendMarkdown(
+      "[(Learn more)](https://docs.confluent.io/cloud/current/flink/how-to-guides/resolve-common-query-problems.html#statement-enters-degraded-state)\n\n",
+    );
+  }
+
+  tooltip
     .addField(
       "Created At",
       resource.createdAt?.toLocaleString(undefined, { timeZoneName: "short" }),

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -24,6 +24,12 @@
               <div class="info-item">
                 <label>Status:</label>
                 <span data-testid="statement-status" data-text="this.statementMeta().status"></span>
+                <template data-if="this.statementMeta().status === 'DEGRADED'">
+                  <a
+                    href="https://docs.confluent.io/cloud/current/flink/how-to-guides/resolve-common-query-problems.html#statement-enters-degraded-state"
+                    >(diagnose and resolve)</a
+                  >
+                </template>
               </div>
               <vscode-button
                 data-testid="view-statement-source-button"


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Show link to ccloud docs in result viewer and statement tooltip if statement is DEGRADED
- allow DEGRADED statements results to be viewed. DEGRADED is a sub-mode of RUNNING.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. Poison CCloudResourceLoader.refreshFlinkStatement() as follows:
```
  public async refreshFlinkStatement(statement: FlinkStatement): Promise<FlinkStatement | null> {
    // Defer to core implementation in flinkSql/statementUtils.ts
    const refreshedStatement = await refreshFlinkStatement(statement);
    // @ts-expect-error read-only property assignment
    refreshedStatement.status.phase = Phase.DEGRADED;
    return refreshedStatement;
  }
```

2. Then submit a statement.
3. See that after a few moments the statements view shows it as degraded. Check out the link in its tooltip.
4. Open up the statement results.
5. See the link beside the statement state.

<img width="511" height="327" alt="Screenshot 2025-10-20 at 10 05 28 AM" src="https://github.com/user-attachments/assets/b70e5ee9-2854-4e37-9937-56a0d0fecd6d" />

<img width="915" height="207" alt="Screenshot 2025-10-20 at 10 06 06 AM" src="https://github.com/user-attachments/assets/cdf8c591-9788-4e41-9267-ee90a73eb2da" />



### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2625

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
