### PR TITLE
Migrate fossa_full_access to Vault V3

### DIFF
--- a/scripts/generate-third-party-notices.sh
+++ b/scripts/generate-third-party-notices.sh
@@ -23,7 +23,7 @@ main() {
   # Full access token created using rsanjay@confluent.io's FOSSA account (on Jul 17, 2024).
   # Rotate every 80-180 days.
   # https://docs.fossa.com/docs/rotating-fossa-api-key#full-access-token
-  export FOSSA_API_KEY=$(vault kv get -field api_key v1/ci/kv/fossa_full_access)
+  . vault-get-secret --vault-role=default --secret-key=api_key --export-as=FOSSA_API_KEY dtx/fossa-full-access
   fossa analyze --exclude-path mk-files --only-target npm
 
   # This might timeout so retry a few times


### PR DESCRIPTION
## Summary
- Replaces direct Vault CLI call (`vault kv get`) with `vault-get-secret` in `scripts/generate-third-party-notices.sh`
- Uses shared semaphore role (`--vault-role=default`)
- V3 secret path: `semaphore/dtx/fossa-full-access`

## Related
- cire-vault PR: https://github.com/confluentinc/cire-vault/pull/3310 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)