### PR TITLE
MINOR: use `sandbox.stub` instead of `sinon.stub` to ensure consistent cleanup

### DIFF
--- a/src/loaders/ccloudResourceLoader.test.ts
+++ b/src/loaders/ccloudResourceLoader.test.ts
@@ -1695,7 +1695,7 @@ describe("CCloudResourceLoader", () => {
         statementUtils,
         "parseAllFlinkStatementResults",
       );
-      sinon.stub(loader, "getOrganization").resolves(TEST_CCLOUD_ORGANIZATION);
+      sandbox.stub(loader, "getOrganization").resolves(TEST_CCLOUD_ORGANIZATION);
       deleteStatementStub = sandbox.stub(loader, "deleteFlinkStatement");
     });
 

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -460,7 +460,7 @@ describe("logging.ts", () => {
     });
 
     it("should delegate getFileUris() to member RotatingLogManager instance", function () {
-      const getFileUrisStub = sinon.stub(logManagerStub, "getFileUris");
+      const getFileUrisStub = sandbox.stub(logManagerStub, "getFileUris");
 
       instance.getFileUris();
 

--- a/src/utils/disposables.test.ts
+++ b/src/utils/disposables.test.ts
@@ -8,11 +8,17 @@ class TestDisposableCollection extends DisposableCollection {
 }
 
 describe("utils/disposables.ts DisposableCollection", function () {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   it("should dispose all registered disposables", function () {
     const manager = new TestDisposableCollection();
 
-    const disposable1 = { dispose: sinon.spy() };
-    const disposable2 = { dispose: sinon.spy() };
+    const disposable1 = { dispose: sandbox.spy() };
+    const disposable2 = { dispose: sandbox.spy() };
     manager["disposables"].push(disposable1);
     manager["disposables"].push(disposable2);
 

--- a/src/utils/privateNetworking.test.ts
+++ b/src/utils/privateNetworking.test.ts
@@ -151,8 +151,8 @@ describe("utils/privateNetworking.ts showPrivateNetworkingHelpNotification()", (
 
   it("should include default error notification buttons", () => {
     sandbox.stub(notifications, "DEFAULT_ERROR_NOTIFICATION_BUTTONS").value({
-      "Open Logs": sinon.stub(),
-      "File Issue": sinon.stub(),
+      "Open Logs": sandbox.stub(),
+      "File Issue": sandbox.stub(),
     });
 
     const showErrorStub = sandbox.stub(notifications, "showErrorNotificationWithButtons");


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Follow-up from https://github.com/confluentinc/vscode/pull/3288 based on some initial findings of inconsistent test patterns

Note: running tests locally will still show two failures until https://github.com/confluentinc/vscode/pull/3286 is merged

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
