### PR TITLE
retry transient CCloud errors when fetching Flink statement results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this extension will be documented in this file.
 ### Fixed
 
 - Flink statement results no longer stop loading when Confluent Cloud returns a temporary error
-  right after a statement is submitted. The Results Viewer now retries before giving up, honoring
-  the `Retry-After` delay when Confluent Cloud sends one, instead of showing "Failed to load
+  right after a statement is submitted. The Results Viewer now retries before giving up, waiting as
+  long as Confluent Cloud asks when it sends a rate-limit delay, instead of showing "Failed to load
   results."
 
 ## 2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this extension will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Flink statement results no longer stop loading when Confluent Cloud returns a temporary error
+  right after a statement is submitted. The Results Viewer now retries before giving up, honoring
+  the `Retry-After` delay when Confluent Cloud sends one, instead of showing "Failed to load
+  results."
+
 ## 2.3.1
 
 ### Fixed

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -7,6 +7,7 @@ import {
   getNestedErrorChain,
   hasErrorCause,
   isResponseErrorWithStatus,
+  isTransientResponseError,
   logError,
 } from "./errors";
 import { Logger } from "./logging";
@@ -167,6 +168,27 @@ describe("errors.ts isResponseErrorWithStatus()", () => {
     const error = createResponseError(404, "Not Found", "test");
     assert.strictEqual(isResponseErrorWithStatus(error, 404), true);
   });
