### PR TITLE
fix(E2E): skip test if we see a 429 notification after CCloud sign-in

### DIFF
--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -135,11 +135,26 @@ export async function setupCCloudConnection(
   );
   await uriInputBox.confirm();
 
-  // Make sure the "Confluent Cloud" item in the Resources view is expanded and doesn't show the
-  // "(No connection)" description
+  // Wait for the CCloud connection to load resources. If the sidecar's GraphQL query hits a 429
+  // rate limit (common when multiple CI jobs share the same test org), the extension shows a
+  // warning notification and returns no environments, so the tree item never expands. Detect this
+  // early instead of waiting for the full test timeout.
   await expect(ccloudItem.locator).toBeVisible();
-  await expect(ccloudItem.locator).not.toContainText(NOT_CONNECTED_TEXT);
-  await expect(ccloudItem.locator).toHaveAttribute("aria-expanded", "true");
+  const notificationArea = new NotificationArea(page);
+  const rateLimitWarning = notificationArea.warningNotifications.filter({
+    hasText: /Exceeded rate limit/,
+  });
+  await expect(async () => {
+    // fail fast if a rate-limit warning appeared (use testInfo.skip so Playwright does NOT retry
+    // the test, which would just amplify the rate limiting with more rapid sign-in attempts)
+    const warningCount = await rateLimitWarning.count();
+    if (warningCount > 0) {
+      testInfo.skip(true, "CCloud sign-in hit rate limiting (HTTP 429).");
+    }
+    // otherwise keep waiting for the connection to expand
+    await expect(ccloudItem.locator).not.toContainText(NOT_CONNECTED_TEXT);
+    await expect(ccloudItem.locator).toHaveAttribute("aria-expanded", "true");
+  }).toPass();
   return ccloudItem;
 }
 

--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -142,17 +142,22 @@ export async function setupCCloudConnection(
   await expect(ccloudItem.locator).toBeVisible();
 
   // check for a 429 rate-limit warning before waiting for the connection status text to update
+  let rateLimited = false;
   const notificationArea = new NotificationArea(page);
   const rateLimitWarning = notificationArea.warningNotifications.filter({
     hasText: /Exceeded rate limit/,
   });
   try {
     await expect(rateLimitWarning).not.toHaveCount(0, { timeout: 5_000 });
-    // use testInfo.skip so Playwright doesn't retry the test, which would just make things worse by
-    // causing more 429s across retries
-    testInfo.skip(true, "CCloud sign-in hit rate limiting (HTTP 429).");
+    // can't call testInfo.skip in here since it will be swallowed by the try/catch, so just flag it
+    rateLimited = true;
   } catch {
-    // no rate-limit warning seen yet
+    // no rate-limit warning seen after 5 seconds
+  }
+  if (rateLimited) {
+    // use testInfo.skip so Playwright doesn't retry the test, which would just make things worse
+    // by causing more 429s across retries
+    testInfo.skip(true, "CCloud sign-in hit rate limiting (HTTP 429).");
   }
 
   await expect(ccloudItem.locator).not.toContainText(NOT_CONNECTED_TEXT);

--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -140,21 +140,23 @@ export async function setupCCloudConnection(
   // warning notification and returns no environments, so the tree item never expands. Detect this
   // early instead of waiting for the full test timeout.
   await expect(ccloudItem.locator).toBeVisible();
+
+  // check for a 429 rate-limit warning before waiting for the connection status text to update
   const notificationArea = new NotificationArea(page);
   const rateLimitWarning = notificationArea.warningNotifications.filter({
     hasText: /Exceeded rate limit/,
   });
-  await expect(async () => {
-    // fail fast if a rate-limit warning appeared (use testInfo.skip so Playwright does NOT retry
-    // the test, which would just amplify the rate limiting with more rapid sign-in attempts)
-    const warningCount = await rateLimitWarning.count();
-    if (warningCount > 0) {
-      testInfo.skip(true, "CCloud sign-in hit rate limiting (HTTP 429).");
-    }
-    // otherwise keep waiting for the connection to expand
-    await expect(ccloudItem.locator).not.toContainText(NOT_CONNECTED_TEXT);
-    await expect(ccloudItem.locator).toHaveAttribute("aria-expanded", "true");
-  }).toPass();
+  try {
+    await expect(rateLimitWarning).not.toHaveCount(0, { timeout: 5_000 });
+    // use testInfo.skip so Playwright doesn't retry the test, which would just make things worse by
+    // causing more 429s across retries
+    testInfo.skip(true, "CCloud sign-in hit rate limiting (HTTP 429).");
+  } catch {
+    // no rate-limit warning seen yet
+  }
+
+  await expect(ccloudItem.locator).not.toContainText(NOT_CONNECTED_TEXT);
+  await expect(ccloudItem.locator).toHaveAttribute("aria-expanded", "true");
   return ccloudItem;
 }
 


### PR DESCRIPTION
<img width="613" height="465" alt="image" src="https://github.com/user-attachments/assets/1ea75416-9106-483a-8ccd-c3b7ff7aaf68" />

Instead of failing early, we skip the test entirely if we see the 429 warning notification after sign-in (while trying to load CCloud environments and associated resources). This is to avoid failing fast, retrying [twice](https://github.com/confluentinc/vscode/blob/881be74695999a5586e9238402632617eca69989/tests/e2e/playwright.config.ts#L24), then seeing even more 429s.

Seen while attempting to run multiple (full test) E2E pipelines in parallel:
<img width="1037" height="513" alt="image" src="https://github.com/user-attachments/assets/4b5bc138-315c-48c2-9a65-509c21fcc678" />


> [!NOTE]
> I don't expect this to be handled by https://github.com/confluentinc/ide-sidecar/issues/521 considering the test account we use only has a single environment with <5 clusters/pools/etc, so the fan-out queries by a single sidecar process aren't the problem in this case. 