### PR TITLE
chore(CI): set up scheduled availability tests

### DIFF
--- a/.semaphore/availability-tests.yml
+++ b/.semaphore/availability-tests.yml
@@ -1,0 +1,58 @@
+version: v1.0
+name: availability-tests
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+execution_time_limit:
+  hours: 1
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - make ci-bin-sem-cache-restore
+  epilogue:
+    always:
+      commands:
+        - make ci-bin-sem-cache-store
+
+blocks:
+  - name: "Linux x64: Availability Smoke Tests"
+    dependencies: []
+    task:
+      prologue:
+        commands:
+          - |
+            if [[ "${SEMAPHORE_ORGANIZATION_URL}" == *".semaphoreci.com" ]]; then
+              echo "Skipping Vault setup for Semaphore CI"
+            else
+              . vault-setup
+            fi
+          - make checkout-latest-release-branch
+          - make load-cached-docker-images
+      jobs:
+        - name: "Playwright: Availability Smoke Tests (VS Code stable)"
+          commands:
+            - make test-playwright-e2e TEST_SUITE=@smoke
+          env_vars:
+            - name: FORCE_COLOR
+              value: "1"
+            - name: TERM
+              value: "xterm-256color"
+            - name: VSCODE_VERSION
+              value: "stable"
+      epilogue:
+        always:
+          commands:
+            - make remove-test-env
+            - make cache-docker-images
+            - make store-test-results-to-semaphore
+            - make merge-blob-reports
+
+after_pipeline:
+  task:
+    jobs:
+      - name: Publish Test Results to Semaphore
+        commands:
+          - test-results gen-pipeline-report || echo "Could not publish pipeline test result report"

--- a/.semaphore/availability-tests.yml
+++ b/.semaphore/availability-tests.yml
@@ -30,11 +30,10 @@ blocks:
               . vault-setup
             fi
           - make checkout-latest-release-branch
-          - make load-cached-docker-images
       jobs:
         - name: "Playwright: Availability Smoke Tests (VS Code stable)"
           commands:
-            - make test-playwright-e2e TEST_SUITE=@smoke
+            - make test-playwright-e2e TEST_SUITE=@smoke TEST_EXCLUDE=@local
           env_vars:
             - name: FORCE_COLOR
               value: "1"
@@ -46,7 +45,6 @@ blocks:
         always:
           commands:
             - make remove-test-env
-            - make cache-docker-images
             - make store-test-results-to-semaphore
             - make merge-blob-reports
 

--- a/.semaphore/release-e2e-smoketests.yml
+++ b/.semaphore/release-e2e-smoketests.yml
@@ -5,7 +5,7 @@ agent:
     type: s1-prod-ubuntu24-04-amd64-1
 
 execution_time_limit:
-  hours: 1
+  minutes: 10
 
 global_job_config:
   prologue:

--- a/.semaphore/release-e2e-smoketests.yml
+++ b/.semaphore/release-e2e-smoketests.yml
@@ -1,5 +1,5 @@
 version: v1.0
-name: availability-tests
+name: "Release E2E Smoketests"
 agent:
   machine:
     type: s1-prod-ubuntu24-04-amd64-1
@@ -18,7 +18,7 @@ global_job_config:
         - make ci-bin-sem-cache-store
 
 blocks:
-  - name: "Linux x64: Availability Smoke Tests"
+  - name: "Linux x64: Release Smoke Tests"
     dependencies: []
     task:
       prologue:
@@ -29,9 +29,13 @@ blocks:
             else
               . vault-setup
             fi
-          - make checkout-latest-release-branch
+          - |
+            RELEASE_TAG=$(make --no-print-directory get-latest-stable-release-tag)
+            make checkout-release-branch RELEASE_TAG=$RELEASE_TAG
+            echo ""
+            echo "Release: $RELEASE_TAG (branch: $(git rev-parse --abbrev-ref HEAD))"
       jobs:
-        - name: "Playwright: Availability Smoke Tests (VS Code stable)"
+        - name: "Playwright: Release Smoke Tests (VS Code stable)"
           commands:
             - make test-playwright-e2e TEST_SUITE=@smoke TEST_EXCLUDE=@local
           env_vars:

--- a/.semaphore/release-e2e-smoketests.yml
+++ b/.semaphore/release-e2e-smoketests.yml
@@ -18,7 +18,9 @@ global_job_config:
         - make ci-bin-sem-cache-store
 
 blocks:
