### PR TITLE
MINOR: update servicebot config for sonarqube

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -115,13 +115,14 @@ sonarqube:
   languages:
     - javascript
     - typescript
+  coverage_sources:
+    - "src"
   # only affects sonar.exclusions in sonar-project.properties
   coverage_exclusions:
     - "src/testing.ts"
     - "src/**/*.test.ts"
     - "src/clients/**/*"
     - "src/**/*.spec.ts"
-    - "tests/**"
   coverage_reports:
     - "coverage/lcov-functional.info"
     - "coverage/lcov.info"


### PR DESCRIPTION
https://github.com/confluentinc/vscode/pull/3267 showed we were missing some defaults (`language`, `coverage_sources`) and merging it would have messed up our coverage/scanning. Once this is merged, servicebot will raise another PR with updates for `sonar-project.properties`