### PR TITLE
[v2.1.x] hotfix: focus the Flink Database view when clicking "View Artifact" after successful upload

### DIFF
--- a/src/commands/utils/uploadArtifactOrUDF.test.ts
+++ b/src/commands/utils/uploadArtifactOrUDF.test.ts
@@ -418,7 +418,7 @@ describe("commands/utils/uploadArtifact", () => {
       await uploadArtifactModule.focusArtifactsInView();
 
       sinon.assert.calledOnce(executeCommandStub);
-      sinon.assert.calledWith(executeCommandStub, "confluent.flinkdatabase.setArtifactsViewMode");
+      sinon.assert.calledWith(executeCommandStub, "confluent-flink-database.focus");
     });
   });
 });

--- a/src/commands/utils/uploadArtifactOrUDF.ts
+++ b/src/commands/utils/uploadArtifactOrUDF.ts
@@ -460,6 +460,6 @@ export function makeMenuItems(
 }
 
 export async function focusArtifactsInView(): Promise<void> {
-  // Focus on the artifacts view specifically
-  await vscode.commands.executeCommand("confluent.flinkdatabase.setArtifactsViewMode");
+  // Focus on the Flink Database view specifically
+  await vscode.commands.executeCommand("confluent-flink-database.focus");
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

...instead of trying to set the "Artifacts" view mode, which no longer exists since https://github.com/confluentinc/vscode/pull/3107 removed all of those view-mode switching things.

Note that we do not directly register any `<view id>.focus` commands, as they are built in to VS Code when the views are registered. See other uses: https://github.com/search?q=repo%3Aconfluentinc%2Fvscode+%22.focus%5C%22%22&type=code

Closes #3145 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Sign in to CCloud
2. Select a Kafka cluster as a Flink database
3. Click the cloud icon on the "Artifacts" item in the Flink Database view
4. Complete the artifact upload flow
5. Optionally collapse the Flink Database view
6. When the success notification appears, click "View Artifact"
7. Expect the Flink Database view to be open and focused

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