-  - name: "Linux x64: Release Smoke Tests"
+  # test the published .vsix artifact (downloads the actual release artifact and runs smoke tests
+  # against it without building from source)
+  - name: "Linux x64: Release VSIX Smoke Tests"
     dependencies: []
     task:
       prologue:
@@ -29,15 +31,12 @@ blocks:
             else
               . vault-setup
             fi
-          - |
-            RELEASE_TAG=$(make --no-print-directory get-latest-stable-release-tag)
-            make checkout-release-branch RELEASE_TAG=$RELEASE_TAG
-            echo ""
-            echo "Release: $RELEASE_TAG (branch: $(git rev-parse --abbrev-ref HEAD))"
+          - make download-latest-release-vsix
       jobs:
-        - name: "Playwright: Release Smoke Tests (VS Code stable)"
+        - name: "Playwright: Release VSIX Smoke Tests (VS Code stable)"
           commands:
-            - make test-playwright-e2e TEST_SUITE=@smoke TEST_EXCLUDE=@local
+            - make test-playwright-vsix E2E_VSIX_PATH="/tmp/vsix/*.vsix" TEST_SUITE=@smoke
+              TEST_EXCLUDE=@local
           env_vars:
             - name: FORCE_COLOR
               value: "1"

--- a/.semaphore/release-e2e-smoketests.yml
+++ b/.semaphore/release-e2e-smoketests.yml
@@ -29,7 +29,7 @@ blocks:
             if [[ "${SEMAPHORE_ORGANIZATION_URL}" == *".semaphoreci.com" ]]; then
               echo "Skipping Vault setup for Semaphore CI"
             else
-              . vault-setup
+              . vault-setup --version v3 --role vscode
             fi
           - make download-latest-release-vsix
       jobs:

--- a/Makefile
+++ b/Makefile
@@ -107,26 +107,46 @@ cache-docker-images:
 		cache store $$SEMAPHORE_SCHEMA_REGISTRY_KEY schema-registry.tgz && \
 		rm -rf schema-registry.tgz)
 
-# Run E2E (Playwright) tests with optional test name and exclusion
+# Run E2E (Playwright) tests by building from source, then testing the resulting .vsix.
 # Usage: make test-playwright-e2e (runs all tests)
 # Usage: make test-playwright-e2e TEST_SUITE=@smoke
 # Usage: make test-playwright-e2e TEST_SUITE=@smoke TEST_EXCLUDE=@local
 .PHONY: test-playwright-e2e
 test-playwright-e2e: setup-test-env install-test-dependencies install-dependencies
-	@if [ -n "$(TEST_SUITE)" ] && [ "$(TEST_SUITE)" != "" ] && [ "$(TEST_SUITE)" != "TEST_SUITE" ]; then \
-			TEST_SUITE_ARG="-t $(TEST_SUITE)"; \
-	else \
-			TEST_SUITE_ARG=""; \
+	npx gulp bundle pullDockerImages
+	@$(MAKE) --no-print-directory _run-playwright-e2e E2E_VSIX_PATH="out/*.vsix" \
+		TEST_SUITE="$(TEST_SUITE)" TEST_EXCLUDE="$(TEST_EXCLUDE)"
+
+# Run Playwright E2E tests directly against a pre-built .vsix (bypasses gulp build/bundle).
+# Requires E2E_VSIX_PATH to be set (path or glob to the .vsix file).
+# Usage: make test-playwright-vsix E2E_VSIX_PATH=/tmp/vsix/*.vsix
+# Usage: make test-playwright-vsix E2E_VSIX_PATH=/tmp/vsix/*.vsix TEST_SUITE=@smoke TEST_EXCLUDE=@local
+.PHONY: test-playwright-vsix
+test-playwright-vsix: setup-test-env install-test-dependencies install-dependencies
+	@if [ -z "$(E2E_VSIX_PATH)" ]; then \
+		echo "ERROR: E2E_VSIX_PATH is required (path or glob to a .vsix file)" >&2; \
+		exit 1; \
+	fi
+	@$(MAKE) --no-print-directory _run-playwright-e2e E2E_VSIX_PATH="$(E2E_VSIX_PATH)" \
+		TEST_SUITE="$(TEST_SUITE)" TEST_EXCLUDE="$(TEST_EXCLUDE)"
+
+# internal: shared Playwright E2E invocation (sets up env vars, filters, and xvfb wrapper)
+.PHONY: _run-playwright-e2e
+_run-playwright-e2e:
+	@GREP_ARG=""; \
+	if [ -n "$(TEST_SUITE)" ] && [ "$(TEST_SUITE)" != "TEST_SUITE" ]; then \
+		GREP_ARG="--grep $(TEST_SUITE)"; \
 	fi; \
