### PR TITLE
MINOR: remove view-level progress indicator from Flink Database view

### DIFF
--- a/src/viewProviders/flinkDatabase.test.ts
+++ b/src/viewProviders/flinkDatabase.test.ts
@@ -1,7 +1,5 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import type { CancellationToken, Progress } from "vscode";
-import { window } from "vscode";
 import { getStubbedCCloudResourceLoader } from "../../tests/stubs/resourceLoaders";
 import { TEST_CCLOUD_FLINK_DB_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { createFlinkAIAgent } from "../../tests/unit/testResources/flinkAIAgent";
@@ -577,30 +575,18 @@ describe("viewProviders/flinkDatabase.ts", () => {
     });
 
     describe("refresh()", () => {
-      let withProgressStub: sinon.SinonStub;
-
-      beforeEach(() => {
-        withProgressStub = sandbox.stub(window, "withProgress").callsFake((_, callback) => {
-          const mockProgress = {} as Progress<unknown>;
-          const mockToken = {} as CancellationToken;
-          return Promise.resolve(callback(mockProgress, mockToken));
-        });
-      });
-
       it("should fire onDidChangeTreeData when no database is selected", async () => {
         viewProvider["resource"] = null;
 
         await viewProvider.refresh();
 
         sinon.assert.calledOnce(onDidChangeTreeDataFireStub);
-        sinon.assert.notCalled(withProgressStub);
       });
 
       it("should refresh all containers when a database is selected", async () => {
         // focused on a database by default
         await viewProvider.refresh();
 
-        sinon.assert.calledOnce(withProgressStub);
         sinon.assert.calledOnce(ccloudLoader.getFlinkRelations);
         sinon.assert.calledOnce(ccloudLoader.getFlinkArtifacts);
         sinon.assert.calledOnce(ccloudLoader.getFlinkUDFs);

--- a/src/viewProviders/flinkDatabase.ts
+++ b/src/viewProviders/flinkDatabase.ts
@@ -13,16 +13,16 @@ import {
 import { extractResponseBody, isResponseError, logError } from "../errors";
 import { IconNames } from "../icons";
 import { CCloudResourceLoader } from "../loaders";
+import {
+  FlinkDatabaseContainerLabel,
+  FlinkDatabaseResourceContainer,
+} from "../models/containers/flinkDatabaseResourceContainer";
 import { FlinkAIAgent, FlinkAIAgentTreeItem } from "../models/flinkAiAgent";
 import { FlinkAIConnection, FlinkAIConnectionTreeItem } from "../models/flinkAiConnection";
 import { FlinkAIModel, FlinkAIModelTreeItem } from "../models/flinkAiModel";
 import { FlinkAITool, FlinkAIToolTreeItem } from "../models/flinkAiTool";
 import { FlinkArtifact, FlinkArtifactTreeItem } from "../models/flinkArtifact";
 import type { FlinkAIResource, FlinkDatabaseResource } from "../models/flinkDatabaseResource";
-import {
-  FlinkDatabaseContainerLabel,
-  FlinkDatabaseResourceContainer,
-} from "../models/containers/flinkDatabaseResourceContainer";
 import { FlinkRelation, FlinkRelationColumn } from "../models/flinkRelation";
 import { FlinkTypeNode } from "../models/flinkTypeNode";
 import { FlinkUdf, FlinkUdfTreeItem } from "../models/flinkUDF";
@@ -339,21 +339,18 @@ export class FlinkDatabaseViewProvider extends ParentedBaseViewProvider<
       `refreshing entire Flink Database view for ${database.name} (${database.id})`,
     );
 
-    await this.withProgress(
-      "Loading Flink Database resources...",
-      async () => {
-        await Promise.allSettled([
-          this.refreshRelationsContainer(database, forceDeepRefresh),
-          this.refreshArtifactsContainer(database, forceDeepRefresh),
-          this.refreshUDFsContainer(database, forceDeepRefresh),
-          this.refreshAIConnectionsContainer(database, forceDeepRefresh),
-          this.refreshAIToolsContainer(database, forceDeepRefresh),
-          this.refreshAIModelsContainer(database, forceDeepRefresh),
-          this.refreshAIAgentsContainer(database, forceDeepRefresh),
-        ]);
-      },
-      false,
-    );
+    // each container manages its own loading state (setLoading/setLoaded), so we deliberately do
+    // not raise a view-level progress indicator here: it would keep the whole pane busy until the
+    // slowest container settles
+    await Promise.allSettled([
+      this.refreshRelationsContainer(database, forceDeepRefresh),
+      this.refreshArtifactsContainer(database, forceDeepRefresh),
+      this.refreshUDFsContainer(database, forceDeepRefresh),
+      this.refreshAIConnectionsContainer(database, forceDeepRefresh),
+      this.refreshAIToolsContainer(database, forceDeepRefresh),
+      this.refreshAIModelsContainer(database, forceDeepRefresh),
+      this.refreshAIAgentsContainer(database, forceDeepRefresh),
+    ]);
 
     this._onDidChangeTreeData.fire();
   }


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Some E2E tests were failing after old resources (mainly Kafka topics) piled up in the test environment, which caused the "Tables and Views" container in the Flink Database view to take longer loading than the tests allowed.

<img width="196" height="94" alt="image" src="https://github.com/user-attachments/assets/8f912bdd-934e-4e48-904d-3038a43cf76b" />

(Screenshot from a `@flink-artifacts` test that was blocked waiting for the view-level progress to resolve, when it should have been able to expand the Artifacts container and confirm the newly-uploaded artifact.)

Since the Flink Database view uses container tree items (that each have their own progress/loading state shown as an icon) after a cluster/database is selected, there's no reason for the redundant view-level progress indicator.

The simplest fix is to remove the view-level progress indicator, which will allow container-specific operations in E2E tests to proceed without needing to hack around the existing search/progress logic (since some views still depend on view-level loading, e.g. Schemas and Flink Statements).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
