### PR TITLE
draft: handle errors upon cleaning out old logs during extension startup

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -401,7 +401,7 @@ export class Logger {
     return `[${this.name}] ${message}`;
   }
 }
-/** Utility function to return permissions for a given file path */
+/** Utility function to return permissions for a file at a given path */
 function getFilePermissions(filePath: string): {
   permissions: string;
   readable?: boolean;


### PR DESCRIPTION
## Summary of Changes

Fixes #3174 

### Click-testing instructions

   1. Create directory with write+execute but NO read permission
  `mkdir -p /tmp/test-unreadable-dir`
  `chmod 311 /tmp/test-unreadable-dir ` # Allows file creation but blocks directory listing

   2. Verify permissions
  `ls -ld /tmp/test-unreadable-dir`  # Should show: d-wx--x--x

   3. Now you're going to file.ts  in src/utils and _temporarily_ changing the "get()" function on L116 to: 
   

```
/** Return the determined writeable tmpdir. Must have awaited determineWriteableTmpDir() prior. */
 get(): string {
   return "/tmp/test-unreadable-dir";
 }
}
```
OR, for the case when it is not a permissions error, create a humongous file name that the system should not allow: 
```
/** Return the determined writeable tmpdir. Must have awaited determineWriteableTmpDir() prior. */
 get(): string {
const longDirName = "a".repeat(300);
return longDirName
 }
}
```

  4. Run the extension dev host. Since the logs are cleaned on activation, this error should pop up immediately, and also on cmd+R. Run it with the unreadable dir, the dir name that is too long, and then return the function to its normal state and confirm that no error is thrown. 


### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

-

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
