### PR TITLE
[v2.0.x] fix: quick-register should allow filtering by description

### DIFF
--- a/src/commands/utils/udfRegistration.ts
+++ b/src/commands/utils/udfRegistration.ts
@@ -122,6 +122,7 @@ export async function selectClassesForUdfRegistration(
     placeHolder: "Select classes to register as UDFs",
     canPickMany: true,
     ignoreFocusOut: true,
+    matchOnDescription: true,
   });
 
   return selectedItems?.map((item) => item.classInfo);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- set `matchOnDescription: true` for better filtering