### PR TITLE
remove prettierignore and revert changes to exclusion patterns affecting `gulp apigen` and `gulp format`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,0 @@
-# auto-generated code from openapi-generator-cli
-src/clients/
-
-# copied from ide-sidecar
-src/graphql/sidecarGraphQL.d.ts
-
-# build output
-out/

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1058,25 +1058,29 @@ export async function format() {
   // Prettier's API does not have a magic method to just fix everything
   // So this is where we add some Gulp FileSystem API to make it work
   return pipeline(
-    src(["src/**/*.{ts,css,html,json}", "*.md", "*.js"]),
+    src([
+      "src/**/*.ts",
+      "!src/clients/**/*.ts", // don't reformat apigen generated code
+      "!src/graphql/sidecarGraphQL.d.ts", // don't reformat gql.tada generated code
+      "src/**/*.css",
+      "src/**/*.html",
+      "src/**/*.json",
+      "*.md",
+      "*.js",
+    ]),
     transform,
     dest((file) => file.base),
   );
 }
 
 async function prettier() {
-  const { check, format, getFileInfo, resolveConfigFile, resolveConfig } = await import("prettier");
+  const { check, format, resolveConfigFile, resolveConfig } = await import("prettier");
   const configFile = (await resolveConfigFile()) ?? ".prettierrc";
   const config = await resolveConfig(configFile);
   /** @param {AsyncIterator<import("vinyl")>} source */
   return async function* process(source) {
     for await (const file of source) {
       if (file.contents != null) {
-        // check if the file is in .prettierignore before trying to format it
-        const fileInfo = await getFileInfo(file.path, { ignorePath: ".prettierignore" });
-        if (fileInfo.ignored) {
-          continue;
-        }
         const options = { filepath: file.path, ...config };
         const code = file.contents.toString();
         const valid = await check(code, options);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

https://github.com/confluentinc/vscode/pull/3256 created a general-purpose `.prettierignore` for both the Claude hook and the `gulp format` task to use, but was ignorant of how it affected `gulp apigen` by not formatting any generated client code.

Since Claude [shouldn't](https://github.com/confluentinc/vscode/blob/a408f79d336fc1f83a49404eb52aca697f02f090/CLAUDE.md?plain=1#L85-L97) be editing those files directly, we can safely remove `.prettierignore` and go back to the old way of handling per-task file patterns when running Prettier, while still allowing Claude to use the hook for files it _can_ edit.

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Run `gulp apigen` on `main`
2. Note the lack of Prettier formatting and the large number of file and line changes
3. Reset/discard the changes
4. Switch to this branch and run `gulp apigen` again
5. Expect no changes to `main`'s current state of `src/clients/`

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
