### PR TITLE
add a `vscode-api` Claude skill [ci skip]

### DIFF
--- a/.claude/skills/vscode-api/SKILL.md
+++ b/.claude/skills/vscode-api/SKILL.md
@@ -1,22 +1,43 @@
 ---
 name: vscode-api
-description: Use when the user asks about VS Code API definitions, methods, interfaces, events, types, or wants to understand what VS Code APIs are available. Triggers on questions like "what does vscode.X do", "how to use VS Code API", "VS Code type definition", or checking API compatibility.
+description:
+  Use when the user asks about VS Code API definitions, methods, interfaces, events, types, or wants
+  to understand what VS Code APIs are available. Triggers on questions like "what does vscode.X do",
+  "how to use VS Code API", "VS Code type definition", or checking API compatibility.
 tools: [Read, Bash, WebFetch]
 ---
 
 # VS Code API Lookup
 
-This skill helps look up VS Code API definitions from the official TypeScript declaration files.
+This skill helps look up VS Code API definitions from official TypeScript declaration files and
+documentation.
 
-## Source URLs
+## Sources
 
-The VS Code API definitions come from the official repository:
+### 1. TypeScript Definitions (vscode.d.ts)
+
+The VS Code API type definitions come from the official repository:
 
 - **Current version** (matching project's `@types/vscode`):
   `https://raw.githubusercontent.com/microsoft/vscode/{version}/src/vscode-dts/vscode.d.ts`
 
 - **Latest (main branch)**:
   `https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.d.ts`
+
+### 2. VS Code API Documentation Website
+
+The official documentation at `https://code.visualstudio.com/api` provides richer context including
+screenshots, examples, and guides. Start with overview pages and navigate to subsections as needed:
+
+| Section                | Entry Point                                      | Use For                                                      |
+| ---------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| UX Guidelines          | `/api/ux-guidelines/overview`                    | UI/UX best practices, visual patterns                        |
+| Extension Capabilities | `/api/extension-capabilities/overview`           | Common capabilities, extending workbench                     |
+| Extension Guides       | `/api/extension-guides/overview`                 | Implementation guides (tree views, webviews, commands, etc.) |
+| Language Extensions    | `/api/language-extensions/overview`              | LSP, syntax highlighting, language features                  |
+| References             | `/api/references/vscode-api`                     | API docs, contribution points, activation events             |
+| Testing & Publishing   | `/api/working-with-extensions/testing-extension` | Testing strategies, bundling                                 |
+| Advanced Topics        | `/api/advanced-topics/extension-host`            | Extension host, remote development                           |
 
 ## Process
 
@@ -30,30 +51,79 @@ grep -A1 '"@types/vscode"' package.json
 
 The version will be something like `"^1.96.0"` - extract the base version number (e.g., `1.96.0`).
 
-### 2. Fetch API Definitions
+### 2. Choose the Right Source
+
+**Use vscode.d.ts when:**
+
+- Looking up exact type signatures, interfaces, or method definitions
+- Checking API compatibility with specific VS Code versions
+- Understanding parameter types and return values
+
+**Use the documentation website when:**
+
+- Understanding UI/UX best practices and visual guidelines
+- Looking for implementation examples and patterns
+- Understanding how different APIs work together
+- Evaluating design decisions for views, notifications, or other UI elements
+- Learning about Language Server Protocol or language features
+
+**Use both when:**
+
+- Implementing a new feature that involves UI/UX decisions
+- Need both the type signature AND usage context/examples
+
+### 3. Fetch API Definitions (vscode.d.ts)
 
 Use WebFetch to retrieve the vscode.d.ts file:
 
 **For the project's current version:**
+
 ```
 https://raw.githubusercontent.com/microsoft/vscode/{version}/src/vscode-dts/vscode.d.ts
 ```
 
 **For the latest main branch:**
+
 ```
 https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.d.ts
 ```
 
-### 3. Search for Specific APIs
+### 4. Fetch Documentation Pages
+
+Start with top-level section pages and explore subsections as needed. This approach generally stays
+current as documentation evolves.
+
+**Top-level entry points:**
+
+```
+https://code.visualstudio.com/api/ux-guidelines/overview
+https://code.visualstudio.com/api/extension-capabilities/overview
+https://code.visualstudio.com/api/extension-guides/overview
+https://code.visualstudio.com/api/language-extensions/overview
+https://code.visualstudio.com/api/references/vscode-api
+https://code.visualstudio.com/api/working-with-extensions/testing-extension
+https://code.visualstudio.com/api/advanced-topics/extension-host
+```
+
+**Navigation strategy:**
+
+1. Fetch the relevant overview page first
+2. Look for links to subsections in the page content
+3. Fetch specific subsection pages based on user's question
+4. This ensures you always find current content, even for rapidly evolving sections (e.g., AI
+   extensibility)
+
+### 5. Search for Specific APIs
 
 When the user asks about a specific API (e.g., `TreeView`, `workspace.onDidChangeConfiguration`):
 
-1. Fetch the vscode.d.ts file
+1. Fetch the vscode.d.ts file for type definitions
 2. Search for the relevant interface, class, function, or type
 3. Extract the definition along with JSDoc comments for context
-4. Present the API signature and description
+4. If implementation guidance is needed, also fetch the relevant documentation page
+5. Present both the API signature and contextual documentation
 
-### 4. Compare Versions (Optional)
+### 6. Compare Versions (Optional)
 
 When the user wants to check for API changes or new features:
 
@@ -63,7 +133,9 @@ When the user wants to check for API changes or new features:
 
 ## Output Format
 
-When presenting API definitions:
+### Type Definitions Only
+
+When presenting API definitions from vscode.d.ts:
 
 ```typescript
 // From vscode.d.ts (version X.X.X)
@@ -75,6 +147,27 @@ interface/class/function ApiName {
   // ... relevant members
 }
 ```
+
+### Combined Type + Documentation
+
+When presenting both type definitions and documentation context:
+
+```
+## API: [name]
+
+### Type Definition
+[TypeScript definition from vscode.d.ts]
+
+### Documentation
+[Summary from code.visualstudio.com/api]
+
+### Key Points
+- [Important usage notes]
+- [Best practices from UX guidelines if applicable]
+- [Related APIs or patterns]
+```
+
+### Version Comparison
 
 If comparing versions, show both with a summary of changes:
 
@@ -101,7 +194,21 @@ If comparing versions, show both with a summary of changes:
 
 ## Tips
 
-- The vscode.d.ts file is large (~15,000+ lines) - always search for specific APIs rather than reading the whole file
+### vscode.d.ts
+
+- The vscode.d.ts file is large (~15,000+ lines) - always search for specific APIs rather than
+  reading the whole file
 - JSDoc comments in the file provide valuable usage guidance
 - Deprecated APIs are marked with `@deprecated` tags
 - Some APIs are proposed/experimental and may not be in stable releases
+
+### Documentation Website
+
+- Start with overview pages and navigate to subsections - avoids stale hardcoded URLs
+- UX guidelines include screenshots showing recommended patterns - reference these for UI decisions
+- Extension guides provide complete working examples, not just type signatures
+- The documentation site is updated with each VS Code release and may include features not yet in
+  stable
+- When in doubt about "how" to implement something (not just "what" the API is), check the guides
+- Some sections evolve rapidly (e.g., AI extensibility) - always fetch current content rather than
+  assuming structure


### PR DESCRIPTION
The default Copilot chat experience in VS Code has a [`#vscodeAPI`](https://code.visualstudio.com/docs/copilot/reference/copilot-vscode-features#:~:text=Go%20to%20Definition%22.-,%23VSCodeAPI,-Ask%20about%20VS) tool to include context about the extension API -- (and possibly more baked-in context? needs confirmation) -- which is slightly lacking from the Claude Code perspective (aside from whatever training data is baked in). This PR adds a new project-level `/vscode-api` skill to point Claude at the `vscode.d.ts` file associated with the version we use for development: https://github.com/confluentinc/vscode/blob/48c3dbaf37ecc832c7879dd87e6d2d8825fe6a01/package.json#L2612
https://github.com/microsoft/vscode/blob/1.96.0/src/vscode-dts/vscode.d.ts

### `vscode-api` tool in action

<img width="985" height="469" alt="image" src="https://github.com/user-attachments/assets/3be75075-7203-478a-9e31-23ae7bb21cfc" />
<img width="889" height="646" alt="image" src="https://github.com/user-attachments/assets/d34fc1c8-75a5-428b-b4db-86b131924945" />

> [!NOTE]
> Compared to `main` with a similar prompt, it still gave an evaluation based on the `TextDocumentProvider` interface, but when asked about how it looked up the information:
> <img width="1013" height="388" alt="image" src="https://github.com/user-attachments/assets/0651dddd-a3cf-4cfd-9f6f-e417b187466b" />

We're also adding some reference links to the main sections of the official VS Code [API documentation](https://code.visualstudio.com/api) to avoid generic web searching, but since [some sections](https://code.visualstudio.com/api/extension-guides/ai/ai-extensibility-overview) of the documentation are more rapidly evolving/changing, Claude will likely need to do a little of its own navigation depending on the current focus.