### PR TITLE
fix: update url validation to match backend pattern

### DIFF
--- a/src/commands/utils/artifactUploadForm.ts
+++ b/src/commands/utils/artifactUploadForm.ts
@@ -272,11 +272,9 @@ export async function artifactUploadQuickPickForm(
           ignoreFocusOut: true,
           validateInput: (value) => {
             if (value && value.trim()) {
-              try {
-                new URL(value);
-                return undefined;
-              } catch {
-                return "Please enter a valid URL";
+              const urlPattern = /^(http:\/\/|https:\/\/).+/;
+              if (!urlPattern.test(value)) {
+                return "Please enter a valid URL starting with http:// or https://";
               }
             }
             return undefined;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- Saw this error detail in the response body in Sentry: `"detail": "documentation_link should be valid URL \"^$|^(http://|https://).+\""` 
- We were not validating the URL correctly, now we are! [[API documentation]](https://docs.confluent.io/cloud/current/api.html#tag/Flink-Artifacts-(artifactv1)/operation/createArtifactV1FlinkArtifact)

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if click-testing is not applicable, for example, changes to docs or CI -->

1. Try to upload a new artifact
2. Intentionally type a non-http url for the documentation link (like `ftp://example.com`)
3. Expect: you won't be allowed to submit with an invalid link (previously you'd be able to Submit then get an error response back)

### Optional: Any additional details or context that should be provided?

| BEFORE | AFTER | 
| -- | -- | 
| <img width="621" height="123" alt="doclink-before" src="https://github.com/user-attachments/assets/677b2e70-5168-4e1c-8dee-2cddb605a8dd" /> | <img width="617" height="108" alt="Screenshot 2025-11-14 at 3 17 22 PM" src="https://github.com/user-attachments/assets/8508004c-3a1c-42ae-9ffc-379e6a4e6480" /> |


- While it does verify the string is a valid URL, `new URL` more permissive than we want - the docs link here must begin with `http` or `https`
- Part of https://github.com/confluentinc/vscode/issues/2959, see [comments](https://github.com/confluentinc/vscode/issues/2959#issuecomment-3533414107) for more of these error types

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
