### PR TITLE
E2E: remove dedicated teardown for `LOCAL` connections, and allow containers to preexist on startup

### DIFF
--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -25,7 +25,6 @@ import {
   setupCCloudConnection,
   setupDirectConnection,
   setupLocalConnection,
-  teardownLocalConnection,
 } from "./utils/connections";
 import { produceMessages } from "./utils/producer";
 import { configureVSCodeSettings } from "./utils/settings";
@@ -265,27 +264,10 @@ export const test = testBase.extend<VSCodeFixtures>({
 
     await use(connection);
 
-    // teardown
-    switch (connectionType) {
-      case ConnectionType.Ccloud:
-        // no explicit teardown needed since shutting down the extension+sidecar will invalidate the
-        // CCloud auth session
-        break;
-      case ConnectionType.Direct:
-        // no teardown needed since each test will use its own storage in TMPDIR, so any direct
-        // connections created will be cleaned up automatically, and subsequent tests will use their
-        // own blank-slate storage
-        break;
-      case ConnectionType.Local:
-        // local resources are discovered automatically through the Docker engine API, so we need
-        // to explicitly stop them to ensure the next tests can start them fresh
-        await teardownLocalConnection(connection.page, {
-          schemaRegistry: localConnectionConfig.schemaRegistry,
-        });
-        break;
-      default:
-        throw new Error(`Unsupported connection type: ${connectionType}`);
-    }
+    // no per-test teardown needed for any connection type:
+    // - CCLOUD: shutting down the extension+sidecar invalidates the auth session
+    // - DIRECT: each test uses its own TMPDIR storage, cleaned up automatically
+    // - LOCAL: containers persist between tests and are reused via idempotent setup
   },
 
   // no default value, must be provided by test

--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -252,7 +252,9 @@ export async function setupLocalConnection(
 
     if (options.schemaRegistry) {
       try {
-        await expect(resourcesView.localSchemaRegistries).not.toHaveCount(0);
+        // use a short check here to see if local SR is already running; the longer timeout is only
+        // used when starting fresh within setupLocalSchemaRegistry()
+        await expect(resourcesView.localSchemaRegistries).not.toHaveCount(0, { timeout: 3000 });
       } catch {
         // start the SR container if it isn't running
         return await setupLocalSchemaRegistry(page);

--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -16,7 +16,6 @@ import { LocalConnectionItem } from "../objects/views/viewItems/LocalConnectionI
 import type { DirectConnectionForm } from "../objects/webviews/DirectConnectionFormWebview";
 import type { DirectConnectionOptions, LocalConnectionOptions } from "../types/connection";
 import { executeVSCodeCommand } from "./commands";
-import { openConfluentSidebar } from "./sidebarNavigation";
 
 export const CCLOUD_SIGNIN_URL_PATH = join(tmpdir(), "vscode-e2e-ccloud-signin-url.txt");
 export const NOT_CONNECTED_TEXT = "(No connection)";
@@ -244,18 +243,30 @@ export async function setupLocalConnection(
   const resourcesView = new ResourcesView(page);
   await expect(resourcesView.localItem).toBeVisible();
 
-  // TEMPORARY: until we can isolate test containers from real containers, we'll have to enforce
-  // no currently running containers and fail sooner rather than waiting for the default timeout
-  await expect(
-    resourcesView.localItem,
-    "Local resources must be stopped before running @local tests.",
-  ).not.toHaveAttribute("aria-expanded", { timeout: 1000 });
+  const localItem = new LocalConnectionItem(page, resourcesView.localItem);
+  const isExpanded = await resourcesView.localItem.getAttribute("aria-expanded");
 
-  let localItem: LocalConnectionItem = await setupLocalKafka(page);
-  if (options.schemaRegistry) {
-    localItem = await setupLocalSchemaRegistry(page);
+  if (isExpanded === "true") {
+    // container(s) already running - at least local Kafka should be available
+    await expect(resourcesView.localKafkaClusters).not.toHaveCount(0);
+
+    if (options.schemaRegistry) {
+      try {
+        await expect(resourcesView.localSchemaRegistries).not.toHaveCount(0);
+      } catch {
+        // start the SR container if it isn't running
+        return await setupLocalSchemaRegistry(page);
+      }
+    }
+    return localItem;
   }
-  return localItem;
+
+  // not running, start fresh
+  let result: LocalConnectionItem = await setupLocalKafka(page);
+  if (options.schemaRegistry) {
+    result = await setupLocalSchemaRegistry(page);
+  }
+  return result;
 }
 
 export async function setupLocalKafka(page: Page) {
@@ -309,29 +320,4 @@ export async function setupLocalSchemaRegistry(page: Page) {
   await expect(resourcesView.localKafkaClusters).not.toHaveCount(0);
   await expect(resourcesView.localSchemaRegistries).not.toHaveCount(0, { timeout: 60_000 });
   return localItem;
-}
-
-/** Stops local resources (Kafka and optionally Schema Registry) through the Resources view. */
-export async function teardownLocalConnection(page: Page, options: LocalConnectionOptions) {
-  // Always make sure the sidebar is open and we're in the Resources view before we try to interact
-  // with the local connection item. This isn't necessary for the `setupLocalConnection()` function
-  // since it's always called at the start of a test after the `openExtensionSidebar` fixture, but
-  // it's needed here since tests may switch windows/views.
-  await openConfluentSidebar(page);
-
-  const resourcesView = new ResourcesView(page);
-  const localItem = new LocalConnectionItem(page, resourcesView.localItem.first());
-  await expect(localItem.locator).toHaveAttribute("aria-expanded", "true");
-  await localItem.clickStopResources();
-
-  if (options.schemaRegistry) {
-    // we only see the quickpick if both local Kafka and SR are running
-    const containerQuickpick = new Quickpick(page);
-    await containerQuickpick.selectItemByText("Schema Registry");
-    await containerQuickpick.selectItemByText("Kafka");
-    await containerQuickpick.confirm();
-  }
-
-  // once the resources are stopped, the local connection shouldn't be expandable
-  await expect(resourcesView.localItem).not.toHaveAttribute("aria-expanded");
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Removes the hard requirement that each `@local`-tagged test needs to handle the full container lifecycle during fixture setup and teardown.

Now we only assert that the Kafka container (and optionally SR container) is available during setup (whether started externally / by another test or the current test) and skips teardown entirely*.

_*Maybe we want to add a single after-all hook to try local teardown in a future branch, but isn't necessary here._

Closes #2951

| | Sample of `@local`-tagged tests' timing |
|--------|--------|
| Before | <img width="1076" height="221" alt="image" src="https://github.com/user-attachments/assets/b52b5074-ef5f-4d89-8e30-2f7e5ecc3933" /> |
| After | <img width="1064" height="219" alt="image" src="https://github.com/user-attachments/assets/550ab44e-619b-4b5f-8954-81fc45bc9441" /> | 

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Start a local Kafka container (from within/outside the extension, doesn't matter here)
2. Run `@local`-tagged tests via:
```
npx gulp e2e -t "@local"
```
3. Expect no early failure state triggering retries
4. Overall `@local` test run times should be significantly reduced

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
