### PR TITLE
bugfix: update SR API key management link

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -164,7 +164,7 @@ describe("Test CCloudSchemaRegistry properties", () => {
 
   it("ccloudApiKeysUrl should return the correct URL for ccloud schema registry cluster", () => {
     assert.strictEqual(
-      `https://${CCLOUD_BASE_PATH}/settings/api-keys?resourceIds=${TEST_CCLOUD_SCHEMA_REGISTRY.id}&resourceScope=SchemaRegistry?utm_source=${UTM_SOURCE_VSCODE}`,
+      `https://${CCLOUD_BASE_PATH}/settings/api-keys?resourceIds=${TEST_CCLOUD_SCHEMA_REGISTRY.id}&resourceScope=SchemaRegistry&utm_source=${UTM_SOURCE_VSCODE}`,
       TEST_CCLOUD_SCHEMA_REGISTRY.ccloudApiKeysUrl,
     );
   });

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -54,7 +54,7 @@ export class CCloudSchemaRegistry extends SchemaRegistry {
   }
 
   get ccloudApiKeysUrl(): string {
-    return `https://${CCLOUD_BASE_PATH}/settings/api-keys?resourceIds=${this.id}&resourceScope=SchemaRegistry?utm_source=${UTM_SOURCE_VSCODE}`;
+    return `https://${CCLOUD_BASE_PATH}/settings/api-keys?resourceIds=${this.id}&resourceScope=SchemaRegistry&utm_source=${UTM_SOURCE_VSCODE}`;
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

This PR fixes #3058 

### Click-testing instructions

Open up the extension dev host, sign in to CCloud, observe that right-clicking "Manage API keys in Confluent Cloud" brings you to a proper API key management area. 

> Note: The change is in /models, but since the test of the SchemaRegistry model does not test the `get` method directly, the only test that needed updating was the one in the /authz package.
> Note 2: I clicktested the cluster API key management link, and since that is not under Stream Governance, it was not affected. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
