### PR TITLE
show consumer groups in Topics view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this extension will be documented in this file.
 
 ### Added
 
+- Consumer groups and their members are now visible in the Topics view under a collapsible "Consumer
+  Groups" container
 - Direct connections form now supports OAuth authentication for WarpStream connections.
 - 'Copy Name' context action enabled for Flink tables, views, their column members, and nested ROW
   fields.

--- a/package.json
+++ b/package.json
@@ -1866,11 +1866,6 @@
           "group": "navigation@1"
         },
         {
-          "command": "confluent.topics.create",
-          "when": "view == confluent-topics && confluent.kafkaClusterSelected",
-          "group": "navigation@2"
-        },
-        {
           "command": "confluent.topics.kafka-cluster.select",
           "when": "view == confluent-topics && (confluent.ccloudConnectionAvailable || confluent.localKafkaClusterAvailable || confluent.directKafkaClusterAvailable)",
           "group": "navigation@3"
@@ -2031,6 +2026,11 @@
           "command": "confluent.connections.ccloud.signOut",
           "when": "viewItem == resources-ccloud-container-connected",
           "group": "inline@2"
+        },
+        {
+          "command": "confluent.topics.create",
+          "when": "view == confluent-topics && viewItem == topics-container",
+          "group": "inline@1"
         },
         {
           "command": "confluent.flinkdatabase.createRelation",

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -163,8 +163,6 @@ export type TopicChangeEvent = {
   change: EventChangeType;
   cluster: KafkaCluster;
 };
+
 /** Fires when a topic has been created or deleted in a Kafka cluster. */
 export const topicChanged = new vscode.EventEmitter<TopicChangeEvent>();
-
-/** Fires when consumer groups for a Kafka cluster have changed (removed or updated, direct addition not supported). */
-export const consumerGroupsChanged = new vscode.EventEmitter<KafkaCluster>();

--- a/src/emitters.ts
+++ b/src/emitters.ts
@@ -163,6 +163,8 @@ export type TopicChangeEvent = {
   change: EventChangeType;
   cluster: KafkaCluster;
 };
-
 /** Fires when a topic has been created or deleted in a Kafka cluster. */
 export const topicChanged = new vscode.EventEmitter<TopicChangeEvent>();
+
+/** Fires when consumer groups for a Kafka cluster have changed (removed or updated, direct addition not supported). */
+export const consumerGroupsChanged = new vscode.EventEmitter<KafkaCluster>();

--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -15,6 +15,7 @@ import {
   fetchConsumerGroupMembers,
   fetchConsumerGroups,
   fetchTopics,
+  parseCoordinatorId,
 } from "./utils/loaderUtils";
 
 const logger = new Logger("cachingResourceLoader");
@@ -287,7 +288,6 @@ export abstract class CachingResourceLoader<
     // Convert API response to ConsumerGroup models, fetching members for each group.
     const consumerGroups: ConsumerGroup[] = await Promise.all(
       responseConsumerGroups.map(async (data) => {
-        // Fetch members for this consumer group
         const memberData = await fetchConsumerGroupMembers(cluster, data.consumer_group_id);
         const members: Consumer[] = memberData.map(
           (m) =>
@@ -312,7 +312,7 @@ export abstract class CachingResourceLoader<
           state: data.state as ConsumerGroupState,
           isSimple: data.is_simple,
           partitionAssignor: data.partition_assignor,
-          coordinatorId: data.coordinator?.related ? parseInt(data.coordinator.related, 10) : null,
+          coordinatorId: parseCoordinatorId(data.coordinator?.related),
           members,
         });
       }),

--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -1,6 +1,7 @@
 import type { ConsumerGroupData, TopicData } from "../clients/kafkaRest";
 import { Logger } from "../logging";
-import { Consumer, ConsumerGroup, parseConsumerGroupState } from "../models/consumerGroup";
+import type { ConsumerGroupState } from "../models/consumerGroup";
+import { Consumer, ConsumerGroup } from "../models/consumerGroup";
 import type { Environment, EnvironmentType } from "../models/environment";
 import type { KafkaCluster, KafkaClusterType } from "../models/kafkaCluster";
 import type { EnvironmentId } from "../models/resource";
@@ -308,7 +309,7 @@ export abstract class CachingResourceLoader<
           environmentId: cluster.environmentId,
           clusterId: cluster.id,
           consumerGroupId: data.consumer_group_id,
-          state: parseConsumerGroupState(data.state),
+          state: data.state as ConsumerGroupState,
           isSimple: data.is_simple,
           partitionAssignor: data.partition_assignor,
           coordinatorId: data.coordinator?.related ? parseInt(data.coordinator.related, 10) : null,

--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -1,5 +1,6 @@
-import type { TopicData } from "../clients/kafkaRest";
+import type { ConsumerGroupData, TopicData } from "../clients/kafkaRest";
 import { Logger } from "../logging";
+import { Consumer, ConsumerGroup, parseConsumerGroupState } from "../models/consumerGroup";
 import type { Environment, EnvironmentType } from "../models/environment";
 import type { KafkaCluster, KafkaClusterType } from "../models/kafkaCluster";
 import type { EnvironmentId } from "../models/resource";
@@ -8,7 +9,12 @@ import type { SchemaRegistry, SchemaRegistryType } from "../models/schemaRegistr
 import type { KafkaTopic } from "../models/topic";
 import { getResourceManager } from "../storage/resourceManager";
 import { ResourceLoader } from "./resourceLoader";
-import { correlateTopicsWithSchemaSubjects, fetchTopics } from "./utils/loaderUtils";
+import {
+  correlateTopicsWithSchemaSubjects,
+  fetchConsumerGroupMembers,
+  fetchConsumerGroups,
+  fetchTopics,
+} from "./utils/loaderUtils";
 
 const logger = new Logger("cachingResourceLoader");
 
@@ -245,5 +251,75 @@ export abstract class CachingResourceLoader<
     await resourceManager.setTopicsForCluster(cluster, topics);
 
     return topics;
+  }
+
+  /**
+   * Return the consumer groups for a given Kafka cluster.
+   *
+   * Caches the consumer groups for the cluster in the resource manager.
+   */
+  public async getConsumerGroupsForCluster(
+    cluster: KCT,
+    forceDeepRefresh: boolean = false,
+  ): Promise<ConsumerGroup[]> {
+    if (cluster.connectionId !== this.connectionId) {
+      throw new Error(
+        `Mismatched connectionId ${this.connectionId} for cluster ${JSON.stringify(cluster, null, 2)}`,
+      );
+    }
+
+    await this.ensureCoarseResourcesLoaded(forceDeepRefresh);
+
+    const resourceManager = getResourceManager();
+    const cachedConsumerGroups = await resourceManager.getConsumerGroupsForCluster(cluster);
+    if (cachedConsumerGroups !== undefined && !forceDeepRefresh) {
+      // Cache hit.
+      logger.debug(
+        `Returning ${cachedConsumerGroups.length} cached consumer groups for cluster ${cluster.id}`,
+      );
+      return cachedConsumerGroups;
+    }
+
+    // Deep fetch consumer groups from the API.
+    const responseConsumerGroups: ConsumerGroupData[] = await fetchConsumerGroups(cluster);
+
+    // Convert API response to ConsumerGroup models, fetching members for each group.
+    const consumerGroups: ConsumerGroup[] = await Promise.all(
+      responseConsumerGroups.map(async (data) => {
+        // Fetch members for this consumer group
+        const memberData = await fetchConsumerGroupMembers(cluster, data.consumer_group_id);
+        const members: Consumer[] = memberData.map(
+          (m) =>
+            new Consumer({
+              connectionId: cluster.connectionId,
+              connectionType: cluster.connectionType,
+              environmentId: cluster.environmentId,
+              clusterId: cluster.id,
+              consumerGroupId: data.consumer_group_id,
+              consumerId: m.consumer_id,
+              clientId: m.client_id,
+              instanceId: m.instance_id ?? null,
+            }),
+        );
+
+        return new ConsumerGroup({
+          connectionId: cluster.connectionId,
+          connectionType: cluster.connectionType,
+          environmentId: cluster.environmentId,
+          clusterId: cluster.id,
+          consumerGroupId: data.consumer_group_id,
+          state: parseConsumerGroupState(data.state),
+          isSimple: data.is_simple,
+          partitionAssignor: data.partition_assignor,
+          coordinatorId: data.coordinator?.related ? parseInt(data.coordinator.related, 10) : null,
+          members,
+        });
+      }),
+    );
+
+    // Cache the consumer groups for this cluster.
+    await resourceManager.setConsumerGroupsForCluster(cluster, consumerGroups);
+
+    return consumerGroups;
   }
 }

