### PR TITLE
fix: prevent settings gear scrolling out of table

### DIFF
--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -99,34 +99,53 @@
 
         <section>
           <div class="flex-row">
-            <vscode-text-field
-              id="results-search"
-              placeholder="Search across results…"
-              type="search"
-              size="50"
-              data-prop-value="this.search()"
-              data-on-change="this.search(event.target.value)"
-              data-on-keydown="this.handleKeydown(event)"
-              data-on-input="this.handleInput(event)"
-              >Search</vscode-text-field
-            >
+            <div class="flex-column">
+              <vscode-text-field
+                id="results-search"
+                placeholder="Search across results…"
+                type="search"
+                size="50"
+                data-prop-value="this.search()"
+                data-on-change="this.search(event.target.value)"
+                data-on-keydown="this.handleKeydown(event)"
+                data-on-input="this.handleInput(event)"
+                >Search</vscode-text-field
+              >
+            </div>
+            <div>
+              <!-- Settings control positioned outside the grid -->
+              <div
+                style="place-content: end; height: 100%"
+                popovertarget="columnSettings"
+                data-on-click="window.columnSettings.togglePopover()"
+                data-position="bottom-end"
+                tabindex="-1"
+              >
+                <span class="codicon codicon-gear"></span>
+              </div>
+              <section popover id="columnSettings" class="column-control">
+                <div class="flex-column" style="--gap: 0">
+                  <label>Columns</label>
+                  <template data-for="column of this.allColumns() by column">
+                    <label class="checkbox">
+                      <input
+                        type="checkbox"
+                        data-prop-checked="this.isColumnVisible(this.columns()[this.column()].index)"
+                        data-prop-disabled="this.isColumnVisible(this.columns()[this.column()].index) && this.columnVisibilityFlags().filter(f => f).length <= 1"
+                        data-on-change="event.preventDefault(); this.toggleColumnVisibility(this.columns()[this.column()].index)"
+                      />
+                      <span data-text="this.columns()[this.column()].title()"></span>
+                    </label>
+                  </template>
+                </div>
+              </section>
+            </div>
           </div>
         </section>
       </header>
 
       <section class="content">
         <div class="grid-container">
-          <!-- Settings control positioned outside the grid -->
-          <div
-            class="grid-cell grid-column-header cell-text-overflow grid-settings-control"
-            popovertarget="columnSettings"
-            data-on-click="window.columnSettings.togglePopover()"
-            data-position="bottom-end"
-            tabindex="-1"
-          >
-            <span class="codicon codicon-gear"></span>
-          </div>
-
           <table
             class="grid"
             cellpadding="0"
@@ -148,24 +167,6 @@
                 </template>
               </tr>
             </thead>
-
-            <section popover id="columnSettings" class="column-control">
-              <div class="flex-column" style="--gap: 0">
-                <label>Columns</label>
-                <template data-for="column of this.allColumns() by column">
-                  <label class="checkbox">
-                    <input
-                      type="checkbox"
-                      data-prop-checked="this.isColumnVisible(this.columns()[this.column()].index)"
-                      data-prop-disabled="this.isColumnVisible(this.columns()[this.column()].index) && this.columnVisibilityFlags().filter(f => f).length <= 1"
-                      data-on-change="event.preventDefault(); this.toggleColumnVisibility(this.columns()[this.column()].index)"
-                    />
-                    <span data-text="this.columns()[this.column()].title()"></span>
-                  </label>
-                </template>
-              </div>
-            </section>
-
             <template data-if="this.hasResults() || this.emptyFilterResult()">
               <tbody>
                 <template data-for="result of this.snapshot().results">
@@ -391,6 +392,7 @@
       .content {
         flex: 1;
         overflow: auto;
+        position: relative;
       }
 
       .cell-text-overflow {
@@ -464,17 +466,8 @@
         color: var(--vscode-progressBar-background);
       }
 
-      .grid-container {
-        position: relative;
-      }
-
-      .grid {
-        padding-left: 26px;
-        /* padding for the settings control width */
-      }
-
       .grid-settings-control {
-        position: absolute;
+        position: sticky;
         top: 0;
         left: 0;
         width: 26px;


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- HTML and CSS changes to move the settings gear ⚙️  in our Flink Statement Results Viewer so it's next to the search bar. Previously, it would scroll out of view when the table scrolled, now it's always visible and prominent. 
- Code changes are only moving blocks of HTML and updating CSS. The underlying logic for any related actions is **unchanged**.
- Closes #3050 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. To see the results viewer with scrollable data, run a flink statement that will generate some columns and > 50 rows. e.g.
```sql
SELECT * FROM `sample_data_stock_trades`;
```
2. In the results table, try scrolling vertically and horizontally. The settings gear is always visible in the header area. 💥 

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- I considered / tried some options where the gear is positioned to appear to stay inside the `<th>`, but with our bi-directional scrolling, this change was a bit cleaner & allows the table data to have full horizontal space. If Design deems it worth keeping in the head we can revisit, but this fix is at least better than the current behavior.

**BEFORE**

https://github.com/user-attachments/assets/6f36d9d3-aade-48aa-9b01-24178d0ea59a

| AFTER | 
| -- |
| <img width="866" height="270" alt="Screenshot 2025-12-03 at 11 16 33 AM" src="https://github.com/user-attachments/assets/7d4b4315-bb34-4cd1-b33c-0e49ae4502dc" /> |