### PR TITLE
[v2.1.x] update the `when` clause for artifact scaffolding to fuzzy-match the artifacts container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1976,7 +1976,7 @@
         },
         {
           "command": "confluent.artifacts.scaffold",
-          "when": "view == confluent-flink-database && viewItem == flink-database-artifacts-container",
+          "when": "view == confluent-flink-database && viewItem =~ /flink-database-artifacts-container.*/",
           "group": "inline@1"
         },
         {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

If a container in the Flink Database view fails to load its resources for any reason, its context value gets the `-error` suffix:
https://github.com/confluentinc/vscode/blob/5ca128a420fc6d17b7012bfdc6c7d3a2800c31be/src/models/flinkDatabaseResourceContainer.ts#L92-L96

That means any action `when` clauses looking for an exact container context value will not appear, so this PR uses regex matching to also include the `-error` case.

| Happy | Not-so-happy |
|--------|--------|
| <img width="386" height="183" alt="image" src="https://github.com/user-attachments/assets/a867bc4a-7fd0-4004-9f26-2ff61c17e3f2" /> | <img width="418" height="173" alt="image" src="https://github.com/user-attachments/assets/83bbf13d-7242-4173-a947-eeeaa9a18761" /> |


### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Sign in to CCloud
2. Select a Kafka cluster in a GCP region as a Flink database (since GCP isn't currently supported for Flink Artifacts)
3. Expect the Artifacts item to get the red ⚠️ icon after failing to load
4. Hover over the Artifacts item and expect the ➕ icon to still be available 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
