### PR TITLE
fix(CI): use single quotes for pushing test result artifacts on Windows agents

### DIFF
--- a/.semaphore/playwright-e2e.yml
+++ b/.semaphore/playwright-e2e.yml
@@ -190,15 +190,15 @@ blocks:
             # Windows version of store-test-results-to-semaphore
             - |
               Write-Output "Publishing test results to Semaphore..."
-              $TestResultE2EFile = Join-Path -Path $PWD -ChildPath 'TEST-result-e2e.xml'
-              if (Test-Path $TestResultE2EFile) {
-                  $fileInfo = Get-Item $TestResultE2EFile
+              $TestResultE2EFileName = 'TEST-result-e2e.xml'
+              if (Test-Path $TestResultE2EFileName) {
+                  $fileInfo = Get-Item $TestResultE2EFileName
                   Write-Output "Publishing E2E test results from $($fileInfo.FullName) ($($fileInfo.Length) bytes)"
                   $TestResultName = 'VS Code ({0}) Extension Tests: E2E (win32 x64)' -f $Env:VSCODE_VERSION
                   Write-Output "Publishing with name: $TestResultName"
-                  test-results publish "$TestResultE2EFile" --name "$TestResultName" --force
+                  test-results publish $TestResultE2EFileName --name "$TestResultName" --force
               } else {
-                  Write-Output "E2E test results not found at $TestResultE2EFile"
+                  Write-Output "E2E test results not found at $(Join-Path -Path $PWD -ChildPath $TestResultE2EFileName)"
               }
             # Windows version of merge-blob-reports
             - |

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -189,26 +189,26 @@ blocks:
             # Windows version of store-test-results-to-semaphore
             - |
               Write-Output "Publishing test results to Semaphore..."
-              $TestResultFile = Join-Path -Path $PWD -ChildPath 'TEST-result.xml'
-              if (Test-Path $TestResultFile) {
-                  Write-Output "Publishing Mocha test results from $TestResultFile"
-                  test-results publish "$TestResultFile" --force
+              $TestResultFileName = 'TEST-result.xml'
+              if (Test-Path $TestResultFileName) {
+                  Write-Output "Publishing Mocha test results from $(Resolve-Path $TestResultFileName)"
+                  test-results publish $TestResultFileName --force
               } else {
-                  Write-Output "Mocha test results not found at $TestResultFile"
+                  Write-Output "Mocha test results not found at $(Join-Path -Path $PWD -ChildPath $TestResultFileName)"
               }
-              $TestResultE2EFile = Join-Path -Path $PWD -ChildPath 'TEST-result-e2e.xml'
-              if (Test-Path $TestResultE2EFile) {
-                  Write-Output "Publishing E2E test results from $TestResultE2EFile"
-                  test-results publish "$TestResultE2EFile" --name 'VS Code (stable) Extension Tests: E2E (win32 x64)' --force
+              $TestResultE2EFileName = 'TEST-result-e2e.xml'
+              if (Test-Path $TestResultE2EFileName) {
+                  Write-Output "Publishing E2E test results from $(Resolve-Path $TestResultE2EFileName)"
+                  test-results publish $TestResultE2EFileName --name 'VS Code (stable) Extension Tests: E2E (win32 x64)' --force
               } else {
-                  Write-Output "E2E test results not found at $TestResultE2EFile"
+                  Write-Output "E2E test results not found at $(Join-Path -Path $PWD -ChildPath $TestResultE2EFileName)"
               }
-              $TestResultWebviewFile = Join-Path -Path $PWD -ChildPath 'TEST-result-webview.xml'
-              if (Test-Path $TestResultWebviewFile) {
-                  Write-Output "Publishing Webview test results from $TestResultWebviewFile"
-                  test-results publish "$TestResultWebviewFile" --name 'Webview Tests' --force
+              $TestResultWebviewFileName = 'TEST-result-webview.xml'
+              if (Test-Path $TestResultWebviewFileName) {
+                  Write-Output "Publishing Webview test results from $(Resolve-Path $TestResultWebviewFileName)"
+                  test-results publish $TestResultWebviewFileName --name 'Webview Tests' --force
               } else {
-                  Write-Output "Webview test results not found at $TestResultWebviewFile"
+                  Write-Output "Webview test results not found at $(Join-Path -Path $PWD -ChildPath $TestResultWebviewFileName)"
               }
 
   # --- End Build & Test (multi-platform/-arch) for VS Code (stable) ---


### PR DESCRIPTION
I'm not sure when the behavior started, but we recently started seeing failures from the Windows agents in CI when they attempted to push test results as Semaphore artifacts (via `test-results publish ...`):
<img width="719" height="357" alt="image" src="https://github.com/user-attachments/assets/33d4b014-ecf6-416a-8a0e-86eeaa82a96a" />

This turned out to be a problem with how the filenames were being handled, which is now working as expected:
<img width="724" height="638" alt="image" src="https://github.com/user-attachments/assets/381470f3-f89f-4b90-bc69-3aa850d96b26" />
