### PR TITLE
JAR entrypoint dimension for Artifacts E2E tests

### DIFF
--- a/tests/e2e/objects/FileExplorer.ts
+++ b/tests/e2e/objects/FileExplorer.ts
@@ -22,7 +22,7 @@ export class FileExplorer extends View {
    */
   async ensureVisible(): Promise<void> {
     try {
-      await expect(this.locator).toBeVisible({ timeout: 500 });
+      await expect(this.locator).toBeVisible({ timeout: 2000 });
     } catch {
       const activityBarItem = new ActivityBarItem(this.page, "Explorer");
       await expect(activityBarItem.locator).toBeVisible();

--- a/tests/e2e/objects/views/FlinkDatabaseView.ts
+++ b/tests/e2e/objects/views/FlinkDatabaseView.ts
@@ -16,7 +16,7 @@ export enum SelectFlinkDatabase {
   DatabaseFromResourcesView = "Flink database action from the Resources view",
   FromDatabaseViewButton = "Flink Database view nav action",
   ComputePoolFromResourcesView = "Compute pool action from the Resources view",
-  JARFile = "JAR file from file explorer",
+  JarFile = "JAR file from file explorer",
 }
 
 /**
@@ -60,7 +60,7 @@ export class FlinkDatabaseView extends View {
         break;
       case SelectFlinkDatabase.ComputePoolFromResourcesView:
         return await this.clickUploadFromComputePool(clusterLabel);
-      case SelectFlinkDatabase.JARFile:
+      case SelectFlinkDatabase.JarFile:
         return;
       default:
         throw new Error(`Unsupported entrypoint: ${entrypoint}`);

--- a/tests/e2e/specs/flinkArtifact.spec.ts
+++ b/tests/e2e/specs/flinkArtifact.spec.ts
@@ -44,7 +44,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
       testName: "should upload Flink Artifact when cluster selected from Flink Compute Pool",
     },
     {
-      entrypoint: SelectFlinkDatabase.JARFile,
+      entrypoint: SelectFlinkDatabase.JarFile,
       testName: "should upload Flink Artifact when initiated from JAR file in file explorer",
     },
   ];
@@ -88,7 +88,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
     electronApp: ElectronApplication,
   ): Promise<void> {
     // JAR file test requires opening the fixtures folder as a workspace
-    if (entrypoint === SelectFlinkDatabase.JARFile) {
+    if (entrypoint === SelectFlinkDatabase.JarFile) {
       const fixturesDir = path.join(__dirname, "..", "..", "fixtures", "flink-artifacts");
 
       await stubDialog(electronApp, "showOpenDialog", {
@@ -122,7 +122,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
           throw new Error("providerRegion is required for ComputePoolFromResourcesView");
         }
         return await completeUploadFlowForComputePool(electronApp, artifactsView, providerRegion);
-      case SelectFlinkDatabase.JARFile:
+      case SelectFlinkDatabase.JarFile:
         return await completeArtifactUploadFlowForJAR(
           page,
           artifactPath,
@@ -182,7 +182,7 @@ async function completeArtifactUploadFlowForJAR(
   await fileExplorer.ensureVisible();
   const jarFile = fileExplorer.treeItems.filter({ hasText: path.basename(artifactPath) });
   await expect(jarFile).toHaveCount(1);
-  // await expect(jarFile).toHaveAttribute("aria-label", `${path.basename(artifactPath)}, File`);
+  await expect(jarFile).not.toHaveAttribute("aria-expanded");
   const fileItem = new ViewItem(page, jarFile);
   await fileItem.rightClickContextMenuAction("Upload Flink Artifact to Confluent Cloud");
 

--- a/tests/e2e/utils/sidebarNavigation.ts
+++ b/tests/e2e/utils/sidebarNavigation.ts
@@ -19,11 +19,13 @@ export async function openConfluentSidebar(page: Page): Promise<void> {
   // check if the view container is already visible in the primary sidebar first
   // and if not, click the activity bar item to show it
   const viewContainer = new ViewContainer(page, "confluent");
-  const isVisible = await viewContainer.locator.isVisible();
-  if (!isVisible) {
+  try {
+    await expect(viewContainer.locator).toBeVisible({ timeout: 2000 });
+  } catch {
     const activityBarItem = new ActivityBarItem(page, "Confluent");
     await expect(activityBarItem.locator).toBeVisible();
     await activityBarItem.locator.click();
+    await expect(viewContainer.locator).toBeVisible();
   }
 
   const resourcesView = new ResourcesView(page);


### PR DESCRIPTION
## Summary of Changes

Adds the last entrypoint for #2481

Next: too large or corrupt files should fail 

- Adds a new object/ with utility functions for managing File Explorer actions
- Adds a new entrypoint, `JARFile`, with accompanying helper functions and test logic in FlinkDatabaseView and the FlinkArtifact spec. 

Note:

Was flaky after merging main in: 
```
  1 flaky
    [vscode-stable] › flinkArtifact.spec.ts:52:5 › Flink Artifacts › should upload Flink Artifact when initiated from JAR file in file explorer 
  1 passed (1.4m)
```

### Click-testing instructions

`gulp e2e -t "Flink Artifacts` should all pass. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
