### PR TITLE
MINOR: fix `allowed-tools` syntax for claude skills

### DIFF
--- a/.claude/skills/mocha/SKILL.md
+++ b/.claude/skills/mocha/SKILL.md
@@ -4,7 +4,11 @@ description:
   Use when the user asks about Mocha test runner APIs and patterns for unit tests. Triggers on
   questions like "Mocha hooks", "before/after setup", "describe/it structure", "async tests in
   Mocha", "test timeouts", ".only/.skip", "how to run a specific test", or test organization.
-allowed-tools: Read, Bash, WebFetch, WebSearch
+allowed-tools:
+  - Read
+  - Bash
+  - WebFetch
+  - WebSearch
 ---
 
 # Mocha Documentation Lookup

--- a/.claude/skills/playwright-triage/SKILL.md
+++ b/.claude/skills/playwright-triage/SKILL.md
@@ -4,7 +4,11 @@ description: >-
   Use when E2E Playwright tests fail, CI reports test failures, the user mentions "triage", "test
   failed", "flaky test", or wants to debug Electron/Playwright test results. Also use when
   investigating trace.zip files, test screenshots, or Playwright HTML report archives from CI.
-allowed-tools: Read, Bash, Glob, Grep
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
 ---
 
 # Playwright E2E Test Failure Triage

--- a/.claude/skills/playwright/SKILL.md
+++ b/.claude/skills/playwright/SKILL.md
@@ -4,7 +4,13 @@ description:
   Use when the user asks about Playwright APIs, selectors, assertions, or patterns for E2E or
   functional tests. Triggers on questions like "how to click a button in Playwright", "Playwright
   locator", "page.waitFor", "expect toBeVisible", "Playwright test fixtures", or E2E test patterns.
-allowed-tools: Read, Bash, Glob, Grep, WebFetch, WebSearch
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - WebFetch
+  - WebSearch
 ---
 
 # Playwright Documentation Lookup

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -4,7 +4,12 @@ description:
   Reviews pull requests for this VS Code extension. Use when reviewing PRs, doing self-review before
   sharing with the team, or when user mentions "review PR", "review changes", "self-review", or
   "check my PR". Focuses on project-specific patterns and critical requirements.
-allowed-tools: Read, Bash, Grep, Glob, Task
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+  - Task
 ---
 
 # PR Review Skill

--- a/.claude/skills/sinon/SKILL.md
+++ b/.claude/skills/sinon/SKILL.md
@@ -4,7 +4,11 @@ description:
   Use when the user asks about Sinon stubbing, spying, mocking, or test double APIs for unit tests.
   Triggers on questions like "how do I stub this", "Sinon fake timers", "spy vs stub", "sandbox
   usage", "assert.calledWith", "stub.resolves", "sinon.match", or test double patterns.
-allowed-tools: Read, Bash, WebFetch, WebSearch
+allowed-tools:
+  - Read
+  - Bash
+  - WebFetch
+  - WebSearch
 ---
 
 # Sinon.JS Documentation Lookup

--- a/.claude/skills/vscode-api/SKILL.md
+++ b/.claude/skills/vscode-api/SKILL.md
@@ -4,7 +4,11 @@ description:
   Use when the user asks about VS Code API definitions, methods, interfaces, events, types, or wants
   to understand what VS Code APIs are available. Triggers on questions like "what does vscode.X do",
   "how to use VS Code API", "VS Code type definition", or checking API compatibility.
-allowed-tools: Read, Bash, WebFetch, WebSearch
+allowed-tools:
+  - Read
+  - Bash
+  - WebFetch
+  - WebSearch
 ---
 
 # VS Code API Lookup


### PR DESCRIPTION
https://code.claude.com/docs/en/skills#frontmatter-reference
> `allowed-tools` - Tools Claude can use without asking permission when this skill is active. **Accepts a space-separated string or a YAML list.**