-	if [ -n "$(TEST_EXCLUDE)" ] && [ "$(TEST_EXCLUDE)" != "" ] && [ "$(TEST_EXCLUDE)" != "TEST_EXCLUDE" ]; then \
-			TEST_EXCLUDE_ARG="-x $(TEST_EXCLUDE)"; \
-	else \
-			TEST_EXCLUDE_ARG=""; \
+	GREP_INVERT_ARG=""; \
+	if [ -n "$(TEST_EXCLUDE)" ] && [ "$(TEST_EXCLUDE)" != "TEST_EXCLUDE" ]; then \
+		GREP_INVERT_ARG="--grep-invert $(TEST_EXCLUDE)"; \
 	fi; \
+	export E2E_VSIX_PATH="$(E2E_VSIX_PATH)"; \
+	export CONFLUENT_VSCODE_E2E_TESTING=true; \
 	if [ $$(uname -s) = "Linux" ]; then \
-			xvfb-run -a npx gulp e2e $$TEST_SUITE_ARG $$TEST_EXCLUDE_ARG; \
+		xvfb-run -a npx playwright test -c tests/e2e/playwright.config.ts tests/e2e $$GREP_ARG $$GREP_INVERT_ARG; \
 	else \
-			npx gulp e2e $$TEST_SUITE_ARG $$TEST_EXCLUDE_ARG; \
+		npx playwright test -c tests/e2e/playwright.config.ts tests/e2e $$GREP_ARG $$GREP_INVERT_ARG; \
 	fi
 
 # Validates bump based on current version (in package.json)

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ cache-docker-images:
 		cache store $$SEMAPHORE_SCHEMA_REGISTRY_KEY schema-registry.tgz && \
 		rm -rf schema-registry.tgz)
 
-# Run E2E (Playwright) tests with optional test name
+# Run E2E (Playwright) tests with optional test name and exclusion
 # Usage: make test-playwright-e2e (runs all tests)
 # Usage: make test-playwright-e2e TEST_SUITE=@smoke
-# Usage: make test-playwright-e2e TEST_SUITE=@regression
+# Usage: make test-playwright-e2e TEST_SUITE=@smoke TEST_EXCLUDE=@local
 .PHONY: test-playwright-e2e
 test-playwright-e2e: setup-test-env install-test-dependencies install-dependencies
 	@if [ -n "$(TEST_SUITE)" ] && [ "$(TEST_SUITE)" != "" ] && [ "$(TEST_SUITE)" != "TEST_SUITE" ]; then \
@@ -118,10 +118,15 @@ test-playwright-e2e: setup-test-env install-test-dependencies install-dependenci
 	else \
 			TEST_SUITE_ARG=""; \
 	fi; \
-	if [ $$(uname -s) = "Linux" ]; then \
-			xvfb-run -a npx gulp e2e $$TEST_SUITE_ARG; \
+	if [ -n "$(TEST_EXCLUDE)" ] && [ "$(TEST_EXCLUDE)" != "" ] && [ "$(TEST_EXCLUDE)" != "TEST_EXCLUDE" ]; then \
+			TEST_EXCLUDE_ARG="-x $(TEST_EXCLUDE)"; \
 	else \
-			npx gulp e2e $$TEST_SUITE_ARG; \
+			TEST_EXCLUDE_ARG=""; \
+	fi; \
+	if [ $$(uname -s) = "Linux" ]; then \
+			xvfb-run -a npx gulp e2e $$TEST_SUITE_ARG $$TEST_EXCLUDE_ARG; \
+	else \
+			npx gulp e2e $$TEST_SUITE_ARG $$TEST_EXCLUDE_ARG; \
 	fi
 
 # Validates bump based on current version (in package.json)

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -34,29 +34,23 @@ get-latest-stable-release-tag:
 	fi; \
 	echo "$$TAG"
 
-# look up and check out the release branch (vX.Y.x) based on the provided release tag (vX.Y.Z) 
-.PHONY: checkout-release-branch
-checkout-release-branch:
+# download the platform-specific .vsix from the latest stable GitHub release
+# Usage: make download-latest-release-vsix
+# Usage: make download-latest-release-vsix RELEASE_TAG=v2.3.0
+# Usage: make download-latest-release-vsix VSIX_PLATFORM=darwin-arm64
+.PHONY: download-latest-release-vsix
+download-latest-release-vsix:
 	@if [ -z "$(RELEASE_TAG)" ]; then \
