### PR TITLE
fix: .prettierignore in apigen task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,7 +10,7 @@ import { runTests } from "@vscode/test-electron";
 import { configDotenv } from "dotenv";
 import { ESLint } from "eslint";
 import { globSync } from "glob";
-import { dest, parallel, series, src } from "gulp";
+import { parallel, series } from "gulp";
 import libCoverage from "istanbul-lib-coverage";
 import libInstrument from "istanbul-lib-instrument";
 import libReport from "istanbul-lib-report";
@@ -20,7 +20,6 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { appendFile, readFile, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve } from "node:path";
-import { pipeline } from "node:stream/promises";
 import { rimrafSync } from "rimraf";
 import { rollup, watch } from "rollup";
 import copy from "rollup-plugin-copy";
@@ -998,10 +997,6 @@ export async function apigen() {
     .map(([key, value]) => `${key}=${value}`)
     .join(",");
 
-  // bypass .prettierignore since it excludes src/clients/ (to prevent other tools from
-  // reformatting generated code), but apigen itself should always format its own output
-  const format = await prettier({ ignoreIgnoreFile: true });
-
   for (const [spec, path] of clients) {
     // other client generator types: https://openapi-generator.tech/docs/generators#client-generators
     const result = spawnSync(
@@ -1023,15 +1018,18 @@ export async function apigen() {
         shell: IS_WINDOWS,
       },
     );
-
-    // apply prettier formatting to generated code
-    await pipeline(
-      src(join(path, "**", "*.ts")),
-      format,
-      dest((file) => file.base),
-    );
     if (result.error) throw result.error;
     if (result.status !== 0) throw new Error(`Failed to generate client for ${spec}`);
+
+    // apply prettier formatting to generated code, bypassing .prettierignore since it
+    // excludes src/clients/ (to prevent other tools from reformatting generated code)
+    const prettierResult = spawnSync(
+      "npx",
+      ["prettier", "--write", "--ignore-path", "/dev/null", join(path, "**", "*.ts")],
+      { stdio: "inherit", shell: IS_WINDOWS },
+    );
+    if (prettierResult.error) throw prettierResult.error;
+    if (prettierResult.status !== 0) throw new Error(`Failed to format generated code in ${path}`);
   }
 
   // While here, also run `npx gql-tada generate output` to generate GraphQL types.
@@ -1044,43 +1042,14 @@ export async function apigen() {
 }
 
 format.description = "Enforce Prettier formatting for all TS/JS/MD/HTML/YAML files.";
-export async function format() {
-  const transform = await prettier();
-  // Prettier's API does not have a magic method to just fix everything
-  // So this is where we add some Gulp FileSystem API to make it work
-  return pipeline(
-    src(["src/**/*.{ts,css,html,json}", "*.md", "*.js"]),
-    transform,
-    dest((file) => file.base),
+export function format() {
+  const result = spawnSync(
+    "npx",
+    ["prettier", "--write", "src/**/*.{ts,css,html,json}", "*.md", "*.js"],
+    { stdio: "inherit", shell: IS_WINDOWS },
   );
-}
-
-async function prettier({ ignoreIgnoreFile = false } = {}) {
-  const { check, format, getFileInfo, resolveConfigFile, resolveConfig } = await import("prettier");
-  const configFile = (await resolveConfigFile()) ?? ".prettierrc";
-  const config = await resolveConfig(configFile);
-  /** @param {AsyncIterator<import("vinyl")>} source */
-  return async function* process(source) {
-    for await (const file of source) {
-      if (file.contents != null) {
-        if (!ignoreIgnoreFile) {
-          // check if the file is in .prettierignore before trying to format it
-          const fileInfo = await getFileInfo(file.path, { ignorePath: ".prettierignore" });
-          if (fileInfo.ignored) {
-            continue;
-          }
-        }
-        const options = { filepath: file.path, ...config };
-        const code = file.contents.toString();
-        const valid = await check(code, options);
-        if (!valid) {
-          const contents = await format(code, options);
-          const clone = file.clone({ contents: false });
-          yield Object.assign(clone, { contents: Buffer.from(contents) });
-        }
-      }
-    }
-  };
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error("Prettier formatting failed");
 }
 
 icongen.description = "Generate font files from SVG icons, and update package.json accordingly.";


### PR DESCRIPTION
# DRAFT 
Testing locally and exploring alternatives first.* 

TL;DR a [recent PR to add a Claude hook for prettier](https://github.com/confluentinc/vscode/pull/3256) also added a `.prettierignore` file + check, which caused [my run of `gulp apigen`](https://github.com/confluentinc/vscode/pull/3310) (the first since then) to skip re-formatting the client file changes.

*Claude's first fix was to add an option to ignore the ignore file in the prettier function. Another option is to have `apigen` run it's own formatting command. Or, maybe Prettier doesn't need to ignore `src/clients`; those files should always follow our prettier config since they get formatted after generation. 

💡 Currently exploring the idea that we may not need this entire `prettier()` function, since the prettier `cli` handles all of that automatically — it reads .prettierrc, respects .prettierignore, discovers files from the glob, and writes them in place.

## Summary

- The `.prettierignore` added in https://github.com/confluentinc/vscode/pull/3256 includes `src/clients/` to prevent the Claude Code formatting hook from reformatting auto-generated client code. However, the `apigen` gulp task's internal Prettier step uses the same `prettier()` helper, which consults `.prettierignore` — causing it to silently skip formatting for **all** generated client files.
- This meant running `gulp apigen` produced raw `openapi-generator` output (4-space indent, single quotes) instead of Prettier-formatted output (2-space indent, double quotes per `.prettierrc`), creating thousands of lines of cosmetic diffs across every client even when only one spec changed.
- Adds an `ignoreIgnoreFile` option to the `prettier()` helper so `apigen` can bypass `.prettierignore` while all other callers (e.g. the `format` task and Claude hook) remain unaffected.

## Investigation

When updating the Flink SQL OpenAPI spec and running `gulp apigen`, all 10 generated clients showed massive formatting-only diffs (indentation, quote style, trailing whitespace). The root cause trace:

1. `apigen` calls `prettier()` at `Gulpfile.js:1001` to get a formatting transform
2. `prettier()` calls `getFileInfo(file.path, { ignorePath: ".prettierignore" })` for each file
3. `.prettierignore` contains `src/clients/`, so `fileInfo.ignored` is `true` for every generated file
4. The formatting transform `continue`s past every file — no formatting is applied
5. The raw `openapi-generator-cli` output (which uses different defaults than our `.prettierrc`) gets written as-is, differing from the previously Prettier-formatted files on `main`

## Test plan

- [x] Run `gulp apigen` on a clean `main` checkout — verify no unexpected diffs in non-changed clients
- [x] Run `gulp format` — verify it still respects `.prettierignore` and skips `src/clients/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)