### PR TITLE
Artifacts E2E: pass clusterLabel in to relevant functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,7 +477,7 @@
       },
       {
         "command": "confluent.flinkdatabase.setRelationsViewMode",
-        "title": "Switch to Flink Relations",
+        "title": "Switch to Flink Database Relations",
         "icon": "$(confluent-code)",
         "category": "Confluent: Flink Database View",
         "enablement": "confluent.flinkDatabaseViewMode != 'relations'"
@@ -1331,7 +1331,7 @@
       },
       {
         "view": "confluent-flink-database",
-        "contents": "No Flink relations found.\n[Create Topic](command:confluent.flinkdatabase.createTopic)",
+        "contents": "No Flink database relations found.\n[Create Topic](command:confluent.flinkdatabase.createTopic)",
         "when": "config.confluent.flink.artifacts && confluent.ccloudConnectionAvailable && confluent.flinkDatabaseSelected && confluent.flinkDatabaseViewMode == 'relations' && !confluent.flinkDatabaseSearchApplied"
       },
       {

--- a/src/viewProviders/multiViewDelegates/flinkRelationsDelegate.ts
+++ b/src/viewProviders/multiViewDelegates/flinkRelationsDelegate.ts
@@ -13,8 +13,8 @@ export class FlinkRelationsDelegate extends ViewProviderDelegate<
   FlinkRelationElements
 > {
   readonly mode = FlinkDatabaseViewProviderMode.Relations;
-  readonly viewTitle = "Flink Relations (Preview)";
-  readonly loadingMessage = "Loading Flink Relations...";
+  readonly viewTitle = "Flink Database Relations (Preview)";
+  readonly loadingMessage = "Loading Flink Database Relations...";
 
   /** Returns the most recent results from fetchChildren() */
   getChildren(parent?: FlinkRelation): FlinkRelationElements[] {

--- a/tests/e2e/specs/flinkArtifact.spec.ts
+++ b/tests/e2e/specs/flinkArtifact.spec.ts
@@ -3,7 +3,11 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { test } from "../baseTest";
 import { ConnectionType } from "../connectionTypes";
-import { FlinkDatabaseView, SelectFlinkDatabase } from "../objects/views/ArtifactsView";
+import {
+  FlinkDatabaseView,
+  FlinkViewMode,
+  SelectFlinkDatabase,
+} from "../objects/views/FlinkDatabaseView";
 import { Tag } from "../tags";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -29,7 +33,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
   }) => {
     const artifactsView = new FlinkDatabaseView(page);
     await artifactsView.loadArtifacts(SelectFlinkDatabase.FromArtifactsViewButton);
-    await artifactsView.clickSwitchToFlinkResource("Switch to Flink Artifacts");
+    await artifactsView.clickSwitchToFlinkResource(FlinkViewMode.Artifacts);
     const uploadedArtifactName = await artifactsView.uploadFlinkArtifact(electronApp, artifactPath);
 
     await expect(artifactsView.artifacts.filter({ hasText: uploadedArtifactName })).toHaveCount(1);
@@ -46,7 +50,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
   }) => {
     const artifactsView = new FlinkDatabaseView(page);
     await artifactsView.loadArtifacts(SelectFlinkDatabase.DatabaseFromResourcesView);
-    await artifactsView.clickSwitchToFlinkResource("Switch to Flink Artifacts");
+    await artifactsView.clickSwitchToFlinkResource(FlinkViewMode.Artifacts);
     const uploadedArtifactName = await artifactsView.uploadFlinkArtifact(electronApp, artifactPath);
 
     await expect(artifactsView.artifacts.filter({ hasText: uploadedArtifactName })).toHaveCount(1);


### PR DESCRIPTION
## Summary of Changes

fixes #3019 

Main changes: 

- `clusterLabel` now passed into `loadArtifactsFromResourcesView` in case we want to do this in the future 
- `clickSwitchToFlinkArtifacts` renamed to `clickSwitchToFlinkResource` and made dynamic
- `clickSwitchToFlinkResource` now called in artifacts spec

###  Click-testing instructions

Run 
` gulp e2e -t "Flink Artifacts"` locally and confirm tests are still passing. 


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