-		echo "ERROR: RELEASE_TAG is required (e.g., make checkout-release-branch RELEASE_TAG=v2.2.2)" >&2; \
-		exit 1; \
+		TAG=$$($(MAKE) --no-print-directory $(MAKE_ARGS) get-latest-stable-release-tag); \
+	else \
+		TAG="$(RELEASE_TAG)"; \
 	fi; \
-	BRANCH=$$(echo "$(RELEASE_TAG)" | sed -E 's/^(v[0-9]+\.[0-9]+)\.[0-9]+$$/\1.x/'); \
-	if [ "$$BRANCH" = "$(RELEASE_TAG)" ]; then \
-		echo "ERROR: Could not derive release branch from tag '$(RELEASE_TAG)'. Expected vX.Y.Z format." >&2; \
-		exit 1; \
-	fi; \
-	echo "Checking out release branch $$BRANCH for tag $(RELEASE_TAG)..."; \
-	git fetch $(GIT_REMOTE_NAME) "$$BRANCH:$$BRANCH" || { echo "ERROR: Branch $$BRANCH not found on $(GIT_REMOTE_NAME)." >&2; exit 1; }; \
-	git checkout "$$BRANCH"; \
-	echo "Checked out: $$(git rev-parse --abbrev-ref HEAD) at $$(git rev-parse --short HEAD)"
-
-# look up the latest release tag, then check out its associated release branch
-.PHONY: checkout-latest-release-branch
-checkout-latest-release-branch:
-	@TAG=$$($(MAKE) --no-print-directory $(MAKE_ARGS) get-latest-stable-release-tag); \
-	echo "Latest stable release: $$TAG"; \
-	$(MAKE) --no-print-directory $(MAKE_ARGS) checkout-release-branch RELEASE_TAG=$$TAG
+	PLATFORM=$${VSIX_PLATFORM:-linux-x64}; \
+	VSIX_DIR="/tmp/vsix"; \
+	mkdir -p "$$VSIX_DIR"; \
+	echo "Downloading $$PLATFORM .vsix for release $$TAG..."; \
+	gh release download "$$TAG" --pattern "*$$PLATFORM*.vsix" --dir "$$VSIX_DIR" --clobber; \
+	echo "Downloaded: $$(ls $$VSIX_DIR/*.vsix)"
 
 .PHONY: create-gh-release
 create-gh-release:

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -24,6 +24,40 @@ set-node-bumped-version:
 			git add package.json && git add package-lock.json) \
 		|| true
 
+# print the latest non-prerelease GitHub release tag (e.g., v2.3.0)
+.PHONY: get-latest-stable-release-tag
+get-latest-stable-release-tag:
+	@TAG=$$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName'); \
+	if [ -z "$$TAG" ] || [ "$$TAG" = "null" ]; then \
+		echo "ERROR: Could not determine latest stable release tag." >&2; \
+		exit 1; \
+	fi; \
+	echo "$$TAG"
+
+# look up and check out the release branch (vX.Y.x) based on the provided release tag (vX.Y.Z) 
+.PHONY: checkout-release-branch
+checkout-release-branch:
+	@if [ -z "$(RELEASE_TAG)" ]; then \
+		echo "ERROR: RELEASE_TAG is required (e.g., make checkout-release-branch RELEASE_TAG=v2.2.2)" >&2; \
+		exit 1; \
+	fi; \
+	BRANCH=$$(echo "$(RELEASE_TAG)" | sed -E 's/^(v[0-9]+\.[0-9]+)\.[0-9]+$$/\1.x/'); \
+	if [ "$$BRANCH" = "$(RELEASE_TAG)" ]; then \
+		echo "ERROR: Could not derive release branch from tag '$(RELEASE_TAG)'. Expected vX.Y.Z format." >&2; \
+		exit 1; \
+	fi; \
+	echo "Checking out release branch $$BRANCH for tag $(RELEASE_TAG)..."; \
+	git fetch $(GIT_REMOTE_NAME) "$$BRANCH:$$BRANCH" || { echo "ERROR: Branch $$BRANCH not found on $(GIT_REMOTE_NAME)." >&2; exit 1; }; \
+	git checkout "$$BRANCH"; \
+	echo "Checked out: $$(git rev-parse --abbrev-ref HEAD) at $$(git rev-parse --short HEAD)"
+
+# look up the latest release tag, then check out its associated release branch
+.PHONY: checkout-latest-release-branch
+checkout-latest-release-branch:
+	@TAG=$$($(MAKE) $(MAKE_ARGS) get-latest-stable-release-tag); \
+	echo "Latest stable release: $$TAG"; \
+	$(MAKE) $(MAKE_ARGS) checkout-release-branch RELEASE_TAG=$$TAG
+
 .PHONY: create-gh-release
 create-gh-release:
 ifeq ($(CI),true)

