### PR TITLE
MINOR cleanup(E2E): try to collapse auxiliary/secondary sidebar before tests start

### DIFF
--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -290,6 +290,16 @@ async function globalBeforeEach(page: Page, electronApp: ElectronApplication): P
   await expect(infoNotifications).not.toHaveCount(0);
   const notification = new Notification(page, infoNotifications.first());
   await notification.dismiss();
+
+  // collapse the secondary sidebar if it's expanded since it isn't used for anything
+  try {
+    await expect(page.locator(`[id="workbench.parts.auxiliarybar"]`)).toBeVisible({
+      timeout: 1000,
+    });
+    await executeVSCodeCommand(page, "View: Toggle Secondary Side Bar Visibility");
+  } catch (error) {
+    console.warn("Error locating/toggling secondary sidebar:", error);
+  }
 }
 
 async function globalAfterEach(


### PR DESCRIPTION
Small try/catch around looking for the sidebar element and closing it during the `page` fixture setup.

From the trace view:
- notification and sidebar are seen 
<img width="682" height="528" alt="image" src="https://github.com/user-attachments/assets/c8fee995-819c-4a39-88ee-181449a1bd43" />

- notification is dismissed
<img width="685" height="520" alt="image" src="https://github.com/user-attachments/assets/7d04b4c3-6d2e-4983-9d78-21040918bc45" />

- sidebar is collapsed
<img width="693" height="514" alt="image" src="https://github.com/user-attachments/assets/b685f6ae-93fe-401b-a20b-0ba92cb292a1" />

(...and then we start tests by clicking the Confluent icon on the activity bar as part of the auto-used [`openExtensionSidebar` fixture](https://github.com/confluentinc/vscode/blob/f47a88aaf524bbf2d474432bd6317d9c105d6f33/tests/e2e/baseTest.ts#L176).)

Closes #2530
