### PR TITLE
fix(E2E): wait for workspace load in Flink artifact setup

### DIFF
--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -346,7 +346,7 @@ async function globalBeforeEach(page: Page, testTempDir: string): Promise<void> 
   // make sure settings are set to defaults for each test
   configureVSCodeSettings(testTempDir);
 
-  // dismiss the disabled-extensions toast and collapse the secondary sidebar
+  // dismiss the disabled-extensions notification and collapse the secondary sidebar
   await prepareTestWorkspace(page);
 }
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -6,7 +6,6 @@ import { createWriteStream, existsSync, mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { DEBUG_LOGGING_ENABLED } from "./constants";
-import { Notification } from "./objects/notifications/Notification";
 import { NotificationArea } from "./objects/notifications/NotificationArea";
 import { Quickpick } from "./objects/quickInputs/Quickpick";
 import {
@@ -28,8 +27,8 @@ import {
 } from "./utils/connections";
 import { produceMessages } from "./utils/producer";
 import { configureVSCodeSettings } from "./utils/settings";
-import { openConfluentSidebar } from "./utils/sidebarNavigation";
 import { randomHexString } from "./utils/strings";
+import { openConfluentSidebar, prepareTestWorkspace } from "./utils/workspace";
 
 // NOTE: we can't import these two directly from 'global.setup.ts'
 // cached test setup file path that's shared across worker processes
@@ -347,25 +346,8 @@ async function globalBeforeEach(page: Page, testTempDir: string): Promise<void> 
   // make sure settings are set to defaults for each test
   configureVSCodeSettings(testTempDir);
 
-  // dismiss the "All installed extensions are temporarily disabled" notification that will
-  // always appear since we launch with --disable-extensions
-  const notificationArea = new NotificationArea(page);
-  const infoNotifications = notificationArea.infoNotifications.filter({
-    hasText: "All installed extensions are temporarily disabled",
-  });
-  await expect(infoNotifications).not.toHaveCount(0);
-  const notification = new Notification(page, infoNotifications.first());
-  await notification.dismiss();
-
-  // collapse the secondary sidebar if it's expanded since it isn't used for anything
-  try {
-    await expect(page.locator(`[id="workbench.parts.auxiliarybar"]`)).toBeVisible({
-      timeout: 1000,
-    });
-    await executeVSCodeCommand(page, "View: Toggle Secondary Side Bar Visibility");
-  } catch {
-    console.warn("Error locating/toggling secondary sidebar");
-  }
+  // dismiss the disabled-extensions toast and collapse the secondary sidebar
+  await prepareTestWorkspace(page);
 }
 
 async function globalAfterEach(

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -6,7 +6,6 @@ import { createWriteStream, existsSync, mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import { DEBUG_LOGGING_ENABLED } from "./constants";
-import { Notification } from "./objects/notifications/Notification";
 import { NotificationArea } from "./objects/notifications/NotificationArea";
 import { Quickpick } from "./objects/quickInputs/Quickpick";
 import {
@@ -29,8 +28,8 @@ import {
 } from "./utils/connections";
 import { produceMessages } from "./utils/producer";
 import { configureVSCodeSettings } from "./utils/settings";
-import { openConfluentSidebar } from "./utils/sidebarNavigation";
 import { randomHexString } from "./utils/strings";
+import { openConfluentSidebar, prepareTestWorkspace } from "./utils/workspace";
 
 // NOTE: we can't import these two directly from 'global.setup.ts'
 // cached test setup file path that's shared across worker processes
@@ -365,25 +364,8 @@ async function globalBeforeEach(page: Page, testTempDir: string): Promise<void> 
   // make sure settings are set to defaults for each test
   configureVSCodeSettings(testTempDir);
 
-  // dismiss the "All installed extensions are temporarily disabled" notification that will
-  // always appear since we launch with --disable-extensions
-  const notificationArea = new NotificationArea(page);
-  const infoNotifications = notificationArea.infoNotifications.filter({
-    hasText: "All installed extensions are temporarily disabled",
-  });
-  await expect(infoNotifications).not.toHaveCount(0);
-  const notification = new Notification(page, infoNotifications.first());
-  await notification.dismiss();
-
-  // collapse the secondary sidebar if it's expanded since it isn't used for anything
-  try {
-    await expect(page.locator(`[id="workbench.parts.auxiliarybar"]`)).toBeVisible({
-      timeout: 1000,
-    });
-    await executeVSCodeCommand(page, "View: Toggle Secondary Side Bar Visibility");
-  } catch {
-    console.warn("Error locating/toggling secondary sidebar");
-  }
+  // dismiss the disabled-extensions toast and collapse the secondary sidebar
+  await prepareTestWorkspace(page);
 }
 
 async function globalAfterEach(

--- a/tests/e2e/specs/confluent.spec.ts
+++ b/tests/e2e/specs/confluent.spec.ts
@@ -5,7 +5,7 @@ import { ResourcesView } from "../objects/views/ResourcesView";
 import { CCloudConnectionItem } from "../objects/views/viewItems/CCloudConnectionItem";
 import { Tag } from "../tags";
 import { NOT_CONNECTED_TEXT, setupCCloudConnection } from "../utils/connections";
-import { openConfluentSidebar } from "../utils/sidebarNavigation";
+import { openConfluentSidebar } from "../utils/workspace";
 
 test.describe(() => {
   test("should activate the extension", { tag: [Tag.Smoke] }, async ({ page }) => {

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -147,11 +147,11 @@ test.describe("Direct Connection CRUD Lifecycle", { tag: [Tag.DirectConnectionCR
           ]);
           await connectionItem.clickExportConnectionDetails();
           const notificationArea = new NotificationArea(page);
-          const exportToast = notificationArea.infoNotifications.filter({
+          const exportNotification = notificationArea.infoNotifications.filter({
             hasText: "Connection file saved at",
           });
-          await expect(exportToast).toHaveCount(1);
-          const notification = new Notification(page, exportToast.first());
+          await expect(exportNotification).toHaveCount(1);
+          const notification = new Notification(page, exportNotification.first());
           await expect(notification.message).toContainText("Connection file saved at");
           // inspect exported file contents
           await notification.clickActionButton("Open File");
@@ -327,11 +327,11 @@ test.describe("Direct Connection CRUD Lifecycle", { tag: [Tag.DirectConnectionCR
           ]);
           await connectionItem.clickExportConnectionDetails();
           const notificationArea = new NotificationArea(page);
-          const exportToast = notificationArea.infoNotifications.filter({
+          const exportNotification = notificationArea.infoNotifications.filter({
             hasText: "Connection file saved at",
           });
-          await expect(exportToast).toHaveCount(1);
-          const notification = new Notification(page, exportToast.first());
+          await expect(exportNotification).toHaveCount(1);
+          const notification = new Notification(page, exportNotification.first());
           await expect(notification.message).toContainText("Connection file saved at");
           // inspect exported file contents
           await notification.clickActionButton("Open File");

--- a/tests/e2e/specs/directConnectionLifecycle.spec.ts
+++ b/tests/e2e/specs/directConnectionLifecycle.spec.ts
@@ -147,8 +147,11 @@ test.describe("Direct Connection CRUD Lifecycle", { tag: [Tag.DirectConnectionCR
           ]);
           await connectionItem.clickExportConnectionDetails();
           const notificationArea = new NotificationArea(page);
-          await expect(notificationArea.infoNotifications).toHaveCount(1);
-          const notification = new Notification(page, notificationArea.infoNotifications.first());
+          const exportToast = notificationArea.infoNotifications.filter({
+            hasText: "Connection file saved at",
+          });
+          await expect(exportToast).toHaveCount(1);
+          const notification = new Notification(page, exportToast.first());
           await expect(notification.message).toContainText("Connection file saved at");
           // inspect exported file contents
           await notification.clickActionButton("Open File");
@@ -324,8 +327,11 @@ test.describe("Direct Connection CRUD Lifecycle", { tag: [Tag.DirectConnectionCR
           ]);
           await connectionItem.clickExportConnectionDetails();
           const notificationArea = new NotificationArea(page);
-          await expect(notificationArea.infoNotifications).toHaveCount(1);
-          const notification = new Notification(page, notificationArea.infoNotifications.first());
+          const exportToast = notificationArea.infoNotifications.filter({
+            hasText: "Connection file saved at",
+          });
+          await expect(exportToast).toHaveCount(1);
+          const notification = new Notification(page, exportToast.first());
           await expect(notification.message).toContainText("Connection file saved at");
           // inspect exported file contents
           await notification.clickActionButton("Open File");

--- a/tests/e2e/specs/flinkArtifact.spec.ts
+++ b/tests/e2e/specs/flinkArtifact.spec.ts
@@ -14,8 +14,8 @@ import { Tag } from "../tags";
 import { ConnectionType } from "../types/connection";
 import { executeVSCodeCommand } from "../utils/commands";
 import { createInvalidJarFile, createLargeFile } from "../utils/flinkDatabase";
-import { openConfluentSidebar } from "../utils/sidebarNavigation";
 import { randomHexString } from "../utils/strings";
+import { openConfluentSidebar, prepareTestWorkspace } from "../utils/workspace";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -194,8 +194,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
 
       // wait for the window to finish transitioning to the new workspace before
       // trying to open the command palette again
-      await page.locator(".monaco-workbench").waitFor();
-      await page.waitForLoadState("domcontentloaded");
+      await prepareTestWorkspace(page);
 
       // make sure the explorer view is visible before we activate the extension
       await executeVSCodeCommand(page, "workbench.view.explorer");

--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -16,7 +16,7 @@ import { LocalConnectionItem } from "../objects/views/viewItems/LocalConnectionI
 import type { DirectConnectionForm } from "../objects/webviews/DirectConnectionFormWebview";
 import type { DirectConnectionOptions, LocalConnectionOptions } from "../types/connection";
 import { executeVSCodeCommand } from "./commands";
-import { openConfluentSidebar } from "./sidebarNavigation";
+import { openConfluentSidebar } from "./workspace";
 
 export const CCLOUD_SIGNIN_URL_PATH = join(tmpdir(), "vscode-e2e-ccloud-signin-url.txt");
 export const NOT_CONNECTED_TEXT = "(No connection)";

--- a/tests/e2e/utils/workspace.ts
+++ b/tests/e2e/utils/workspace.ts
@@ -1,8 +1,49 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
+import { Notification } from "../objects/notifications/Notification";
+import { NotificationArea } from "../objects/notifications/NotificationArea";
 import { ViewContainer } from "../objects/ViewContainer";
 import { ResourcesView } from "../objects/views/ResourcesView";
 import { executeVSCodeCommand } from "./commands";
+
+/**
+ * Prepare a freshly-loaded VS Code workspace/window before any test interactions.
+ *
+ * NOTE: This should be safe to call at fixture startup (before any test has touched the window) and
+ * after any workspace/window reload.
+ */
+export async function prepareTestWorkspace(page: Page): Promise<void> {
+  // wait for the (new) VS Code window DOM + workbench shell to be ready; same waits the
+  // electronApp fixture uses at initial launch
+  await page.waitForLoadState("domcontentloaded");
+  await page.locator(".monaco-workbench").waitFor({ timeout: 30000 });
+
+  // dismiss the "All installed extensions are temporarily disabled" toast that always appears
+  // under --disable-extensions; tolerate it being absent on subsequent reloads
+  try {
+    const notificationArea = new NotificationArea(page);
+    const infoNotifications = notificationArea.infoNotifications.filter({
+      hasText: "All installed extensions are temporarily disabled",
+    });
+    await expect(infoNotifications).not.toHaveCount(0, { timeout: 2000 });
+    await new Notification(page, infoNotifications.first()).dismiss();
+  } catch {
+    // toast wasn't present or couldn't be dismissed
+  }
+
+  // collapse the secondary sidebar if it's expanded since it isn't used for anything
+  try {
+    await expect(page.locator(`[id="workbench.parts.auxiliarybar"]`)).toBeVisible({
+      timeout: 1000,
+    });
+    // use the default VS Code keybinding instead of the command palette: `Ctrl+Shift+P` can be
+    // swallowed by a focused Chat webview on workspace reload, but `Ctrl+Alt+B` is a global
+    // workbench keybinding that routes regardless of webview focus
+    await page.keyboard.press("ControlOrMeta+Alt+B");
+  } catch {
+    console.warn("Error locating/toggling secondary sidebar");
+  }
+}
 
 /**
  * Opens the primary sidebar with the main Confluent

--- a/tests/e2e/utils/workspace.ts
+++ b/tests/e2e/utils/workspace.ts
@@ -9,29 +9,27 @@ import { executeVSCodeCommand } from "./commands";
 /**
  * Prepare a freshly-loaded VS Code workspace/window before any test interactions.
  *
- * NOTE: This should be safe to call at fixture startup (before any test has touched the window) and
- * after any workspace/window reload.
+ * NOTE: Safe to call at fixture startup and after a reload that re-applies `--disable-extensions`
+ * (e.g. `workbench.action.files.openFolder`), since the dismissal step blocks until the
+ * "disabled extensions" notification re-emits. Calling it after a reload that drops that flag
+ * would block until the expect timeout and then fail, since the notification never appears.
  */
 export async function prepareTestWorkspace(page: Page): Promise<void> {
-  // wait for the (new) VS Code window DOM + workbench shell to be ready; same waits the
-  // electronApp fixture uses at initial launch
+  // wait for the (new) VS Code window DOM + workbench shell to be ready
   await page.waitForLoadState("domcontentloaded");
   await page.locator(".monaco-workbench").waitFor({ timeout: 30000 });
   // any locator-based interactions below this point will naturally wait for the Electron DOM to be
   // ready/visible/etc, so we don't need additional waits for that here
 
-  // dismiss the "All installed extensions are temporarily disabled" toast that always appears
-  // under --disable-extensions; tolerate it being absent on subsequent reloads
-  try {
-    const notificationArea = new NotificationArea(page);
-    const infoNotifications = notificationArea.infoNotifications.filter({
-      hasText: "All installed extensions are temporarily disabled",
-    });
-    await expect(infoNotifications).not.toHaveCount(0, { timeout: 2000 });
-    await new Notification(page, infoNotifications.first()).dismiss();
-  } catch {
-    // toast wasn't present or couldn't be dismissed
-  }
+  // explicitly dismiss the "All installed extensions are temporarily disabled" notification that
+  // always appears under --disable-extensions since it won't automatically disappear and will get
+  // in the way of some test assertions
+  const notificationArea = new NotificationArea(page);
+  const disabledExtensionsNotification = notificationArea.infoNotifications.filter({
+    hasText: "All installed extensions are temporarily disabled",
+  });
+  await expect(disabledExtensionsNotification).not.toHaveCount(0);
+  await new Notification(page, disabledExtensionsNotification.first()).dismiss();
 
   // collapse the secondary sidebar if it's expanded since it isn't used for anything
   try {

--- a/tests/e2e/utils/workspace.ts
+++ b/tests/e2e/utils/workspace.ts
@@ -17,6 +17,8 @@ export async function prepareTestWorkspace(page: Page): Promise<void> {
   // electronApp fixture uses at initial launch
   await page.waitForLoadState("domcontentloaded");
   await page.locator(".monaco-workbench").waitFor({ timeout: 30000 });
+  // any locator-based interactions below this point will naturally wait for the Electron DOM to be
+  // ready/visible/etc, so we don't need additional waits for that here
 
   // dismiss the "All installed extensions are temporarily disabled" toast that always appears
   // under --disable-extensions; tolerate it being absent on subsequent reloads


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Unfortunately delayed follow-up to #3365 since it was missing a critical step: we needed to wait for some of the initial "workspace/window loaded" locators to be available before any interactions could take place (like invoking the command palette).

Recent failures show that command invocation happened while the (new) workspace window was still loading, resulting in a failed assertion waiting for the quick input box:
<img width="1480" height="760" alt="image" src="https://github.com/user-attachments/assets/0989fe5d-17e4-4168-b8b2-54a65d323389" />

The new behavior is bundled into a new `prepareTestWorkspace()` function that includes:
- waiting for the correct Electron DOM state (similar to `electronApp` [setup](https://github.com/confluentinc/vscode/blob/bc18eb97076289fdbb1bc144fc061d41543ed6c5/tests/e2e/baseTest.ts#L149-L150))
- waiting for and dismissing the "extensions disabled" info notification and collapsing the secondary sidebar (currently in the `page` [setup](https://github.com/confluentinc/vscode/blob/bc18eb97076289fdbb1bc144fc061d41543ed6c5/tests/e2e/baseTest.ts#L368-L386), now moved into its own function)

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
