### PR TITLE
MINOR fix: check for `coverage.json` file before trying to create report

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -756,7 +756,7 @@ export async function testRun() {
       ],
     });
   } finally {
-    if (reportCoverage) {
+    if (reportCoverage && existsSync("./coverage.json")) {
       let coverageMap = libCoverage.createCoverageMap();
       let sourceMapStore = libSourceMaps.createSourceMapStore();
       coverageMap.merge(JSON.parse(await readFile("./coverage.json")));


### PR DESCRIPTION
In rare instances, we'll have a test failure during setup that will be masked by the fact that we don't have a `coverage.json` file created. This throws a new error and prevents seeing what the actual error was:
<img width="526" height="136" alt="image" src="https://github.com/user-attachments/assets/e12fbd7e-1f1b-423f-8030-458b6dff38b1" />
