### PR TITLE
chore: add E2E tests for Flink UDFs

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -405,7 +405,7 @@ promotions:
     parameters:
       env_vars:
         - name: TEST_SUITE
-          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts"
+          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts|@flink-udfs"
           description: "Playwright E2E test tags to run, separated by |. By default, runs the smoketests and CUJ-related tests."
         - name: VSCODE_VERSION
           default_value: "stable"

--- a/service.yml
+++ b/service.yml
@@ -54,7 +54,7 @@ semaphore:
         - name: TEST_SUITE
           required: false
           description: The test name or tag(s) (pipe-separated, e.g. `@ccloud|@direct`) to run. If not specified, will run all E2E tests.
-          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts"
+          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts|@flink-udfs"
         - name: PLATFORM
           required: true
           options:
@@ -107,7 +107,7 @@ semaphore:
         - name: TEST_SUITE
           required: true
           description: The test tag(s) (pipe-separated, e.g. `@smoke|@topic-message-viewer`) to run. By default, runs the smoke tests and critical user flow tests.
-          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts"
+          default_value: "@smoke|@topic-message-viewer|@evolve-schema|@produce-message-to-topic|@project-scaffolding|@flink-statements|@direct-connection-crud|@flink-artifacts|@flink-udfs"
         - name: PLATFORM
           required: true
           options:

