### PR TITLE
Test `extractWorkspaceParamsFromUri`

### DIFF
--- a/src/flinkSql/flinkWorkspace.test.ts
+++ b/src/flinkSql/flinkWorkspace.test.ts
@@ -864,6 +864,7 @@ describe("flinkSql/flinkWorkspace.ts", function () {
         workspaceName: "my workspace with spaces",
       });
       // createUri encodes the parameters, so we verify that here
+      // might need to expand the function for + vs %20 checks
       assert.ok(uri.query.includes("my+workspace+with+spaces"), uri.query);
 
       const result = extractWorkspaceParamsFromUri(uri);


### PR DESCRIPTION
## Summary of Changes

Testing `extractWorkspaceParamsFromUri`. 

Coverage of this file now:
 
<img width="502" height="22" alt="Screenshot 2026-01-27 at 8 16 59 AM" src="https://github.com/user-attachments/assets/982e2553-804c-437d-82e4-083c8b4487bc" />

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