--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -1,6 +1,5 @@
 import type { ConsumerGroupData, TopicData } from "../clients/kafkaRest";
 import { Logger } from "../logging";
-import type { ConsumerGroupState } from "../models/consumerGroup";
 import { Consumer, ConsumerGroup } from "../models/consumerGroup";
 import type { Environment, EnvironmentType } from "../models/environment";
 import type { KafkaCluster, KafkaClusterType } from "../models/kafkaCluster";
@@ -17,6 +16,7 @@ import {
   fetchConsumerGroups,
   fetchTopics,
   parseCoordinatorId,
+  toConsumerGroupState,
 } from "./utils/loaderUtils";
 
 const logger = new Logger("cachingResourceLoader");
@@ -318,7 +318,7 @@ export abstract class CachingResourceLoader<
         environmentId: cluster.environmentId,
         clusterId: cluster.id,
         consumerGroupId: data.consumer_group_id,
-        state: data.state as ConsumerGroupState,
+        state: toConsumerGroupState(data.state),
         isSimple: data.is_simple,
         partitionAssignor: data.partition_assignor,
         coordinatorId: parseCoordinatorId(data.coordinator?.related),

--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -1,5 +1,4 @@
 import type { ConsumerGroupData, TopicData } from "../clients/kafkaRest";
-import { logError } from "../errors";
 import { Logger } from "../logging";
 import type { ConsumerGroupState } from "../models/consumerGroup";
 import { Consumer, ConsumerGroup } from "../models/consumerGroup";
@@ -10,6 +9,7 @@ import type { Subject } from "../models/schema";
 import type { SchemaRegistry, SchemaRegistryType } from "../models/schemaRegistry";
 import type { KafkaTopic } from "../models/topic";
 import { getResourceManager } from "../storage/resourceManager";
