### PR TITLE
[security] run `npm audit fix` to update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "rollup": "^4.18.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-esbuild": "^6.1.1",
-        "rollwright": "^0.0.6",
+        "rollwright": "^0.0.7",
         "sanitize-html": "^2.14.0",
         "sinon": "^18.0.1",
         "typescript": "^5.4.2",
@@ -16274,9 +16274,9 @@
       }
     },
     "node_modules/rollwright": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/rollwright/-/rollwright-0.0.6.tgz",
-      "integrity": "sha512-a/UrNHRIQe32CiphhaSRh+wsCHExYtCjqN1XreHYQhcI0l11kmitZZi75Q0dS3cYEX3uCmyyww4rQR+9DFsi5A==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/rollwright/-/rollwright-0.0.7.tgz",
+      "integrity": "sha512-i1Z8d10dCKXwVDJval40yNhCvlU5DpLDoPXPfi1vfbBu5qsjlpk4mPI4nFXkEZZiNj3DiKPBb++3vQlaWDiyDQ==",
       "dev": true,
       "dependencies": {
         "@hono/node-server": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -2642,7 +2642,7 @@
     "rollup": "^4.18.0",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-esbuild": "^6.1.1",
-    "rollwright": "^0.0.6",
+    "rollwright": "^0.0.7",
     "sanitize-html": "^2.14.0",
     "sinon": "^18.0.1",
     "typescript": "^5.4.2",
@@ -2676,10 +2676,5 @@
     "vscode-languageserver": "^9.0.1",
     "ws": "^8.18.0",
     "yauzl": "^2.10.0"
-  },
-  "overrides": {
-    "rollwright": {
-      "@hono/node-server": "1.11.4"
-    }
   }
 }


### PR DESCRIPTION
Before:
```
29 vulnerabilities (3 low, 5 moderate, 20 high, 1 critical)
```

After:
```
15 vulnerabilities (2 low, 3 moderate, 10 high)
```
(via `npm audit`)