### PR TITLE
MINOR: push playwright trace files as job artifacts

### DIFF
--- a/.semaphore/playwright-e2e.yml
+++ b/.semaphore/playwright-e2e.yml
@@ -205,6 +205,7 @@ blocks:
                   Write-Output "Creating artifact: $FILENAME"
                   Compress-Archive -Path playwright-report -DestinationPath $FILENAME -Force
                   artifact push workflow $FILENAME --destination "playwright-reports/$FILENAME" --force
+                  artifact push job $FILENAME --destination "playwright-reports/$FILENAME" --force
               } else {
                   Write-Output "No blob-report directory found, skipping merge"
               }

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -90,3 +90,4 @@ merge-blob-reports:
 	$(eval FILENAME := playwright-report-$(PLATFORM)-$(ARCH)-vscode-$(VSCODE_VERSION)--$(TEST_SUITE_NAME).zip)
 	tar -zcvf $(FILENAME) playwright-report
 	artifact push workflow $(FILENAME) --destination "playwright-reports/$(FILENAME)" --force
+	artifact push job $(FILENAME) --destination "playwright-reports/$(FILENAME)" --force


### PR DESCRIPTION
We already push them as _workflow_ artifacts, but this makes it easier to look at a specific job (logs or otherwise) and download the associated trace file.

Current workflow artifacts:
<img width="466" height="568" alt="image" src="https://github.com/user-attachments/assets/38d59f5c-85f6-40d2-b749-542820b57755" />

Current job artifacts (nothing useful for test failure triage):
<img width="145" height="171" alt="image" src="https://github.com/user-attachments/assets/bcaa29c7-82f1-4a79-aa42-bfd49d4ba287" />


Ref: https://docs.semaphore.io/using-semaphore/artifacts