### PR TITLE
Add tests for `openSqlStatementsAsDocuments`

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -2080,8 +2080,6 @@ describe("CCloudResourceLoader", () => {
     });
 
     it("should return the workspace when fetch succeeds", async () => {
-      //  only needs the auth check to pass so the test can verify the next behavior
-      getCCloudAuthSessionStub.resolves();
       workspacesApiStub.getWsV1Workspace.resolves(mockWorkspaceResponse);
 
       const result = await loader.getFlinkWorkspace(testParams);
@@ -2131,7 +2129,6 @@ describe("CCloudResourceLoader", () => {
     });
 
     it("should return null when workspace API call fails", async () => {
-      getCCloudAuthSessionStub.resolves();
       const apiError = new Error("Workspace not found");
       workspacesApiStub.getWsV1Workspace.rejects(apiError);
 
@@ -2143,7 +2140,6 @@ describe("CCloudResourceLoader", () => {
     });
 
     it("should build queryable with correct provider/region from params", async () => {
-      getCCloudAuthSessionStub.resolves();
       workspacesApiStub.getWsV1Workspace.resolves(mockWorkspaceResponse);
 
       await loader.getFlinkWorkspace(testParams);


### PR DESCRIPTION
## Summary of Changes

Using claude to generate the unit tests for `flinkWorkspace`, but bit by bit, going in reverse order of functions called in `handleFlinkWorkspaceUriEvent` and pointing it at relevant unit tests in `flinkSql`. This way we build fixtures from the ground up and maintain some focus for self-review as well by breaking it up. 

Coverage on this branch:
```
 flinkWorkspace.ts                        |    9.09 |    
```

Coverage on main: 
```
  flinkWorkspace.ts                        |    2.59 |
```

> [!NOTE] 
> This PR also includes 2 minor cleanups from [these comments ](https://github.com/confluentinc/vscode/pull/3221#pullrequestreview-3683901799)
## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