+import { executeInWorkerPool } from "../utils/workerPool";
 import { ResourceLoader } from "./resourceLoader";
 import {
   correlateTopicsWithSchemaSubjects,
@@ -286,43 +286,45 @@ export abstract class CachingResourceLoader<
     // Deep fetch consumer groups from the API.
     const responseConsumerGroups: ConsumerGroupData[] = await fetchConsumerGroups(cluster);
 
-    // Convert API response to ConsumerGroup models, fetching members for each group.
-    const consumerGroups: ConsumerGroup[] = await Promise.all(
-      responseConsumerGroups.map(async (data) => {
-        let members: Consumer[] = [];
-        try {
-          const memberData = await fetchConsumerGroupMembers(cluster, data.consumer_group_id);
-          members = memberData.map(
-            (m) =>
-              new Consumer({
-                connectionId: cluster.connectionId,
-                connectionType: cluster.connectionType,
-                environmentId: cluster.environmentId,
-                clusterId: cluster.id,
-                consumerGroupId: data.consumer_group_id,
-                consumerId: m.consumer_id,
-                clientId: m.client_id,
-                instanceId: m.instance_id ?? null,
-              }),
-          );
-        } catch (error) {
-          logError(error, `fetching members for consumer group ${data.consumer_group_id}`);
-        }
-
-        return new ConsumerGroup({
-          connectionId: cluster.connectionId,
-          connectionType: cluster.connectionType,
-          environmentId: cluster.environmentId,
-          clusterId: cluster.id,
-          consumerGroupId: data.consumer_group_id,
-          state: data.state as ConsumerGroupState,
-          isSimple: data.is_simple,
-          partitionAssignor: data.partition_assignor,
-          coordinatorId: parseCoordinatorId(data.coordinator?.related),
-          members,
-        });
-      }),
+    // Fetch members for each group with bounded concurrency to avoid overwhelming
+    // the sidecar/Kafka REST API on clusters with many consumer groups.
+    const memberResults = await executeInWorkerPool(
+      (data: ConsumerGroupData) => fetchConsumerGroupMembers(cluster, data.consumer_group_id),
+      responseConsumerGroups,
+      { maxWorkers: 5, taskName: "fetchConsumerGroupMembers" },
     );
+
+    // Convert API responses to ConsumerGroup models.
+    const consumerGroups: ConsumerGroup[] = responseConsumerGroups.map((data, index) => {
+      const memberResult = memberResults[index];
+      const members: Consumer[] =
+        memberResult?.result?.map(
+          (m) =>
+            new Consumer({
+              connectionId: cluster.connectionId,
+              connectionType: cluster.connectionType,
+              environmentId: cluster.environmentId,
+              clusterId: cluster.id,
+              consumerGroupId: data.consumer_group_id,
+              consumerId: m.consumer_id,
+              clientId: m.client_id,
+              instanceId: m.instance_id ?? null,
+            }),
+        ) ?? [];
+
+      return new ConsumerGroup({
+        connectionId: cluster.connectionId,
+        connectionType: cluster.connectionType,
+        environmentId: cluster.environmentId,
+        clusterId: cluster.id,
+        consumerGroupId: data.consumer_group_id,
+        state: data.state as ConsumerGroupState,
+        isSimple: data.is_simple,
+        partitionAssignor: data.partition_assignor,
+        coordinatorId: parseCoordinatorId(data.coordinator?.related),
+        members,
+      });
+    });
 
     // Cache the consumer groups for this cluster.
     await resourceManager.setConsumerGroupsForCluster(cluster, consumerGroups);

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import * as sinon from "sinon";
+import { getStubbedResourceManager } from "../../tests/stubs/extensionStorage";
 import { getStubbedLocalResourceLoader } from "../../tests/stubs/resourceLoaders";
 import { getSidecarStub } from "../../tests/stubs/sidecar";
 import {
@@ -17,16 +18,17 @@ import {
   TEST_LOCAL_SUBJECT_WITH_SCHEMAS,
 } from "../../tests/unit/testResources";
 import { createTestSubject, createTestTopicData } from "../../tests/unit/testUtils";
-import type { TopicData } from "../clients/kafkaRest";
+import type { ConsumerData, ConsumerGroupData, TopicData } from "../clients/kafkaRest";
 import { SubjectsV1Api } from "../clients/schemaRegistryRest";
 import { CCLOUD_CONNECTION_ID, LOCAL_CONNECTION_ID } from "../constants";
 import * as errors from "../errors";
+import { Consumer, ConsumerGroup, ConsumerGroupState } from "../models/consumerGroup";
 import type { ConnectionId } from "../models/resource";
 import type { Subject } from "../models/schema";
 import { Schema } from "../models/schema";
 import * as notifications from "../notifications";
 import type { SidecarHandle } from "../sidecar";
-import { getResourceManager } from "../storage/resourceManager";
+import { getResourceManager, type ResourceManager } from "../storage/resourceManager";
 import { clearWorkspaceState } from "../storage/utils";
 import { CCloudResourceLoader } from "./ccloudResourceLoader";
 import { DirectResourceLoader } from "./directResourceLoader";
@@ -466,6 +468,130 @@ describe("ResourceLoader::getTopicsForCluster()", () => {
     assert.ok(!topics[0].hasSchema);
 
     sinon.assert.calledOnce(showWarningNotificationWithButtonsStub);
+  });
+});
+
+describe("ResourceLoader::getConsumerGroupsForCluster()", () => {
+  let loaderInstance: LocalResourceLoader;
+  let sandbox: sinon.SinonSandbox;
+  let fetchConsumerGroupsStub: sinon.SinonStub;
+  let fetchConsumerGroupMembersStub: sinon.SinonStub;
+  let rmStub: sinon.SinonStubbedInstance<ResourceManager>;
+
+  // minimal ConsumerGroupData fixture matching the API response shape
+  const testConsumerGroupData: ConsumerGroupData = {
+    kind: "KafkaConsumerGroup",
+    metadata: { self: "", resource_name: "" },
+    cluster_id: TEST_LOCAL_KAFKA_CLUSTER.id,
+    consumer_group_id: "test-group-1",
+    is_simple: false,
+    partition_assignor: "range",
+    state: "STABLE",
+    coordinator: {
+      related: `http://localhost/kafka/v3/clusters/${TEST_LOCAL_KAFKA_CLUSTER.id}/brokers/0`,
+    },
+    lag_summary: { related: "" },
+  };
+
+  const testConsumerData: ConsumerData = {
+    kind: "KafkaConsumer",
+    metadata: { self: "", resource_name: "" },
+    cluster_id: TEST_LOCAL_KAFKA_CLUSTER.id,
+    consumer_group_id: "test-group-1",
+    consumer_id: "consumer-1",
+    client_id: "client-1",
+    assignments: { related: "" },
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    fetchConsumerGroupsStub = sandbox.stub(loaderUtils, "fetchConsumerGroups");
+    fetchConsumerGroupMembersStub = sandbox.stub(loaderUtils, "fetchConsumerGroupMembers");
+    loaderInstance = LocalResourceLoader.getInstance();
+    // bracket notation to stub protected method (same pattern as ccloudResourceLoader.test.ts)
+    loaderInstance["ensureCoarseResourcesLoaded"] = sandbox.stub().resolves();
+
+    rmStub = getStubbedResourceManager(sandbox);
+    rmStub.getConsumerGroupsForCluster.resolves(undefined);
+    rmStub.setConsumerGroupsForCluster.resolves();
+  });
+
+  afterEach(async () => {
+    await clearWorkspaceState();
+    sandbox.restore();
+  });
+
+  it("raises error for mismatched connectionId", async () => {
+    await assert.rejects(
+      loaderInstance.getConsumerGroupsForCluster(TEST_CCLOUD_KAFKA_CLUSTER),
+      (err) => {
+        return (err as Error).message.startsWith("Mismatched connectionId");
+      },
+    );
+  });
+
+  it("returns cached data if available", async () => {
+    const cachedGroups = [
+      new ConsumerGroup({
+        connectionId: TEST_LOCAL_KAFKA_CLUSTER.connectionId,
+        connectionType: TEST_LOCAL_KAFKA_CLUSTER.connectionType,
+        environmentId: TEST_LOCAL_KAFKA_CLUSTER.environmentId,
+        clusterId: TEST_LOCAL_KAFKA_CLUSTER.id,
+        consumerGroupId: "cached-group",
+        state: ConsumerGroupState.Stable,
+        isSimple: false,
+        partitionAssignor: "range",
+        coordinatorId: 0,
+        members: [],
+      }),
+    ];
+    rmStub.getConsumerGroupsForCluster.resolves(cachedGroups);
+
+    const groups = await loaderInstance.getConsumerGroupsForCluster(TEST_LOCAL_KAFKA_CLUSTER);
+
+    assert.deepStrictEqual(groups, cachedGroups);
+    sinon.assert.notCalled(fetchConsumerGroupsStub);
+    sinon.assert.calledOnce(rmStub.getConsumerGroupsForCluster);
+  });
+
+  it("fetches consumer groups and members from the API on cache miss", async () => {
+    fetchConsumerGroupsStub.resolves([testConsumerGroupData]);
+    fetchConsumerGroupMembersStub.resolves([testConsumerData]);
+
+    const groups = await loaderInstance.getConsumerGroupsForCluster(TEST_LOCAL_KAFKA_CLUSTER);
+
+    assert.strictEqual(groups.length, 1);
+    assert.ok(groups[0] instanceof ConsumerGroup);
+    assert.strictEqual(groups[0].consumerGroupId, "test-group-1");
+    assert.strictEqual(groups[0].members.length, 1);
+    assert.ok(groups[0].members[0] instanceof Consumer);
+    assert.strictEqual(groups[0].members[0].consumerId, "consumer-1");
+    sinon.assert.calledOnce(fetchConsumerGroupsStub);
+    sinon.assert.calledOnce(fetchConsumerGroupMembersStub);
+  });
+
+  it("returns group with empty members when member fetch fails", async () => {
+    fetchConsumerGroupsStub.resolves([testConsumerGroupData]);
+    fetchConsumerGroupMembersStub.rejects(new Error("member fetch failed"));
+
+    const groups = await loaderInstance.getConsumerGroupsForCluster(TEST_LOCAL_KAFKA_CLUSTER);
+
+    assert.strictEqual(groups.length, 1);
+    assert.strictEqual(groups[0].members.length, 0);
+  });
+
+  it("bypasses cache when forceDeepRefresh is true", async () => {
+    // even though cache returns data, forceDeepRefresh should re-fetch
+    rmStub.getConsumerGroupsForCluster.resolves([]);
+
+    fetchConsumerGroupsStub.resolves([testConsumerGroupData]);
+    fetchConsumerGroupMembersStub.resolves([]);
+
+    const groups = await loaderInstance.getConsumerGroupsForCluster(TEST_LOCAL_KAFKA_CLUSTER, true);
+
+    assert.strictEqual(groups.length, 1);
+    sinon.assert.calledOnce(fetchConsumerGroupsStub);
   });
 });
 

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -11,6 +11,7 @@ import type { ConnectionId, EnvironmentId, IResourceBase } from "../models/resou
 import type { Schema } from "../models/schema";
 import { Subject, subjectMatchesTopicName } from "../models/schema";
 import type { SchemaRegistry } from "../models/schemaRegistry";
+import type { ConsumerGroup } from "../models/consumerGroup";
 import type { KafkaTopic } from "../models/topic";
 import { showWarningNotificationWithButtons } from "../notifications";
 import { getSidecar } from "../sidecar";
@@ -132,6 +133,17 @@ export abstract class ResourceLoader extends DisposableCollection implements IRe
     cluster: KafkaCluster,
     forceRefresh?: boolean,
   ): Promise<KafkaTopic[]>;
+
+  /**
+   * Return the consumer groups for a given Kafka cluster.
+   * @param cluster The Kafka cluster to fetch consumer groups for.
+   * @param forceRefresh If true, will ignore any cached consumer groups and fetch anew.
+   * @returns An array of consumer groups for the cluster.
+   */
+  public abstract getConsumerGroupsForCluster(
+    cluster: KafkaCluster,
+    forceRefresh?: boolean,
+  ): Promise<ConsumerGroup[]>;
 
   // Schema registry methods.
 

--- a/src/loaders/utils/loaderUtils.test.ts
+++ b/src/loaders/utils/loaderUtils.test.ts
@@ -399,6 +399,14 @@ describe("loaderUtils.ts", () => {
 
       assert.strictEqual(result.length, 0);
     });
