### PR TITLE
MINOR: update npm audit scheduled task to run daily

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -134,7 +134,7 @@ semaphore:
       branch: main
       pipeline_file: .semaphore/npm-audit.yml
       scheduled: true
-      at: '0 6 * * 1' # Every Monday at 06:00 UTC
+      at: '0 6 * * *' # Daily at 06:00 UTC
       parameters:
         - name: TARGET_BRANCH
           required: false


### PR DESCRIPTION
Weekly is _fine_, but we still see dependabot alerts and `npm audit` flags in between those runs. Changing to daily to more easily stay on top of vulnerabilities.