### PR TITLE
fix: upload extension+sidecar logs as CI artifacts for CCloud auth smoketests

### DIFF
--- a/.semaphore/ccloud-auth-smoketests.yml
+++ b/.semaphore/ccloud-auth-smoketests.yml
@@ -31,6 +31,7 @@ blocks:
             - make remove-test-env
             - make ci-bin-sem-cache-store
             - make store-test-results-to-semaphore
+            - make store-test-logs-to-semaphore
 
 after_pipeline:
   task:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -105,7 +105,7 @@ blocks:
             - make store-test-logs-to-semaphore
             # Upload Playwright artifacts if available
             - |
-              PLATFORM_ARCH="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+              PLATFORM_ARCH="$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
               if [ -d test-results ]; then
                 artifact push workflow test-results --destination test-results-${PLATFORM_ARCH} --force
               fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -101,17 +101,11 @@ blocks:
                 artifact push workflow coverage/lcov-functional.info --force
                 echo "Uploaded Playwright coverage artifacts"
               fi
-            # Bundle Mocha test results + logs into a single triage artifact;
-            # upload Playwright artifacts if available
+            # Bundle Mocha test results + logs into a single triage artifact
+            - make store-test-logs-to-semaphore
+            # Upload Playwright artifacts if available
             - |
               PLATFORM_ARCH="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
-              TRIAGE_ZIP="test-results-mocha-${PLATFORM_ARCH}.zip"
-              zip -j "${TRIAGE_ZIP}" TEST-result.xml TEST-extension.log TEST-sidecar.log 2>/dev/null || true
-              if [ -f "${TRIAGE_ZIP}" ]; then
-                artifact push workflow "${TRIAGE_ZIP}" \
-                  --destination "test-results-mocha/${TRIAGE_ZIP}" --force
-                echo "Uploaded ${TRIAGE_ZIP}"
-              fi
               if [ -d test-results ]; then
                 artifact push workflow test-results --destination test-results-${PLATFORM_ARCH} --force
               fi

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -1,6 +1,7 @@
 TEST_RESULT_FILE = $(CURDIR)/TEST-result.xml
 TEST_RESULT_E2E_FILE = $(CURDIR)/TEST-result-e2e.xml
 TEST_RESULT_WEBVIEW_FILE = $(CURDIR)/TEST-result-webview.xml
+MOCHA_TRIAGE_ZIP = test-results-mocha-$(PLATFORM)-$(ARCH).zip
 
 # How many days cache entries can stay in the semaphore cache before they are considered stale
 SEM_CACHE_DURATION_DAYS ?= 7
@@ -36,6 +37,20 @@ ifneq ($(wildcard $(TEST_RESULT_WEBVIEW_FILE)),)
 else
 	@echo "Webview test results not found at $(TEST_RESULT_WEBVIEW_FILE)"
 endif
+
+# Bundle Mocha JUnit results + extension/sidecar logs into one downloadable triage artifact.
+# Unlike `store-test-results-to-semaphore` (which only publishes the JUnit summary), this keeps
+# the logs needed to diagnose failures whose cause never reaches the JUnit XML.
+.PHONY: store-test-logs-to-semaphore
+store-test-logs-to-semaphore:
+	@echo "Bundling Mocha triage logs..."
+	@zip -j "$(MOCHA_TRIAGE_ZIP)" TEST-result.xml TEST-extension.log TEST-sidecar.log 2>/dev/null || true
+	@if [ -f "$(MOCHA_TRIAGE_ZIP)" ]; then \
+		artifact push workflow "$(MOCHA_TRIAGE_ZIP)" --destination "test-results-mocha/$(MOCHA_TRIAGE_ZIP)" --force || true; \
+		echo "Uploaded $(MOCHA_TRIAGE_ZIP)"; \
+	else \
+		echo "Triage log files not found, skipping bundle"; \
+	fi
 
 # Only write to the cache from main builds because of security reasons.
 .PHONY: ci-bin-sem-cache-store

--- a/mk-files/semaphore.mk
+++ b/mk-files/semaphore.mk
@@ -46,7 +46,7 @@ store-test-logs-to-semaphore:
 	@echo "Bundling Mocha triage logs..."
 	@zip -j "$(MOCHA_TRIAGE_ZIP)" TEST-result.xml TEST-extension.log TEST-sidecar.log 2>/dev/null || true
 	@if [ -f "$(MOCHA_TRIAGE_ZIP)" ]; then \
-		artifact push workflow "$(MOCHA_TRIAGE_ZIP)" --destination "test-results-mocha/$(MOCHA_TRIAGE_ZIP)" --force || true; \
+		artifact push workflow "$(MOCHA_TRIAGE_ZIP)" --destination "test-results-mocha/$(MOCHA_TRIAGE_ZIP)" --force; \
 		echo "Uploaded $(MOCHA_TRIAGE_ZIP)"; \
 	else \
 		echo "Triage log files not found, skipping bundle"; \


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Continuation of https://github.com/confluentinc/vscode/pull/3355, but for the CCloud auth smoketest pipeline. This PR just pushes the logic from `semaphore.yml` to a dedicated make target for it and the `ccloud-auth-smoketests.yml` to share.

This is mainly some cleanup since we've recently had test flakes with this pipeline, but the logs are limited and no artifacts were being uploaded: https://semaphore.ci.confluent.io/workflows/50951702-a0b7-48ca-bfb3-71ac098a10f2

Sample run: https://semaphore.ci.confluent.io/workflows/42106c9f-5920-404e-8365-7a534f895d8e?pipeline_id=65addc5c-46e4-476f-b2ae-c7a8dbd003d6
<img width="626" height="312" alt="image" src="https://github.com/user-attachments/assets/46bb5d98-ccfd-4b85-b7d8-a093abd9cc71" />


## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
