### PR TITLE
[v2.3.x] fix: allow suppressing telemetry calls through `executeInWorkerPool`

### DIFF
--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -371,7 +371,10 @@ async function produceMessages(
   const results: ExecutionResult<ProduceResult>[] = await executeInWorkerPool(
     (content) => produceMessage(content, topic, schemaOptions),
     contents,
-    { maxWorkers: 20, taskName: "produceMessage" },
+    // per-message failures are surfaced via the failure-count notification below (with
+    // schema-validation diagnostics where applicable) and via logError to the output channel;
+    // no need to send them to Sentry
+    { maxWorkers: 20, taskName: "produceMessage", suppressErrorTelemetry: true },
     progress,
     token,
   );

--- a/src/loaders/cachingResourceLoader.ts
+++ b/src/loaders/cachingResourceLoader.ts
@@ -291,7 +291,10 @@ export abstract class CachingResourceLoader<
     const memberResults = await executeInWorkerPool(
       (data: ConsumerGroupData) => fetchConsumerGroupMembers(cluster, data.consumer_group_id),
       responseConsumerGroups,
-      { maxWorkers: 5, taskName: "fetchConsumerGroupMembers" },
+      // 404s here are expected (e.g. groups deleted between list + member fetch); the user
+      // sees the group missing from the tree, and the error still lands in the output channel
+      // via logError, no need to send them to Sentry
+      { maxWorkers: 5, taskName: "fetchConsumerGroupMembers", suppressErrorTelemetry: true },
     );
 
     // Convert API responses to ConsumerGroup models.

--- a/src/utils/workerPool.test.ts
+++ b/src/utils/workerPool.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import sinon from "sinon";
 import type { Progress } from "vscode";
 import { CancellationTokenSource } from "vscode";
+import * as errors from "../errors";
 import { executeInWorkerPool, extract, isErrorResult, isSuccessResult } from "./workerPool";
 
 describe("utils/workerPool.ts executeInWorkerPool()", () => {
@@ -42,6 +43,52 @@ describe("utils/workerPool.ts executeInWorkerPool()", () => {
     assert.strictEqual(isSuccessResult(results[0]), true);
     assert.strictEqual(isErrorResult(results[1]), true);
     assert.strictEqual(isSuccessResult(results[2]), true);
+  });
+
+  it("should call logError on per-task failure when suppressErrorTelemetry is unset (default)", async () => {
+    const logErrorStub = sandbox.stub(errors, "logError");
+    const items = [1];
+    const callable = async () => {
+      throw new Error("default-telemetry");
+    };
+
+    await executeInWorkerPool(callable, items, {
+      maxWorkers: 2,
+      taskName: "default-test",
+    });
+
+    sinon.assert.calledOnce(logErrorStub);
+    sinon.assert.calledWith(
+      logErrorStub,
+      sinon.match.instanceOf(Error),
+      "workerPool",
+      sinon.match({ extra: sinon.match({ taskName: "default-test" }) }),
+    );
+  });
+
+  it("should call logError without sentryContext when suppressErrorTelemetry is true", async () => {
+    const logErrorStub = sandbox.stub(errors, "logError");
+    const items = [1];
+    const callable = async () => {
+      throw new Error("suppressed-telemetry");
+    };
+
+    const results = await executeInWorkerPool(callable, items, {
+      maxWorkers: 2,
+      taskName: "suppressed-test",
+      suppressErrorTelemetry: true,
+    });
+
+    // logError still fires for local logging, but with an undefined sentryContext
+    sinon.assert.calledOnceWithExactly(
+      logErrorStub,
+      sinon.match.instanceOf(Error),
+      "workerPool",
+      undefined,
+    );
+    // suppression is Sentry-only: the ErrorResult is still returned to the caller
+    assert.strictEqual(isErrorResult(results[0]), true);
+    assert.strictEqual(results[0].error?.message, "suppressed-telemetry");
   });
 
   it("should respect cancellation token by exiting early", async () => {

--- a/src/utils/workerPool.ts
+++ b/src/utils/workerPool.ts
@@ -40,6 +40,12 @@ export function isErrorResult(result: ExecutionResult<unknown> | undefined): res
 interface WorkerPoolOptions {
   maxWorkers: number;
   taskName?: string;
+  /**
+   * If true, errors are still passed to {@linkcode logError} but not captured by Sentry.
+   * `ErrorResult` entries and `errorCount` are unchanged. Use when per-item errors are
+   * expected and would otherwise create per-call telemetry noise.
+   */
+  suppressErrorTelemetry?: boolean;
 }
 
 /**
@@ -109,14 +115,18 @@ export async function executeInWorkerPool<T, R>(
         results[taskIndex] = { result };
       } catch (error) {
         errorCount++;
-        logError(error, "workerPool", {
-          extra: {
-            taskName: String(options.taskName),
-            errorCount: errorCount.toString(),
-            resultCount: resultCount.toString(),
-            totalCount: totalCount.toString(),
-          },
-        });
+        // omit the sentryContext when suppressed so logError() still writes locally
+        const sentryContext = options.suppressErrorTelemetry
+          ? undefined
+          : {
+              extra: {
+                taskName: String(options.taskName),
+                errorCount: errorCount.toString(),
+                resultCount: resultCount.toString(),
+                totalCount: totalCount.toString(),
+              },
+            };
+        logError(error, "workerPool", sentryContext);
         if (error instanceof Error) {
           results[taskIndex] = { error };
         } else {


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

We've seen some spikes in errors to Sentry in two main areas:
- producing messages (not needed since the user sees error notifications)
- fetching consumers for consumer groups (not necessary, and would benefit from https://github.com/confluentinc/ide-sidecar/issues/521 being done)

This PR allows callers of `executeInWorkerPool` to pass `suppressErrorTelemetry: true/false` to opt out of passing a Sentry context object, preventing spikes in error reporting.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