--- a/mk-files/release.mk
+++ b/mk-files/release.mk
@@ -54,9 +54,9 @@ checkout-release-branch:
 # look up the latest release tag, then check out its associated release branch
 .PHONY: checkout-latest-release-branch
 checkout-latest-release-branch:
-	@TAG=$$($(MAKE) $(MAKE_ARGS) get-latest-stable-release-tag); \
+	@TAG=$$($(MAKE) --no-print-directory $(MAKE_ARGS) get-latest-stable-release-tag); \
 	echo "Latest stable release: $$TAG"; \
-	$(MAKE) $(MAKE_ARGS) checkout-release-branch RELEASE_TAG=$$TAG
+	$(MAKE) --no-print-directory $(MAKE_ARGS) checkout-release-branch RELEASE_TAG=$$TAG
 
 .PHONY: create-gh-release
 create-gh-release:

--- a/service.yml
+++ b/service.yml
@@ -130,9 +130,9 @@ semaphore:
           description: |
             Which platform(s) to run E2E tests on. 'linux' runs only the Linux block(s);
             'windows' runs only the Windows block(s); 'all' runs everything.
-    - name: scheduled-availability-tests
+    - name: scheduled-release-e2e-smoketests
       branch: main
-      pipeline_file: ".semaphore/availability-tests.yml"
+      pipeline_file: ".semaphore/release-e2e-smoketests.yml"
       scheduled: true
       at: "*/15 * * * *"
   managed_sections:

--- a/service.yml
+++ b/service.yml
@@ -130,6 +130,11 @@ semaphore:
           description: |
             Which platform(s) to run E2E tests on. 'linux' runs only the Linux block(s);
             'windows' runs only the Windows block(s); 'all' runs everything.
+    - name: scheduled-availability-tests
+      branch: main
+      pipeline_file: ".semaphore/availability-tests.yml"
+      scheduled: true
+      at: "*/15 * * * *"
   managed_sections:
     - version
     - name

--- a/service.yml
+++ b/service.yml
@@ -140,9 +140,9 @@ semaphore:
           required: false
           default_value: 'main'
           description: 'The branch to audit and base the PR against. Defaults to main; override for release branches like v1.2.x.'
-    - name: scheduled-availability-tests
+    - name: scheduled-release-e2e-smoketests
       branch: main
-      pipeline_file: ".semaphore/availability-tests.yml"
+      pipeline_file: ".semaphore/release-e2e-smoketests.yml"
       scheduled: true
       at: "*/15 * * * *"
   managed_sections:

--- a/service.yml
+++ b/service.yml
@@ -140,6 +140,11 @@ semaphore:
           required: false
           default_value: 'main'
           description: 'The branch to audit and base the PR against. Defaults to main; override for release branches like v1.2.x.'
+    - name: scheduled-availability-tests
+      branch: main
+      pipeline_file: ".semaphore/availability-tests.yml"
+      scheduled: true
+      at: "*/15 * * * *"
   managed_sections:
     - version
     - name

--- a/tests/e2e/global.setup.ts
+++ b/tests/e2e/global.setup.ts
@@ -1,6 +1,7 @@
 import { test as setup } from "@playwright/test";
 import { downloadAndUnzipVSCode } from "@vscode/test-electron";
-import { writeFileSync } from "fs";
+import { execSync } from "child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "fs";
 import { globSync } from "glob";
 import { tmpdir } from "os";
 import path from "path";
@@ -44,13 +45,23 @@ setup("setup VS Code for E2E tests", async () => {
     });
   }
 
