### PR TITLE
MINOR: update names in artifacts E2E 

### DIFF
--- a/tests/e2e/objects/views/ArtifactsView.ts
+++ b/tests/e2e/objects/views/ArtifactsView.ts
@@ -11,7 +11,7 @@ import { KafkaClusterItem } from "./viewItems/KafkaClusterItem";
 import { ViewItem } from "./viewItems/ViewItem";
 
 export enum SelectFlinkDatabase {
-  FromResourcesView = "Flink database action from the Resources view",
+  DatabaseFromResourcesView = "Flink database action from the Resources view",
   FromArtifactsViewButton = "Artifacts view nav action",
 }
 
@@ -21,7 +21,7 @@ export enum SelectFlinkDatabase {
  * {@link https://code.visualstudio.com/api/ux-guidelines/views#view-containers view container}.
  * Provides access to Flink artifact items and actions within the view.
  */
-export class ArtifactsView extends View {
+export class FlinkDatabaseView extends View {
   constructor(page: Page) {
     super(page, /Flink Database.*Section/);
   }
@@ -43,7 +43,7 @@ export class ArtifactsView extends View {
     clusterLabel?: string | RegExp,
   ): Promise<void> {
     switch (entrypoint) {
-      case SelectFlinkDatabase.FromResourcesView:
+      case SelectFlinkDatabase.DatabaseFromResourcesView:
         await this.loadArtifactsFromResourcesView();
         break;
       case SelectFlinkDatabase.FromArtifactsViewButton:

--- a/tests/e2e/specs/flinkArtifact.spec.ts
+++ b/tests/e2e/specs/flinkArtifact.spec.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { test } from "../baseTest";
 import { ConnectionType } from "../connectionTypes";
-import { ArtifactsView, SelectFlinkDatabase } from "../objects/views/ArtifactsView";
+import { FlinkDatabaseView, SelectFlinkDatabase } from "../objects/views/ArtifactsView";
 import { Tag } from "../tags";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -27,7 +27,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
     page,
     electronApp,
   }) => {
-    const artifactsView = new ArtifactsView(page);
+    const artifactsView = new FlinkDatabaseView(page);
     await artifactsView.loadArtifacts(SelectFlinkDatabase.FromArtifactsViewButton);
 
     const uploadedArtifactName = await artifactsView.uploadFlinkArtifact(electronApp, artifactPath);
@@ -44,8 +44,8 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
     page,
     electronApp,
   }) => {
-    const artifactsView = new ArtifactsView(page);
-    await artifactsView.loadArtifacts(SelectFlinkDatabase.FromResourcesView);
+    const artifactsView = new FlinkDatabaseView(page);
+    await artifactsView.loadArtifacts(SelectFlinkDatabase.DatabaseFromResourcesView);
 
     const uploadedArtifactName = await artifactsView.uploadFlinkArtifact(electronApp, artifactPath);
 


### PR DESCRIPTION
## Summary of Changes

Very minor change prior to juggling the different view modes and for when the "from compute pool" entrypoint is handled. 

Fixes #3018 

### Optional: Click-testing instructions

can run `gulp e2e -t "Flink Artifacts"` locally, I'll also run the @flink-artifacts tests in CI here. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
