### PR TITLE
fix(build): run gql.tada CLI via node to avoid Windows cmd hang

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -602,12 +602,33 @@ function stylesheet(options = {}) {
 
 check.description = "Run TypeScript compiler to check for any type errors.";
 export function check(done) {
-  // Before running type checking, make sure to generate declarations for GraphQL schemas
-  const precheck = spawnSync("npx", ["gql.tada", "generate-output"], {
-    stdio: "ignore",
-    shell: IS_WINDOWS,
-  });
+  // Before running type checking, make sure to generate declarations for GraphQL schemas.
+  // Invoke gql.tada's CLI directly via node rather than `npx gql.tada`: the published bin
+  // name contains a dot, so on Windows `cmd` treats ".tada" as the file extension, runs the
+  // extension-less shim instead of `gql.tada.cmd`, falls back to ShellExecuteExW, and hangs
+  // forever on a modal "no .tada association" error dialog on headless CI runners.
+  // (gql.tada also ships a no-dot `gql-tada` alias, but invoking node directly avoids
+  // npx/cmd/shell entirely and is the most robust fix.) See confluentinc/vscode#3408.
+  const gqlTadaPkg = JSON.parse(
+    readFileSync(resolve("node_modules", "gql.tada", "package.json"), "utf8"),
+  );
+  const gqlTadaBin =
+    typeof gqlTadaPkg.bin === "string" ? gqlTadaPkg.bin : gqlTadaPkg.bin?.["gql.tada"];
+  if (!gqlTadaBin) {
+    throw new Error(
+      `Could not resolve the gql.tada CLI from its package.json "bin" field: ${JSON.stringify(gqlTadaPkg.bin)}`,
+    );
+  }
+  const precheck = spawnSync(
+    process.execPath,
+    [resolve("node_modules", "gql.tada", gqlTadaBin), "generate-output"],
+    // stdout is noisy on success; keep stderr so a codegen failure is visible (not silent).
+    { stdio: ["ignore", "ignore", "inherit"] },
+  );
   if (precheck.error) throw precheck.error;
+  if (precheck.status !== 0) {
+    throw new Error(`gql.tada generate-output failed (exit code ${precheck.status})`);
+  }
 
   // Entry points are the extension.ts and webview script files, but also include test files
   // so we can catch any type errors in them as well.


### PR DESCRIPTION
## What

`gulp check` (run as part of `gulp ci`) generated GraphQL declarations via `npx gql.tada generate-output`. On Windows this **hangs the entire build** on headless CI runners until the job hits its timeout (the unit-test build that normally takes a few minutes ran for nearly an hour).

## Why it hangs (root cause)

The published bin name **`gql.tada` contains a dot**. When `cmd` runs `gql.tada`, it parses `.tada` as the *file extension*, so it executes the extension-less shim instead of `gql.tada.cmd`. `CreateProcess` can't run that, so `cmd` falls back to `ShellExecuteExW`; Windows has **no association for `.tada`** and raises a **modal error dialog** — which blocks forever on a non-interactive runner with no desktop to dismiss it.

Confirmed with a debugger (`cdb`) attached to the stuck `cmd.exe`:

```
cmd!ExecPgm → cmdext!ShellExecuteWorker → ShellExecuteExW → CShellExecute::ExecuteNormal
  → SHProcessMessagesUntilEventsEx → NtUserMsgWaitForMultipleObjectsEx            [blocked]
SHELL32!SHExecuteErrorMessageBox → comctl32!TaskDialogInternal → USER32!DialogBoxIndirectParamW
  → NtUserWaitMessage                                                             [blocked forever]
```

Node/libuv is not at fault — it's simply (and correctly) waiting on the wedged `cmd.exe` child. Full investigation in #3408.

## Fix

Invoke gql.tada's CLI **directly with `node`** (no `npx`, no `cmd`, no shell), resolving the bin path from its `package.json`. With an absolute `node` path and an absolute script path there's no shell dispatch, so the dot-named bin can't be misparsed.

Verified on a Windows Server 2025 runner:
- `node node_modules/gql.tada/bin/cli.js generate-output` → exits cleanly ✅
- `npx gql.tada generate-output` → hangs ✋

Also hardened while here: guard against an unresolvable bin path, and surface stderr + throw on a non-zero exit so a codegen failure is no longer silently swallowed (the old `stdio: "ignore"` + `precheck.error`-only check hid it).

## Safety / scope

- **Cross-platform equivalent.** On macOS/Linux (where `npx gql.tada` already worked) this runs the same entry point with the same args — it only removes the `npx`/shell layer. No change to the generated output.
- **Minimal.** One function (`check`) in `Gulpfile.js`; no dependency or config changes.
- The separate dev-only `codegen` task already invokes the no-dot `gql-tada` alias, so it is unaffected.

## Testing

The Windows CI on this PR is the integration test (it previously hung at the `gql.tada` step). On macOS the equivalent `node` invocation produces the GraphQL declarations exactly as before.

Fixes #3408
