### PR TITLE
fix `after_pipeline` for E2E reporting

### DIFF
--- a/.semaphore/playwright-e2e.yml
+++ b/.semaphore/playwright-e2e.yml
@@ -217,6 +217,10 @@ after_pipeline:
     jobs:
       - name: Publish Test Results to Semaphore
         commands:
+          - checkout
+          - make ci-bin-sem-cache-restore
+          - npm ci --prefer-offline --include=dev
+          # Publish to dedicated Kafka topic for additional test result visualization/analysis
           - export E2E_KAFKA_REPORTER_TOPIC=vscode-test-results
           - if [[ "$SEMAPHORE_WORKFLOW_TRIGGERED_BY_SCHEDULE" == "true" ]]; then
             artifact pull workflow blob-report;


### PR DESCRIPTION
Follow-up based on the errors we're seeing in CI For the scheduled E2E test runs:
```
[Mar 23 07:56:31.361] Successfully pulled artifact for current workflow.
[Mar 23 07:56:31.361] * Remote source: 'artifacts/workflows/33e65626-f701-4c4e-a707-6b8b066c142c/blob-report'.
[Mar 23 07:56:31.361] * Local destination: 'blob-report'.
[Mar 23 07:56:31.361] Pulled 8 files. Total of 172.6 MB
npm warn exec The following package was not found and will be installed: playwright@1.58.2
Error: Cannot find module './tests/e2e/reporters/kafka-results-reporter.ts'
```

- need `checkout` so `tests/e2e/reporters/kafka-results-reporter.ts` is available
- `make ci-bin-sem-cache-restore` isn't _really_ necessary, but should help speed up `npm ci`
- `npm ci` added since the custom [reporter](https://github.com/confluentinc/vscode/blob/main/tests/e2e/reporters/kafka-results-reporter.ts) needs to use a few packages
