### PR TITLE
fix(E2E): wait for window load before opening command palette

### DIFF
--- a/tests/e2e/specs/flinkArtifact.spec.ts
+++ b/tests/e2e/specs/flinkArtifact.spec.ts
@@ -192,6 +192,11 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
       });
       await executeVSCodeCommand(page, "workbench.action.files.openFolder");
 
+      // wait for the window to finish transitioning to the new workspace before
+      // trying to open the command palette again
+      await page.locator(".monaco-workbench").waitFor();
+      await page.waitForLoadState("domcontentloaded");
+
       // make sure the explorer view is visible before we activate the extension
       await executeVSCodeCommand(page, "workbench.view.explorer");
 


### PR DESCRIPTION
Minor fix to the Flink artifact testing `setupTestEnvironment` step; we were previously calling the command to open a workspace and then immediately transitioning to calling a command to open the Explorer view without waiting for the new workspace window to load.