### PR TITLE
fix(CI): set up precheck pipeline for scheduled prereleases

### DIFF
--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -18,8 +18,8 @@ queue:
 global_job_config:
   prologue:
     commands:
-      # the scheduled task pins us to main's HEAD via `branch: main`, so we don't
-      # need the TARGET_BRANCH/COMMIT_SHA fetch+checkout dance from release-version.yml
+      # checkout just sets up the repo + origin remote; the job resolves origin/main itself (not the
+      # triggering ref), so we skip release-version.yml's TARGET_BRANCH/COMMIT_SHA checkout dance
       - checkout
       - . vault-setup --version v3 --role vscode
   env_vars:
@@ -38,7 +38,8 @@ blocks:
             # 2) build RELEASE_NAME from main's .versions/next.txt the same way release-version.yml does, then
             # 3) skip the rebuild when that tag already points at main's HEAD with all 5 platform VSIX assets
             - |
-              git fetch --tags --force --quiet origin main || true
+              set -e
+              git fetch --tags --force --quiet origin main
               TARGET_SHA=$(git rev-parse FETCH_HEAD)
               VERSION=$(git show FETCH_HEAD:.versions/next.txt)
               RELEASE_NAME="v$VERSION-pre"

--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -33,17 +33,13 @@ blocks:
       jobs:
         - name: "Check for Existing Release"
           commands:
-            # the scheduled task passes no parameters, so derive the prerelease name deterministically
-            # from .versions/next.txt (matching what release-version.yml computes for IS_PRERELEASE=true)
+            # no parameters for this task, so we need to build RELEASE_NAME from .versions/next.txt
+            # (release-version.yml does the same for IS_PRERELEASE=true), then check if we should
+            # skip the rebuild when that tag already points at HEAD with all 5 platform VSIX assets
             - |
               VERSION=$(cat .versions/next.txt)
               RELEASE_NAME="v$VERSION-pre"
               echo "RELEASE_NAME=$RELEASE_NAME"
-            # halt the workflow when the tag at this name already points at the current HEAD
-            # and the release has all five expected VSIX assets attached. exit 1
-            # produces result=failed,result_reason=test which the auto_promote below
-            # explicitly does not match (see comment on the promotion)
-            - |
               git fetch --tags --quiet origin || true
               CURRENT_SHA=$(git rev-parse HEAD)
               EXISTING_SHA=$(git rev-parse --verify "refs/tags/$RELEASE_NAME^{commit}" 2>/dev/null || true)

