### PR TITLE
minor: expand search highlight color to global styles

### DIFF
--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -603,11 +603,6 @@
         display: flex;
         gap: 0.5rem;
       }
-      /* search highlight */
-      .grid-cell mark {
-        background-color: var(--vscode-editor-findMatchHighlightBackground);
-        color: var(--vscode-editor-findMatchHighlightForeground);
-      }
     </style>
     <script type="module" nonce="${nonce}" src="${path('main.js')}"></script>
     <script

--- a/src/webview/uikit/uikit.css
+++ b/src/webview/uikit/uikit.css
@@ -51,6 +51,12 @@
   color: var(--vscode-list-activeSelectionForeground, #ffffff);
 }
 
+/* Search highlight for grid cells */
+.grid-cell mark {
+  background-color: var(--vscode-editor-findMatchHighlightBackground);
+  color: var(--vscode-editor-findMatchHighlightForeground);
+  overflow: clip;
+}
 /**
  * <label class="checkbox">
  *   <input type="checkbox" />


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

- The `.grid-cell mark` theme color style is now in `uikit.css` instead of `flink-statement-results.html`, so it will apply to message viewer and any future `grid-cell`s we write.
- Attempted to prevent the mark color showing when text is truncated using an `overflow:clip` rule, but it doesn't work. The ellipsis + text overflow rule + css aren't making it easy. However I'm going to merge as-is, this is not an issue caused by/related to the color change. 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Try searching in both topic message viewer and flink statement results to verify the highlight color matches your theme(s).

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->
Topic Highlighting AFTER:
<img width="854" height="533" alt="topic-highlight" src="https://github.com/user-attachments/assets/3bdda251-0e5d-411c-9305-85d74036a328" />
