### PR TITLE
add `pr-review` claude skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -4,7 +4,7 @@ description:
   Reviews pull requests for this VS Code extension. Use when reviewing PRs, doing self-review before
   sharing with the team, or when user mentions "review PR", "review changes", "self-review", or
   "check my PR". Focuses on project-specific patterns and critical requirements.
-tools: [Read, Bash, Grep, Glob, Task]
+allowed-tools: Read, Bash, Grep, Glob, Task
 ---
 
 # PR Review Skill

--- a/.claude/skills/vscode-api/SKILL.md
+++ b/.claude/skills/vscode-api/SKILL.md
@@ -4,7 +4,7 @@ description:
   Use when the user asks about VS Code API definitions, methods, interfaces, events, types, or wants
   to understand what VS Code APIs are available. Triggers on questions like "what does vscode.X do",
   "how to use VS Code API", "VS Code type definition", or checking API compatibility.
-tools: [Read, Bash, WebFetch]
+allowed-tools: Read, Bash, WebFetch, WebSearch
 ---
 
 # VS Code API Lookup


### PR DESCRIPTION
Original context pulled from [`copilot-instructions.md`](https://github.com/confluentinc/vscode/blob/main/.github/copilot-instructions.md#code-review-guidelines-github-pr-reviews), but should help with two use cases (thanks @flippingbits!):
- extra project-level context for PR reviewers
- self-review for PR authors

Also includes a slight adjustment to the `vscode-api` skill frontmatter to follow https://code.claude.com/docs/en/skills#frontmatter-reference