### PR TITLE
MINOR: update "Local" item description 

### DIFF
--- a/src/viewProviders/resources.test.ts
+++ b/src/viewProviders/resources.test.ts
@@ -473,7 +473,7 @@ describe("viewProviders/resources.ts", () => {
 
         for (const [label, dockerAvailable, connectedness, expectedStatus] of [
           ["No docker service", false, false, "(Docker Unavailable)"],
-          ["Docker service but no kafka container", true, false, "(Local Kafka not running)"],
+          ["Docker service but no kafka container", true, false, "(Kafka not running)"],
           [
             "Docker and local kafka running",
             true,

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -458,7 +458,7 @@ export class LocalConnectionRow extends SingleEnvironmentConnectionRow<
       getContextValue<boolean>(ContextValues.dockerServiceAvailable) === true;
 
     if (isDockerAvailable) {
-      return this.kafkaCluster ? this.kafkaCluster.uri! : "(Local Kafka not running)";
+      return this.kafkaCluster ? this.kafkaCluster.uri! : "(Kafka not running)";
     } else {
       return "(Docker Unavailable)";
     }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

#2931 reverted the `Local Kafka not available` description based on https://github.com/confluentinc/vscode/pull/2931#discussion_r2490858706, so this updates the behavior to take the [`connected` state](https://github.com/confluentinc/vscode/blob/ca70bac89cb9c2113c8b37e964c6a73862656b37/src/viewProviders/resources.ts#L434-L438) into account and only check for the local Kafka cluster availability.

So there are only three possible states:
- "Docker unavailable" (usually seen momentarily during extension activation, then only if the Docker engine isn't reachable)
- "Kafka not running" (Docker is available, but no Kafka broker containers are running)
- Kafka URI when Docker is available and at least one container is running

We can update the description around Medusa/datagen container more in future branches as we get closer to an MVP state there.

Closes #2967 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Activate the extension
2. Start/stop Docker and expect the description to change between "Docker unavailable" and "Kafka not running"
3. With Docked running, start/stop the local Kafka container from the Resources view -> "Local" item and associated quickpick and expect the description to change between "Kafka not running" and the container URI

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [x] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