--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -1,0 +1,92 @@
+version: v1.0
+name: release-version-precheck
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+auto_cancel:
+  running:
+    when: "branch != 'main'"
+
+execution_time_limit:
+  hours: 1
+
+queue:
+  - when: "branch != 'main'"
+    processing: parallel
+
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+      - |
+        if [ -n "$TARGET_BRANCH" ]; then
+          git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH"
+          git checkout "$TARGET_BRANCH"
+        else
+          git fetch --all
+        fi
+        if [ -z "$COMMIT_SHA" ]; then
+          COMMIT_SHA=$(git rev-parse HEAD)
+        fi
+        git checkout "$COMMIT_SHA"
+      - . vault-setup --version v3 --role vscode
+  env_vars:
+    - name: NODE_ENV
+      value: "production"
+
+blocks:
+  - name: "Verify Parameters and Existing Release"
+    dependencies: []
+    task:
+      jobs:
+        - name: "Verify Parameters and Existing Release"
+          commands:
+            # fail early if the package.json version includes a micro-version when IS_PRERELEASE is false
+            - |
+              PKG_VERSION=$(jq -r '.version' package.json)
+              echo "package.json version: $PKG_VERSION"
+              if [ "$IS_PRERELEASE" != "true" ] && echo "$PKG_VERSION" | grep -q '-'; then
+                echo "ERROR: package.json version contains a micro-version or prerelease segment ($PKG_VERSION) but IS_PRERELEASE is false. Aborting."
+                exit 1
+              fi
+            # ensure RELEASE_NAME is set and adjust for prereleases, if necessary
+            - |
+              if [ -n "$RELEASE_NAME" ] && [ "$RELEASE_NAME" != "RELEASE_NAME" ]; then
+                echo "Using provided RELEASE_NAME: $RELEASE_NAME"
+              else
+                VERSION=$(cat .versions/next.txt)
+                RELEASE_NAME="v$VERSION"
+              fi
+              if [ "$IS_PRERELEASE" = "true" ]; then
+                if [[ "$RELEASE_NAME" != *"-pre"* ]]; then
+                  RELEASE_NAME="${RELEASE_NAME}-pre"
+                fi
+              fi
+              echo "RELEASE_NAME=$RELEASE_NAME"
+            # halt the workflow when the tag at this name already points at COMMIT_SHA
+            # and the release has all five expected VSIX assets attached. exit 1
+            # produces result=failed,result_reason=test which the auto_promote below
+            # explicitly does not match (see comment on the promotion)
+            - |
+              git fetch --tags --quiet origin || true
+              CURRENT_SHA=$(git rev-parse --verify "$COMMIT_SHA" 2>/dev/null || true)
+              EXISTING_SHA=$(git rev-parse --verify "refs/tags/$RELEASE_NAME^{commit}" 2>/dev/null || true)
+              ASSET_COUNT=$(gh release view "$RELEASE_NAME" --json assets -q '[.assets[] | select(.name | endswith(".vsix"))] | length' 2>/dev/null || echo 0)
+              if [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" = "$CURRENT_SHA" ] && [ "$ASSET_COUNT" -ge 5 ]; then
+                echo "Release $RELEASE_NAME already points to $CURRENT_SHA with $ASSET_COUNT VSIX assets; no rebuild needed."
+                echo "Halting the workflow before auto_promote (intentional exit 1)."
+                exit 1
+              fi
+              echo "Rebuild needed: existing_sha='$EXISTING_SHA' current_sha='$CURRENT_SHA' assets=$ASSET_COUNT. Auto-promoting to release-version.yml."
+
+promotions:
+  - name: "Run release-version pipeline"
+    pipeline_file: release-version.yml
+    auto_promote:
+      # the precheck halts the workflow before this promotion fires when:
+      #   - intentional skip:    result=failed, result_reason=test (exit 1 on no-op)
+      #   - YAML / config error: result=failed, result_reason=malformed
+      #   - infrastructure hang: result=failed, result_reason=stuck
+      # only a clean pass (no result_reason) auto-promotes to release-version.yml
+      when: "result = 'passed'"

--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -18,26 +18,15 @@ queue:
 global_job_config:
   prologue:
     commands:
+      # the scheduled task pins us to main's HEAD via `branch: main`, so we don't
+      # need the TARGET_BRANCH/COMMIT_SHA fetch+checkout dance from release-version.yml
       - checkout
-      - |
-        if [ -n "$TARGET_BRANCH" ]; then
-          git fetch origin "$TARGET_BRANCH:$TARGET_BRANCH"
-          git checkout "$TARGET_BRANCH"
-        else
-          git fetch --all
-        fi
-        if [ -z "$COMMIT_SHA" ]; then
-          COMMIT_SHA=$(git rev-parse HEAD)
-        fi
-        git checkout "$COMMIT_SHA"
       - . vault-setup --version v3 --role vscode
   env_vars:
     - name: NODE_ENV
       value: "production"
     - name: IS_PRERELEASE
       value: "true"
-    - name: TARGET_BRANCH
-      value: "main"
 
 blocks:
   - name: "Verify Parameters and Existing Release"
@@ -74,7 +63,7 @@ blocks:
             # explicitly does not match (see comment on the promotion)
             - |
               git fetch --tags --quiet origin || true
-              CURRENT_SHA=$(git rev-parse --verify "$COMMIT_SHA" 2>/dev/null || true)
+              CURRENT_SHA=$(git rev-parse HEAD)
               EXISTING_SHA=$(git rev-parse --verify "refs/tags/$RELEASE_NAME^{commit}" 2>/dev/null || true)
               ASSET_COUNT=$(gh release view "$RELEASE_NAME" --json assets -q '[.assets[] | select(.name | endswith(".vsix"))] | length' 2>/dev/null || echo 0)
               if [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" = "$CURRENT_SHA" ] && [ "$ASSET_COUNT" -ge 5 ]; then

--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -25,39 +25,21 @@ global_job_config:
   env_vars:
     - name: NODE_ENV
       value: "production"
-    - name: IS_PRERELEASE
-      value: "true"
 
 blocks:
-  - name: "Verify Parameters and Existing Release"
+  - name: "Check for Existing Release"
     dependencies: []
     task:
       jobs:
-        - name: "Verify Parameters and Existing Release"
+        - name: "Check for Existing Release"
           commands:
-            # fail early if the package.json version includes a micro-version when IS_PRERELEASE is false
+            # the scheduled task passes no parameters, so derive the prerelease name deterministically
+            # from .versions/next.txt (matching what release-version.yml computes for IS_PRERELEASE=true)
             - |
-              PKG_VERSION=$(jq -r '.version' package.json)
-              echo "package.json version: $PKG_VERSION"
-              if [ "$IS_PRERELEASE" != "true" ] && echo "$PKG_VERSION" | grep -q '-'; then
-                echo "ERROR: package.json version contains a micro-version or prerelease segment ($PKG_VERSION) but IS_PRERELEASE is false. Aborting."
-                exit 1
-              fi
-            # ensure RELEASE_NAME is set and adjust for prereleases, if necessary
-            - |
-              if [ -n "$RELEASE_NAME" ] && [ "$RELEASE_NAME" != "RELEASE_NAME" ]; then
-                echo "Using provided RELEASE_NAME: $RELEASE_NAME"
-              else
-                VERSION=$(cat .versions/next.txt)
-                RELEASE_NAME="v$VERSION"
-              fi
-              if [ "$IS_PRERELEASE" = "true" ]; then
-                if [[ "$RELEASE_NAME" != *"-pre"* ]]; then
-                  RELEASE_NAME="${RELEASE_NAME}-pre"
-                fi
-              fi
+              VERSION=$(cat .versions/next.txt)
+              RELEASE_NAME="v$VERSION-pre"
               echo "RELEASE_NAME=$RELEASE_NAME"
-            # halt the workflow when the tag at this name already points at COMMIT_SHA
+            # halt the workflow when the tag at this name already points at the current HEAD
             # and the release has all five expected VSIX assets attached. exit 1
             # produces result=failed,result_reason=test which the auto_promote below
             # explicitly does not match (see comment on the promotion)

--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -33,23 +33,24 @@ blocks:
       jobs:
         - name: "Check for Existing Release"
           commands:
-            # no parameters for this task, so we need to build RELEASE_NAME from .versions/next.txt
-            # (release-version.yml does the same for IS_PRERELEASE=true), then check if we should
-            # skip the rebuild when that tag already points at HEAD with all 5 platform VSIX assets
+            # this task takes no parameters, so we need to handle a few things:
+            # 1) evaluate origin/main here (not the triggering ref, whose HEAD never matches the tag pinned to main).
+            # 2) build RELEASE_NAME from main's .versions/next.txt the same way release-version.yml does, then
+            # 3) skip the rebuild when that tag already points at main's HEAD with all 5 platform VSIX assets
             - |
-              VERSION=$(cat .versions/next.txt)
+              git fetch --tags --force --quiet origin main || true
+              TARGET_SHA=$(git rev-parse FETCH_HEAD)
+              VERSION=$(git show FETCH_HEAD:.versions/next.txt)
               RELEASE_NAME="v$VERSION-pre"
-              echo "RELEASE_NAME=$RELEASE_NAME"
-              git fetch --tags --quiet origin || true
-              CURRENT_SHA=$(git rev-parse HEAD)
+              echo "RELEASE_NAME=$RELEASE_NAME TARGET_SHA=$TARGET_SHA"
               EXISTING_SHA=$(git rev-parse --verify "refs/tags/$RELEASE_NAME^{commit}" 2>/dev/null || true)
               ASSET_COUNT=$(gh release view "$RELEASE_NAME" --json assets -q '[.assets[] | select(.name | endswith(".vsix"))] | length' 2>/dev/null || echo 0)
-              if [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" = "$CURRENT_SHA" ] && [ "$ASSET_COUNT" -ge 5 ]; then
-                echo "Release $RELEASE_NAME already points to $CURRENT_SHA with $ASSET_COUNT VSIX assets; no rebuild needed."
+              if [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" = "$TARGET_SHA" ] && [ "$ASSET_COUNT" -ge 5 ]; then
+                echo "Release $RELEASE_NAME already points to $TARGET_SHA with $ASSET_COUNT VSIX assets; no rebuild needed."
                 echo "Halting the workflow before auto_promote (intentional exit 1)."
                 exit 1
               fi
-              echo "Rebuild needed: existing_sha='$EXISTING_SHA' current_sha='$CURRENT_SHA' assets=$ASSET_COUNT. Auto-promoting to release-version.yml."
+              echo "Rebuild needed: existing_sha='$EXISTING_SHA' target_sha='$TARGET_SHA' assets=$ASSET_COUNT. Auto-promoting to release-version.yml."
 
 promotions:
   - name: "Run release-version pipeline"

--- a/.semaphore/release-version-precheck.yml
+++ b/.semaphore/release-version-precheck.yml
@@ -34,6 +34,10 @@ global_job_config:
   env_vars:
     - name: NODE_ENV
       value: "production"
+    - name: IS_PRERELEASE
+      value: "true"
+    - name: TARGET_BRANCH
+      value: "main"
 
 blocks:
   - name: "Verify Parameters and Existing Release"
@@ -83,6 +87,29 @@ blocks:
 promotions:
   - name: "Run release-version pipeline"
     pipeline_file: release-version.yml
+    # promotions don't inherit env vars from the parent pipeline, so any param release-version.yml
+    # needs from the scheduled task must be re-declared here with explicit defaults
+    # (optional params can stay unset since release-version.yml handles their defaults)
+    parameters:
+      env_vars:
+        - name: IS_PRERELEASE
+          required: true
+          default_value: "true"
+          description: scheduled prereleases are always true
+        - name: TARGET_BRANCH
+          required: true
+          default_value: "main"
+          description: branch to (pre)release from
+        - name: RELEASE_NAME
+          required: false
+          description:
+            if not provided, release-version computes from .versions/next.txt with -pre suffix
+        - name: COMMIT_SHA
+          required: false
+          description: if not provided, release-version uses latest commit from TARGET_BRANCH
+        - name: PREVIOUS_RELEASE_TAG
+          required: false
+          description: if not provided, release-version auto-discovers latest non-prerelease tag
     auto_promote:
       # the precheck halts the workflow before this promotion fires when:
       #   - intentional skip:    result=failed, result_reason=test (exit 1 on no-op)

--- a/.semaphore/release-version.yml
+++ b/.semaphore/release-version.yml
@@ -65,12 +65,31 @@ blocks:
               fi
             - echo "$RELEASE_NAME" > RELEASE_NAME.txt
             - artifact push workflow RELEASE_NAME.txt --force
+            # skip the rebuild when the existing tag already points at COMMIT_SHA and the release
+            # has all five expected VSIX assets attached
+            - |
+              git fetch --tags --quiet origin || true
+              CURRENT_SHA=$(git rev-parse --verify "$COMMIT_SHA" 2>/dev/null || true)
+              EXISTING_SHA=$(git rev-parse --verify "refs/tags/$RELEASE_NAME^{commit}" 2>/dev/null || true)
+              ASSET_COUNT=$(gh release view "$RELEASE_NAME" --json assets -q '[.assets[] | select(.name | endswith(".vsix"))] | length' 2>/dev/null || echo 0)
+              if [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" = "$CURRENT_SHA" ] && [ "$ASSET_COUNT" -ge 5 ]; then
+                echo "Release $RELEASE_NAME already points to $CURRENT_SHA with $ASSET_COUNT VSIX assets; skipping rebuild."
+                touch SKIP_RELEASE.txt
+                artifact push workflow SKIP_RELEASE.txt --force
+              else
+                echo "Proceeding: existing_sha='$EXISTING_SHA' current_sha='$CURRENT_SHA' assets=$ASSET_COUNT"
+              fi
   - name: "Delete GitHub Release and Tag"
     dependencies: ["Parameter Verification"]
     task:
       jobs:
         - name: "Delete GitHub Release and Tag"
           commands:
+            - |
+              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
+                echo "Release already current for this commit; skipping."
+                exit 0
+              fi
             - artifact pull workflow RELEASE_NAME.txt
             - RELEASE_NAME=$(cat RELEASE_NAME.txt)
             # Delete the existing GitHub Release and tag if they exist
@@ -83,6 +102,11 @@ blocks:
       jobs:
         - name: "Create GitHub Release and Tag"
           commands:
+            - |
+              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
+                echo "Release already current for this commit; skipping."
+                exit 0
+              fi
             - artifact pull workflow RELEASE_NAME.txt
             - RELEASE_NAME=$(cat RELEASE_NAME.txt)
             # Try to determine previous release tag for generating release notes
@@ -119,9 +143,6 @@ blocks:
   - name: "Package VSIX Files"
     dependencies: ["Create GitHub Release and Tag"]
     task:
-      prologue:
-        commands:
-          - make install-dependencies
       jobs:
         - name: "Package VSIX Files"
           matrix:
@@ -133,6 +154,14 @@ blocks:
                 - linux-arm64
                 - win32-x64
           commands:
+            # short-circuit before installing deps when the prior run is still current.
+            # install-dependencies moved out of the block prologue so the guard can avoid it.
+            - |
+              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
+                echo "Release already current for this commit; skipping."
+                exit 0
+              fi
+            - make install-dependencies
             - |
               case "$TARGET" in
                 darwin-x64)  export SIDECAR_OS_ARCH=macos-amd64 ;;
@@ -153,6 +182,11 @@ blocks:
       jobs:
         - name: "Upload VSIX Files to GitHub Release"
           commands:
+            - |
+              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
+                echo "Release already current for this commit; skipping."
+                exit 0
+              fi
             - artifact pull workflow RELEASE_NAME.txt
             - RELEASE_NAME=$(cat RELEASE_NAME.txt)
             - artifact pull workflow packaged-vsix-files/

--- a/.semaphore/release-version.yml
+++ b/.semaphore/release-version.yml
@@ -65,31 +65,12 @@ blocks:
               fi
             - echo "$RELEASE_NAME" > RELEASE_NAME.txt
             - artifact push workflow RELEASE_NAME.txt --force
-            # skip the rebuild when the existing tag already points at COMMIT_SHA and the release
-            # has all five expected VSIX assets attached
-            - |
-              git fetch --tags --quiet origin || true
-              CURRENT_SHA=$(git rev-parse --verify "$COMMIT_SHA" 2>/dev/null || true)
-              EXISTING_SHA=$(git rev-parse --verify "refs/tags/$RELEASE_NAME^{commit}" 2>/dev/null || true)
-              ASSET_COUNT=$(gh release view "$RELEASE_NAME" --json assets -q '[.assets[] | select(.name | endswith(".vsix"))] | length' 2>/dev/null || echo 0)
-              if [ -n "$EXISTING_SHA" ] && [ "$EXISTING_SHA" = "$CURRENT_SHA" ] && [ "$ASSET_COUNT" -ge 5 ]; then
-                echo "Release $RELEASE_NAME already points to $CURRENT_SHA with $ASSET_COUNT VSIX assets; skipping rebuild."
-                touch SKIP_RELEASE.txt
-                artifact push workflow SKIP_RELEASE.txt --force
-              else
-                echo "Proceeding: existing_sha='$EXISTING_SHA' current_sha='$CURRENT_SHA' assets=$ASSET_COUNT"
-              fi
   - name: "Delete GitHub Release and Tag"
     dependencies: ["Parameter Verification"]
     task:
       jobs:
         - name: "Delete GitHub Release and Tag"
           commands:
-            - |
-              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
-                echo "Release already current for this commit; skipping."
-                exit 0
-              fi
             - artifact pull workflow RELEASE_NAME.txt
             - RELEASE_NAME=$(cat RELEASE_NAME.txt)
             # Delete the existing GitHub Release and tag if they exist
@@ -102,11 +83,6 @@ blocks:
       jobs:
         - name: "Create GitHub Release and Tag"
           commands:
-            - |
-              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
-                echo "Release already current for this commit; skipping."
-                exit 0
-              fi
             - artifact pull workflow RELEASE_NAME.txt
             - RELEASE_NAME=$(cat RELEASE_NAME.txt)
             # Try to determine previous release tag for generating release notes
@@ -143,6 +119,9 @@ blocks:
   - name: "Package VSIX Files"
     dependencies: ["Create GitHub Release and Tag"]
     task:
+      prologue:
+        commands:
+          - make install-dependencies
       jobs:
         - name: "Package VSIX Files"
           matrix:
@@ -154,14 +133,6 @@ blocks:
                 - linux-arm64
                 - win32-x64
           commands:
-            # short-circuit before installing deps when the prior run is still current.
-            # install-dependencies moved out of the block prologue so the guard can avoid it.
-            - |
-              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
-                echo "Release already current for this commit; skipping."
-                exit 0
-              fi
-            - make install-dependencies
             - |
               case "$TARGET" in
                 darwin-x64)  export SIDECAR_OS_ARCH=macos-amd64 ;;
@@ -182,11 +153,6 @@ blocks:
       jobs:
         - name: "Upload VSIX Files to GitHub Release"
           commands:
-            - |
-              if artifact pull workflow SKIP_RELEASE.txt 2>/dev/null; then
-                echo "Release already current for this commit; skipping."
-                exit 0
-              fi
             - artifact pull workflow RELEASE_NAME.txt
             - RELEASE_NAME=$(cat RELEASE_NAME.txt)
             - artifact pull workflow packaged-vsix-files/

--- a/service.yml
+++ b/service.yml
@@ -87,28 +87,13 @@ semaphore:
           required: true
     - name: scheduled-prerelease-version
       branch: main
-      # routed through release-version-precheck so we don't recreate a (pre)release
-      # on quiet nights with no new commits. the precheck auto-promotes to
-      # release-version.yml when a rebuild is needed.
+      # precheck to avoid re-running `release-version` when no changes have landed on `main` since
+      # the last run
+      # NOTE: no parameters are used here because they wouldn't survive the promotion boundary to
+      # `release-version`; use `release-version` directly instead to override default parameters
       pipeline_file: ".semaphore/release-version-precheck.yml"
       scheduled: true
       at: "10 4 * * *" # Every day at 04:10 UTC
-      parameters:
-        - name: IS_PRERELEASE
-          required: true
-          default_value: "true"
-        - name: TARGET_BRANCH
-          required: true
-          default_value: "main"
-        - name: RELEASE_NAME
-          required: false
-          description: If not provided, will use version from .versions/next.txt with -pre suffix
-        - name: COMMIT_SHA
-          required: false
-          description: If not provided, will use latest commit from TARGET_BRANCH
-        - name: PREVIOUS_RELEASE_TAG
-          required: false
-          description: If not provided, will auto-discover latest non-prerelease tag
     - name: scheduled-run-playwright-e2e-tests
       branch: main
       pipeline_file: ".semaphore/playwright-e2e.yml"

--- a/service.yml
+++ b/service.yml
@@ -87,7 +87,10 @@ semaphore:
           required: true
     - name: scheduled-prerelease-version
       branch: main
-      pipeline_file: ".semaphore/release-version.yml"
+      # routed through release-version-precheck so we don't recreate a (pre)release
+      # on quiet nights with no new commits. the precheck auto-promotes to
+      # release-version.yml when a rebuild is needed.
+      pipeline_file: ".semaphore/release-version-precheck.yml"
       scheduled: true
       at: "10 4 * * *" # Every day at 04:10 UTC
       parameters:


### PR DESCRIPTION
Since we occasionally have days where nothing is merged to `main`, it doesn't make sense to continue recreating prereleases in the scheduled `release-version` pipeline when:
- the commit SHA is the same as the existing release+tag
- all five .vsix were uploaded to the GitHub release

Unfortunately, we can't cleanly* exit early from an existing pipeline to effectively "skip" the rest of the pipeline, so this PR adds a separate `release-version-precheck` pipeline for the `scheduled-prerelease-version` task to use first, which compares the two items listed above to determine whether or not we actually need to run `release-version`.
- If that pipeline passes (i.e. "yes we should recreate the prerelease"), it auto promotes and runs `release-version`
- If the pipeline fails, `release-version` does not run

Sample workflows:
- skip: https://semaphore.ci.confluent.io/workflows/d8cb301a-2787-4842-bde6-609b09f9a89d
    <img width="1075" height="281" alt="image" src="https://github.com/user-attachments/assets/883db0b0-7a4d-4cf9-baa7-e527a6c798f2" />

- recreate: https://semaphore.ci.confluent.io/workflows/9d5e0101-cce1-4d96-85b0-dc6a27800014
    <img width="1190" height="273" alt="image" src="https://github.com/user-attachments/assets/73c7bb07-074d-4cb1-aefb-0a1bb7b75880" />

> [!NOTE]
> _*We can `exit 0` pipelines in the middle of any job, but that marks the whole pipeline as failed, which will trigger a Semaphore notification for `release-version`. Since we don't want "failed" pipeline alerts for "no need to recreate the prerelease" scenarios, it's simpler to set up a standalone pipeline and go through the automatic promotion flow.  (No notifications configured for `release-version-precheck`.)_

