### PR TITLE
Update quickpick labels to use region and provider

### DIFF
--- a/src/quickpicks/flinkComputePools.test.ts
+++ b/src/quickpicks/flinkComputePools.test.ts
@@ -87,7 +87,7 @@ describe("quickpicks/flinkComputePools.ts", () => {
       // simulate user selecting the second pool in the list
       showQuickPickStub.resolves({
         label: TEST_CCLOUD_FLINK_COMPUTE_POOL_2.name,
-        description: TEST_CCLOUD_FLINK_COMPUTE_POOL_2.id,
+        description: `${TEST_CCLOUD_FLINK_COMPUTE_POOL_2.provider}/${TEST_CCLOUD_FLINK_COMPUTE_POOL_2.region}`,
         value: TEST_CCLOUD_FLINK_COMPUTE_POOL_2,
       });
 
@@ -107,7 +107,10 @@ describe("quickpicks/flinkComputePools.ts", () => {
       const quickPickItems = extractPoolItemsFromQuickPickCall();
       assert.strictEqual(quickPickItems.length, 1);
       const onlyPool = quickPickItems[0];
-      assert.strictEqual(onlyPool.description, TEST_CCLOUD_FLINK_COMPUTE_POOL_2_ID);
+      assert.strictEqual(
+        onlyPool.description,
+        `${TEST_CCLOUD_FLINK_COMPUTE_POOL_2.provider}/${TEST_CCLOUD_FLINK_COMPUTE_POOL_2.region}`,
+      );
     });
 
     for (const preferredPool of [
@@ -123,8 +126,11 @@ describe("quickpicks/flinkComputePools.ts", () => {
         const quickPickItems = extractPoolItemsFromQuickPickCall();
         assert.strictEqual(quickPickItems.length, 2);
         const firstItem = quickPickItems[0];
-        // The pool's id is in the description field.
-        assert.strictEqual(firstItem.description, preferredPool.id);
+        // The pool's provider/region is in the description field.
+        assert.strictEqual(
+          firstItem.description,
+          `${preferredPool.provider}/${preferredPool.region}`,
+        );
       });
 
       it(`If user has default compute pool set, and called with that selected pool, the default/selected should be at the top of the list and not duplicated: ${preferredPool.id}`, async () => {
@@ -136,8 +142,11 @@ describe("quickpicks/flinkComputePools.ts", () => {
         const quickPickItems = extractPoolItemsFromQuickPickCall();
         assert.strictEqual(quickPickItems.length, 2);
         const firstItem = quickPickItems[0];
-        // The pool's id is in the description field.
-        assert.strictEqual(firstItem.description, preferredPool.id);
+        // The pool's provider/region is in the description field.
+        assert.strictEqual(
+          firstItem.description,
+          `${preferredPool.provider}/${preferredPool.region}`,
+        );
         // Should use icon checked
         assert.strictEqual((firstItem.iconPath as vscode.ThemeIcon).id, IconNames.CURRENT_RESOURCE);
 
@@ -147,7 +156,7 @@ describe("quickpicks/flinkComputePools.ts", () => {
           preferredPool === TEST_CCLOUD_FLINK_COMPUTE_POOL
             ? TEST_CCLOUD_FLINK_COMPUTE_POOL_2
             : TEST_CCLOUD_FLINK_COMPUTE_POOL;
-        assert.strictEqual(secondItem.description, secondPool.id);
+        assert.strictEqual(secondItem.description, `${secondPool.provider}/${secondPool.region}`);
         // and should use the pool's own icon, not the 'selected' icon
         assert.strictEqual((secondItem.iconPath as vscode.ThemeIcon).id, secondPool.iconName);
       });
@@ -166,14 +175,20 @@ describe("quickpicks/flinkComputePools.ts", () => {
         const quickPickItems = extractPoolItemsFromQuickPickCall();
         assert.strictEqual(quickPickItems.length, 2);
         const firstItem = quickPickItems[0];
-        // The pool's id is in the description field.
-        assert.strictEqual(firstItem.description, selectedPool.id);
+        // The pool's provider/region is in the description field.
+        assert.strictEqual(
+          firstItem.description,
+          `${selectedPool.provider}/${selectedPool.region}`,
+        );
         // Should use icon checked
         assert.strictEqual((firstItem.iconPath as vscode.ThemeIcon).id, IconNames.CURRENT_RESOURCE);
 
         // the second item should be the other pool
         const secondItem = quickPickItems[1];
-        assert.strictEqual(secondItem.description, preferredPool.id);
+        assert.strictEqual(
+          secondItem.description,
+          `${preferredPool.provider}/${preferredPool.region}`,
+        );
         // and should use the pool's own icon, not the 'selected' icon
         assert.strictEqual((secondItem.iconPath as vscode.ThemeIcon).id, preferredPool.iconName);
       });

--- a/src/quickpicks/flinkComputePools.ts
+++ b/src/quickpicks/flinkComputePools.ts
@@ -140,7 +140,7 @@ export async function flinkComputePoolQuickPick(
     const icon = isCurrentlySelectedPool ? IconNames.CURRENT_RESOURCE : pool.iconName;
     items.push({
       label: pool.name,
-      description: pool.id,
+      description: `${pool.provider}/${pool.region}`,
       iconPath: new ThemeIcon(icon),
       value: pool,
     });

--- a/src/quickpicks/kafkaClusters.test.ts
+++ b/src/quickpicks/kafkaClusters.test.ts
@@ -254,9 +254,12 @@ describe("quickpicks/kafkaClusters", () => {
       // cluster in same provider/region.
       assert.strictEqual(itemsCalledWith.length, 2);
       assert.strictEqual(itemsCalledWith[0].kind, QuickPickItemKind.Separator);
-      // other two items are the clusters. Their description should be the id.
+      // other two items are the clusters. Their description should be the provider/region.
       // and their .value should be the cluster.
-      assert.strictEqual(itemsCalledWith[1].description, ccloudClusters[0].id);
+      assert.strictEqual(
+        itemsCalledWith[1].description,
+        `${ccloudClusters[0].provider}/${ccloudClusters[0].region}`,
+      );
       assert.strictEqual(itemsCalledWith[1].value, TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
     });
 
@@ -273,9 +276,12 @@ describe("quickpicks/kafkaClusters", () => {
       // cluster that is Flinkable.
       assert.strictEqual(itemsCalledWith.length, 2);
       assert.strictEqual(itemsCalledWith[0].kind, QuickPickItemKind.Separator);
-      // other two items are the clusters. Their description should be the id.
+      // other two items are the clusters. Their description should be the provider/region.
       // and their .value should be the cluster.
-      assert.strictEqual(itemsCalledWith[1].description, TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER.id);
+      assert.strictEqual(
+        itemsCalledWith[1].description,
+        `${TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER.provider}/${TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER.region}`,
+      );
       assert.strictEqual(itemsCalledWith[1].value, TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER);
     });
   });

--- a/src/quickpicks/kafkaClusters.ts
+++ b/src/quickpicks/kafkaClusters.ts
@@ -155,9 +155,12 @@ export async function kafkaClusterQuickPick(
     }
     // show the currently-focused cluster, if there is one
     const icon = isFocusedCluster ? IconNames.CURRENT_RESOURCE : cluster.iconName;
+    const description = isCCloud(cluster)
+      ? `${(cluster as CCloudKafkaCluster).provider}/${(cluster as CCloudKafkaCluster).region}`
+      : cluster.id;
     clusterItems.push({
       label: cluster.name,
-      description: cluster.id,
+      description,
       iconPath: new ThemeIcon(icon),
       value: cluster,
     });


### PR DESCRIPTION
## Summary of Changes

This PR changes the quickpick labels to show region/provider rather than ID, which should help unblock #3074 and continues in the direction set by #3075 

The actual changes are pretty minor:
- `description` changed in `kafkaClusters.ts` + accompanying test changes
- `description` changed in `flinkComputePools.ts` + accompanying test changes

### Click-testing instructions

1. Open up the ext dev host, sign in to CCloud, select a kafka cluster or flink compute pool and confirm you can see the region/provider:

<img width="1476" height="973" alt="Screenshot 2025-12-02 at 8 57 06 AM" src="https://github.com/user-attachments/assets/6b4e8067-2896-4fec-9403-6bb5d0dbbcce" />
<img width="1591" height="937" alt="Screenshot 2025-12-02 at 8 57 01 AM" src="https://github.com/user-attachments/assets/8d36d76c-546e-42e5-a2ce-4deef1783c67" />

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