-  const extensionPath = path.normalize(path.resolve(__dirname, "..", ".."));
-  const outPath: string = path.normalize(path.resolve(extensionPath, "out"));
-  const vsixFiles: string[] = globSync("*.vsix", { cwd: outPath });
-  const vsixPath = vsixFiles.length > 0 ? path.join(outPath, vsixFiles[0]) : "";
-  if (!vsixPath) {
-    // shouldn't happen during normal `gulp e2e`
-    throw new Error("No VSIX file found in the out/ directory. Run 'npx gulp bundle' first.");
+  // resolve the extension path: either from a pre-built .vsix (E2E_VSIX_PATH) or the local
+  // build output directory (out/)
+  let outPath: string;
+
+  if (process.env.E2E_VSIX_PATH) {
+    // testing a pre-built .vsix artifact (e.g. from a GitHub release)
+    outPath = extractVsix(process.env.E2E_VSIX_PATH);
+  } else {
+    // default: use the locally-built extension in out/
+    const extensionPath = path.normalize(path.resolve(__dirname, "..", ".."));
+    outPath = path.normalize(path.resolve(extensionPath, "out"));
+    const vsixFiles: string[] = globSync("*.vsix", { cwd: outPath });
+    const vsixPath = vsixFiles.length > 0 ? path.join(outPath, vsixFiles[0]) : "";
+    if (!vsixPath) {
+      // shouldn't happen during normal `gulp e2e`
+      throw new Error("No VSIX file found in the out/ directory. Run 'npx gulp bundle' first.");
+    }
   }
 
   // save test setup cache to file for other workers to read
@@ -63,11 +74,33 @@ setup("setup VS Code for E2E tests", async () => {
   if (DEBUG_LOGGING_ENABLED) {
     console.debug("Test setup complete", {
       vscodeVersion,
-      extensionPath,
-      vsixPath,
       vscodeExecutablePath,
       outPath,
       testSetupCacheFile: TEST_SETUP_CACHE_FILE,
     });
   }
 });
+
+/**
+ * Extract a `.vsix` file to a temp directory and return the path to the `extension/` subdirectory
+ * inside it. A `.vsix` is a ZIP archive with the extension contents under `extension/`.
+ */
+function extractVsix(vsixGlob: string): string {
+  const matches = globSync(vsixGlob);
+  if (matches.length === 0) {
+    throw new Error(`No .vsix file found matching "${vsixGlob}".`);
+  }
+  const vsixPath = matches[0];
+  const extractDir = mkdtempSync(path.join(tmpdir(), "vsix-extract-"));
+
+  console.log(`Extracting .vsix from "${vsixPath}" to "${extractDir}"...`);
+  execSync(`unzip -q "${vsixPath}" -d "${extractDir}"`, { stdio: "inherit" });
+
+  const extensionDir = path.join(extractDir, "extension");
+  if (!existsSync(extensionDir)) {
+    throw new Error(`Expected "extension/" subdirectory not found after extracting "${vsixPath}".`);
+  }
+
+  console.log(`Using extracted extension at "${extensionDir}"`);
+  return extensionDir;
+}

--- a/tests/e2e/specs/confluent.spec.ts
+++ b/tests/e2e/specs/confluent.spec.ts
@@ -30,6 +30,8 @@ test.describe(() => {
       const resourcesView = new ResourcesView(page);
       const ccloudItem = new CCloudConnectionItem(page, resourcesView.confluentCloudItem);
       await expect(ccloudItem.locator).not.toContainText(NOT_CONNECTED_TEXT);
+      // also make sure we have at least one environment listed
+      await expect(resourcesView.ccloudEnvironments).not.toHaveCount(0);
     },
   );
 });


### PR DESCRIPTION
Similar to our scheduled (nightly) E2E test runs and (hourly) CCloud auth smoketests (Mocha, not E2E), we wanted a way of testing the most recent release to ensure the latest release .vsix successfully activates and can sign in through the CCloud auth flow.

This required some additional logic in our Make targets to look up the GitHub releases/tags, but instead of going through `gulp e2e` -- (to include building, like [`playwright-e2e.yml`](https://github.com/confluentinc/vscode/blob/main/.semaphore/playwright-e2e.yml)) -- this downloads the .vsix file from the release and runs the E2E tests directly with it (which cuts the timing down by 40+ seconds for `@smoke` tests).

Tested with an ephemeral manual task [run](https://semaphore.ci.confluent.io/workflows/4b3671d8-1a60-4f70-8420-433fc46c738d?pipeline_id=b314c98a-2870-4022-b786-04a49882332a) in the Semaphore UI:
<img width="413" height="211" alt="image" src="https://github.com/user-attachments/assets/caa153f0-bcb0-4d0d-95bb-ddd41fc92104" />

<img width="475" height="83" alt="image" src="https://github.com/user-attachments/assets/d872c520-7b22-452c-82ae-39300f8cddf5" />

<img width="1043" height="302" alt="image" src="https://github.com/user-attachments/assets/2bf94406-57e1-476f-af7d-2b21e7df3126" />


