### PR TITLE
hotfix for template gen: don't automatically reassign pickedTemplate

### DIFF
--- a/src/commands/utils/scaffoldUtils.ts
+++ b/src/commands/utils/scaffoldUtils.ts
@@ -93,8 +93,9 @@ export const scaffoldProjectRequest = async (
         return tags.includes("producer") || tags.includes("consumer");
       });
     }
-
-    pickedTemplate = await pickTemplate(templateList);
+    if (!pickedTemplate) {
+      pickedTemplate = await pickTemplate(templateList);
+    }
   } catch (err) {
     logError(err, "template picking", { extra: { functionName: "scaffoldProjectRequest" } });
     const baseMessage = await parseErrorMessage(err);


### PR DESCRIPTION
## Summary of Changes

Template generation was formerly broken to due to automatically reassigning `pickedTemplate`. This change conditionally reassigns the variable and fixes the bug. 

### Click-testing instructions

1. Start the ext dev host, open a browser (Chrome, Firefox, or Safari) and drop `vscode://confluentinc.vscode-confluent/projectScaffold?collection=vscode&template=go-client&cc_bootstrap_server=localhost:9092&isFormNeeded=true` into a tab. You should see the golang client form pop up in VS Code with `localhost:9092` pre-filled.

3. Log in to CC. Clicktest the other routes:
a) from right-clicking a topic
b) from right-clicking a cluster
c) from the Help Center panel
d) from Cmd+Shift+P control panel generation command

These should all work as expected with the proper pre-filled options, and `gulp test` should pass. 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
