### PR TITLE
hotfix: import `ConnectionType` from sidecar client code, not e2e helpers

### DIFF
--- a/tests/unit/testResources/flinkDatabaseResource.ts
+++ b/tests/unit/testResources/flinkDatabaseResource.ts
@@ -1,6 +1,6 @@
+import { ConnectionType } from "../../../src/clients/sidecar";
 import { CCLOUD_CONNECTION_ID, IconNames } from "../../../src/constants";
 import type { FlinkDatabaseResource } from "../../../src/models/flinkDatabaseResource";
-import { ConnectionType } from "../../e2e/connectionTypes";
 import {
   TEST_CCLOUD_ENVIRONMENT_ID,
   TEST_CCLOUD_PROVIDER,


### PR DESCRIPTION
They're the same enum, but the E2E one is moving in https://github.com/confluentinc/vscode/pull/3021 and showed a conflict indicating this (Mocha test helper) was importing from the wrong module.

https://github.com/confluentinc/vscode/blob/8c5d0453d01b32451646829045889dfd6f410ef1/src/clients/sidecar/models/ConnectionType.ts#L20-L24
https://github.com/confluentinc/vscode/blob/8c5d0453d01b32451646829045889dfd6f410ef1/tests/e2e/connectionTypes.ts#L1-L6
(Reminder that we can't import `src/` code into E2E test modules due to dependency issues, mainly `vscode`.)