### PR TITLE
[security] update @isaacs/brace-expansion to v5.0.1 and hono to v4.11.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1504,10 +1504,11 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
       },
@@ -8940,9 +8941,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.8.tgz",
+      "integrity": "sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Closes https://github.com/confluentinc/vscode/security/dependabot/56, https://github.com/confluentinc/vscode/security/dependabot/57, and https://github.com/confluentinc/vscode/security/dependabot/58