### PR TITLE
[v2.1.x] skip trying to fetch results for `CREATE FUNCTION` kinds of statements

### DIFF
--- a/src/loaders/ccloudResourceLoader.ts
+++ b/src/loaders/ccloudResourceLoader.ts
@@ -71,7 +71,7 @@ import {
 const logger = new Logger("storage.ccloudResourceLoader");
 
 /** Flink SQL statement kinds for which we skip fetching results */
-const SKIP_RESULTS_KINDS: string[] = ["CREATE_FUNCTION"];
+export const SKIP_RESULTS_SQL_KINDS: string[] = ["CREATE_FUNCTION"];
 
 /** Options for executing a background Flink statement. */
 export interface ExecuteBackgroundStatementOptions {
@@ -768,15 +768,14 @@ export class CCloudResourceLoader extends CachingResourceLoader<
       );
     }
 
-    if (statement.sqlKind && SKIP_RESULTS_KINDS.includes(statement.sqlKind)) {
+    let resultRows: Array<RT> = [];
+    if (statement.sqlKind && SKIP_RESULTS_SQL_KINDS.includes(statement.sqlKind)) {
       logger.debug(
         `Skipping fetching results for statement ${statement.id} of kind ${statement.sqlKind}`,
       );
-      return [];
+    } else {
+      resultRows = await parseAllFlinkStatementResults<RT>(statement);
     }
-
-    // Consume all results.
-    const resultRows: Array<RT> = await parseAllFlinkStatementResults<RT>(statement);
 
     // Delete the now completed statement. Even though is a hidden statement and won't be displayed
     // in the UI, we still want to delete it to avoid accumulating so many completed statements


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

There aren't any results from a statement that has the `sqlKind=CREATE_FUNCTION`, so there isn't any reason we need to try fetching results. (And recently, we saw some odd 403 responses from trying to do so, even when the UDF created successfully.)

Clicktesting this will be difficult now that we no longer see the 403s, but you can run this branch locally and set a breakpoint to make sure we never even call into `parseAllFlinkStatementResults()` when registering a UDF.

Closes #3147 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