+
+    it("should propagate API errors from listKafkaConsumerGroups", async () => {
+      stubbedClient.listKafkaConsumerGroups.rejects(new Error("Connection refused"));
+
+      await assert.rejects(loaderUtils.fetchConsumerGroups(TEST_LOCAL_KAFKA_CLUSTER), {
+        message: "Connection refused",
+      });
+    });
   });
 
   describe("fetchConsumerGroupMembers()", () => {
@@ -474,6 +482,15 @@ describe("loaderUtils.ts", () => {
         cluster_id: TEST_LOCAL_KAFKA_CLUSTER.id,
         consumer_group_id: testGroupId,
       });
+    });
+
+    it("should propagate API errors from listKafkaConsumers", async () => {
+      stubbedClient.listKafkaConsumers.rejects(new Error("Connection refused"));
+
+      await assert.rejects(
+        loaderUtils.fetchConsumerGroupMembers(TEST_LOCAL_KAFKA_CLUSTER, testGroupId),
+        { message: "Connection refused" },
+      );
     });
   });
 

--- a/src/loaders/utils/loaderUtils.test.ts
+++ b/src/loaders/utils/loaderUtils.test.ts
@@ -477,6 +477,40 @@ describe("loaderUtils.ts", () => {
     });
   });
 
+  describe("parseCoordinatorId()", () => {
+    it("should parse broker ID from a full Kafka REST URL", () => {
+      const url = "http://localhost:26636/kafka/v3/clusters/lkc-abc123/brokers/2";
+      assert.strictEqual(loaderUtils.parseCoordinatorId(url), 2);
+    });
+
+    it("should parse broker ID from a CCloud-style URL", () => {
+      const url =
+        "https://pkc-abc123.us-east-1.aws.confluent.cloud/kafka/v3/clusters/lkc-5vmjd8/brokers/0";
+      assert.strictEqual(loaderUtils.parseCoordinatorId(url), 0);
+    });
+
+    it("should parse a plain numeric string", () => {
+      assert.strictEqual(loaderUtils.parseCoordinatorId("7"), 7);
+    });
+
+    it("should return null for undefined", () => {
+      assert.strictEqual(loaderUtils.parseCoordinatorId(undefined), null);
+    });
+
+    it("should return null for empty string", () => {
+      assert.strictEqual(loaderUtils.parseCoordinatorId(""), null);
+    });
+
+    it("should return null when the last segment is non-numeric", () => {
+      assert.strictEqual(
+        loaderUtils.parseCoordinatorId(
+          "http://localhost/kafka/v3/clusters/lkc-abc123/brokers/notanumber",
+        ),
+        null,
+      );
+    });
+  });
+
   describe("generateFlinkStatementKey()", () => {
     const mainStatementParams: IFlinkStatementSubmitParameters = {
       statement: "SHOW USER FUNCTIONS",

--- a/src/loaders/utils/loaderUtils.test.ts
+++ b/src/loaders/utils/loaderUtils.test.ts
@@ -25,6 +25,7 @@ import type {
 } from "../../clients/schemaRegistryRest";
 import { SubjectsV1Api } from "../../clients/schemaRegistryRest";
 import type { IFlinkStatementSubmitParameters } from "../../flinkSql/statementUtils";
+import { ConsumerGroupState } from "../../models/consumerGroup";
 import type { Schema } from "../../models/schema";
 import { SchemaType, Subject } from "../../models/schema";
 import type * as sidecar from "../../sidecar";
@@ -492,6 +493,32 @@ describe("loaderUtils.ts", () => {
         { message: "Connection refused" },
       );
     });
+  });
+
+  describe("toConsumerGroupState()", () => {
+    it("should return the matching enum value for each valid state", () => {
+      for (const state of Object.values(ConsumerGroupState)) {
+        assert.strictEqual(loaderUtils.toConsumerGroupState(state), state);
+      }
+    });
+
+    it("should match case-insensitively", () => {
+      assert.strictEqual(loaderUtils.toConsumerGroupState("stable"), ConsumerGroupState.Stable);
+      assert.strictEqual(loaderUtils.toConsumerGroupState("Stable"), ConsumerGroupState.Stable);
+      assert.strictEqual(loaderUtils.toConsumerGroupState("dead"), ConsumerGroupState.Dead);
+    });
+
+    const unknownInputs: [string, string | undefined][] = [
+      ["an unrecognized state string", "SOME_NEW_STATE"],
+      ["undefined", undefined],
+      ["an empty string", ""],
+    ];
+
+    for (const [label, input] of unknownInputs) {
+      it(`should return Unknown for ${label}`, () => {
+        assert.strictEqual(loaderUtils.toConsumerGroupState(input), ConsumerGroupState.Unknown);
+      });
+    }
   });
 
   describe("parseCoordinatorId()", () => {

--- a/src/loaders/utils/loaderUtils.ts
+++ b/src/loaders/utils/loaderUtils.ts
@@ -315,3 +315,13 @@ export function generateFlinkStatementKey(params: IFlinkStatementSubmitParameter
   hasher.update(params.statement);
   return hasher.digest("hex");
 }
+
+/** Parse a broker ID from a Kafka REST API relationship URL, returning null if non-numeric.
+ *  e.g. "http://localhost:26636/kafka/v3/clusters/lkc-abc123/brokers/1" → 1 */
+export function parseCoordinatorId(related: string | undefined): number | null {
+  if (!related) return null;
+  const lastSegment = related.split("/").pop();
+  if (!lastSegment) return null;
+  const parsed = parseInt(lastSegment, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}

--- a/src/loaders/utils/loaderUtils.ts
+++ b/src/loaders/utils/loaderUtils.ts
@@ -14,6 +14,7 @@ import type { Schema as ResponseSchema, SubjectsV1Api } from "../../clients/sche
 import { isResponseError } from "../../errors";
 import type { IFlinkStatementSubmitParameters } from "../../flinkSql/statementUtils";
 import { Logger } from "../../logging";
+import { ConsumerGroupState } from "../../models/consumerGroup";
 import type { CCloudKafkaCluster, KafkaCluster } from "../../models/kafkaCluster";
 import { isCCloud } from "../../models/resource";
 import { Schema, SchemaType, Subject, subjectMatchesTopicName } from "../../models/schema";
@@ -314,6 +315,17 @@ export function generateFlinkStatementKey(params: IFlinkStatementSubmitParameter
   hasher.update(params.properties.currentCatalog || ""); // catalog may be empty
   hasher.update(params.statement);
   return hasher.digest("hex");
+}
+
+/** Validate an API state string against the {@link ConsumerGroupState} enum, falling back to `Unknown`. */
+export function toConsumerGroupState(value: string | undefined): ConsumerGroupState {
+  if (!value) {
+    return ConsumerGroupState.Unknown;
+  }
+  // CCLOUD returns uppercase, LOCAL/DIRECT return title case
+  const normalized = value.toUpperCase();
+  const match = Object.values(ConsumerGroupState).find((s) => s === normalized);
+  return match ?? ConsumerGroupState.Unknown;
 }
 
 /** Parse a broker ID from a Kafka REST API relationship URL, returning null if non-numeric.

--- a/src/loaders/utils/loaderUtils.ts
+++ b/src/loaders/utils/loaderUtils.ts
@@ -334,6 +334,6 @@ export function parseCoordinatorId(related: string | undefined): number | null {
   if (!related) return null;
   const lastSegment = related.split("/").pop();
   if (!lastSegment) return null;
-  const parsed = parseInt(lastSegment, 10);
+  const parsed = Number.parseInt(lastSegment, 10);
   return Number.isNaN(parsed) ? null : parsed;
 }

--- a/src/models/consumerGroup.ts
+++ b/src/models/consumerGroup.ts
@@ -185,6 +185,10 @@ export class ConsumerGroupTreeItem extends vscode.TreeItem {
     );
 
     this.tooltip = createConsumerGroupTooltip(resource);
+
+    this.accessibilityInformation = {
+      label: `Consumer Group: ${resource.consumerGroupId}`,
+    };
   }
 }
 
@@ -239,6 +243,10 @@ export class ConsumerTreeItem extends vscode.TreeItem {
 
     this.iconPath = new vscode.ThemeIcon(resource.iconName);
     this.tooltip = createConsumerTooltip(resource);
+
+    this.accessibilityInformation = {
+      label: `Consumer: ${resource.consumerId}`,
+    };
   }
 }
 

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -282,6 +282,10 @@ export class SubjectTreeItem extends vscode.TreeItem {
     }
     propertyParts.push("schema-subject");
     this.contextValue = propertyParts.join("-");
+
+    this.accessibilityInformation = {
+      label: `Schema Subject: ${subject.name}`,
+    };
   }
 }
 

--- a/src/models/topic.ts
+++ b/src/models/topic.ts
@@ -134,6 +134,10 @@ export class KafkaTopicTreeItem extends vscode.TreeItem {
 
     const missingAuthz: KafkaTopicOperation[] = this.checkMissingAuthorizedOperations(resource);
     this.tooltip = createKafkaTopicTooltip(this.resource, missingAuthz);
+
+    this.accessibilityInformation = {
+      label: `Kafka Topic: ${resource.name}`,
+    };
   }
 
   checkMissingAuthorizedOperations(resource: KafkaTopic): KafkaTopicOperation[] {

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -48,6 +48,7 @@ describe("viewProviders/topics.ts", () => {
 
       stubbedLoader = getStubbedCCloudResourceLoader(sandbox);
       stubbedLoader.getTopicsForCluster.resolves([]);
+      stubbedLoader.getConsumerGroupsForCluster.resolves([]);
     });
 
     afterEach(() => {
@@ -64,7 +65,8 @@ describe("viewProviders/topics.ts", () => {
       it("no-arg refresh() when focused on a cluster should call onDidChangeTreeData.fire()", async () => {
         provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
         await provider.refresh();
-        sinon.assert.calledOnce(onDidChangeTreeDataFireStub);
+        // called once for topics, twice for consumer groups (loading start/end)
+        sinon.assert.called(onDidChangeTreeDataFireStub);
       });
 
       it("no-arg refresh() when no cluster is set should call onDidChangeTreeData.fire() once to clear (disconnect scenario)", async () => {
@@ -104,7 +106,8 @@ describe("viewProviders/topics.ts", () => {
       it("onlyIfMatching a kafka cluster when the cluster matches should call onDidChangeTreeData.fire()", async () => {
         provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
         await provider.refresh(false, TEST_CCLOUD_KAFKA_CLUSTER);
-        sinon.assert.calledOnce(onDidChangeTreeDataFireStub);
+        // called once for topics, twice for consumer groups (loading start/end)
+        sinon.assert.called(onDidChangeTreeDataFireStub);
       });
 
       it("onlyIfMatching a contained Kafka topic when the cluster doesn't match should do nothing", async () => {
@@ -116,7 +119,8 @@ describe("viewProviders/topics.ts", () => {
       it("onlyIfMatching a contained Kafka topic when the cluster matches should call onDidChangeTreeData.fire()", async () => {
         provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
         await provider.refresh(false, TEST_CCLOUD_KAFKA_TOPIC);
-        sinon.assert.calledOnce(onDidChangeTreeDataFireStub);
+        // called once for topics, twice for consumer groups (loading start/end)
+        sinon.assert.called(onDidChangeTreeDataFireStub);
       });
     });
 
@@ -565,6 +569,7 @@ describe("viewProviders/topics.ts", () => {
         ["schemaSubjectChanged", "subjectChangeHandler"],
         ["schemaVersionsChanged", "subjectChangeHandler"],
         ["topicChanged", "topicChangedHandler"],
+        ["consumerGroupsChanged", "consumerGroupsChangedHandler"],
       ];
 
       it("should return the expected number of listeners", () => {

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -781,6 +781,39 @@ describe("viewProviders/topics.ts", () => {
           });
         }
       });
+
+      describe("consumerGroupsChangedHandler", () => {
+        let refreshConsumerGroupsStub: sinon.SinonStub;
+
+        beforeEach(() => {
+          refreshConsumerGroupsStub = sandbox.stub(provider, "refreshConsumerGroups");
+        });
+
+        it("should do nothing when no cluster is focused", async () => {
+          provider.kafkaCluster = null;
+
+          await provider.consumerGroupsChangedHandler(TEST_CCLOUD_KAFKA_CLUSTER);
+
+          sinon.assert.notCalled(refreshConsumerGroupsStub);
+        });
+
+        it("should do nothing when the event cluster does not match the focused cluster", async () => {
+          provider.kafkaCluster = TEST_LOCAL_KAFKA_CLUSTER;
+
+          await provider.consumerGroupsChangedHandler(TEST_CCLOUD_KAFKA_CLUSTER);
+
+          sinon.assert.notCalled(refreshConsumerGroupsStub);
+        });
+
+        it("should call refreshConsumerGroups when the event cluster matches the focused cluster", async () => {
+          provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
+
+          await provider.consumerGroupsChangedHandler(TEST_CCLOUD_KAFKA_CLUSTER);
+
+          sinon.assert.calledOnce(refreshConsumerGroupsStub);
+          sinon.assert.calledWith(refreshConsumerGroupsStub, TEST_CCLOUD_KAFKA_CLUSTER, true);
+        });
+      });
     });
 
     describe("setCustomEventListeners()", () => {

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -781,39 +781,6 @@ describe("viewProviders/topics.ts", () => {
           });
         }
       });
-
-      describe("consumerGroupsChangedHandler", () => {
-        let refreshConsumerGroupsStub: sinon.SinonStub;
-
-        beforeEach(() => {
-          refreshConsumerGroupsStub = sandbox.stub(provider, "refreshConsumerGroups");
-        });
-
-        it("should do nothing when no cluster is focused", async () => {
-          provider.kafkaCluster = null;
-
-          await provider.consumerGroupsChangedHandler(TEST_CCLOUD_KAFKA_CLUSTER);
-
-          sinon.assert.notCalled(refreshConsumerGroupsStub);
-        });
-
-        it("should do nothing when the event cluster does not match the focused cluster", async () => {
-          provider.kafkaCluster = TEST_LOCAL_KAFKA_CLUSTER;
-
-          await provider.consumerGroupsChangedHandler(TEST_CCLOUD_KAFKA_CLUSTER);
-
-          sinon.assert.notCalled(refreshConsumerGroupsStub);
-        });
-
-        it("should call refreshConsumerGroups when the event cluster matches the focused cluster", async () => {
-          provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
-
-          await provider.consumerGroupsChangedHandler(TEST_CCLOUD_KAFKA_CLUSTER);
-
-          sinon.assert.calledOnce(refreshConsumerGroupsStub);
-          sinon.assert.calledWith(refreshConsumerGroupsStub, TEST_CCLOUD_KAFKA_CLUSTER, true);
-        });
-      });
     });
 
     describe("setCustomEventListeners()", () => {
@@ -832,7 +799,6 @@ describe("viewProviders/topics.ts", () => {
         ["schemaSubjectChanged", "subjectChangeHandler"],
         ["schemaVersionsChanged", "subjectChangeHandler"],
         ["topicChanged", "topicChangedHandler"],
-        ["consumerGroupsChanged", "consumerGroupsChangedHandler"],
       ];
 
       it("should return the expected number of listeners", () => {

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -25,7 +25,12 @@ import type { CCloudResourceLoader } from "../loaders";
 import { TopicFetchError } from "../loaders/utils/loaderUtils";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
-import { Consumer, type ConsumerGroup } from "../models/consumerGroup";
+import {
+  Consumer,
+  type ConsumerGroup,
+  ConsumerGroupTreeItem,
+  ConsumerTreeItem,
+} from "../models/consumerGroup";
 import type { CustomMarkdownString } from "../models/main";
 import { KafkaClusterResourceContainer } from "../models/containers/kafkaClusterResourceContainer";
 import { SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
@@ -337,6 +342,26 @@ describe("viewProviders/topics.ts", () => {
         const treeItem = provider.getTreeItem(TEST_CCLOUD_SUBJECT_WITH_SCHEMAS);
         assert.ok(treeItem instanceof SubjectTreeItem);
       });
+
+      it("should return a ConsumerGroupTreeItem for a ConsumerGroup instance", () => {
+        const treeItem = provider.getTreeItem(TEST_CCLOUD_CONSUMER_GROUP);
+        assert.ok(treeItem instanceof ConsumerGroupTreeItem);
+      });
+
+      it("should return a ConsumerTreeItem for a Consumer instance", () => {
+        const treeItem = provider.getTreeItem(TEST_CCLOUD_CONSUMER);
+        assert.ok(treeItem instanceof ConsumerTreeItem);
+      });
+
+      it("should return the container itself for a KafkaClusterResourceContainer", () => {
+        const container = new KafkaClusterResourceContainer<KafkaTopic>(
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionId,
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionType,
+          "Topics",
+        );
+        const treeItem = provider.getTreeItem(container);
+        assert.strictEqual(treeItem, container);
+      });
     });
 
     describe("isFocusedOnCCloud()", () => {
@@ -430,6 +455,32 @@ describe("viewProviders/topics.ts", () => {
 
         assert.strictEqual(children.length, 0);
       });
+
+      it("should return members when expanding a ConsumerGroup in the cache", () => {
+        provider["consumerGroupsInTreeView"].set(
+          TEST_CCLOUD_CONSUMER_GROUP.consumerGroupId,
+          TEST_CCLOUD_CONSUMER_GROUP,
+        );
+
+        const children = provider.getChildren(TEST_CCLOUD_CONSUMER_GROUP);
+
+        assert.strictEqual(children.length, TEST_CCLOUD_CONSUMER_GROUP.members.length);
+        assert.ok(children[0] instanceof Consumer);
+      });
+
+      it("should return an empty array when expanding a ConsumerGroup not in the cache", () => {
+        const otherGroup = createConsumerGroup({
+          connectionId: CCLOUD_CONNECTION_ID,
+          connectionType: ConnectionType.Ccloud,
+          environmentId: TEST_CCLOUD_KAFKA_CLUSTER.environmentId,
+          clusterId: TEST_CCLOUD_KAFKA_CLUSTER.id,
+          consumerGroupId: "not-in-cache",
+        });
+
+        const children = provider.getChildren(otherGroup);
+
+        assert.strictEqual(children.length, 0);
+      });
     });
 
     describe("getParent()", () => {
@@ -475,6 +526,41 @@ describe("viewProviders/topics.ts", () => {
 
       it("should return undefined for a Schema whose subject is not in the cache", () => {
         const parent = provider.getParent(TEST_CCLOUD_SCHEMA);
+
+        assert.strictEqual(parent, undefined);
+      });
+
+      it("should return the consumer groups container for a ConsumerGroup", () => {
+        provider["consumerGroupsContainer"] = new KafkaClusterResourceContainer<ConsumerGroup>(
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionId,
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionType,
+          "Consumer Groups",
+        );
+
+        const parent = provider.getParent(TEST_CCLOUD_CONSUMER_GROUP);
+
+        assert.strictEqual(parent, provider["consumerGroupsContainer"]);
+      });
+
+      it("should return the parent ConsumerGroup for a Consumer", () => {
+        provider["consumerGroupsInTreeView"].set(
+          TEST_CCLOUD_CONSUMER_GROUP.consumerGroupId,
+          TEST_CCLOUD_CONSUMER_GROUP,
+        );
+
+        const parent = provider.getParent(TEST_CCLOUD_CONSUMER);
+
+        assert.strictEqual(parent, TEST_CCLOUD_CONSUMER_GROUP);
+      });
+
+      it("should return undefined for a KafkaClusterResourceContainer", () => {
+        const container = new KafkaClusterResourceContainer<KafkaTopic>(
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionId,
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionType,
+          "Topics",
+        );
+
+        const parent = provider.getParent(container);
 
         assert.strictEqual(parent, undefined);
       });
@@ -621,6 +707,27 @@ describe("viewProviders/topics.ts", () => {
         await provider.reveal(TEST_CCLOUD_CONSUMER_GROUP);
 
         sinon.assert.notCalled(treeViewRevealStub);
+      });
+
+      it("should reveal a KafkaClusterResourceContainer (consumer groups container)", async () => {
+        provider["consumerGroupsContainer"] = new KafkaClusterResourceContainer<ConsumerGroup>(
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionId,
+          TEST_CCLOUD_KAFKA_CLUSTER.connectionType,
+          "Consumer Groups",
+        );
+        const lookupContainer = new KafkaClusterResourceContainer<ConsumerGroup>(
+          CCLOUD_CONNECTION_ID,
+          ConnectionType.Ccloud,
+          "Consumer Groups",
+        );
+
+        await provider.reveal(lookupContainer, { focus: true });
+
+        sinon.assert.calledOnceWithExactly(
+          treeViewRevealStub,
+          provider["consumerGroupsContainer"],
+          { focus: true },
+        );
       });
     });
 

--- a/src/viewProviders/topics.test.ts
+++ b/src/viewProviders/topics.test.ts
@@ -125,6 +125,39 @@ describe("viewProviders/topics.ts", () => {
         sinon.assert.callCount(onDidChangeTreeDataFireStub, 4);
       });
 
+      it("refresh() reuses existing container instances so targeted fires match VS Code's references", async () => {
+        provider.kafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
+        await provider.refresh();
+
+        const topicsContainerAfterFirst = provider["topicsContainer"];
+        const consumerGroupsContainerAfterFirst = provider["consumerGroupsContainer"];
+
+        // second refresh on the same cluster should reuse the same container instances
+        onDidChangeTreeDataFireStub.resetHistory();
+        await provider.refresh(true);
+
+        assert.strictEqual(
+          provider["topicsContainer"],
+          topicsContainerAfterFirst,
+          "topicsContainer should be the same instance after refresh",
+        );
+        assert.strictEqual(
+          provider["consumerGroupsContainer"],
+          consumerGroupsContainerAfterFirst,
+          "consumerGroupsContainer should be the same instance after refresh",
+        );
+        // targeted fires should reference the same container instances
+        const firedElements = onDidChangeTreeDataFireStub.args.map((args: unknown[]) => args[0]);
+        assert.ok(
+          firedElements.includes(topicsContainerAfterFirst),
+          "should fire with the reused topicsContainer",
+        );
+        assert.ok(
+          firedElements.includes(consumerGroupsContainerAfterFirst),
+          "should fire with the reused consumerGroupsContainer",
+        );
+      });
+
       it("onlyIfMatching a contained Kafka topic when the cluster doesn't match should do nothing", async () => {
         provider.kafkaCluster = TEST_LOCAL_KAFKA_CLUSTER;
         await provider.refresh(false, TEST_CCLOUD_KAFKA_TOPIC);

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -196,7 +196,7 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
     }
 
     const cluster: KafkaCluster = this.kafkaCluster;
-    await this.withProgress("Loading topics...", async () => {
+    await this.withProgress("Loading topics and consumer groups...", async () => {
       // set up containers before loading
       this.topicsContainer = new KafkaClusterResourceContainer<KafkaTopic>(
         cluster.connectionId,

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -265,7 +265,6 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
     this._onDidChangeTreeData.fire(this.topicsContainer);
   }
 
-  // similar to the Flink Database provider's refreshResourceContainer method:
   /** Fetch and cache consumer groups for the focused cluster. */
   async refreshConsumerGroups(
     cluster: KafkaCluster,

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -197,13 +197,11 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
 
     const cluster: KafkaCluster = this.kafkaCluster;
     await this.withProgress("Loading topics and consumer groups...", async () => {
-      // set up containers before loading
+      // set up containers with the focused cluster's connection info
       this.topicsContainer = new KafkaClusterResourceContainer<KafkaTopic>(
         cluster.connectionId,
         cluster.connectionType,
-        cluster.id,
-        cluster.environmentId,
-        "Topics",
+        KafkaClusterContainerLabel.TOPICS,
         [],
         "topics-container",
         new ThemeIcon(IconNames.TOPIC),
@@ -213,11 +211,9 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
       this.consumerGroupsContainer = new KafkaClusterResourceContainer<ConsumerGroup>(
         cluster.connectionId,
         cluster.connectionType,
-        cluster.id,
-        cluster.environmentId,
-        "Consumer Groups",
+        KafkaClusterContainerLabel.CONSUMER_GROUPS,
         [],
-        undefined,
+        undefined, // no context value for now since no commands are needed yet for this container
         new ThemeIcon(IconNames.CONSUMER_GROUP),
       );
 

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -221,7 +221,7 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
         new ThemeIcon(IconNames.CONSUMER_GROUP),
       );
 
-      await Promise.all([
+      await Promise.allSettled([
         this.refreshTopics(cluster, forceDeepRefresh),
         this.refreshConsumerGroups(cluster, forceDeepRefresh),
       ]);

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -8,7 +8,6 @@ import type {
   TopicChangeEvent,
 } from "../emitters";
 import {
-  consumerGroupsChanged,
   environmentChanged,
   localKafkaConnected,
   schemaSubjectChanged,
@@ -400,7 +399,6 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
       schemaSubjectChanged.event(this.subjectChangeHandler.bind(this)),
       schemaVersionsChanged.event(this.subjectChangeHandler.bind(this)),
       topicChanged.event(this.topicChangedHandler.bind(this)),
-      consumerGroupsChanged.event(this.consumerGroupsChangedHandler.bind(this)),
     ];
   }
 
@@ -411,16 +409,6 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
         cluster: event.cluster.name,
       });
       await this.refresh(true);
-    }
-  }
-
-  async consumerGroupsChangedHandler(cluster: KafkaCluster): Promise<void> {
-    if (this.kafkaCluster && this.kafkaCluster.equals(cluster)) {
-      this.logger.debug(
-        "consumerGroupsChanged event fired for the focused cluster, refreshing consumer groups",
-        { clusterId: cluster.id },
-      );
-      await this.refreshConsumerGroups(cluster, true);
     }
   }
 

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -82,11 +82,9 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
   private consumerGroupsInTreeView: Map<string, ConsumerGroup> = new Map();
 
   private clearCaches(): void {
-    this.topicsContainer = null;
     this.topicsInTreeView.clear();
     this.subjectsInTreeView.clear();
     this.subjectToTopicMap.clear();
-    this.consumerGroupsContainer = null;
     this.consumerGroupsInTreeView.clear();
   }
 
@@ -194,31 +192,39 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
     this.clearCaches();
     if (!this.kafkaCluster) {
       // nothing focused; return to empty state
+      this.topicsContainer = null;
+      this.consumerGroupsContainer = null;
       this._onDidChangeTreeData.fire();
       return;
     }
 
     const cluster: KafkaCluster = this.kafkaCluster;
     await this.withProgress("Loading topics and consumer groups...", async () => {
-      // set up containers with the focused cluster's connection info
-      this.topicsContainer = new KafkaClusterResourceContainer<KafkaTopic>(
-        cluster.connectionId,
-        cluster.connectionType,
-        KafkaClusterContainerLabel.TOPICS,
-        [],
-        "topics-container",
-        new ThemeIcon(IconNames.TOPIC),
-      );
-      this.topicsContainer.collapsibleState = TreeItemCollapsibleState.Expanded;
+      // reuse existing containers so VS Code can match targeted tree-data-change fires
+      // against the same object references it already tracks; only create when absent
+      // (e.g. first load after reset or cluster change)
+      if (!this.topicsContainer) {
+        this.topicsContainer = new KafkaClusterResourceContainer<KafkaTopic>(
+          cluster.connectionId,
+          cluster.connectionType,
+          KafkaClusterContainerLabel.TOPICS,
+          [],
+          "topics-container",
+          new ThemeIcon(IconNames.TOPIC),
+        );
+        this.topicsContainer.collapsibleState = TreeItemCollapsibleState.Expanded;
+      }
 
-      this.consumerGroupsContainer = new KafkaClusterResourceContainer<ConsumerGroup>(
-        cluster.connectionId,
-        cluster.connectionType,
-        KafkaClusterContainerLabel.CONSUMER_GROUPS,
-        [],
-        undefined, // no context value for now since no commands are needed yet for this container
-        new ThemeIcon(IconNames.CONSUMER_GROUP),
-      );
+      if (!this.consumerGroupsContainer) {
+        this.consumerGroupsContainer = new KafkaClusterResourceContainer<ConsumerGroup>(
+          cluster.connectionId,
+          cluster.connectionType,
+          KafkaClusterContainerLabel.CONSUMER_GROUPS,
+          [],
+          undefined, // no context value for now since no commands are needed yet for this container
+          new ThemeIcon(IconNames.CONSUMER_GROUP),
+        );
+      }
 
       await Promise.allSettled([
         this.refreshTopics(cluster, forceDeepRefresh),
@@ -388,6 +394,8 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
   }
 
   async reset(): Promise<void> {
+    this.topicsContainer = null;
+    this.consumerGroupsContainer = null;
     this.clearCaches();
     await super.reset();
   }

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -18,7 +18,6 @@ import {
 } from "../emitters";
 import { IconNames } from "../icons";
 import { ResourceLoader } from "../loaders";
-import { TopicFetchError } from "../loaders/utils/loaderUtils";
 import {
   Consumer,
   ConsumerGroup,
@@ -260,18 +259,16 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
       });
       this.topicsContainer.setLoaded(topics);
     } catch (err) {
-      this.logger.error("Error fetching topics for cluster", cluster, err);
       const message = err instanceof Error ? err.message : String(err);
+      this.logger.error("error fetching topics for cluster", { clusterId: cluster.id, err });
       this.topicsContainer.setError(
         new CustomMarkdownString()
           .addWarning(`Failed to load topics for **${cluster.name}**:`)
           .addCodeBlock(message),
       );
-      if (err instanceof TopicFetchError) {
-        void showErrorNotificationWithButtons(
-          `Failed to list topics for cluster "${cluster.name}": ${err.message}`,
-        );
-      }
+      void showErrorNotificationWithButtons(
+        `Failed to load topics for cluster "${cluster.name}": ${message}`,
+      );
     }
 
     this._onDidChangeTreeData.fire(this.topicsContainer);
@@ -299,8 +296,11 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
       });
       this.consumerGroupsContainer.setLoaded(consumerGroups);
     } catch (err) {
-      this.logger.error("Error fetching consumer groups for cluster", cluster, err);
       const message = err instanceof Error ? err.message : String(err);
+      this.logger.error("error fetching consumer groups for cluster", {
+        clusterId: cluster.id,
+        err,
+      });
       this.consumerGroupsContainer.setError(
         new CustomMarkdownString()
           .addWarning(`Failed to load consumer groups for **${cluster.name}**:`)

--- a/src/viewProviders/topics.ts
+++ b/src/viewProviders/topics.ts
@@ -1,5 +1,5 @@
 import type { Disposable, TreeItem } from "vscode";
-import { ThemeIcon, TreeItemCollapsibleState, window } from "vscode";
+import { ThemeIcon, TreeItemCollapsibleState } from "vscode";
 import { ContextValues } from "../context/values";
 import type {
   EnvironmentChangeEvent,
@@ -34,6 +34,7 @@ import { CustomMarkdownString } from "../models/main";
 import { isCCloud, isLocal } from "../models/resource";
 import { Schema, SchemaTreeItem, Subject, SubjectTreeItem } from "../models/schema";
 import { KafkaTopic, KafkaTopicTreeItem } from "../models/topic";
+import { showErrorNotificationWithButtons } from "../notifications";
 import { ParentedBaseViewProvider } from "./baseModels/parentedBase";
 
 /**
@@ -267,7 +268,7 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
           .addCodeBlock(message),
       );
       if (err instanceof TopicFetchError) {
-        window.showErrorMessage(
+        void showErrorNotificationWithButtons(
           `Failed to list topics for cluster "${cluster.name}": ${err.message}`,
         );
       }
@@ -304,6 +305,9 @@ export class TopicViewProvider extends ParentedBaseViewProvider<
         new CustomMarkdownString()
           .addWarning(`Failed to load consumer groups for **${cluster.name}**:`)
           .addCodeBlock(message),
+      );
+      void showErrorNotificationWithButtons(
+        `Failed to load consumer groups for cluster "${cluster.name}": ${message}`,
       );
     }
 

--- a/tests/e2e/objects/views/TopicsView.ts
+++ b/tests/e2e/objects/views/TopicsView.ts
@@ -6,6 +6,7 @@ import { Quickpick } from "../quickInputs/Quickpick";
 import { ResourcesView } from "./ResourcesView";
 import { SearchableView } from "./View";
 import { TopicItem } from "./viewItems/TopicItem";
+import { ViewItem } from "./viewItems/ViewItem";
 
 export enum SelectKafkaCluster {
   FromResourcesView = "Kafka cluster action from the Resources view",
@@ -29,9 +30,10 @@ export class TopicsView extends SearchableView {
     await this.clickNavAction("Search");
   }
 
-  /** Click the "Create Topic" nav action in the view title area. */
+  /** Click the "Create Topic" inline action on the Topics container item. */
   async clickCreateTopic(): Promise<void> {
-    await this.clickNavAction("Create Topic");
+    const containerItem = new ViewItem(this.page, this.topicsContainer);
+    await containerItem.clickInlineAction("Create Topic");
   }
 
   /**
@@ -49,9 +51,14 @@ export class TopicsView extends SearchableView {
     await expect(this.progressIndicator).toBeHidden();
   }
 
-  /** Get all (root-level) topic items in the view. */
+  /** Get the "Topics" container at the root level of the tree. */
+  get topicsContainer(): Locator {
+    return this.body.locator("[role='treeitem'][aria-level='1']").filter({ hasText: "Topics" });
+  }
+
+  /** Get all topic items in the view (nested under the Topics container). */
   get topics(): Locator {
-    return this.body.locator("[role='treeitem'][aria-level='1']");
+    return this.body.locator("[role='treeitem'][aria-level='2']");
   }
 
   /** Get a topic item by its label/name. */
@@ -78,7 +85,7 @@ export class TopicsView extends SearchableView {
    */
   get subjects(): Locator {
     // we don't use `this.topicsWithSchemas` because these are sibling elements to topics in the DOM
-    return this.body.locator("[role='treeitem'][aria-level='2']");
+    return this.body.locator("[role='treeitem'][aria-level='3']");
   }
 
   /**
@@ -87,7 +94,7 @@ export class TopicsView extends SearchableView {
    */
   get schemaVersions(): Locator {
     // we don't use `this.subjects` because these are sibling elements to subjects in the DOM
-    return this.body.locator("[role='treeitem'][aria-level='3']");
+    return this.body.locator("[role='treeitem'][aria-level='4']");
   }
 
   /**
@@ -130,8 +137,8 @@ export class TopicsView extends SearchableView {
   }
 
   /**
-   * Create a new topic using the "Create Topic" nav action in the view title area, filling out the
-   * required inputs in the subsequent input boxes.
+   * Create a new topic using the "Create Topic" inline action on the Topics container, filling out
+   * the required inputs in the subsequent input boxes.
    *
    * @param topicName The name of the new topic to create.
    * @param numPartitions (Optional) The number of partitions for the new topic. If not provided,

--- a/tests/e2e/objects/views/TopicsView.ts
+++ b/tests/e2e/objects/views/TopicsView.ts
@@ -56,9 +56,11 @@ export class TopicsView extends SearchableView {
     return this.body.locator("[role='treeitem'][aria-level='1']").filter({ hasText: "Topics" });
   }
 
-  /** Get all topic items in the view (nested under the Topics container). */
+  /** Get all topic items in the view (filtered by topic icon classes to exclude consumer groups). */
   get topics(): Locator {
-    return this.body.locator("[role='treeitem'][aria-level='2']");
+    return this.body.locator("[role='treeitem'][aria-level='2']").filter({
+      has: this.page.locator(".codicon-confluent-topic, .codicon-confluent-topic-without-schema"),
+    });
   }
 
   /** Get a topic item by its label/name. */

--- a/tests/e2e/objects/views/TopicsView.ts
+++ b/tests/e2e/objects/views/TopicsView.ts
@@ -56,11 +56,9 @@ export class TopicsView extends SearchableView {
     return this.body.locator("[role='treeitem'][aria-level='1']").filter({ hasText: "Topics" });
   }
 
-  /** Get all topic items in the view (filtered by topic icon classes to exclude consumer groups). */
+  /** Get all topic items in the view (filtered by aria-label to exclude consumer groups). */
   get topics(): Locator {
-    return this.body.locator("[role='treeitem'][aria-level='2']").filter({
-      has: this.page.locator(".codicon-confluent-topic, .codicon-confluent-topic-without-schema"),
-    });
+    return this.body.locator("[role='treeitem'][aria-label^='Kafka Topic:']");
   }
 
   /** Get a topic item by its label/name. */
@@ -86,8 +84,7 @@ export class TopicsView extends SearchableView {
    * (One level below {@link topicsWithSchemas topic items with schemas}.)
    */
   get subjects(): Locator {
-    // we don't use `this.topicsWithSchemas` because these are sibling elements to topics in the DOM
-    return this.body.locator("[role='treeitem'][aria-level='3']");
+    return this.body.locator("[role='treeitem'][aria-label^='Schema Subject:']");
   }
 
   /**


### PR DESCRIPTION
## Summary of Changes

Adds consumer groups as a visible resource in the Topics view (pending rename in a future branch):
<img width="368" height="308" alt="image" src="https://github.com/user-attachments/assets/9dd77755-b7fc-41e8-9b92-2d1c8d05ceb7" />
<img width="660" height="383" alt="image" src="https://github.com/user-attachments/assets/91a14371-4a86-4109-a867-469997d19176" />

The Consumer Groups container is shown at the top in a collapsed state, while the (also new) Topics container is auto-expanded to be as minimally disruptive as possible for users.

Closes #3300

(Still more work to be done as part of the https://github.com/confluentinc/vscode/issues/3227 parent issue)

### Associated PRs
- https://github.com/confluentinc/vscode/pull/3292
  - https://github.com/confluentinc/vscode/pull/3264 👈
    - https://github.com/confluentinc/vscode/pull/3312

### Click-testing instructions

1. Connect to a Confluent Cloud environment with an active Kafka cluster **or** start local Kafka **or** set up a direct connection with a valid Kafka config
2. Select a Kafka cluster to populate the Topics view
3. Verify a "Consumer Groups" container appears (collapsed) above the "Topics" container (expanded)
4. Expand the Consumer Groups container and confirm any available groups are listed with their state (if consumers have been active recently)
5. Expand a consumer group to verify its members (consumers) are shown

### Optional: Any additional details or context that should be provided?

- The downstream commands branch will add context menu actions for consumer groups (e.g. per-container refreshing, copying IDs)
- Consumer group members are fetched per-group using `Promise.allSettled`, so one failed member fetch won't block the rest

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?