### PR TITLE
Remove Content-Type from default request headers

### DIFF
--- a/src/sidecar/sidecarHandle.ts
+++ b/src/sidecar/sidecarHandle.ts
@@ -103,9 +103,8 @@ export class SidecarHandle {
     // used for client creation for individual service (class) methods, merged with any custom
     // config parameters provided by the caller
     this.defaultHeaders = {
-      // Expect JSON request and response bodies unless otherwise overridden (e.g. TemplatesApi).
+      // Expect JSON response bodies unless otherwise overridden (e.g. TemplatesApi).
       Accept: "application/json",
-      "Content-Type": "application/json",
       // Set the Authorization header to the current auth token.
       Authorization: `Bearer ${this.auth_secret}`,
     };


### PR DESCRIPTION
## Summary of Changes

This change removes `Content-Type:application/json` from the set of default request headers since it might cause issues when being used on a request without any payload.

Fixes #3133

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

I generated a very [minimal mock SR server](https://gist.github.com/flippingbits/ca5c766c7da1e10bf0824c114f585afa) with Copilot to click-test the request headers sent to Schema Registry endpoints. You could start it by running `python server.py` and then create a Direct Connection with the Schema Registry URI being set to `http://localhost:8080`.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
