### PR TITLE
Allow sub-second values for OAuth connect timeout

### DIFF
--- a/src/webview/auth-credentials.ts
+++ b/src/webview/auth-credentials.ts
@@ -320,7 +320,7 @@ export class AuthCredentials extends HTMLElement {
                 data-on-input="this.updateValue(event)"
                 max="60000"
                 min="0"
-                step="1000"
+                step="1"
                 placeholder="0"
                 title="The timeout in milliseconds when connecting to your identity provider."
               />


### PR DESCRIPTION
## Summary
- Changed the `step` attribute on the Connect Timeout (ms) input from `1000` to `1` in the direct connection form's OAuth credentials section.
- The `min="0"` was already correct, but `step="1000"` constrained valid values to multiples of 1000 (0, 1000, 2000, ...), causing any other value to be rejected as "Invalid input."
- Users can now enter any non-negative integer for the connect timeout.

## Test plan
- [ ] Open the direct connection form, select SASL/OAUTHBEARER auth type
- [ ] Verify that entering values like `0`, `5`, `100`, `500` into "Connect Timeout (ms)" no longer shows "Invalid input"
- [ ] Verify that the up/down spinner arrows increment by 1 ms
- [ ] Verify that negative values and values above 60000 are still rejected


🤖 Generated with [Claude Code](https://claude.com/claude-code)