### PR TITLE
MINOR: set project-level `.npmrc` to point at public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Avoids trying to look at a CodeArtifact mirror since this repo doesn't use any internal dependencies.

Required for https://github.com/confluentinc/vscode/pull/3372