### PR TITLE
[2.0.x] Exclude virtual (replication_factor=0) topics from topics listings.

### DIFF
--- a/src/loaders/utils/loaderUtils.ts
+++ b/src/loaders/utils/loaderUtils.ts
@@ -70,10 +70,14 @@ export async function fetchTopics(cluster: KafkaCluster): Promise<TopicData[]> {
     }
   }
 
-  // sort multiple topics by name
+  // Sort multiple topics by name
   if (topicsResp.data.length > 1) {
     topicsResp.data.sort((a, b) => a.topic_name.localeCompare(b.topic_name));
   }
+
+  // Exclude "virtual" topics (say, corresponding to Flink views) that have 0 replication factor per #2940.
+  // (These cannot be queried or used in any way.)
+  topicsResp.data = topicsResp.data.filter((topic) => topic.replication_factor! > 0);
 
   return topicsResp.data;
 }

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -69,6 +69,7 @@ export function createTestTopicData(
   clusterId: string,
   topicName: string,
   authorizedOperations: KafkaTopicOperation[],
+  replicationFactor: number = 1,
 ): TopicData {
   return TopicDataFromJSON({
     kind: "KafkaTopic",
@@ -78,7 +79,7 @@ export function createTestTopicData(
     cluster_id: clusterId,
     topic_name: topicName,
     is_internal: false,
-    replication_factor: 1,
+    replication_factor: replicationFactor,
     partitions_count: 3,
     partitions: {
       related: "test",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Exclude virtual topics (replication_factor===0), such as those created for Flink Views, from ever being listed in the Topics view. They are not consumable-from or producable-to, and seem to serve to just prevent any 'real' topics from using the name of the view.

### Optional: Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable -->

1. List the topics in realworld-data-cluster, either via ccloud connection or a shadowing direct connection.
2. No longer see `SunnyTimeTempsView`

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Closes #2940 in v2.0.x timestream.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
