### PR TITLE
fix: add id for settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -832,6 +832,7 @@
     ],
     "configuration": [
       {
+        "id": "general",
         "title": "General",
         "properties": {
           "confluent.debugging.showSidecarExceptions": {
@@ -857,6 +858,7 @@
         }
       },
       {
+        "id": "confluent-cloud",
         "title": "Confluent Cloud",
         "properties": {
           "confluent.cloud.messageViewer.showSchemaWarningNotifications": {
@@ -888,6 +890,7 @@
         }
       },
       {
+        "id": "connections",
         "title": "Connections",
         "properties": {
           "confluent.krb5ConfigPath": {
@@ -898,6 +901,7 @@
         }
       },
       {
+        "id": "local-docker",
         "title": "Local",
         "properties": {
           "confluent.localDocker.socketPath": {
@@ -940,6 +944,7 @@
         }
       },
       {
+        "id": "flink",
         "title": "Flink",
         "properties": {
           "confluent.flink.languageServer": {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->
- Update: looks like a known [issue](https://github.com/microsoft/vscode/issues/273163) to be fixed with next release. However, adding IDs doesn't hurt and mitigates for now.
- Fixes #3090 
- Adding IDs expands our settings categories again. 
-  [API Documentation](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration)


| BEFORE | AFTER | 
| -- | -- |
| <img width="351" height="219" alt="Screenshot 2025-12-08 at 12 41 48 PM" src="https://github.com/user-attachments/assets/66b0f453-6814-429e-b9ad-c481159eab2e" /> | <img width="276" height="219" alt="Screenshot 2025-12-08 at 12 38 29 PM" src="https://github.com/user-attachments/assets/83c09c29-6bbb-42db-bd5a-6ea55f589a35" /> |


### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Open the VSCode settings UI via command palette or our Open Settings command, and look at ours under Extensions

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
