### PR TITLE
cache VS Code downloads to speed up test runs

### DIFF
--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -47,7 +47,7 @@ ifneq ($(SEMAPHORE_GIT_REF_TYPE),pull-request)
 	[[ $(os_name) == "Darwin" ]] && $(MAKE) sem-cache-store-entry SEM_CACHE_KEY=$(PLATFORM)_$(ARCH)_playwright_cache SEM_CACHE_PATH=$(HOME)/Library/Caches/ms-playwright || true
 	[[ $(os_name) == "Linux" ]] && $(MAKE) sem-cache-store-entry SEM_CACHE_KEY=$(PLATFORM)_$(ARCH)_playwright_cache SEM_CACHE_PATH=$(HOME)/.cache/ms-playwright || true
 # Also cache VS Code binaries downloaded by @vscode/test-electron if present
-	[[ -d $(CURDIR)/.vscode-test ]] && $(MAKE) sem-cache-store-entry SEM_CACHE_KEY=$(PLATFORM)_$(ARCH)_vscode_test_cache SEM_CACHE_PATH=$(CURDIR)/.vscode-test || true
+	[[ -d $(CURDIR)/.vscode-test ]] && $(MAKE) sem-cache-store-entry SEM_CACHE_KEY=$(PLATFORM)_$(ARCH)_vscode_test_cache_$${VSCODE_VERSION:-stable} SEM_CACHE_PATH=$(CURDIR)/.vscode-test || true
 endif
 
 # cache restore allows fuzzy matching. When it finds multiple matches, it will select the most recent cache archive.
@@ -77,7 +77,7 @@ ci-bin-sem-cache-restore:
 	@echo "Restoring semaphore caches"
 	cache restore $(PLATFORM)_$(ARCH)_npm_cache
 	cache restore $(PLATFORM)_$(ARCH)_playwright_cache || true
-	cache restore $(PLATFORM)_$(ARCH)_vscode_test_cache || true
+	cache restore $(PLATFORM)_$(ARCH)_vscode_test_cache_$${VSCODE_VERSION:-stable} || true
 
 # Merge per-job blob reports into one HTML report by test job:
 # - Each job's blob reporter will write a report zip to `blob-report/`, so we'll have multiple files


### PR DESCRIPTION
Minor addition to the caching to include the VS Code executable (150MB+), which will also help if we see waves of failed downloads like we did today:
<img width="695" height="568" alt="image" src="https://github.com/user-attachments/assets/0b213418-31d6-4d26-aea6-8bacc2a59546" />

