### PR TITLE
Patch 🩹: update array so all proto schemas are included

### DIFF
--- a/src/commands/schemas.ts
+++ b/src/commands/schemas.ts
@@ -532,7 +532,7 @@ export async function uploadSchemaFromFileCommand(
   // prompt for the editor/file first via the URI quickpick, only allowing a subset of URI schemes,
   // editor languages, and file extensions
   const uriSchemes = ["file", "untitled", SCHEMA_URI_SCHEME];
-  const languageIds = ["plaintext", "avroavsc", "protobuf", "proto3", "json"];
+  const languageIds = ["plaintext", "avroavsc", "protobuf", "proto3", "json", "proto", "textproto"];
   const fileFilters = {
     "Schema files": ["avsc", "avro", "json", "proto"],
   };


### PR DESCRIPTION
## Summary of Changes

Updates the array in the schemas.ts file so when you evolve a protobuf schema the current file ends up being the default selection. 

### Click-testing instructions

Try this out with any protobuf schema locally, you should see the current file selected upon evolving. 



## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
