### PR TITLE
MINOR: set default icons for Flink relation columns and tables in tree view

### DIFF
--- a/src/models/flinkRelation.ts
+++ b/src/models/flinkRelation.ts
@@ -1,4 +1,4 @@
-import { TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID, IconNames } from "../constants";
 import { formatSqlType } from "../utils/flinkTypes";
@@ -123,7 +123,7 @@ export class FlinkRelationColumn {
 
   getTreeItem(): TreeItem {
     const item = new TreeItem(this.name, TreeItemCollapsibleState.None);
-    // item.iconPath = new ThemeIcon(IconNames.FLINK_FUNCTION); // TODO replace with column specific icon when available
+    item.iconPath = new ThemeIcon("symbol-constant"); // TODO replace with column specific icon when available
     item.id = this.id;
     item.contextValue = "ccloud-flink-column";
     item.tooltip = this.getToolTip();
@@ -324,7 +324,7 @@ export class FlinkRelation {
 
   getTreeItem(): TreeItem {
     const item = new TreeItem(this.name, TreeItemCollapsibleState.Collapsed);
-    // item.iconPath = new ThemeIcon(IconNames.FLINK_FUNCTION); // TODO replace with table/view specific icons when available
+    item.iconPath = new ThemeIcon(IconNames.TOPIC); // topic = table
     item.id = this.name;
 
     const typeSnippet = this.type.toLowerCase().replace(" ", "-");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

If we don't set default icons for a resource's tree item, when we decorate them with the [`SEARCH_DECORATION_URI_SCHEME`](https://github.com/confluentinc/vscode/blob/7db297f69f5bd43c2553165349f653f7ac07ce75/src/viewProviders/utils/search.ts#L63-L64), VS Code will try to visually treat them as files/folders depending on their collapsible state:
- `none`: `file`
- `collapsed`: `folder`
- `expanded`: `folder-opened`

This PR sets the "table"/relation icon to the same icon used for the Kafka topics, and uses a placeholder symbol icon until we have column-specific icons available.

| Before | After |
|--------|--------|
| <img height="256" alt="image" src="https://github.com/user-attachments/assets/9533d0f8-2c72-4fc0-a885-fd793cfb4107" /> | <img height="256" alt="image" src="https://github.com/user-attachments/assets/89445f1f-db97-4085-a946-75e6d86c5501" /> | 

Closes #3029 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Sign into Confluent Cloud
2. Select a Flink database (Kafka cluster)
3. Search in the Flink Database view (with the default "Flink Relations" view mode set)
4. Expect no file/folder icons suddenly appear

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
