### PR TITLE
MINOR: fix Flink workspace loader tests timing out locally

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -2047,6 +2047,7 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.calledOnce(statementsApiStub.updateSqlv1Statement);
     });
   });
+
   describe("getFlinkWorkspace", () => {
     let stubbedSidecar: sinon.SinonStubbedInstance<sidecar.SidecarHandle>;
     let workspacesApiStub: sinon.SinonStubbedInstance<WorkspacesWsV1Api>;
@@ -2055,6 +2056,7 @@ describe("CCloudResourceLoader", () => {
     let tryToUpdateConnectionStub: sinon.SinonStub;
     let resetStub: sinon.SinonStub;
     let waitForConnectionToBeStableStub: sinon.SinonStub;
+    let ensureCoarseResourcesLoadedStub: sinon.SinonStub;
     let ccloudOrganizationChangedFireStub: sinon.SinonStub;
     let showErrorNotificationStub: sinon.SinonStub;
     let showInformationMessageStub: sinon.SinonStub;
@@ -2097,7 +2099,8 @@ describe("CCloudResourceLoader", () => {
       showInformationMessageStub = sandbox.stub(vscode.window, "showInformationMessage");
       waitForConnectionToBeStableStub = sandbox.stub(watcher, "waitForConnectionToBeStable");
       // slightly different setup for stubbing protected/private methods:
-      loader["ensureCoarseResourcesLoaded"] = sandbox.stub();
+      ensureCoarseResourcesLoadedStub = sandbox.stub();
+      loader["ensureCoarseResourcesLoaded"] = ensureCoarseResourcesLoadedStub;
     });
 
     it("should return the workspace when fetch succeeds", async () => {
@@ -2190,6 +2193,7 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.notCalled(waitForConnectionToBeStableStub);
       sinon.assert.notCalled(resetStub);
       sinon.assert.notCalled(ccloudOrganizationChangedFireStub);
+      sinon.assert.notCalled(ensureCoarseResourcesLoadedStub);
     });
 
     it("should switch organizations when current org differs from params", async () => {
@@ -2217,6 +2221,7 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.calledOnce(waitForConnectionToBeStableStub);
       sinon.assert.calledOnce(resetStub);
       sinon.assert.calledOnce(ccloudOrganizationChangedFireStub);
+      sinon.assert.calledOnce(ensureCoarseResourcesLoadedStub);
     });
 
     it("should not switch organizations when no current org exists", async () => {
@@ -2231,6 +2236,7 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.notCalled(waitForConnectionToBeStableStub);
       sinon.assert.notCalled(resetStub);
       sinon.assert.notCalled(ccloudOrganizationChangedFireStub);
+      sinon.assert.notCalled(ensureCoarseResourcesLoadedStub);
     });
 
     it("should switch organizations before fetching workspace", async () => {
@@ -2251,6 +2257,7 @@ describe("CCloudResourceLoader", () => {
         waitForConnectionToBeStableStub,
         resetStub,
         ccloudOrganizationChangedFireStub,
+        ensureCoarseResourcesLoadedStub,
         workspacesApiStub.getWsV1Workspace,
       );
     });
@@ -2276,6 +2283,7 @@ describe("CCloudResourceLoader", () => {
       sinon.assert.notCalled(waitForConnectionToBeStableStub);
       sinon.assert.notCalled(resetStub);
       sinon.assert.notCalled(ccloudOrganizationChangedFireStub);
+      sinon.assert.notCalled(ensureCoarseResourcesLoadedStub);
       sinon.assert.notCalled(workspacesApiStub.getWsV1Workspace);
     });
   });


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

These tests weren't stubbing `waitForConnectionToBeStable`, so they were taking 15+ seconds to run locally and failing the 10sec timeout changed in https://github.com/confluentinc/vscode/pull/3259.

Closes #3283 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Pull this branch and run `npx gulp test` locally; all tests should be passing without any timeouts.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- Some other protected method stub patterns were cleaned up here to avoid `as any` usage

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
