### PR TITLE
bugfix: Wrap readDirSync to handle err

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, unlinkSync } from "fs";
+import { statSync, unlinkSync } from "fs";
 import { join, normalize } from "path";
 import type { RotatingFileStream } from "rotating-file-stream";
 import { createStream } from "rotating-file-stream";
@@ -6,7 +6,7 @@ import type { Event, LogLevel, LogOutputChannel } from "vscode";
 import { Uri, window } from "vscode";
 import { SIDECAR_LOGFILE_NAME } from "./sidecar/constants";
 import { WriteableTmpDir } from "./utils/file";
-import { existsSync } from "./utils/fsWrappers";
+import { existsSync, readdirSync } from "./utils/fsWrappers";
 
 /** The base file name prefix for the log file. Helps with clean up of old log files. @see {@link cleanupOldLogFiles} */
 export const BASEFILE_PREFIX: string = "vscode-confluent";

--- a/src/utils/fsWrappers.ts
+++ b/src/utils/fsWrappers.ts
@@ -86,3 +86,16 @@ export function closeSync(fd: number): void {
 export function existsSync(uri: vscode.Uri): boolean {
   return fs.existsSync(uri.fsPath);
 }
+
+/**
+ * Wrapper for fs.readdirSync()
+ * Return the list of files in the directory, or an empty array on error.
+ */
+
+export function readdirSync(path: fs.PathLike): string[] {
+  try {
+    return fs.readdirSync(path);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary of Changes

Fixes #3174 

### Click-testing instructions

Create directory with write+execute but NO read permission
`mkdir -p /tmp/test-unreadable-dir`
`chmod 311 /tmp/test-unreadable-dir ` # Allows file creation but blocks directory listing

Verify permissions
`ls -ld /tmp/test-unreadable-dir` # Should show: d-wx--x--x

Now you're going to file.ts in src/utils and temporarily changing the "get()" function on L116 to:
```
/** Return the determined writeable tmpdir. Must have awaited determineWriteableTmpDir() prior. */
 get(): string {
   return "/tmp/test-unreadable-dir";
 }
```
Run the extension dev host. You should see no logs for this scenario. 

### Optional: Any additional details or context that should be provided?

Purpose: error cleanup in sentry 

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
