### PR TITLE
MINOR: set CUJ-tag defaults for manual E2E task in Semaphore

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -54,6 +54,7 @@ semaphore:
         - name: TEST_SUITE
           required: false
           description: The test name or tag(s) (pipe-separated, e.g. `@ccloud|@direct`) to run. If not specified, will run all E2E tests.
+          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts"
     - name: scheduled-ccloud-auth-smoketests-prod
       branch: main
       pipeline_file: ".semaphore/ccloud-auth-smoketests.yml"


### PR DESCRIPTION
I'm tired of hunting down the pipe-delimited string every time I want to run them all or a subset
<img width="435" height="308" alt="image" src="https://github.com/user-attachments/assets/f102ed27-cb6a-401a-bb32-44ab3f532b8b" />

AFAIK there isn't a way to set them in a standalone file for `service.yml` and `playwright-e2e.yml` and `semaphore.yml` to all read from, but it's the same as what we have already:
https://github.com/confluentinc/vscode/blob/ece7fcd21f93f7f105420a8b703cdf0bb0cb5610/service.yml#L112
https://github.com/confluentinc/vscode/blob/ece7fcd21f93f7f105420a8b703cdf0bb0cb5610/.semaphore/semaphore.yml#L392