### PR TITLE
[security] update `undici`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -667,11 +667,17 @@
       }
     },
     "node_modules/@confluentinc/kafka-javascript": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@confluentinc/kafka-javascript/-/kafka-javascript-1.6.0.tgz",
-      "integrity": "sha512-MEdf2+PqAcqB6WegmzZnu56DFdGWmTzGk3soCavYf2nN2D5vpDkGCjfbfMbOBjtWHr35Q/QtFDOd0GHGGNdatQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@confluentinc/kafka-javascript/-/kafka-javascript-1.8.0.tgz",
+      "integrity": "sha512-VNrfUkLmnTYklLsjgrq1xDq6e6DU/oSGTkfSDeA5TnkTN8PC9dyWhn/8VLQ6ywsV5i1FwQfqs6Y021Fi6NDKKw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "schemaregistry",
+        "schemaregistry-examples"
+      ],
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "bindings": "^1.3.1",
@@ -7168,10 +7174,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -14544,9 +14551,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
Closes https://github.com/confluentinc/vscode/security/dependabot/49.

Remaining dependabot alerts require upstream releases that don't pin `node-tar@^6.x`