--- a/src/models/flinkUDF.ts
+++ b/src/models/flinkUDF.ts
@@ -147,6 +147,7 @@ export class FlinkUdfTreeItem extends TreeItem {
     this.id = resource.id;
     this.resource = resource;
     this.contextValue = `${resource.connectionType.toLowerCase()}-flink-udf`;
+    this.accessibilityInformation = { label: `Flink UDF: ${resource.name}` };
 
     this.description = `${resource.parametersSignature} → ${formatSqlType(resource.returnType)}`;
     this.tooltip = createFlinkUdfToolTip(resource);

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -386,15 +386,21 @@ export const test = testBase.extend<VSCodeFixtures>({
       await artifactsView.loadArtifacts(entrypoint);
     }
 
-    const artifactName = await artifactsView.uploadFlinkArtifact(electronApp, jarPath);
-    await artifactsView.waitForUploadSuccess();
-
-    await use(artifactName);
-
-    await openConfluentSidebar(page);
-    await artifactsView.ensureExpanded();
-    // deleteFlinkArtifact searches internally; expanding here could be hidden by a prior search
-    await artifactsView.deleteFlinkArtifact(artifactName);
+    // track the artifact name across try/finally so cleanup runs even if a
+    // post-upload setup step throws before use()
+    let artifactName: string | undefined;
+    try {
+      artifactName = await artifactsView.uploadFlinkArtifact(electronApp, jarPath);
+      await artifactsView.waitForUploadSuccess();
+      await use(artifactName);
+    } finally {
+      if (artifactName) {
+        await openConfluentSidebar(page);
+        await artifactsView.ensureExpanded();
+        // deleteFlinkArtifact searches internally; expanding here could be hidden by a prior search
+        await artifactsView.deleteFlinkArtifact(artifactName);
+      }
+    }
   },
 });
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -5,9 +5,11 @@ import { stubAllDialogs, stubDialog } from "electron-playwright-helpers";
 import { createWriteStream, existsSync, mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
+import { fileURLToPath } from "url";
 import { DEBUG_LOGGING_ENABLED } from "./constants";
 import { NotificationArea } from "./objects/notifications/NotificationArea";
 import { Quickpick } from "./objects/quickInputs/Quickpick";
+import { FlinkDatabaseView, SelectFlinkDatabase } from "./objects/views/FlinkDatabaseView";
 import {
   DEFAULT_CCLOUD_TOPIC_REPLICATION_FACTOR,
   SelectKafkaCluster,
@@ -16,6 +18,7 @@ import {
 import type { CCloudConnectionItem } from "./objects/views/viewItems/CCloudConnectionItem";
 import type { DirectConnectionItem } from "./objects/views/viewItems/DirectConnectionItem";
 import type { LocalConnectionItem } from "./objects/views/viewItems/LocalConnectionItem";
+import type { ArtifactConfig } from "./types/artifact";
 import type { DirectConnectionOptions, LocalConnectionOptions } from "./types/connection";
 import { ConnectionType, FormConnectionType, SupportedAuthType } from "./types/connection";
 import type { TopicConfig } from "./types/topic";
@@ -96,6 +99,16 @@ interface VSCodeFixtures {
    * `name` for tests to reference.
    */
   topic: string;
+
+  /**
+   * Configuration options for creating an artifact with the {@linkcode artifact} fixture.
+   */
+  artifactConfig: ArtifactConfig | undefined;
+  /**
+   * Set up a Flink artifact based on the {@linkcode artifactConfig} option and return the
+   * artifact `name` for tests to reference. Tears down the artifact after the test completes.
+   */
+  artifact: string;
 }
 
 export const test = testBase.extend<VSCodeFixtures>({
@@ -338,6 +351,51 @@ export const test = testBase.extend<VSCodeFixtures>({
       topicConfig.clusterLabel,
     );
     await topicsView.deleteTopic(topicName);
+  },
+
+  // no default value, must be provided by test
+  artifactConfig: [undefined, { option: true }],
+
+  artifact: async ({ electronApp, page, connectionItem, artifactConfig }, use) => {
+    if (!artifactConfig) {
+      throw new Error("artifactConfig must be set, like `test.use({ artifactConfig: {} })`");
+    }
+
+    await expect(connectionItem.locator).toHaveAttribute("aria-expanded", "true");
+
+    const entrypoint = artifactConfig.entrypoint ?? SelectFlinkDatabase.FromDatabaseViewButton;
+    const jarPath =
+      artifactConfig.jarPath ??
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "fixtures",
+        "flink-artifacts",
+        "udfs-simple.jar",
+      );
+
+    const artifactsView = new FlinkDatabaseView(page);
+
+    if (artifactConfig.provider && artifactConfig.region) {
+      await artifactsView.selectKafkaClusterByProviderRegion(
+        artifactConfig.provider,
+        artifactConfig.region,
+      );
+    } else {
+      await artifactsView.ensureExpanded();
+      await artifactsView.loadArtifacts(entrypoint);
+    }
+
+    const artifactName = await artifactsView.uploadFlinkArtifact(electronApp, jarPath);
+    await artifactsView.waitForUploadSuccess();
+
+    await use(artifactName);
+
+    await openConfluentSidebar(page);
+    await artifactsView.ensureExpanded();
+    // deleteFlinkArtifact searches to isolate the artifact, so no need to manually expand
+    // the Artifacts container here (and a prior search from the test body could hide it)
+    await artifactsView.deleteFlinkArtifact(artifactName);
   },
 });
 

--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -393,8 +393,7 @@ export const test = testBase.extend<VSCodeFixtures>({
 
     await openConfluentSidebar(page);
     await artifactsView.ensureExpanded();
-    // deleteFlinkArtifact searches to isolate the artifact, so no need to manually expand
-    // the Artifacts container here (and a prior search from the test body could hide it)
+    // deleteFlinkArtifact searches internally; expanding here could be hidden by a prior search
     await artifactsView.deleteFlinkArtifact(artifactName);
   },
 });

--- a/tests/e2e/objects/views/FlinkDatabaseView.ts
+++ b/tests/e2e/objects/views/FlinkDatabaseView.ts
@@ -50,7 +50,7 @@ export class FlinkDatabaseView extends SearchableView {
 
   /** Get the UDFs container item. */
   get udfsContainer(): Locator {
-    return this.treeItems.filter({ hasText: "UDFs" }).first();
+    return this.treeItems.filter({ hasText: /^UDFs/ }).first();
   }
 
   /** UDF items based on their accessibilityInformation label. */
@@ -213,6 +213,61 @@ export class FlinkDatabaseView extends SearchableView {
     await this.expandContainer(this.artifactsContainer);
   }
 
+  /** Expand the UDFs container to show any available UDF tree items. */
+  async expandUdfsContainer(): Promise<void> {
+    await this.expandContainer(this.udfsContainer);
+  }
+
+  /**
+   * Run the "Register As UDF" guided flow for the given artifact, providing `className` and
+   * `functionName` to the series of quickinput boxes.
+   */
+  async startGuidedUdfCreation(
+    artifactName: string,
+    className: string,
+    functionName: string,
+  ): Promise<void> {
+    await this.expandArtifactsContainer();
+    const artifactLocator = this.artifacts.filter({ hasText: artifactName });
+    await expect(artifactLocator).toHaveCount(1);
+    const artifactItem = new ViewItem(this.page, artifactLocator.first());
+    await artifactItem.rightClickContextMenuAction("Register As UDF");
+
+    const classNameInput = new InputBox(this.page);
+    await expect(classNameInput.locator).toBeVisible();
+    await classNameInput.input.fill(className);
+    await classNameInput.confirm();
+
+    const functionNameInput = new InputBox(this.page);
+    await expect(functionNameInput.locator).toBeVisible();
+    await functionNameInput.input.fill(functionName);
+    await functionNameInput.confirm();
+  }
+
+  /** Open the "Register With Flink SQL" document for the given artifact. */
+  async openUdfRegistrationDocument(artifactName: string): Promise<void> {
+    await this.expandArtifactsContainer();
+    const artifactLocator = this.artifacts.filter({ hasText: artifactName });
+    await expect(artifactLocator).toHaveCount(1);
+    const artifactItem = new ViewItem(this.page, artifactLocator.first());
+    await artifactItem.rightClickContextMenuAction("Register With Flink SQL");
+  }
+
+  /** Delete a Flink UDF via its tree-item context menu. */
+  async deleteFlinkUdf(functionName: string): Promise<void> {
+    const udfLocator = await this.getItemByLabel(functionName);
+    const udfItem = new ViewItem(this.page, udfLocator);
+    await udfItem.locator.scrollIntoViewIfNeeded();
+    await expect(udfItem.locator).toBeVisible();
+
+    await udfItem.rightClickContextMenuAction("Delete UDF");
+    const notificationArea = new NotificationArea(this.page);
+    const successNotifications = notificationArea.infoNotifications.filter({
+      hasText: "deleted successfully",
+    });
+    await expect(successNotifications).not.toHaveCount(0);
+  }
+
   /**
    * Click the upload button on the Artifacts container to initiate the artifact upload flow.
    */
@@ -292,9 +347,8 @@ export class FlinkDatabaseView extends SearchableView {
    * @param artifactName - The name of the artifact to delete
    */
   async deleteFlinkArtifact(artifactName: string): Promise<void> {
-    const artifactLocator = this.artifacts.filter({ hasText: artifactName });
-    await expect(artifactLocator).toHaveCount(1);
-    const artifactItem = new ViewItem(this.page, artifactLocator.first());
+    const artifactLocator = await this.getItemByLabel(artifactName);
+    const artifactItem = new ViewItem(this.page, artifactLocator);
     await artifactItem.locator.scrollIntoViewIfNeeded();
     await expect(artifactItem.locator).toBeVisible();
 

--- a/tests/e2e/objects/views/FlinkDatabaseView.ts
+++ b/tests/e2e/objects/views/FlinkDatabaseView.ts
@@ -48,6 +48,16 @@ export class FlinkDatabaseView extends SearchableView {
     return this.treeItems.and(this.page.locator('[aria-label^="Flink Artifact: "]'));
   }
 
+  /** Get the UDFs container item. */
+  get udfsContainer(): Locator {
+    return this.treeItems.filter({ hasText: "UDFs" }).first();
+  }
+
+  /** UDF items based on their accessibilityInformation label. */
+  get udfs(): Locator {
+    return this.treeItems.and(this.page.locator('[aria-label^="Flink UDF: "]'));
+  }
+
   /**
    * Load the Flink Artifacts view by selecting a Kafka cluster as the Flink database,
    * using the specified entrypoint.

--- a/tests/e2e/objects/views/FlinkDatabaseView.ts
+++ b/tests/e2e/objects/views/FlinkDatabaseView.ts
@@ -255,7 +255,9 @@ export class FlinkDatabaseView extends SearchableView {
 
   /** Delete a Flink UDF via its tree-item context menu. */
   async deleteFlinkUdf(functionName: string): Promise<void> {
-    const udfLocator = await this.getItemByLabel(functionName);
+    // scope to UDF tree items so the search result can't match a same-named item from a
+    // different container (e.g. an artifact reusing the suffix)
+    const udfLocator = await this.getItemByLabel(functionName, this.udfs);
     const udfItem = new ViewItem(this.page, udfLocator);
     await udfItem.locator.scrollIntoViewIfNeeded();
     await expect(udfItem.locator).toBeVisible();
@@ -347,7 +349,9 @@ export class FlinkDatabaseView extends SearchableView {
    * @param artifactName - The name of the artifact to delete
    */
   async deleteFlinkArtifact(artifactName: string): Promise<void> {
-    const artifactLocator = await this.getItemByLabel(artifactName);
+    // scope to artifact tree items so the search result can't match a same-named item from a
+    // different container (e.g. a UDF reusing the suffix)
+    const artifactLocator = await this.getItemByLabel(artifactName, this.artifacts);
     const artifactItem = new ViewItem(this.page, artifactLocator);
     await artifactItem.locator.scrollIntoViewIfNeeded();
     await expect(artifactItem.locator).toBeVisible();

--- a/tests/e2e/specs/flinkArtifact.spec.ts
+++ b/tests/e2e/specs/flinkArtifact.spec.ts
@@ -25,7 +25,23 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
     await expect(connectionItem.locator).toHaveAttribute("aria-expanded", "true");
   });
 
-  test.afterEach(async () => {
+  test.afterEach(async ({ page }) => {
+    // server-side cleanup: if the happy-path test didn't reach its inline delete
+    // (e.g. an earlier assertion failed), drop the orphaned artifact here so
+    // reruns don't pile up dangling artifacts on the cluster. Best-effort: a
+    // failed cleanup must not mask the original test failure, hence the catch.
+    if (uploadedArtifactName) {
+      try {
+        const artifactsView = new FlinkDatabaseView(page);
+        await openConfluentSidebar(page);
+        await artifactsView.ensureExpanded();
+        await artifactsView.deleteFlinkArtifact(uploadedArtifactName);
+      } catch (err) {
+        console.warn(`failed to clean up orphaned artifact "${uploadedArtifactName}":`, err);
+      }
+      uploadedArtifactName = undefined;
+    }
+
     // Only delete temporary test files, not permanent fixtures
     const permanentFixture = path.join(fixturesDir, "udfs-simple.jar");
     if (artifactPath && existsSync(artifactPath) && artifactPath !== permanentFixture) {
@@ -35,6 +51,8 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
 
   /** The path to an artifact created by the test suite, to be cleaned up in afterEach. */
   let artifactPath: string | undefined;
+  /** The name of an artifact uploaded to CCloud, tracked so afterEach can clean it up if a happy-path test fails before its inline deletion runs. */
+  let uploadedArtifactName: string | undefined;
 
   const fixturesDir = path.join(__dirname, "..", "..", "fixtures", "flink-artifacts");
 
@@ -82,7 +100,7 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
 
         await artifactsView.ensureExpanded();
         await artifactsView.loadArtifacts(entrypoint);
-        const uploadedArtifactName = await startUploadFlow(
+        const artifactName = await startUploadFlow(
           entrypoint,
           page,
           electronApp,
@@ -91,6 +109,10 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
           region,
           artifactPath,
         );
+        // record the upload so afterEach can clean it up if the rest of the
+        // test throws before the inline deletion below
+        uploadedArtifactName = artifactName;
+
         await artifactsView.waitForUploadSuccess();
         const notificationArea = new NotificationArea(page);
         const successNotifications = notificationArea.infoNotifications.filter({
@@ -98,15 +120,15 @@ test.describe("Flink Artifacts", { tag: [Tag.CCloud, Tag.FlinkArtifacts] }, () =
         });
         await expect(successNotifications.first()).toBeVisible();
         const artifactViewItem = await artifactsView.getDatabaseResourceByLabel(
-          uploadedArtifactName,
+          artifactName,
           artifactsView.artifactsContainer,
         );
 
         await expect(artifactViewItem).toBeVisible();
-        await artifactsView.deleteFlinkArtifact(uploadedArtifactName);
-        await expect(artifactsView.artifacts.filter({ hasText: uploadedArtifactName })).toHaveCount(
-          0,
-        );
+        await artifactsView.deleteFlinkArtifact(artifactName);
+        await expect(artifactsView.artifacts.filter({ hasText: artifactName })).toHaveCount(0);
+        // inline deletion succeeded, so afterEach has no server-side work to do
+        uploadedArtifactName = undefined;
       });
 
       test(`should fail to upload a jar exceeding the file limit [${provider}/${region}] - ${testName}`, async ({

--- a/tests/e2e/specs/flinkUdf.spec.ts
+++ b/tests/e2e/specs/flinkUdf.spec.ts
@@ -5,7 +5,7 @@ import { NotificationArea } from "../objects/notifications/NotificationArea";
 import { FlinkDatabaseView } from "../objects/views/FlinkDatabaseView";
 import { Tag } from "../tags";
 import { ConnectionType } from "../types/connection";
-import { randomHexString } from "../utils/strings";
+import { e2eResourceName } from "../utils/uniqueName";
 
 test.describe("Flink UDFs", { tag: [Tag.CCloud, Tag.FlinkUDFs] }, () => {
   test.use({ connectionType: ConnectionType.Ccloud });
@@ -22,7 +22,7 @@ test.describe("Flink UDFs", { tag: [Tag.CCloud, Tag.FlinkUDFs] }, () => {
 
       test("should create a UDF via the guided flow", async ({ page, artifact }) => {
         const flinkDatabaseView = new FlinkDatabaseView(page);
-        const functionName = `test_udf_${randomHexString(6)}`;
+        const functionName = e2eResourceName("udf");
 
         await flinkDatabaseView.startGuidedUdfCreation(
           artifact,
@@ -61,7 +61,7 @@ test.describe("Flink UDFs", { tag: [Tag.CCloud, Tag.FlinkUDFs] }, () => {
 
       test("should delete a UDF", async ({ page, artifact }) => {
         const flinkDatabaseView = new FlinkDatabaseView(page);
-        const functionName = `test_udf_delete_${randomHexString(6)}`;
+        const functionName = e2eResourceName("udf-delete");
 
         await flinkDatabaseView.startGuidedUdfCreation(
           artifact,

--- a/tests/e2e/specs/flinkUdf.spec.ts
+++ b/tests/e2e/specs/flinkUdf.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from "@playwright/test";
+import { test } from "../baseTest";
+import { NotificationArea } from "../objects/notifications/NotificationArea";
+import { FlinkDatabaseView } from "../objects/views/FlinkDatabaseView";
+import { Tag } from "../tags";
+import { ConnectionType } from "../types/connection";
+import { randomHexString } from "../utils/strings";
+
+test.describe("Flink UDFs", { tag: [Tag.CCloud, Tag.FlinkUDFs] }, () => {
+  test.use({ connectionType: ConnectionType.Ccloud });
+
+  // TODO: add GCP, see https://github.com/confluentinc/vscode/issues/2817
+  const providers = [
+    { provider: "AWS", region: "us-east-2" },
+    { provider: "AZURE", region: "eastus" },
+  ];
+
+  for (const { provider, region } of providers) {
+    test.describe(provider, () => {
+      test.use({ artifactConfig: { provider, region } });
+
+      test("should create a UDF via the guided flow", async ({ page, artifact }) => {
+        const flinkDatabaseView = new FlinkDatabaseView(page);
+        const functionName = `test_udf_${randomHexString(6)}`;
+
+        await flinkDatabaseView.startGuidedUdfCreation(
+          artifact,
+          "io.confluent.udf.examples.scalar.SumScalarFunction",
+          functionName,
+        );
+
+        const notificationArea = new NotificationArea(page);
+        const successNotifications = notificationArea.infoNotifications.filter({
+          hasText: "function created successfully",
+        });
+        await expect(successNotifications.first()).toBeVisible({ timeout: 60_000 });
+
+        // search auto-expands the matching container, so we don't need to expand UDFs manually
+        const udfItem = await flinkDatabaseView.getItemByLabel(functionName);
+        await expect(udfItem).toBeVisible();
+      });
+
+      test("should open a Flink SQL document with the appropriate content", async ({
+        page,
+        artifact,
+      }) => {
+        const flinkDatabaseView = new FlinkDatabaseView(page);
+
+        await flinkDatabaseView.openUdfRegistrationDocument(artifact);
+
+        const editorContent = page.locator(".monaco-editor .view-lines");
+        await expect(editorContent).toBeVisible();
+
+        const editorText = await editorContent.textContent();
+        expect(editorText).toMatch(/CREATE\s+FUNCTION/);
+        expect(editorText).toMatch(/USING\s+JAR/);
+        expect(editorText).toContain("confluent-artifact://");
+        // not testing the statement submission behavior here since those are covered by the
+        // @flink-statements tests, and the document is just a template with snippet placeholders
+      });
+
+      test("should delete a UDF", async ({ page, artifact }) => {
+        const flinkDatabaseView = new FlinkDatabaseView(page);
+        const functionName = `test_udf_delete_${randomHexString(6)}`;
+
+        await flinkDatabaseView.startGuidedUdfCreation(
+          artifact,
+          "io.confluent.udf.examples.scalar.ConcatScalarFunction",
+          functionName,
+        );
+
+        const notificationArea = new NotificationArea(page);
+        const createNotifications = notificationArea.infoNotifications.filter({
+          hasText: "function created successfully",
+        });
+        await expect(createNotifications.first()).toBeVisible({ timeout: 60_000 });
+
+        const udfItemBefore = await flinkDatabaseView.getItemByLabel(functionName);
+        await expect(udfItemBefore).toBeVisible();
+
+        await flinkDatabaseView.deleteFlinkUdf(functionName);
+        // search filter from deleteFlinkUdf is still applied, so the deleted UDF drops out
+        const udfItemAfter = flinkDatabaseView.udfs.filter({ hasText: functionName });
+        await expect(udfItemAfter).toHaveCount(0);
+      });
+    });
+  }
+});

--- a/tests/e2e/specs/flinkUdf.spec.ts
+++ b/tests/e2e/specs/flinkUdf.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../baseTest";
+import { TextDocument } from "../objects/editor/TextDocument";
 import { NotificationArea } from "../objects/notifications/NotificationArea";
 import { FlinkDatabaseView } from "../objects/views/FlinkDatabaseView";
 import { Tag } from "../tags";
@@ -48,13 +49,12 @@ test.describe("Flink UDFs", { tag: [Tag.CCloud, Tag.FlinkUDFs] }, () => {
 
         await flinkDatabaseView.openUdfRegistrationDocument(artifact);
 
-        const editorContent = page.locator(".monaco-editor .view-lines");
-        await expect(editorContent).toBeVisible();
-
-        const editorText = await editorContent.textContent();
-        expect(editorText).toMatch(/CREATE\s+FUNCTION/);
-        expect(editorText).toMatch(/USING\s+JAR/);
-        expect(editorText).toContain("confluent-artifact://");
+        // the registration command opens a fresh untitled doc with snippets
+        const registrationDoc = new TextDocument(page, "Untitled-1");
+        await expect(registrationDoc.locator).toBeVisible();
+        await expect(registrationDoc.editorContent).toContainText(/CREATE\s+FUNCTION/);
+        await expect(registrationDoc.editorContent).toContainText(/USING\s+JAR/);
+        await expect(registrationDoc.editorContent).toContainText("confluent-artifact://");
         // not testing the statement submission behavior here since those are covered by the
         // @flink-statements tests, and the document is just a template with snippet placeholders
       });

--- a/tests/e2e/tags.ts
+++ b/tests/e2e/tags.ts
@@ -27,7 +27,7 @@ export enum Tag {
   DirectConnectionCRUD = "@direct-connection-crud",
   /** Tests that upload and delete Flink artifacts. */
   FlinkArtifacts = "@flink-artifacts",
-  /** Tests that create and delete Flink UDFs from artifacts. */
+  /** Tests that create and delete Flink UDFs. */
   FlinkUDFs = "@flink-udfs",
 
   // Resource-/fixture-specific tags

--- a/tests/e2e/tags.ts
+++ b/tests/e2e/tags.ts
@@ -27,6 +27,8 @@ export enum Tag {
   DirectConnectionCRUD = "@direct-connection-crud",
   /** Tests that upload and delete Flink artifacts. */
   FlinkArtifacts = "@flink-artifacts",
+  /** Tests that create and delete Flink UDFs from artifacts. */
+  FlinkUDFs = "@flink-udfs",
 
   // Resource-/fixture-specific tags
 

--- a/tests/e2e/types/artifact.ts
+++ b/tests/e2e/types/artifact.ts
@@ -1,0 +1,13 @@
+import type { SelectFlinkDatabase } from "../objects/views/FlinkDatabaseView";
+
+/** Configuration for creating a Flink artifact. */
+export interface ArtifactConfig {
+  /** Path to the JAR file. Defaults to the `udfs-simple.jar` fixture. */
+  jarPath?: string;
+  /** Entrypoint for uploading. Defaults to FromDatabaseViewButton. */
+  entrypoint?: SelectFlinkDatabase;
+  /** Cloud provider. Defaults to "AWS". */
+  provider?: string;
+  /** Cloud region. Defaults to "us-east-2". */
+  region?: string;
+}

--- a/tests/e2e/types/artifact.ts
+++ b/tests/e2e/types/artifact.ts
@@ -4,10 +4,10 @@ import type { SelectFlinkDatabase } from "../objects/views/FlinkDatabaseView";
 export interface ArtifactConfig {
   /** Path to the JAR file. Defaults to the `udfs-simple.jar` fixture. */
   jarPath?: string;
-  /** Entrypoint for uploading. Defaults to FromDatabaseViewButton. */
+  /** Entrypoint for uploading. Defaults to {@linkcode SelectFlinkDatabase.FromDatabaseViewButton}. */
   entrypoint?: SelectFlinkDatabase;
-  /** Cloud provider. Defaults to "AWS". */
+  /** Cloud provider; if both `provider` and `region` are set, the upload skips the entrypoint flow. */
   provider?: string;
-  /** Cloud region. Defaults to "us-east-2". */
+  /** Cloud region; if both `provider` and `region` are set, the upload skips the entrypoint flow. */
   region?: string;
 }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Sample run: https://semaphore.ci.confluent.io/workflows/fe780ab0-c8d1-4314-8be7-127b44de7217?pipeline_id=9b07a948-933a-4cfd-9ec5-17047030507c

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d3fceed0-3e5b-492e-8887-72741b860990" />

Closes #2482, and also closes #3110 by setting up the `artifact` playwright fixture.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
