### PR TITLE
chore(CI): run `@flink-artifacts`-tagged E2E tests by default

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -389,7 +389,7 @@ promotions:
     parameters:
       env_vars:
         - name: TEST_SUITE
-          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud"
+          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts"
           description: "Playwright E2E test tags to run, separated by |. By default, runs the smoketests and CUJ-related tests."
         - name: VSCODE_VERSION
           default_value: "stable"

--- a/service.yml
+++ b/service.yml
@@ -108,7 +108,7 @@ semaphore:
         - name: TEST_SUITE
           required: true
           description: The test tag(s) (pipe-separated, e.g. `@smoke|@topic-message-viewer`) to run. By default, runs the smoke tests and critical user flow tests.
-          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud"
+          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts"
 sonarqube:
   enable: false
 make:


### PR DESCRIPTION
Minor follow-up from https://github.com/confluentinc/vscode/pull/3008

https://github.com/confluentinc/vscode/blob/d147c20c5b098086f6bfc8fbbb0e99096af640cb/tests/e2e/tags.ts#L28-L29