### PR TITLE
MINOR: reorder Flink database view title action ordering for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1802,16 +1802,6 @@
           "group": "navigation@1"
         },
         {
-          "command": "confluent.flink.database.search",
-          "when": "view == confluent-flink-database && confluent.flinkDatabaseSelected && !confluent.flinkDatabaseSearchApplied",
-          "group": "navigation@1"
-        },
-        {
-          "command": "confluent.flink.database.search.clear",
-          "when": "view == confluent-flink-database && confluent.flinkDatabaseSelected && confluent.flinkDatabaseSearchApplied",
-          "group": "navigation@1"
-        },
-        {
           "command": "confluent.statements.create",
           "when": "view == confluent-flink-statements && confluent.ccloudConnectionAvailable && confluent.flinkStatementsPoolSelected",
           "group": "navigation@2"
@@ -1832,19 +1822,29 @@
           "group": "navigation@5"
         },
         {
+          "command": "confluent.flink.database.search",
+          "when": "view == confluent-flink-database && confluent.flinkDatabaseSelected && !confluent.flinkDatabaseSearchApplied",
+          "group": "navigation@1"
+        },
+        {
+          "command": "confluent.flink.database.search.clear",
+          "when": "view == confluent-flink-database && confluent.flinkDatabaseSelected && confluent.flinkDatabaseSearchApplied",
+          "group": "navigation@1"
+        },
+        {
           "command": "confluent.artifacts.scaffold",
           "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.artifacts && confluent.flinkDatabaseSelected",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "confluent.uploadArtifact",
           "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected && config.confluent.flink.artifacts",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "confluent.flinkdatabase.kafka-cluster.select",
           "when": "view == confluent-flink-database && confluent.ccloudConnectionAvailable && config.confluent.flink.artifacts",
-          "group": "navigation@3"
+          "group": "navigation@4"
         },
         {
           "command": "confluent.flinkdatabase.refresh",


### PR DESCRIPTION
`confluent.flink.database.search`+`confluent.flink.database.search.clear` were set to `navigation@1` as well as `confluent.artifacts.scaffold`, and so VS Code orders them alphabetically.

This PR explicitly sets the search-related actions to `navigation@1` and drops the position of the rest of the `view/title` actions for the `confluent-flink-database` view to match the behavior of our other views, which roughly follows this pattern:
```
Search | Create | (Upload?) | Select [Parent Resource] | Refresh | ...more
```

- Topics view
<img width="471" height="57" alt="image" src="https://github.com/user-attachments/assets/3eb4cdbc-ab92-4f7b-9cb8-7aa8320e740c" />

- Schemas view
<img width="467" height="52" alt="image" src="https://github.com/user-attachments/assets/fda187c3-2e78-4719-bacb-44cb679d1cbd" />

- Flink Statements view
<img width="472" height="55" alt="image" src="https://github.com/user-attachments/assets/c108a83b-0608-48a4-83d7-fa87a61d4b4e" />

- Flink Database view

| | |
|--------|--------|
| Before | <img width="465" height="54" alt="image" src="https://github.com/user-attachments/assets/095ca2b0-2c58-4d1f-a538-bf58765381c4" /> |
| After | <img width="463" height="55" alt="image" src="https://github.com/user-attachments/assets/419e967c-12e7-4d04-b6e4-eccf22fbf003" /> | 
