### PR TITLE
MINOR fix(CI): force push blob reports

### DIFF
--- a/.semaphore/playwright-e2e.yml
+++ b/.semaphore/playwright-e2e.yml
@@ -67,7 +67,7 @@ blocks:
       epilogue: &e2e-epilogue
         always:
           commands:
-            - artifact push workflow blob-report/*.zip --destination blob-report/$(basename blob-report/*.zip)
+            - artifact push workflow blob-report/*.zip --destination blob-report/$(basename blob-report/*.zip) --force
             - make remove-test-env
             - make cache-docker-images
             - make store-test-results-to-semaphore
@@ -200,7 +200,7 @@ blocks:
             - |
               Write-Output "Merging blob reports..."
               if (Test-Path "blob-report") {
-                  artifact push workflow blob-report/*.zip --destination blob-report/$(basename blob-report/*.zip)
+                  artifact push workflow blob-report/*.zip --destination blob-report/$(basename blob-report/*.zip) --force
                   npx playwright merge-reports --reporter html ./blob-report
                   $VSCODE_VERSION = $Env:VSCODE_VERSION
                   if ([string]::IsNullOrEmpty($Env:TEST_SUITE_TAG) -or $Env:TEST_SUITE_TAG -eq "TEST_SUITE_TAG") {


### PR DESCRIPTION
Re-running seems to be blocking our epilogue actions for pushing other artifacts:
<img width="547" height="102" alt="image" src="https://github.com/user-attachments/assets/f78abfd4-a1bf-4214-a357-3fe12acbd424" />

So we're adding the `--force` flag as suggested, matching [existing](https://github.com/search?q=repo%3Aconfluentinc%2Fvscode%20%22artifact%20push%22&type=code) patterns