+});
+
+describe("errors.ts isTransientResponseError()", () => {
+  it("should return false for not-a-response-error", () => {
+    const error = new Error("test");
+    assert.strictEqual(isTransientResponseError(error), false);
+  });
+
+  for (const status of [429, 500, 502, 503, 504]) {
+    it(`should return true for a ${status} response error`, () => {
+      const error = createResponseError(status, "Transient", "test");
+      assert.strictEqual(isTransientResponseError(error), true);
+    });
+  }
+
+  for (const status of [400, 401, 403, 404, 409]) {
+    it(`should return false for a ${status} response error`, () => {
+      const error = createResponseError(status, "Client Error", "test");
+      assert.strictEqual(isTransientResponseError(error), false);
+    });
+  }
 });
 
 describe("errors.ts extractResponseBody()", () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -56,11 +56,11 @@ export function isResponseErrorWithStatus(
 }
 
 /** HTTP statuses where repeating the same request after a short delay may succeed. */
-const TRANSIENT_RESPONSE_STATUSES = [429, 500, 502, 503, 504];
+const TRANSIENT_RESPONSE_STATUSES = new Set([429, 500, 502, 503, 504]);
 
 /** Was this a response error whose status suggests the request is worth retrying? */
 export function isTransientResponseError(error: unknown): error is AnyResponseError {
-  return isResponseError(error) && TRANSIENT_RESPONSE_STATUSES.includes(error.response.status);
+  return isResponseError(error) && TRANSIENT_RESPONSE_STATUSES.has(error.response.status);
 }
 
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -55,6 +55,14 @@ export function isResponseErrorWithStatus(
   return isResponseError(error) && error.response.status === statusCode;
 }
 
+/** HTTP statuses where repeating the same request after a short delay may succeed. */
+const TRANSIENT_RESPONSE_STATUSES = [429, 500, 502, 503, 504];
+
+/** Was this a response error whose status suggests the request is worth retrying? */
+export function isTransientResponseError(error: unknown): error is AnyResponseError {
+  return isResponseError(error) && TRANSIENT_RESPONSE_STATUSES.includes(error.response.status);
+}
+
 /**
  * If error is a response error, try to decode its response body
  * from JSON and return the resulting object.

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -16,13 +16,13 @@ import {
   GetSqlv1StatementResult200ResponseKindEnum,
 } from "../clients/flinkSql";
 import * as messageUtils from "../documentProviders/message";
-import { transientBackoffWindow } from "./flinkStatementResultsManager";
 import { FlinkStatement, Phase } from "../models/flinkStatement";
 import type { WebviewStorage } from "../webview/comms/comms";
 import type {
   FlinkStatementResultsViewModel,
   ResultsViewerStorageState,
 } from "../webview/flink-statement-results";
+import { transientBackoffWindow } from "./flinkStatementResultsManager";
 
 /** A successful results response carrying no rows. */
 const EMPTY_RESULTS_RESPONSE: GetSqlv1StatementResult200Response = {
@@ -543,7 +543,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
 
       const fetchPromise = ctx.manager.fetchResults();
 
-      // 7500ms covers the transient backoffs, then 60 x 500ms of 409 backoff
+      // 7500ms covers the transient backoffs, then the 409 waits with a little margin
       await clock.tickAsync(7500 + 61 * 500);
 
       await fetchPromise;

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -869,7 +869,25 @@ describe("flinkStatementResultsManager.ts transientBackoffWindow()", () => {
     assert.equal(minMs, 8000);
   });
 
-  it("should fall back to an exponential curve without a Retry-After", () => {
+  it("should fall back to X-RateLimit-Reset when a 429 omits Retry-After", () => {
+    const { minMs } = transientBackoffWindow(
+      responseWithHeaders({ "x-ratelimit-limit": "5", "x-ratelimit-reset": "3" }),
+      0,
+    );
+
+    assert.equal(minMs, 3000);
+  });
+
+  it("should prefer Retry-After over X-RateLimit-Reset when both are present", () => {
+    const { minMs } = transientBackoffWindow(
+      responseWithHeaders({ "retry-after": "1", "x-ratelimit-reset": "3" }),
+      0,
+    );
+
+    assert.equal(minMs, 1000);
+  });
+
+  it("should fall back to an exponential curve without either header", () => {
     const windows = [0, 1, 2, 3].map((attempt) =>
       transientBackoffWindow(responseWithHeaders({}), attempt),
     );

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -533,7 +533,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       assert.equal(ctx.manager["_state"](), "completed");
     });
 
-    it("should abandon a transient backoff when the manager is disposed", async () => {
+    it("should stop waiting out a transient backoff when the manager is disposed", async () => {
       const stub = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult;
       stub.rejects(createResponseError(500, "Internal Server Error", "{}"));
 
@@ -543,12 +543,24 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       sinon.assert.calledOnce(stub);
 
       ctx.manager.dispose();
-      // well past the rest of the transient budget
-      await clock.tickAsync(7500);
+
+      // settles without the clock ever reaching the end of that backoff, which is the point: a real
+      // aborted signal would also end the loop, but only after the full wait
+      await fetchPromise;
+    });
+
+    it("should not report a disposal-interrupted fetch as an error", async () => {
+      const stub = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult;
+      stub.rejects(createResponseError(500, "Internal Server Error", "{}"));
+
+      const fetchPromise = ctx.manager.fetchResults();
+      await clock.tickAsync(1);
+      ctx.manager.dispose();
       await fetchPromise;
 
-      // without the abort race, the remaining 4 retries would have fired after disposal
-      sinon.assert.calledOnce(stub);
+      // aborting rethrows the 500 that started the retry; surfacing it would toast the user for
+      // closing the results pane
+      assert.equal(ctx.manager["_latestError"](), null);
     });
 
     it("should not let transient retries eat into the 409 budget", async () => {

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -5,19 +5,32 @@ import type { FlinkStatementResultsManagerTestContext } from "../../tests/create
 import { createTestResultsManagerContext } from "../../tests/createResultsManager";
 import { eventually } from "../../tests/eventually";
 import { loadFixtureFromFile } from "../../tests/fixtures/utils";
-import { createResponseError } from "../../tests/unit/testUtils";
+import {
+  createResponseError,
+  createSingleUseResponseError,
+  ResponseErrorSource,
+} from "../../tests/unit/testUtils";
 import type { GetSqlv1StatementResult200Response } from "../clients/flinkSql";
 import {
   GetSqlv1StatementResult200ResponseApiVersionEnum,
   GetSqlv1StatementResult200ResponseKindEnum,
 } from "../clients/flinkSql";
 import * as messageUtils from "../documentProviders/message";
+import { transientBackoffWindow } from "./flinkStatementResultsManager";
 import { FlinkStatement, Phase } from "../models/flinkStatement";
 import type { WebviewStorage } from "../webview/comms/comms";
 import type {
   FlinkStatementResultsViewModel,
   ResultsViewerStorageState,
 } from "../webview/flink-statement-results";
+
+/** A successful results response carrying no rows. */
+const EMPTY_RESULTS_RESPONSE: GetSqlv1StatementResult200Response = {
+  api_version: GetSqlv1StatementResult200ResponseApiVersionEnum.SqlV1,
+  kind: GetSqlv1StatementResult200ResponseKindEnum.StatementResult,
+  metadata: {},
+  results: { data: [] },
+};
 
 function createMockStatement(): FlinkStatement {
   const fakeFlinkStatement = loadFixtureFromFile(
@@ -401,14 +414,9 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
         .onSecondCall()
         .rejects(createResponseError(409, "Conflict", "{}"));
-      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.onThirdCall().resolves({
-        api_version: GetSqlv1StatementResult200ResponseApiVersionEnum.SqlV1,
-        kind: GetSqlv1StatementResult200ResponseKindEnum.StatementResult,
-        metadata: {},
-        results: {
-          data: [],
-        },
-      });
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onThirdCall()
+        .resolves(EMPTY_RESULTS_RESPONSE);
 
       // Trigger a fetch
       const fetchPromise = ctx.manager.fetchResults();
@@ -442,9 +450,8 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       assert.ok(ctx.manager["_latestError"]());
     });
 
-    it("should not retry on non-409 errors during fetch", async () => {
-      // Mock the getSqlv1StatementResult to fail with 500
-      const responseError = createResponseError(500, "Internal Server Error", "{}");
+    it("should not retry on errors that are neither 409 nor transient during fetch", async () => {
+      const responseError = createResponseError(403, "Forbidden", "{}");
       ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(responseError);
 
       // Trigger a fetch
@@ -455,9 +462,89 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
 
       await fetchPromise;
 
-      assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
+      sinon.assert.calledOnce(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult);
       // Verify error state is set
       assert.ok(ctx.manager["_latestError"]());
+    });
+
+    it("should retry get statement results on transient errors", async () => {
+      // CCloud briefly can't resolve a just-created statement, answering 429 or 5xx before the
+      // results endpoint starts working
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onFirstCall()
+        .rejects(createResponseError(429, "Too Many Requests", "{}"));
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onSecondCall()
+        .rejects(createResponseError(500, "Internal Server Error", "{}"));
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onThirdCall()
+        .resolves(EMPTY_RESULTS_RESPONSE);
+
+      const fetchPromise = ctx.manager.fetchResults();
+
+      // backoff doubles from 500ms and is jittered, so tick past the two maximums
+      await clock.tickAsync(500 + 1000);
+
+      await fetchPromise;
+
+      sinon.assert.calledThrice(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult);
+      assert.equal(ctx.manager["_latestError"](), null);
+    });
+
+    it("should wait for the server's Retry-After rather than the exponential curve", async () => {
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.onFirstCall().rejects(
+        createResponseError(429, "Too Many Requests", "{}", ResponseErrorSource.Sidecar, {
+          "retry-after": "2",
+        }),
+      );
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult
+        .onSecondCall()
+        .resolves(EMPTY_RESULTS_RESPONSE);
+
+      const fetchPromise = ctx.manager.fetchResults();
+
+      // the exponential curve would have retried by now, but the server asked for 2s
+      await clock.tickAsync(1000);
+      sinon.assert.calledOnce(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult);
+
+      // 2s as requested, plus up to one base delay of jitter on top
+      await clock.tickAsync(1500);
+      await fetchPromise;
+
+      sinon.assert.calledTwice(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult);
+      assert.equal(ctx.manager["_latestError"](), null);
+    });
+
+    it("should complete the stream after exhausting transient retries", async () => {
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(
+        createResponseError(500, "Internal Server Error", "{}"),
+      );
+
+      const fetchPromise = ctx.manager.fetchResults();
+
+      // 4 transient retries at up to 500/1000/2000/4000ms
+      await clock.tickAsync(7500);
+
+      await fetchPromise;
+
+      // 1 initial attempt + MAX_TRANSIENT_RETRIES
+      sinon.assert.callCount(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult, 5);
+      assert.ok(ctx.manager["_latestError"]());
+      assert.equal(ctx.manager["_state"](), "completed");
+    });
+
+    it("should leave the error response body readable for logging", async () => {
+      // a real single-use Response, so reading the body without cloning would be observable
+      const responseError = createSingleUseResponseError(
+        400,
+        "Bad Request",
+        '{"errors":[{"code":"cr_failed_get_stmt_name"}]}',
+      );
+      ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.rejects(responseError);
+
+      await ctx.manager.fetchResults();
+
+      assert.strictEqual(responseError.response.bodyUsed, false);
     });
 
     it("should only allow one instance of fetchResults to run at a time", async () => {
@@ -486,12 +573,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       assert.equal(ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.callCount, 1);
 
       // Resolve the API call
-      resolveRequest!({
-        api_version: GetSqlv1StatementResult200ResponseApiVersionEnum.SqlV1,
-        kind: GetSqlv1StatementResult200ResponseKindEnum.StatementResult,
-        metadata: {},
-        results: { data: [] },
-      });
+      resolveRequest!(EMPTY_RESULTS_RESPONSE);
 
       // Wait for all calls to complete
       await Promise.all(fetchPromises);
@@ -766,5 +848,49 @@ describe("FlinkStatementResultsViewModel only", () => {
       ctx.manager.dispose();
       vm.dispose();
     }
+  });
+});
+
+describe("flinkStatementResultsManager.ts transientBackoffWindow()", () => {
+  function responseWithHeaders(headers: Record<string, string>): Response {
+    return new Response("{}", { status: 429, headers });
+  }
+
+  it("should honor a Retry-After the server sends, never shortening it", () => {
+    const { minMs, maxMs } = transientBackoffWindow(responseWithHeaders({ "retry-after": "2" }), 0);
+
+    assert.equal(minMs, 2000);
+    assert.ok(maxMs > minMs, "jitter should only extend a server-requested delay");
+  });
+
+  it("should cap an outsized Retry-After", () => {
+    const { minMs } = transientBackoffWindow(responseWithHeaders({ "retry-after": "600" }), 0);
+
+    assert.equal(minMs, 8000);
+  });
+
+  it("should fall back to an exponential curve without a Retry-After", () => {
+    const windows = [0, 1, 2, 3].map((attempt) =>
+      transientBackoffWindow(responseWithHeaders({}), attempt),
+    );
+
+    assert.deepEqual(
+      windows.map((w) => w.maxMs),
+      [500, 1000, 2000, 4000],
+    );
+    assert.deepEqual(
+      windows.map((w) => w.minMs),
+      [250, 500, 1000, 2000],
+    );
+  });
+
+  it("should fall back to the curve for a non-numeric Retry-After", () => {
+    // RFC 7231 also permits an HTTP-date, which we don't parse
+    const { maxMs } = transientBackoffWindow(
+      responseWithHeaders({ "retry-after": "Wed, 21 Oct 2015 07:28:00 GMT" }),
+      0,
+    );
+
+    assert.equal(maxMs, 500);
   });
 });

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -533,6 +533,25 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       assert.equal(ctx.manager["_state"](), "completed");
     });
 
+    it("should not let transient retries eat into the 409 budget", async () => {
+      // 4 transient retries first, exhausting that budget, then nothing but 409s
+      const stub = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult;
+      for (let i = 0; i < 4; i++) {
+        stub.onCall(i).rejects(createResponseError(500, "Internal Server Error", "{}"));
+      }
+      stub.rejects(createResponseError(409, "Conflict", "{}"));
+
+      const fetchPromise = ctx.manager.fetchResults();
+
+      // 7500ms covers the transient backoffs, then 60 x 500ms of 409 backoff
+      await clock.tickAsync(7500 + 61 * 500);
+
+      await fetchPromise;
+
+      // 4 transient calls + the 409s' full 60-attempt budget, untouched by them
+      sinon.assert.callCount(stub, 64);
+    });
+
     it("should leave the error response body readable for logging", async () => {
       // a real single-use Response, so reading the body without cloning would be observable
       const responseError = createSingleUseResponseError(

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -533,6 +533,24 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       assert.equal(ctx.manager["_state"](), "completed");
     });
 
+    it("should abandon a transient backoff when the manager is disposed", async () => {
+      const stub = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult;
+      stub.rejects(createResponseError(500, "Internal Server Error", "{}"));
+
+      const fetchPromise = ctx.manager.fetchResults();
+      // let the first attempt fail and settle into its backoff
+      await clock.tickAsync(1);
+      sinon.assert.calledOnce(stub);
+
+      ctx.manager.dispose();
+      // well past the rest of the transient budget
+      await clock.tickAsync(7500);
+      await fetchPromise;
+
+      // without the abort race, the remaining 4 retries would have fired after disposal
+      sinon.assert.calledOnce(stub);
+    });
+
     it("should not let transient retries eat into the 409 budget", async () => {
       // 4 transient retries first, exhausting that budget, then nothing but 409s
       const stub = ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult;

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -424,7 +424,10 @@ export class FlinkStatementResultsManager {
           logger.debug(
             `Retrying ${operationName} after status ${err.response.status}. Transient attempt ${transientAttempts}/${MAX_TRANSIENT_RETRIES}`,
           );
-          await pauseWithJitter(minMs, maxMs);
+          await this.pauseUnlessAborted(minMs, maxMs);
+          if (this._getResultsAbortController.signal.aborted) {
+            break;
+          }
         } else {
           break;
         }
@@ -432,6 +435,32 @@ export class FlinkStatementResultsManager {
     }
 
     throw lastErr;
+  }
+
+  /**
+   * Sleep for a jittered interval, returning as soon as the results fetch is aborted so a backoff
+   * can't outlive {@linkcode dispose}. Only the results fetch opts into transient retries, so this
+   * deliberately watches that controller; `stopStatement()` aborts it before its own retries and
+   * must not be cut short.
+   */
+  private async pauseUnlessAborted(minMs: number, maxMs: number): Promise<void> {
+    const { signal } = this._getResultsAbortController;
+    if (signal.aborted) {
+      return;
+    }
+
+    let stopWatchingAbort = () => {};
+    const abortedEarly = new Promise<void>((resolve) => {
+      const onAbort = () => resolve();
+      signal.addEventListener("abort", onAbort, { once: true });
+      stopWatchingAbort = () => signal.removeEventListener("abort", onAbort);
+    });
+
+    try {
+      await Promise.race([pauseWithJitter(minMs, maxMs), abortedEarly]);
+    } finally {
+      stopWatchingAbort();
+    }
   }
 
   private async stopStatement(): Promise<void> {

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -579,24 +579,35 @@ export class FlinkStatementResultsManager {
 }
 
 /**
- * Pick the backoff window for a transient response, preferring the server's own `Retry-After`
- * (CCloud sends it on 429) over a locally-guessed exponential delay.
+ * Pick the backoff window for a transient response, preferring a delay Confluent Cloud asked for
+ * over a locally-guessed exponential one.
  *
- * A server-requested delay is only ever extended by jitter, never shortened - retrying before the
- * rate-limit window resets just earns another 429. The exponential fallback covers 5xx responses,
- * which carry no `Retry-After`.
+ * `Retry-After` is only sent once a rate limit is actually hit, so `X-RateLimit-Reset` (which rides
+ * along on every response) covers a 429 that omits it. A server-requested delay is only ever
+ * extended by jitter, never shortened, since retrying before the window resets just earns another
+ * 429. The exponential fallback covers 5xx responses, which carry neither header.
  */
 export function transientBackoffWindow(
   response: Response,
   attempt: number,
 ): { minMs: number; maxMs: number } {
-  // per RFC 7231 this may also be an HTTP-date, which is not a finite number and so falls through
-  const retryAfterSeconds = Number(response.headers?.get("retry-after"));
-  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
-    const minMs = Math.min(retryAfterSeconds * 1000, MAX_TRANSIENT_BACKOFF_MS);
+  const serverDelaySeconds =
+    relativeSeconds(response.headers?.get("retry-after")) ??
+    relativeSeconds(response.headers?.get("x-ratelimit-reset"));
+  if (serverDelaySeconds !== undefined) {
+    const minMs = Math.min(serverDelaySeconds * 1000, MAX_TRANSIENT_BACKOFF_MS);
     return { minMs, maxMs: minMs + TRANSIENT_BASE_BACKOFF_MS };
   }
 
   const maxMs = Math.min(TRANSIENT_BASE_BACKOFF_MS * 2 ** attempt, MAX_TRANSIENT_BACKOFF_MS);
   return { minMs: maxMs / 2, maxMs };
+}
+
+/**
+ * Read a header carrying a positive number of seconds, ignoring absent values and the HTTP-date
+ * form of `Retry-After` that RFC 7231 also permits.
+ */
+function relativeSeconds(header: string | null | undefined): number | undefined {
+  const seconds = Number(header);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
 }

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -396,19 +396,24 @@ export class FlinkStatementResultsManager {
     retryTransient: boolean = false,
   ): Promise<T> {
     let lastErr: Error | undefined;
+    let conflictAttempts = 0;
     let transientAttempts = 0;
-    for (let attempt = 0; attempt < MAX_CONFLICT_RETRIES; attempt++) {
+    // each branch is bounded by its own counter, so this ceiling should never be what stops us;
+    // it is here only so the loop is self-evidently finite
+    for (let i = 0; i <= MAX_CONFLICT_RETRIES + MAX_TRANSIENT_RETRIES; i++) {
       try {
         return await operation();
       } catch (err) {
         lastErr = err as Error;
         if (isResponseErrorWithStatus(err, 409)) {
-          if (attempt < MAX_CONFLICT_RETRIES - 1) {
-            logger.debug(
-              `Retrying ${operationName} after 409 conflict. Attempt ${attempt + 1}/${MAX_CONFLICT_RETRIES}. Waiting ${CONFLICT_BACKOFF_MS}ms`,
-            );
-            await new Promise((resolve) => setTimeout(resolve, CONFLICT_BACKOFF_MS));
+          if (conflictAttempts >= MAX_CONFLICT_RETRIES - 1) {
+            break;
           }
+          conflictAttempts++;
+          logger.debug(
+            `Retrying ${operationName} after 409 conflict. Attempt ${conflictAttempts}/${MAX_CONFLICT_RETRIES}. Waiting ${CONFLICT_BACKOFF_MS}ms`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, CONFLICT_BACKOFF_MS));
         } else if (
           retryTransient &&
           isTransientResponseError(err) &&

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -294,12 +294,7 @@ export class FlinkStatementResultsManager {
           this.notifyUI();
         });
       } catch (error) {
-        // Aborting mid-backoff rethrows whatever failure started the retry, so the signal has to be
-        // checked too: otherwise closing the results pane reports that failure to the user.
-        if (
-          this._getResultsAbortController.signal.aborted ||
-          (error instanceof FetchError && error?.cause?.name === "AbortError")
-        ) {
+        if (this.wasFetchAborted(error)) {
           logger.info("Statement results fetch was aborted");
           return;
         }
@@ -419,6 +414,18 @@ export class FlinkStatementResultsManager {
     }
 
     throw lastErr;
+  }
+
+  /**
+   * Did this failure come from the fetch being abandoned rather than from the server? Aborting
+   * mid-backoff rethrows whatever failure started the retry, so the signal has to be checked as
+   * well, or closing the results pane would report that failure to the user.
+   */
+  private wasFetchAborted(error: unknown): boolean {
+    return (
+      this._getResultsAbortController.signal.aborted ||
+      (error instanceof FetchError && error?.cause?.name === "AbortError")
+    );
   }
 
   /**

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -44,6 +44,9 @@ const MAX_TRANSIENT_BACKOFF_MS = 8_000;
 export type ResultCount = { total: number; filter: number | null };
 export type StreamState = "running" | "completed";
 
+/** Retry attempts already spent, per class of failure. */
+type RetryBudget = { conflict: number; transient: number };
+
 export type MessageType =
   | "GetResults"
   | "GetResultsCount"
@@ -291,7 +294,12 @@ export class FlinkStatementResultsManager {
           this.notifyUI();
         });
       } catch (error) {
-        if (error instanceof FetchError && error?.cause?.name === "AbortError") {
+        // Aborting mid-backoff rethrows whatever failure started the retry, so the signal has to be
+        // checked too: otherwise closing the results pane reports that failure to the user.
+        if (
+          this._getResultsAbortController.signal.aborted ||
+          (error instanceof FetchError && error?.cause?.name === "AbortError")
+        ) {
           logger.info("Statement results fetch was aborted");
           return;
         }
@@ -396,45 +404,61 @@ export class FlinkStatementResultsManager {
     retryTransient: boolean = false,
   ): Promise<T> {
     let lastErr: Error | undefined;
-    let conflictAttempts = 0;
-    let transientAttempts = 0;
-    // each branch is bounded by its own counter, so this ceiling should never be what stops us;
+    const spent: RetryBudget = { conflict: 0, transient: 0 };
+    // each budget is bounded by its own counter, so this ceiling should never be what stops us;
     // it is here only so the loop is self-evidently finite
     for (let i = 0; i <= MAX_CONFLICT_RETRIES + MAX_TRANSIENT_RETRIES; i++) {
       try {
         return await operation();
       } catch (err) {
         lastErr = err as Error;
-        if (isResponseErrorWithStatus(err, 409)) {
-          if (conflictAttempts >= MAX_CONFLICT_RETRIES - 1) {
-            break;
-          }
-          conflictAttempts++;
-          logger.debug(
-            `Retrying ${operationName} after 409 conflict. Attempt ${conflictAttempts}/${MAX_CONFLICT_RETRIES}. Waiting ${CONFLICT_BACKOFF_MS}ms`,
-          );
-          await new Promise((resolve) => setTimeout(resolve, CONFLICT_BACKOFF_MS));
-        } else if (
-          retryTransient &&
-          isTransientResponseError(err) &&
-          transientAttempts < MAX_TRANSIENT_RETRIES
-        ) {
-          const { minMs, maxMs } = transientBackoffWindow(err.response, transientAttempts);
-          transientAttempts++;
-          logger.debug(
-            `Retrying ${operationName} after status ${err.response.status}. Transient attempt ${transientAttempts}/${MAX_TRANSIENT_RETRIES}`,
-          );
-          await this.pauseUnlessAborted(minMs, maxMs);
-          if (this._getResultsAbortController.signal.aborted) {
-            break;
-          }
-        } else {
+        if (!(await this.backOffBeforeRetry(err, operationName, retryTransient, spent))) {
           break;
         }
       }
     }
 
     throw lastErr;
+  }
+
+  /**
+   * Wait out a retryable failure, charging it to the matching budget in {@linkcode spent}. Returns
+   * false when the error isn't retryable, its budget is spent, or the fetch was aborted while
+   * waiting, all of which mean {@linkcode retry} should give up.
+   */
+  private async backOffBeforeRetry(
+    err: unknown,
+    operationName: string,
+    retryTransient: boolean,
+    spent: RetryBudget,
+  ): Promise<boolean> {
+    if (isResponseErrorWithStatus(err, 409)) {
+      if (spent.conflict >= MAX_CONFLICT_RETRIES - 1) {
+        return false;
+      }
+      spent.conflict++;
+      logger.debug(
+        `Retrying ${operationName} after 409 conflict. Attempt ${spent.conflict}/${MAX_CONFLICT_RETRIES}. Waiting ${CONFLICT_BACKOFF_MS}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, CONFLICT_BACKOFF_MS));
+      return true;
+    }
+
+    if (
+      retryTransient &&
+      isTransientResponseError(err) &&
+      spent.transient < MAX_TRANSIENT_RETRIES
+    ) {
+      const { minMs, maxMs } = transientBackoffWindow(err.response, spent.transient);
+      spent.transient++;
+      logger.debug(
+        `Retrying ${operationName} after status ${err.response.status}. Transient attempt ${spent.transient}/${MAX_TRANSIENT_RETRIES}`,
+      );
+      await this.pauseUnlessAborted(minMs, maxMs);
+      return !this._getResultsAbortController.signal.aborted;
+    }
+
+    return false;
   }
 
   /**

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -9,7 +9,13 @@ import type {
 } from "../clients/flinkSql";
 import { FetchError } from "../clients/flinkSql";
 import { showJsonPreview } from "../documentProviders/message";
-import { isResponseError, isResponseErrorWithStatus, logError } from "../errors";
+import {
+  extractResponseBody,
+  isResponseError,
+  isResponseErrorWithStatus,
+  isTransientResponseError,
+  logError,
+} from "../errors";
 import { CCloudResourceLoader } from "../loaders/ccloudResourceLoader";
 import { Logger } from "../logging";
 import type { FlinkStatement } from "../models/flinkStatement";
@@ -19,9 +25,21 @@ import type { ViewMode } from "./flinkStatementResultColumns";
 import type { StatementResultsRow } from "./flinkStatementResults";
 import { parseResults } from "./flinkStatementResults";
 import { extractPageToken } from "./utils";
+import { pauseWithJitter } from "../utils/timing";
 import type { SqlV1StatementWarning } from "../clients/flinkSql";
 
 const logger = new Logger("flink-statement-results");
+
+/** Attempts allowed while the statement's results are still being prepared (HTTP 409). */
+const MAX_CONFLICT_RETRIES = 60;
+/** Constant delay between 409 attempts. */
+const CONFLICT_BACKOFF_MS = 500;
+/** Retries allowed per transient response, on top of the initial attempt. */
+const MAX_TRANSIENT_RETRIES = 4;
+/** First transient backoff delay; doubles each retry, so 500/1000/2000/4000ms. */
+const TRANSIENT_BASE_BACKOFF_MS = 500;
+/** Ceiling on any transient backoff, so an outsized `Retry-After` can't stall the viewer. */
+const MAX_TRANSIENT_BACKOFF_MS = 8_000;
 
 export type ResultCount = { total: number; filter: number | null };
 export type StreamState = "running" | "completed";
@@ -229,19 +247,23 @@ export class FlinkStatementResultsManager {
         const priorRawResults = this._rawResults();
         const pageToken = extractPageToken(this._latestResult()?.metadata?.next);
 
-        const response = await this.retry(async () => {
-          return await this._flinkStatementResultsSqlApi.getSqlv1StatementResult(
-            {
-              environment_id: this.statement.environmentId,
-              organization_id: this.statement.organizationId,
-              name: this.statement.name,
-              page_token: pageToken,
-            },
-            {
-              signal: this._getResultsAbortController.signal,
-            },
-          );
-        }, "fetch statement results");
+        const response = await this.retry(
+          async () => {
+            return await this._flinkStatementResultsSqlApi.getSqlv1StatementResult(
+              {
+                environment_id: this.statement.environmentId,
+                organization_id: this.statement.organizationId,
+                name: this.statement.name,
+                page_token: pageToken,
+              },
+              {
+                signal: this._getResultsAbortController.signal,
+              },
+            );
+          },
+          "fetch statement results",
+          true,
+        );
 
         const resultsData: SqlV1StatementResultResults = response.results ?? {};
 
@@ -275,7 +297,8 @@ export class FlinkStatementResultsManager {
         }
 
         if (isResponseError(error)) {
-          const payload = await error.response.json();
+          // clone before reading, so logError() below can still read the body for Sentry
+          const payload = await extractResponseBody(error);
           if (!payload?.aborted) {
             const status = error.response.status;
             shouldComplete = status >= 400;
@@ -360,28 +383,43 @@ export class FlinkStatementResultsManager {
   }
 
   /**
-   * Retries {@link maxRetries} times with a constant backoff delay of
-   * {@link backoffMs}. Nothing fancy.
+   * Retries a 409 conflict up to {@linkcode MAX_CONFLICT_RETRIES} times with a constant backoff
+   * delay of {@linkcode CONFLICT_BACKOFF_MS}. Nothing fancy.
+   *
+   * When {@linkcode retryTransient} is set, statuses that may clear on their own (429 and 5xx) also
+   * get up to {@linkcode MAX_TRANSIENT_RETRIES} attempts on a separate backoff budget, delegated to
+   * {@linkcode transientBackoffWindow}. Only safe for idempotent operations.
    */
   private async retry<T>(
     operation: () => Promise<T>,
     operationName: string,
-    maxRetries: number = 60,
-    backoffMs: number = 500,
+    retryTransient: boolean = false,
   ): Promise<T> {
     let lastErr: Error | undefined;
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
+    let transientAttempts = 0;
+    for (let attempt = 0; attempt < MAX_CONFLICT_RETRIES; attempt++) {
       try {
         return await operation();
       } catch (err) {
         lastErr = err as Error;
         if (isResponseErrorWithStatus(err, 409)) {
-          if (attempt < maxRetries - 1) {
+          if (attempt < MAX_CONFLICT_RETRIES - 1) {
             logger.debug(
-              `Retrying ${operationName} after 409 conflict. Attempt ${attempt + 1}/${maxRetries}. Waiting ${backoffMs}ms`,
+              `Retrying ${operationName} after 409 conflict. Attempt ${attempt + 1}/${MAX_CONFLICT_RETRIES}. Waiting ${CONFLICT_BACKOFF_MS}ms`,
             );
-            await new Promise((resolve) => setTimeout(resolve, backoffMs));
+            await new Promise((resolve) => setTimeout(resolve, CONFLICT_BACKOFF_MS));
           }
+        } else if (
+          retryTransient &&
+          isTransientResponseError(err) &&
+          transientAttempts < MAX_TRANSIENT_RETRIES
+        ) {
+          const { minMs, maxMs } = transientBackoffWindow(err.response, transientAttempts);
+          transientAttempts++;
+          logger.debug(
+            `Retrying ${operationName} after status ${err.response.status}. Transient attempt ${transientAttempts}/${MAX_TRANSIENT_RETRIES}`,
+          );
+          await pauseWithJitter(minMs, maxMs);
         } else {
           break;
         }
@@ -538,4 +576,27 @@ export class FlinkStatementResultsManager {
     // Abort any in-flight requests
     this._getResultsAbortController.abort();
   }
+}
+
+/**
+ * Pick the backoff window for a transient response, preferring the server's own `Retry-After`
+ * (CCloud sends it on 429) over a locally-guessed exponential delay.
+ *
+ * A server-requested delay is only ever extended by jitter, never shortened - retrying before the
+ * rate-limit window resets just earns another 429. The exponential fallback covers 5xx responses,
+ * which carry no `Retry-After`.
+ */
+export function transientBackoffWindow(
+  response: Response,
+  attempt: number,
+): { minMs: number; maxMs: number } {
+  // per RFC 7231 this may also be an HTTP-date, which is not a finite number and so falls through
+  const retryAfterSeconds = Number(response.headers?.get("retry-after"));
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+    const minMs = Math.min(retryAfterSeconds * 1000, MAX_TRANSIENT_BACKOFF_MS);
+    return { minMs, maxMs: minMs + TRANSIENT_BASE_BACKOFF_MS };
+  }
+
+  const maxMs = Math.min(TRANSIENT_BASE_BACKOFF_MS * 2 ** attempt, MAX_TRANSIENT_BACKOFF_MS);
+  return { minMs: maxMs / 2, maxMs };
 }

--- a/tests/unit/testUtils.ts
+++ b/tests/unit/testUtils.ts
@@ -121,6 +121,7 @@ export enum ResponseErrorSource {
  * @param statusText - HTTP status text
  * @param body - Response body
  * @param source - Which {@link ResponseErrorSource client source} ResponseError is returned, defaults to sidecar
+ * @param headers - Response headers, for code that reads things like `Retry-After`
  * @returns A ResponseError instance
  */
 export function createResponseError(
@@ -128,10 +129,12 @@ export function createResponseError(
   statusText: string,
   body: string,
   source: ResponseErrorSource = ResponseErrorSource.Sidecar,
+  headers: Record<string, string> = {},
 ): AnyResponseError {
   const response = {
     status,
     statusText,
+    headers: new Headers(headers),
     clone: () => ({
       text: () => Promise.resolve(body),
       json: () => Promise.resolve(JSON.parse(body)),
@@ -140,8 +143,28 @@ export function createResponseError(
     json: () => Promise.resolve(JSON.parse(body)),
   } as Response;
 
-  // any callers that end up using `isResponseError()` will need to know which client code subdir
-  // the error came from, so we need to return the correct subclass of ResponseError
+  return wrapResponseError(response, source);
+}
+
+/**
+ * Create a mock ResponseError backed by a real single-use {@link Response}, so a body consumed
+ * without `.clone()` is observable. {@linkcode createResponseError}'s stand-in is re-readable
+ * forever and can't catch that.
+ */
+export function createSingleUseResponseError(
+  status: number,
+  statusText: string,
+  body: string,
+  source: ResponseErrorSource = ResponseErrorSource.Sidecar,
+): AnyResponseError {
+  return wrapResponseError(new Response(body, { status, statusText }), source);
+}
+
+/**
+ * Wrap a response in the ResponseError subclass matching its client source, since callers relying
+ * on `isResponseError()` need the subdir the error came from.
+ */
+function wrapResponseError(response: Response, source: ResponseErrorSource): AnyResponseError {
   switch (source) {
     case ResponseErrorSource.Docker:
       return new DockerResponseError(response);


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Submit a Flink statement and the Results Viewer sometimes shows "Failed to load results. Something
went wrong." and never recovers, even though the statement itself completes fine. This is the flake
behind the `flink-statements` E2E job.

Confluent Cloud briefly rejects requests for a statement's results in the first seconds after it is
submitted, before the statement name is resolvable. We gave up on the very first rejection and
permanently stopped fetching, so the pane got stuck on the error even though the next poll (800ms
later) would have worked.

Now those rejections are retried a few times before giving up. When Confluent Cloud tells us how
long to wait, we wait exactly that long; otherwise we back off 500ms, 1s, 2s, 4s. Retries stop
immediately if you close the results pane.

Also fixes a logging bug in the same code path that was hiding these failures from Sentry entirely.

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

1. Submit a Flink statement and confirm the Results Viewer still loads normally. This is the
   important regression check.
2. To watch a retry happen, breakpoint `retry()` in
   `src/flinkSql/flinkStatementResultsManager.ts` and make the first `getSqlv1StatementResult()`
   call reject with a 429 or 500. The pane should recover instead of showing the error.

Forcing the real failure isn't practical, since it depends on Confluent Cloud timing. The unit tests
carry the real coverage: each new behavior test was confirmed to fail against the unfixed code.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

<details>
<summary>Implementation detail</summary>

Retried statuses are 429 and 5xx, via a new `isTransientResponseError()` in `src/errors.ts`. Delay
comes from `Retry-After` if present, else `X-RateLimit-Reset`, else a jittered exponential curve,
all capped at 8s (`transientBackoffWindow()`). 409 keeps its existing 60-attempt budget, and the two
budgets no longer consume each other. Transient retries are opt-in per call site, so
`stopStatement()` still fails fast on anything but a 409.

Backoff sleeps race against the results `AbortController`, so closing the pane stops the wait
immediately instead of sitting out a backoff of up to 8s. The aborted signal would have ended the
loop on its own at the next attempt regardless; the race just skips the dead waiting. Aborting is
also checked in the catch, so an interrupted fetch isn't reported to the user as a failure.

The logging fix: the error handler read the response body without cloning it, so `logError()` then
threw `Response.clone: Body has already been consumed` and swallowed it. It now uses the existing
`extractResponseBody()`.

Not doing proactive rate limiting off `X-RateLimit-Limit`/`Remaining` here. The sidecar already has
that machinery in `CCloudApiRateLimiter`; extending it to cover proxied requests is the better fix.

That also explains why the sidecar update in #3419 didn't already cover this. Its limiter only
guards the calls the sidecar makes on its own behalf, not the ones it proxies for us. The failing
run was already on 0.273.0.

</details>

Follow-ups, one line each:

- `src/consume.ts` has the same give-up-on-first-error shape and the same un-cloned body read.
- `sanitizeHeaders()` in `src/sidecar/middlewares.ts` calls `Object.entries()` on a `Headers`
  instance, which always returns `[]`, so response headers never appear in our logs.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [x] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
