### PR TITLE
[medusa-integration] Deflake fetch()-using tests.

### DIFF
--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -10,6 +10,7 @@ import { Logger } from "../logging";
 import { defaultRequestInit } from "./configs";
 import { MANAGED_CONTAINER_LABEL } from "./constants";
 import { imageExists, pullImage } from "./images";
+import { containerFetch } from "./wrappers";
 
 const logger = new Logger("docker.containers");
 
@@ -157,7 +158,7 @@ export async function waitForServiceHealthCheck(
     const healthCheckStartTime = Date.now();
     while (Date.now() - healthCheckStartTime < maxWaitTimeSec * 1000) {
       try {
-        const response = await fetch(healthUrl, {
+        const response = await containerFetch(healthUrl, {
           method: "GET",
           signal: AbortSignal.timeout(requestTimeoutMs),
         });

--- a/src/docker/wrappers.ts
+++ b/src/docker/wrappers.ts
@@ -1,0 +1,7 @@
+/** Interference-free stubbable wrapper around global fetch() */
+export function containerFetch(
+  input: string | URL | globalThis.Request,
+  init?: RequestInit,
+): Promise<Response> {
+  return fetch(input, init);
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Deflake the `fetch()`-calling tests by wrapping `fetch()` and then stubbing the wrapper. This aims to prevent flake by shielding these tests from any other detached task use of `fetch()` which might happen to have leaked out from running other tests (ugh).
- Use `SinonFakeTimers` in the tests to make run faster.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2921

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
