### PR TITLE
Flink Snapshot Statement UI affordances.

### DIFF
--- a/.claude/rules/testing/unit-tests.md
+++ b/.claude/rules/testing/unit-tests.md
@@ -77,6 +77,29 @@ after adding the symlink:
 codesign --force --deep --sign - "Visual Studio Code.app"
 ```
 
-Re-run `npx gulp test` after both steps. If it still fails with `SIGKILL` or an Electron "bad
-option" error, that's a genuine headless/no-GUI-session environment (e.g. a sandboxed agent session
-without display access) — not a code or signing issue, and not fixable with the above.
+Re-run `npx gulp test` after both steps.
+
+**3. `bad option: --no-sandbox` (and every other flag), exit code 9** — the test host is being run
+as plain Node instead of as Electron, so it rejects all of the Chromium/VS Code flags the runner
+passes. The cause is an inherited `ELECTRON_RUN_AS_NODE=1`, which any terminal hosted inside VS Code
+(or another Electron app) exports to its child processes — including agent sessions running in the
+IDE. Confirm with `env | grep -i electron`, then run the suite with it stripped:
+
+```bash
+env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE npx gulp test
+```
+
+A quick tell that this is the problem rather than a broken bundle:
+`.../Contents/MacOS/Code --version` prints a Node version (e.g. `v24.18.0`) instead of a VS Code
+version.
+
+**4. Global suite setup times out or fails with `PORT_IN_USE` on 26636** — activation starts the
+sidecar, and the sidecar port is shared machine-wide. Another VS Code window running the
+marketplace-installed Confluent extension (or a second dev host) already owns it, and it re-spawns
+its own sidecar within seconds of being killed, so the test run loses the race repeatedly. Close the
+other workspace (or disable its Confluent extension) rather than killing the sidecar process in a
+loop.
+
+If it still fails with `SIGKILL`, that's a genuine headless/no-GUI-session environment (e.g. a
+sandboxed agent session without display access) — not a code or signing issue, and not fixable with
+the above.

--- a/.claude/rules/testing/unit-tests.md
+++ b/.claude/rules/testing/unit-tests.md
@@ -86,8 +86,12 @@ passes. The cause is an inherited `ELECTRON_RUN_AS_NODE=1`, which any terminal h
 IDE. Confirm with `env | grep -i electron`, then run the suite with it stripped:
 
 ```bash
-env -u ELECTRON_RUN_AS_NODE -u ELECTRON_NO_ATTACH_CONSOLE npx gulp test
+env -u ELECTRON_RUN_AS_NODE npx gulp test
 ```
+
+`ELECTRON_NO_ATTACH_CONSOLE=1` is usually inherited alongside it, but it is harmless — verified
+against VS Code 1.132.0: stripping `ELECTRON_RUN_AS_NODE` alone is enough, so there is no need to
+unset both.
 
 A quick tell that this is the problem rather than a broken bundle:
 `.../Contents/MacOS/Code --version` prints a Node version (e.g. `v24.18.0`) instead of a VS Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ All notable changes to this extension will be documented in this file.
   "[snapshot](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html)" mode.
   New codelens control for toggling streaming vs snapshot submission.
 - Flink statement results now show which mode the statement was submitted in, plus timing details:
-  an elapsed clock while the statement runs, and its end time, total duration, and Confluent Cloud
-  execution time once it finishes. While waiting for the first rows, the viewer names the phase the
-  statement is in, and notes that snapshot queries return no rows until they complete.
+  an elapsed clock while the statement runs, and its end time and total duration once it finishes.
+  Streaming statements, which can spend meaningful time queued, additionally report Confluent
+  Cloud's execution time. While waiting for the first rows, the viewer names the phase the statement
+  is in, and notes that snapshot queries return no rows until they complete.
   ([#1851](https://github.com/confluentinc/vscode/issues/1851),
   [#1852](https://github.com/confluentinc/vscode/issues/1852),
   [#2674](https://github.com/confluentinc/vscode/issues/2674))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to this extension will be documented in this file.
 - Support for submitting Flink statements in
   "[snapshot](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html)" mode.
   New codelens control for toggling streaming vs snapshot submission.
+- Flink statement results now show which mode the statement was submitted in, plus timing details:
+  an elapsed clock while the statement runs, and its end time, total duration, and Confluent Cloud
+  execution time once it finishes. While waiting for the first rows, the viewer names the phase the
+  statement is in, and notes that snapshot queries return no rows until they complete.
+  ([#1851](https://github.com/confluentinc/vscode/issues/1851),
+  [#1852](https://github.com/confluentinc/vscode/issues/1852),
+  [#2674](https://github.com/confluentinc/vscode/issues/2674))
+- Flink statement tooltips now include the submission mode, and, for statements that have finished,
+  when they ended and how long they took.
+  ([#2673](https://github.com/confluentinc/vscode/issues/2673))
 
 ## 2.3.1
 

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -6,7 +6,7 @@ import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import type { CCloudEnvironment } from "../models/environment";
 import type { CCloudFlinkComputePool } from "../models/flinkComputePool";
-import { FlinkSnapshotMode } from "../models/flinkStatement";
+import { FlinkSnapshotMode, flinkSnapshotModeLabel } from "../models/flinkStatement";
 import type { CCloudKafkaCluster } from "../models/kafkaCluster";
 import { hasCCloudAuthSession } from "../sidecar/connections/ccloud";
 import { UriMetadataKeys } from "../storage/constants";
@@ -94,7 +94,7 @@ export class FlinkSqlCodelensProvider extends DisposableCollection implements Co
     // bounded) statement execution mode
     const isSnapshotMode = snapshotMode === FlinkSnapshotMode.BATCH;
     const toggleSnapshotModeCommand: Command = {
-      title: isSnapshotMode ? "Mode: Snapshot" : "Mode: Streaming",
+      title: `Mode: ${flinkSnapshotModeLabel(snapshotMode)}`,
       command: "confluent.document.flinksql.toggleSnapshotMode",
       tooltip: isSnapshotMode
         ? "Statement will run once against a snapshot of current data, then complete. Click to switch to streaming mode."

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -965,6 +965,82 @@ describe("FlinkStatementResultsViewModel only", () => {
   });
 });
 
+/**
+ * Whether the results viewer shows CCloud's execution time, which depends on the statement's mode
+ * and so has to be baked into the statement before the view model is built. Kept in its own describe
+ * for that reason: each test needs the one and only results manager context of its sandbox.
+ */
+describe("FlinkStatementResultsViewModel execution duration display", () => {
+  let sandbox: sinon.SinonSandbox;
+  let ctx: FlinkStatementResultsManagerTestContext | undefined;
+  let vm: FlinkStatementResultsViewModel | undefined;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    ctx = undefined;
+    vm = undefined;
+  });
+
+  afterEach(() => {
+    ctx?.manager.dispose();
+    vm?.dispose();
+    sandbox.restore();
+  });
+
+  /**
+   * Build a view model over a terminal statement in the given mode, reporting both a wall-clock
+   * total (90s) and CCloud's shorter execution-only duration (1m 15s).
+   */
+  async function createViewModel(mode: FlinkSnapshotMode): Promise<FlinkStatementResultsViewModel> {
+    const base: FlinkStatement = createMockStatement();
+    const terminalStatement = new FlinkStatement({
+      ...base,
+      spec: {
+        ...base.spec,
+        properties:
+          mode === FlinkSnapshotMode.BATCH
+            ? { ...base.spec.properties, "sql.snapshot.mode": "now" }
+            : base.spec.properties,
+      },
+      status: {
+        ...base.status,
+        phase: Phase.COMPLETED,
+        end_time: new Date(base.createdAt!.getTime() + 90_000),
+        duration: "PT1M15S",
+      },
+    });
+
+    ({ ctx, vm } = await createTestResultsManagerContext(sandbox, terminalStatement));
+    return vm;
+  }
+
+  it("should withhold execution time for a snapshot statement", async () => {
+    const snapshotVm: FlinkStatementResultsViewModel = await createViewModel(
+      FlinkSnapshotMode.BATCH,
+    );
+
+    await eventually(() => {
+      assert.strictEqual(snapshotVm.statementMeta().isSnapshotMode, true);
+    });
+
+    // the meta still carries CCloud's duration...
+    assert.strictEqual(snapshotVm.statementMeta().executionDuration, "PT1M15S");
+    // ...but a snapshot statement barely queues, so displaying it beside the wall-clock total would
+    // only invite comparing two measurements of the same span
+    assert.strictEqual(snapshotVm.executionDurationDisplay(), null);
+  });
+
+  it("should display execution time for a streaming statement", async () => {
+    const streamingVm: FlinkStatementResultsViewModel = await createViewModel(
+      FlinkSnapshotMode.STREAMING,
+    );
+
+    await eventually(() => {
+      assert.strictEqual(streamingVm.executionDurationDisplay(), "1m 15s");
+    });
+  });
+});
+
 describe("flinkStatementResultsManager.ts transientBackoffWindow()", () => {
   function responseWithHeaders(headers: Record<string, string>): Response {
     return new Response("{}", { status: 429, headers });

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -16,12 +16,18 @@ import {
   GetSqlv1StatementResult200ResponseKindEnum,
 } from "../clients/flinkSql";
 import * as messageUtils from "../documentProviders/message";
-import { FlinkStatement, Phase } from "../models/flinkStatement";
+import {
+  FlinkSnapshotMode,
+  flinkSnapshotModeDescription,
+  FlinkStatement,
+  Phase,
+} from "../models/flinkStatement";
 import type { WebviewStorage } from "../webview/comms/comms";
 import type {
   FlinkStatementResultsViewModel,
   ResultsViewerStorageState,
 } from "../webview/flink-statement-results";
+import type { StatementMeta } from "./flinkStatementResultsManager";
 import { transientBackoffWindow } from "./flinkStatementResultsManager";
 
 /** A successful results response carrying no rows. */
@@ -264,11 +270,20 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
   });
 
   it("should handle GetStatementMeta message", async () => {
-    const meta = vm.statementMeta();
+    const { fetchedBytes, ...meta } = vm.statementMeta();
+
     assert.deepStrictEqual(meta, {
       name: ctx.statement.name,
-      status: ctx.statement.status?.phase,
-      startTime: ctx.statement.metadata?.created_at,
+      status: ctx.statement.phase,
+      startTimeMillis: ctx.statement.createdAt!.getTime(),
+      // the fixture statement is still RUNNING, so nothing terminal to report yet
+      endTimeMillis: null,
+      totalDurationMillis: null,
+      executionDuration: null,
+      modeLabel: "Streaming",
+      modeDescription: flinkSnapshotModeDescription(FlinkSnapshotMode.STREAMING),
+      isSnapshotMode: false,
+      isTerminal: false,
       detail: ctx.statement.status?.detail ?? null,
       failed: ctx.statement.failed,
       stoppable: ctx.statement.stoppable,
@@ -276,6 +291,56 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       possiblyViewable: ctx.statement.possiblyViewable,
       isForeground: ctx.statement.isForeground,
       warnings: ctx.statement.warnings,
+    });
+
+    // the fixture rows have already been fetched by the time the view model is created
+    assert.ok(fetchedBytes > 0, `expected some fetched bytes, got ${fetchedBytes}`);
+  });
+
+  it("should report snapshot mode in GetStatementMeta for a snapshot-mode statement", async () => {
+    const snapshotStatement = new FlinkStatement({
+      ...ctx.statement,
+      spec: {
+        ...ctx.statement.spec,
+        properties: { ...ctx.statement.spec.properties, "sql.snapshot.mode": "now" },
+      },
+    });
+    ctx.refreshFlinkStatementStub.returns(Promise.resolve(snapshotStatement));
+
+    // asserting against the manager rather than the view model: the view model only re-resolves
+    // when the host pushes a new timestamp, which the test harness stubs out
+    await eventually(() => {
+      const meta: StatementMeta = ctx.manager.handleMessage("GetStatementMeta", {});
+      assert.strictEqual(meta.modeLabel, "Snapshot");
+      assert.strictEqual(meta.isSnapshotMode, true);
+      assert.strictEqual(
+        meta.modeDescription,
+        flinkSnapshotModeDescription(FlinkSnapshotMode.BATCH),
+      );
+    });
+  });
+
+  it("should report end time and durations in GetStatementMeta once the statement is terminal", async () => {
+    const createdAt: Date = ctx.statement.createdAt!;
+    const endTime = new Date(createdAt.getTime() + 90_000);
+    const completedStatement = new FlinkStatement({
+      ...ctx.statement,
+      status: {
+        ...ctx.statement.status,
+        phase: Phase.COMPLETED,
+        end_time: endTime,
+        duration: "PT1M15S",
+      },
+    });
+    ctx.refreshFlinkStatementStub.returns(Promise.resolve(completedStatement));
+
+    await eventually(() => {
+      const meta: StatementMeta = ctx.manager.handleMessage("GetStatementMeta", {});
+      assert.strictEqual(meta.isTerminal, true);
+      assert.strictEqual(meta.endTimeMillis, endTime.getTime());
+      // wall clock includes the time spent PENDING; CCloud's own duration does not
+      assert.strictEqual(meta.totalDurationMillis, 90_000);
+      assert.strictEqual(meta.executionDuration, "PT1M15S");
     });
   });
 

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -174,36 +174,36 @@ export class FlinkStatementResultsManager {
    * where each key is a unique identifier for the row and the value is the row data.
    * The row data value is a {@link Map} of column names to their respective data value (represented as `any`).
    */
-  private _results: Signal<Map<string, Map<string, any>>>;
+  private readonly _results: Signal<Map<string, Map<string, any>>>;
   /**
    * Signal containing the raw statement results as received from the API, before any processing or transformation.
    * This represents a changelog stream where each result represents a change to the data rather than just the current state.
    * This is used in changelog view mode to show the history of changes, while table view mode uses the processed {@link _results}.
    */
-  private _rawResults: Signal<StatementResultsRow[]>;
-  private _state: Signal<StreamState>;
-  private _moreResults: Signal<boolean>;
-  private _latestResult: Signal<GetSqlv1StatementResult200Response | null>;
-  private _latestError: Signal<{ message: string } | null>;
-  private _isResultsFull: Signal<boolean>;
+  private readonly _rawResults: Signal<StatementResultsRow[]>;
+  private readonly _state: Signal<StreamState>;
+  private readonly _moreResults: Signal<boolean>;
+  private readonly _latestResult: Signal<GetSqlv1StatementResult200Response | null>;
+  private readonly _latestError: Signal<{ message: string } | null>;
+  private readonly _isResultsFull: Signal<boolean>;
   /**
    * Running total of the estimated bytes of result rows fetched so far. Client-side accounting:
    * CCloud exposes no server-side result-set size, so this describes what this viewer has pulled
    * down, not how large the statement's full result set is.
    */
-  private _fetchedBytes: Signal<number>;
+  private readonly _fetchedBytes: Signal<number>;
   private _pollingInterval: NodeJS.Timeout | undefined;
-  private _getResultsAbortController: AbortController;
+  private readonly _getResultsAbortController: AbortController;
   /** Filter by substring text query. */
-  private _searchQuery: Signal<string | null>;
-  private _visibleColumns: Signal<string[] | null>;
-  private _filteredResults: Signal<any[]>;
+  private readonly _searchQuery: Signal<string | null>;
+  private readonly _visibleColumns: Signal<string[] | null>;
+  private readonly _filteredResults: Signal<any[]>;
   private _fetchCount = 0;
   private _statementRefreshInterval: NodeJS.Timeout | undefined;
-  private _viewMode!: Signal<ViewMode>;
+  private readonly _viewMode: Signal<ViewMode>;
 
-  private _flinkStatementResultsSqlApi: StatementResultsSqlV1Api;
-  private _flinkStatementsSqlApi: StatementsSqlV1Api;
+  private readonly _flinkStatementResultsSqlApi: StatementResultsSqlV1Api;
+  private readonly _flinkStatementsSqlApi: StatementsSqlV1Api;
 
   private _fetchResultsLocked = false;
 

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -19,6 +19,11 @@ import {
 import { CCloudResourceLoader } from "../loaders/ccloudResourceLoader";
 import { Logger } from "../logging";
 import type { FlinkStatement } from "../models/flinkStatement";
+import {
+  FlinkSnapshotMode,
+  flinkSnapshotModeDescription,
+  flinkSnapshotModeLabel,
+} from "../models/flinkStatement";
 import { showErrorNotificationWithButtons } from "../notifications";
 import type { SidecarHandle } from "../sidecar";
 import type { ViewMode } from "./flinkStatementResultColumns";
@@ -26,6 +31,7 @@ import type { StatementResultsRow } from "./flinkStatementResults";
 import { parseResults } from "./flinkStatementResults";
 import { extractPageToken } from "./utils";
 import { pauseWithJitter } from "../utils/timing";
+import { estimateJsonBytes } from "../utils/bytes";
 import type { SqlV1StatementWarning } from "../clients/flinkSql";
 
 const logger = new Logger("flink-statement-results");
@@ -43,6 +49,53 @@ const MAX_TRANSIENT_BACKOFF_MS = 8_000;
 
 export type ResultCount = { total: number; filter: number | null };
 export type StreamState = "running" | "completed";
+
+/**
+ * Statement facts the results viewer renders in its header and progress banner. Dates cross the
+ * webview boundary as epoch millis so the webview can both format them and do timer arithmetic
+ * without reparsing strings.
+ */
+export type StatementMeta = {
+  name: string;
+  status: string;
+  /** When the statement was submitted. Start of the elapsed-time clock. */
+  startTimeMillis: number | null;
+  /** When the statement reached a terminal phase, if it has gotten there yet. */
+  endTimeMillis: number | null;
+  /**
+   * Wall-clock duration from submission to terminal phase, including time spent PENDING — the
+   * elapsed time the user actually waited. Null while the statement is still going.
+   */
+  totalDurationMillis: number | null;
+  /**
+   * CCloud's own execution time as an ISO 8601 duration, measured from PENDING -> RUNNING onward, so
+   * it excludes queue time and reads shorter than {@link totalDurationMillis}.
+   */
+  executionDuration: string | null;
+  /**
+   * Estimated bytes of result rows this viewer has fetched. Not the size of the statement's full
+   * result set, which CCloud does not report.
+   */
+  fetchedBytes: number;
+  /**
+   * Execution mode label — "Snapshot" or "Streaming" — worded the same as the Flink SQL document's
+   * CodeLens toggle. Labeled here rather than in the webview so the wording lives in one place and
+   * the webview doesn't have to import the vscode-coupled statement model.
+   */
+  modeLabel: string;
+  /** One-line explanation of the execution mode, for the mode chip's hover text. */
+  modeDescription: string;
+  /** Whether this is a bounded snapshot ("batch") query, which yields no rows until it finishes. */
+  isSnapshotMode: boolean;
+  isTerminal: boolean;
+  detail: string | null;
+  failed: boolean;
+  stoppable: boolean;
+  areResultsViewable: boolean;
+  possiblyViewable: boolean;
+  isForeground: boolean;
+  warnings: SqlV1StatementWarning[];
+};
 
 /** Retry attempts already spent, per class of failure. */
 type RetryBudget = { conflict: number; transient: number };
@@ -96,19 +149,7 @@ export type PostFunction = {
     type: "SetVisibleColumns",
     body: { visibleColumns: string[] | null; timestamp?: number },
   ): Promise<null>;
-  (
-    type: "GetStatementMeta",
-    body: { timestamp?: number },
-  ): Promise<{
-    name: string;
-    status: string;
-    startTime: string | null;
-    detail: string | null;
-    failed: boolean;
-    areResultsViewable: boolean;
-    isForeground: boolean;
-    warnings: SqlV1StatementWarning[];
-  }>;
+  (type: "GetStatementMeta", body: { timestamp?: number }): Promise<StatementMeta>;
   (type: "StopStatement", body: { timestamp?: number }): Promise<null>;
   (type: "ViewStatementSource", body: { timestamp?: number }): Promise<null>;
   (type: "SetViewMode", body: { viewMode: ViewMode; timestamp?: number }): Promise<null>;
@@ -145,6 +186,12 @@ export class FlinkStatementResultsManager {
   private _latestResult: Signal<GetSqlv1StatementResult200Response | null>;
   private _latestError: Signal<{ message: string } | null>;
   private _isResultsFull: Signal<boolean>;
+  /**
+   * Running total of the estimated bytes of result rows fetched so far. Client-side accounting:
+   * CCloud exposes no server-side result-set size, so this describes what this viewer has pulled
+   * down, not how large the statement's full result set is.
+   */
+  private _fetchedBytes: Signal<number>;
   private _pollingInterval: NodeJS.Timeout | undefined;
   private _getResultsAbortController: AbortController;
   /** Filter by substring text query. */
@@ -177,6 +224,7 @@ export class FlinkStatementResultsManager {
     this._latestResult = os.signal<GetSqlv1StatementResult200Response | null>(null);
     this._latestError = os.signal<{ message: string } | null>(null);
     this._isResultsFull = os.signal(false);
+    this._fetchedBytes = os.signal(0);
     this._searchQuery = os.signal<string | null>(null);
     this._visibleColumns = os.signal<string[] | null>(null);
     this._filteredResults = os.signal<any[]>([]);
@@ -273,6 +321,11 @@ export class FlinkStatementResultsManager {
         this.os.batch(() => {
           // Store raw changelog data in order
           this._rawResults([...priorRawResults, ...(resultsData?.data ?? [])]);
+
+          // skip empty pages so idle polling doesn't accrue phantom bytes for the empty envelope
+          if (resultsData?.data?.length) {
+            this._fetchedBytes(this._fetchedBytes() + estimateJsonBytes(resultsData.data));
+          }
 
           // Process results for table view
           parseResults({
@@ -588,18 +641,7 @@ export class FlinkStatementResultsManager {
         return escaped;
       }
       case "GetStatementMeta": {
-        return {
-          name: this.statement.name,
-          status: this.statement.status?.phase,
-          startTime: this.statement.metadata?.created_at ?? null,
-          detail: this.statement.status?.detail ?? null,
-          failed: this.statement.failed,
-          stoppable: this.statement.stoppable,
-          areResultsViewable: this.statement.canRequestResults,
-          possiblyViewable: this.statement.possiblyViewable,
-          isForeground: this.statement.isForeground,
-          warnings: this.statement.warnings,
-        };
+        return this.statementMeta();
       }
       case "StopStatement": {
         return this.stopStatement();
@@ -621,6 +663,31 @@ export class FlinkStatementResultsManager {
         return _exhaustiveCheck;
       }
     }
+  }
+
+  /** Statement facts the results viewer renders, as of right now. */
+  private statementMeta(): StatementMeta {
+    const statement: FlinkStatement = this.statement;
+    return {
+      name: statement.name,
+      status: statement.phase,
+      startTimeMillis: statement.createdAt?.getTime() ?? null,
+      endTimeMillis: statement.endTime?.getTime() ?? null,
+      totalDurationMillis: statement.totalDurationMillis ?? null,
+      executionDuration: statement.executionDuration ?? null,
+      fetchedBytes: this._fetchedBytes(),
+      modeLabel: flinkSnapshotModeLabel(statement.mode),
+      modeDescription: flinkSnapshotModeDescription(statement.mode),
+      isSnapshotMode: statement.mode === FlinkSnapshotMode.BATCH,
+      isTerminal: statement.isTerminal,
+      detail: statement.status?.detail ?? null,
+      failed: statement.failed,
+      stoppable: statement.stoppable,
+      areResultsViewable: statement.canRequestResults,
+      possiblyViewable: statement.possiblyViewable,
+      isForeground: statement.isForeground,
+      warnings: statement.warnings,
+    };
   }
 
   private getResultsArray() {

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -565,7 +565,40 @@ describe("FlinkStatementTreeItem", () => {
     const expectedKeyValuePairs: KeyValuePairArray = [
       ["Mode", "Snapshot"],
       ["Ended At", statement.endTime!.toLocaleString()],
-      // wall clock from submission (1m 35s), versus CCloud's execution-only 1m 15s
+      ["Total Duration", "1m 35s"],
+    ];
+
+    for (const [key, value] of expectedKeyValuePairs) {
+      assert.ok(tooltip.value.includes(key), `expected key ${key} to be in tooltip`);
+      assert.ok(
+        tooltip.value.includes(value!),
+        `expected value ${value} to be in tooltip for key ${key}\n${tooltip.value}`,
+      );
+    }
+
+    // snapshot statements barely queue, so CCloud's execution time only invites a nonsensical
+    // comparison against the wall-clock total; it's withheld here
+    assert.ok(!tooltip.value.includes("Execution Time"), tooltip.value);
+  });
+
+  it("tooltip reports execution time alongside the total for a terminal streaming statement", () => {
+    const createdAt = new Date("2026-08-10T12:00:00Z");
+    const statement = createFlinkStatement({
+      name: "statement0",
+      phase: Phase.STOPPED,
+      mode: FlinkSnapshotMode.STREAMING,
+      createdAt,
+      endTime: new Date(createdAt.getTime() + 95_000),
+      duration: "PT1M15S",
+    });
+
+    const treeItem = new FlinkStatementTreeItem(statement);
+    const tooltip = treeItem.tooltip as CustomMarkdownString;
+
+    const expectedKeyValuePairs: KeyValuePairArray = [
+      ["Mode", "Streaming"],
+      // wall clock from submission (1m 35s), versus CCloud's execution-only 1m 15s: the difference
+      // is the time the statement spent PENDING
       ["Total Duration", "1m 35s"],
       ["Execution Time", "1m 15s"],
     ];

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -315,6 +315,67 @@ describe("FlinkStatement", () => {
     });
   });
 
+  describe("endTime / executionDuration", () => {
+    it("returns undefined for a statement CCloud hasn't reported timings for", () => {
+      const statement = createFlinkStatement({ phase: Phase.RUNNING });
+      assert.strictEqual(statement.endTime, undefined);
+      assert.strictEqual(statement.executionDuration, undefined);
+    });
+
+    it("returns what the status reports", () => {
+      const endTime = new Date();
+      const statement = createFlinkStatement({
+        phase: Phase.COMPLETED,
+        endTime,
+        duration: "PT1M30S",
+      });
+      assert.strictEqual(statement.endTime, endTime);
+      assert.strictEqual(statement.executionDuration, "PT1M30S");
+    });
+  });
+
+  describe("totalDurationMillis", () => {
+    const createdAt = new Date("2026-08-10T12:00:00Z");
+
+    it("returns undefined while the statement is not terminal", () => {
+      const statement = createFlinkStatement({
+        phase: Phase.RUNNING,
+        createdAt,
+        endTime: new Date(createdAt.getTime() + 5_000),
+      });
+      assert.strictEqual(statement.totalDurationMillis, undefined);
+    });
+
+    it("measures from creation to end time, including time spent PENDING", () => {
+      const statement = createFlinkStatement({
+        phase: Phase.COMPLETED,
+        createdAt,
+        endTime: new Date(createdAt.getTime() + 95_000),
+        // CCloud's own duration excludes queue time, so it should not be what we measure
+        duration: "PT1M15S",
+      });
+      assert.strictEqual(statement.totalDurationMillis, 95_000);
+    });
+
+    it("falls back to updatedAt when end time is missing", () => {
+      const statement = createFlinkStatement({
+        phase: Phase.STOPPED,
+        createdAt,
+        updatedAt: new Date(createdAt.getTime() + 42_000),
+      });
+      assert.strictEqual(statement.totalDurationMillis, 42_000);
+    });
+
+    it("returns undefined rather than a negative duration when timestamps disagree", () => {
+      const statement = createFlinkStatement({
+        phase: Phase.FAILED,
+        createdAt,
+        endTime: new Date(createdAt.getTime() - 1_000),
+      });
+      assert.strictEqual(statement.totalDurationMillis, undefined);
+    });
+  });
+
   describe("possiblyViewable", () => {
     const ONE_DAY_MS = 24 * 60 * 60 * 1000;
     const now = new Date();
@@ -464,12 +525,49 @@ describe("FlinkStatementTreeItem", () => {
 
     const expectedKeyValuePairs: KeyValuePairArray = [
       ["Kind", statement.sqlKindDisplay],
+      ["Mode", "Streaming"],
       ["Status", statement.phase],
       ["Created At", statement.createdAt!.toLocaleString()],
       ["Updated At", statement.updatedAt!.toLocaleString()],
       ["Environment", statement.environmentId],
       ["Compute Pool", statement.computePoolId],
       ["Detail", statement.status.detail],
+    ];
+
+    for (const [key, value] of expectedKeyValuePairs) {
+      assert.ok(tooltip.value.includes(key), `expected key ${key} to be in tooltip`);
+      assert.ok(
+        tooltip.value.includes(value!),
+        `expected value ${value} to be in tooltip for key ${key}\n${tooltip.value}`,
+      );
+    }
+
+    // nothing terminal to report while the statement is still running
+    assert.ok(!tooltip.value.includes("Ended At"));
+    assert.ok(!tooltip.value.includes("Total Duration"));
+    assert.ok(!tooltip.value.includes("Execution Time"));
+  });
+
+  it("tooltip describes snapshot mode and terminal timings", () => {
+    const createdAt = new Date("2026-08-10T12:00:00Z");
+    const statement = createFlinkStatement({
+      name: "statement0",
+      phase: Phase.COMPLETED,
+      mode: FlinkSnapshotMode.BATCH,
+      createdAt,
+      endTime: new Date(createdAt.getTime() + 95_000),
+      duration: "PT1M15S",
+    });
+
+    const treeItem = new FlinkStatementTreeItem(statement);
+    const tooltip = treeItem.tooltip as CustomMarkdownString;
+
+    const expectedKeyValuePairs: KeyValuePairArray = [
+      ["Mode", "Snapshot"],
+      ["Ended At", statement.endTime!.toLocaleString()],
+      // wall clock from submission (1m 35s), versus CCloud's execution-only 1m 15s
+      ["Total Duration", "1m 35s"],
+      ["Execution Time", "1m 15s"],
     ];
 
     for (const [key, value] of expectedKeyValuePairs) {

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -474,6 +474,7 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
     );
   }
 
+  const totalDurationMillis: number | undefined = resource.totalDurationMillis;
   tooltip
     .addField(
       "Created At",
@@ -486,9 +487,8 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
     .addField("Ended At", resource.endTime?.toLocaleString(undefined, { timeZoneName: "short" }))
     .addField(
       "Total Duration",
-      resource.totalDurationMillis !== undefined
-        ? formatDurationMillis(resource.totalDurationMillis)
-        : undefined,
+      // not a truthiness check: 0 is a real duration, and formats as "0s" rather than dropping the field
+      totalDurationMillis === undefined ? undefined : formatDurationMillis(totalDurationMillis),
     )
     .addField(
       "Execution Time",

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -14,6 +14,7 @@ import { extractWarnings } from "../flinkSql/warningParser";
 import { IconNames } from "../icons";
 import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
+import { formatDurationMillis, formatIsoDuration } from "../utils/durations";
 import type {
   ConnectionId,
   EnvironmentId,
@@ -265,6 +266,47 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable, IEnvP
       : FlinkSnapshotMode.STREAMING;
   }
 
+  /**
+   * When the statement reached its final terminal phase, if it has gotten there. CCloud only sets
+   * this once the phase is COMPLETED, FAILED, or STOPPED.
+   */
+  get endTime(): Date | undefined {
+    return this.status?.end_time;
+  }
+
+  /**
+   * How long the statement spent executing, as an ISO 8601 duration (say, `PT1M30S`), measured from
+   * the PENDING -> RUNNING transition through reaching a terminal phase. Excludes any time spent
+   * waiting in PENDING, so it reads shorter than {@link totalDurationMillis}.
+   */
+  get executionDuration(): string | undefined {
+    return this.status?.duration;
+  }
+
+  /**
+   * Wall-clock milliseconds from submission until the statement reached a terminal phase, or
+   * undefined while it's still going (or if we can't tell). Includes time spent PENDING, so this is
+   * the elapsed time the user actually waited on.
+   *
+   * `end_time` is an Early Access field and may be missing, so fall back to `updatedAt`, which lands
+   * on the terminal transition.
+   */
+  get totalDurationMillis(): number | undefined {
+    const startedAt: Date | undefined = this.createdAt;
+    if (!startedAt || !this.isTerminal) {
+      return undefined;
+    }
+
+    const finishedAt: Date | undefined = this.endTime ?? this.updatedAt;
+    if (!finishedAt) {
+      return undefined;
+    }
+
+    const elapsed: number = finishedAt.getTime() - startedAt.getTime();
+    // guard against clock skew between the two timestamps reading as negative elapsed time
+    return elapsed >= 0 ? elapsed : undefined;
+  }
+
   /** Returns true if the statement is in a failed or failing phase. */
   get failed(): boolean {
     return FAILED_PHASES.includes(this.phase);
@@ -286,10 +328,6 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable, IEnvP
   get warnings(): SqlV1StatementWarning[] {
     const statusWarnings = this.status.warnings;
     return extractWarnings(statusWarnings, this.detail);
-  }
-
-  get startTime(): Date | undefined {
-    return this.metadata?.created_at;
   }
 }
 
@@ -427,6 +465,7 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
   const tooltip = new CustomMarkdownString()
     .addHeader("Flink Statement", getFlinkStatementThemeIcon(resource.phase).id as IconNames)
     .addField("Kind", resource.sqlKindDisplay)
+    .addField("Mode", flinkSnapshotModeLabel(resource.mode))
     .addField("Status", resource.phase);
 
   if (resource.phase === Phase.DEGRADED) {
@@ -443,6 +482,17 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
     .addField(
       "Updated At",
       resource.updatedAt?.toLocaleString(undefined, { timeZoneName: "short" }),
+    )
+    .addField("Ended At", resource.endTime?.toLocaleString(undefined, { timeZoneName: "short" }))
+    .addField(
+      "Total Duration",
+      resource.totalDurationMillis !== undefined
+        ? formatDurationMillis(resource.totalDurationMillis)
+        : undefined,
+    )
+    .addField(
+      "Execution Time",
+      resource.executionDuration ? formatIsoDuration(resource.executionDuration) : undefined,
     )
     .addField("Environment", resource.environmentId)
     .addField("Compute Pool", resource.computePoolId)
@@ -461,6 +511,25 @@ export enum FlinkSnapshotMode {
   BATCH = "batch",
   /** Continuous, unbounded evaluation against data as it arrives. This is the CCloud default. */
   STREAMING = "streaming",
+}
+
+/**
+ * User-facing label for a {@link FlinkSnapshotMode}. Shared by the CodeLens toggle, the statement
+ * tooltip, and the results viewer so all three name the mode the same way.
+ */
+export function flinkSnapshotModeLabel(mode: FlinkSnapshotMode): string {
+  return mode === FlinkSnapshotMode.BATCH ? "Snapshot" : "Streaming";
+}
+
+/**
+ * One-line explanation of what a {@link FlinkSnapshotMode} means for a statement that has already
+ * been submitted, for hover text in read-only views. (The CodeLens toggle has its own wording, since
+ * there the mode is still a choice the user can click to change.)
+ */
+export function flinkSnapshotModeDescription(mode: FlinkSnapshotMode): string {
+  return mode === FlinkSnapshotMode.BATCH
+    ? "Bounded query: ran once against a snapshot of the data as of submission time, then completed."
+    : "Streaming query: runs continuously against new data as it arrives.";
 }
 
 export class FlinkSpecProperties {

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -492,7 +492,12 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
     )
     .addField(
       "Execution Time",
-      resource.executionDuration ? formatIsoDuration(resource.executionDuration) : undefined,
+      // withheld for snapshot statements, which barely queue: CCloud's duration and our own
+      // "Total Duration" then measure the same span two ways and can disagree by a second in
+      // either direction, which reads as nonsense rather than as queue time
+      resource.executionDuration && resource.mode !== FlinkSnapshotMode.BATCH
+        ? formatIsoDuration(resource.executionDuration)
+        : undefined,
     )
     .addField("Environment", resource.environmentId)
     .addField("Compute Pool", resource.computePoolId)

--- a/src/utils/bytes.test.ts
+++ b/src/utils/bytes.test.ts
@@ -1,0 +1,53 @@
+import * as assert from "assert";
+import { estimateJsonBytes, formatBytes } from "./bytes";
+
+describe("utils/bytes.ts", () => {
+  describe("formatBytes()", () => {
+    const testCases: Array<[number, string]> = [
+      [0, "0 B"],
+      [-1, "0 B"],
+      [NaN, "0 B"],
+      [1, "1 B"],
+      [947, "947 B"],
+      [1023, "1023 B"],
+      [1024, "1.0 KB"],
+      [12_595, "12.3 KB"],
+      [1_048_576, "1.0 MB"],
+      [1_887_437, "1.8 MB"],
+      [1_073_741_824, "1.0 GB"],
+      [1_099_511_627_776, "1.0 TB"],
+      // beyond the largest unit we label, keep scaling the number rather than inventing a unit
+      [1_125_899_906_842_624, "1024.0 TB"],
+    ];
+
+    testCases.forEach(([bytes, expected]) => {
+      it(`should render ${bytes} as "${expected}"`, () => {
+        assert.strictEqual(formatBytes(bytes), expected);
+      });
+    });
+  });
+
+  describe("estimateJsonBytes()", () => {
+    it("should count the bytes of the serialized value", () => {
+      assert.strictEqual(estimateJsonBytes([1, 2, 3]), "[1,2,3]".length);
+      assert.strictEqual(estimateJsonBytes({ a: "b" }), '{"a":"b"}'.length);
+    });
+
+    it("should count multi-byte characters as their UTF-8 length", () => {
+      // "é" is two UTF-8 bytes but one UTF-16 code unit, so .length alone would undercount
+      assert.strictEqual(estimateJsonBytes("é"), 4);
+    });
+
+    it("should return 0 for values JSON cannot represent", () => {
+      assert.strictEqual(estimateJsonBytes(undefined), 0);
+      assert.strictEqual(
+        estimateJsonBytes(() => {}),
+        0,
+      );
+    });
+
+    it("should return 0 for an empty array", () => {
+      assert.strictEqual(estimateJsonBytes([]), 2);
+    });
+  });
+});

--- a/src/utils/bytes.test.ts
+++ b/src/utils/bytes.test.ts
@@ -46,7 +46,7 @@ describe("utils/bytes.ts", () => {
       );
     });
 
-    it("should return 0 for an empty array", () => {
+    it("should count an empty array as its two bracket bytes", () => {
       assert.strictEqual(estimateJsonBytes([]), 2);
     });
   });

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,40 @@
+/**
+ * Binary units, labeled the way VS Code's own UI labels them (KB for 1024 bytes, not KiB).
+ */
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+const BYTES_PER_UNIT = 1024;
+
+/**
+ * Render a byte count for display, e.g. `947 B`, `12.3 KB`, `1.8 MB`.
+ *
+ * @param bytes Number of bytes. Negative and non-finite values render as `0 B`.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+
+  let unitIndex = 0;
+  let value = bytes;
+  while (value >= BYTES_PER_UNIT && unitIndex < BYTE_UNITS.length - 1) {
+    value /= BYTES_PER_UNIT;
+    unitIndex++;
+  }
+
+  // whole bytes never need a decimal point; larger units read better with one
+  const rendered: string = unitIndex === 0 ? Math.round(value).toString() : value.toFixed(1);
+  return `${rendered} ${BYTE_UNITS[unitIndex]}`;
+}
+
+/**
+ * Approximate the UTF-8 byte size of a value as it arrived over the wire, by re-serializing it.
+ *
+ * Only ever an estimate: the generated API clients hand back parsed JSON, so the original response
+ * body — with its whitespace and key ordering — is gone by the time we can see the value.
+ *
+ * @returns Byte count, or 0 for values JSON can't represent.
+ */
+export function estimateJsonBytes(value: unknown): number {
+  const json: string | undefined = JSON.stringify(value);
+  return json === undefined ? 0 : new TextEncoder().encode(json).length;
+}

--- a/src/utils/durations.test.ts
+++ b/src/utils/durations.test.ts
@@ -1,0 +1,73 @@
+import * as assert from "assert";
+import { formatDurationMillis, formatIsoDuration, isoDurationToMillis } from "./durations";
+
+describe("utils/durations.ts", () => {
+  describe("formatDurationMillis()", () => {
+    const testCases: Array<[number, string]> = [
+      [0, "0s"],
+      [-500, "0s"],
+      [NaN, "0s"],
+      [1, "1ms"],
+      [947, "947ms"],
+      [1000, "1.0s"],
+      [1250, "1.3s"],
+      [59_400, "59.4s"],
+      [60_000, "1m 0s"],
+      [90_000, "1m 30s"],
+      [3_599_000, "59m 59s"],
+      [3_600_000, "1h 0m 0s"],
+      [7_384_000, "2h 3m 4s"],
+    ];
+
+    testCases.forEach(([millis, expected]) => {
+      it(`should render ${millis}ms as "${expected}"`, () => {
+        assert.strictEqual(formatDurationMillis(millis), expected);
+      });
+    });
+  });
+
+  describe("isoDurationToMillis()", () => {
+    const parseable: Array<[string, number]> = [
+      ["PT1S", 1000],
+      ["PT0.5S", 500],
+      ["PT1M30S", 90_000],
+      ["PT2H3M4S", 7_384_000],
+      ["P1D", 86_400_000],
+      ["P1DT2H", 93_600_000],
+      [" PT30S ", 30_000],
+    ];
+
+    parseable.forEach(([duration, expected]) => {
+      it(`should parse "${duration}" as ${expected}ms`, () => {
+        assert.strictEqual(isoDurationToMillis(duration), expected);
+      });
+    });
+
+    const unparseable: string[] = [
+      "",
+      "P",
+      "PT",
+      "90s",
+      "1m30s",
+      "P1Y",
+      "PT1H30",
+      "not a duration",
+    ];
+
+    unparseable.forEach((duration) => {
+      it(`should return undefined for "${duration}"`, () => {
+        assert.strictEqual(isoDurationToMillis(duration), undefined);
+      });
+    });
+  });
+
+  describe("formatIsoDuration()", () => {
+    it("should format a parseable duration", () => {
+      assert.strictEqual(formatIsoDuration("PT1M30S"), "1m 30s");
+    });
+
+    it("should fall back to the raw string when unparseable", () => {
+      assert.strictEqual(formatIsoDuration("P1Y2M"), "P1Y2M");
+    });
+  });
+});

--- a/src/utils/durations.test.ts
+++ b/src/utils/durations.test.ts
@@ -35,6 +35,8 @@ describe("utils/durations.ts", () => {
       ["P1D", 86_400_000],
       ["P1DT2H", 93_600_000],
       [" PT30S ", 30_000],
+      ["PT1.5H", 5_400_000],
+      ["P1DT", 86_400_000], // trailing "T" with no time components
     ];
 
     parseable.forEach(([duration, expected]) => {
@@ -52,6 +54,13 @@ describe("utils/durations.ts", () => {
       "P1Y",
       "PT1H30",
       "not a duration",
+      "pt30s", // lowercase isn't ISO 8601
+      "P1M", // months, not minutes: ambiguous in milliseconds, so not ours to guess at
+      "P1W", // weeks are a unit we don't accept
+      "PT1S30M", // components out of order
+      "PT1S1S", // repeated component
+      "P1DT1HT1S", // two time sections
+      "PT.5S", // no digits before the decimal point
     ];
 
     unparseable.forEach((duration) => {

--- a/src/utils/durations.ts
+++ b/src/utils/durations.ts
@@ -1,0 +1,75 @@
+/** Matches an ISO 8601 duration limited to the day-and-below components CCloud actually emits. */
+const ISO_DURATION_PATTERN =
+  /^P(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+
+const MILLIS_PER_SECOND = 1000;
+const MILLIS_PER_MINUTE = 60 * MILLIS_PER_SECOND;
+const MILLIS_PER_HOUR = 60 * MILLIS_PER_MINUTE;
+const MILLIS_PER_DAY = 24 * MILLIS_PER_HOUR;
+
+/**
+ * Render a span of milliseconds the way someone timing a query would read it: coarse units when the
+ * wait is long, sub-second precision when it's short.
+ *
+ * @param millis Duration in milliseconds. Negative values are treated as zero.
+ */
+export function formatDurationMillis(millis: number): string {
+  if (!Number.isFinite(millis) || millis <= 0) {
+    return "0s";
+  }
+
+  if (millis >= MILLIS_PER_HOUR) {
+    const hours = Math.floor(millis / MILLIS_PER_HOUR);
+    const minutes = Math.floor((millis % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE);
+    const seconds = Math.floor((millis % MILLIS_PER_MINUTE) / MILLIS_PER_SECOND);
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  if (millis >= MILLIS_PER_MINUTE) {
+    const minutes = Math.floor(millis / MILLIS_PER_MINUTE);
+    const seconds = Math.floor((millis % MILLIS_PER_MINUTE) / MILLIS_PER_SECOND);
+    return `${minutes}m ${seconds}s`;
+  }
+
+  if (millis >= MILLIS_PER_SECOND) {
+    // one decimal place is enough to tell 1.2s from 1.9s without looking noisy
+    return `${(millis / MILLIS_PER_SECOND).toFixed(1)}s`;
+  }
+
+  return `${Math.round(millis)}ms`;
+}
+
+/**
+ * Convert an ISO 8601 duration string (say, `PT1M30S`) to milliseconds.
+ *
+ * @returns The duration in milliseconds, or undefined if the string isn't a duration we recognize,
+ *   leaving the caller free to fall back to displaying it verbatim.
+ */
+export function isoDurationToMillis(duration: string): number | undefined {
+  const match: RegExpMatchArray | null = duration.trim().match(ISO_DURATION_PATTERN);
+  if (!match) {
+    return undefined;
+  }
+
+  const [, days, hours, minutes, seconds] = match;
+  if (days === undefined && hours === undefined && minutes === undefined && seconds === undefined) {
+    // bare "P" or "PT" carries no duration at all
+    return undefined;
+  }
+
+  return (
+    Number(days ?? 0) * MILLIS_PER_DAY +
+    Number(hours ?? 0) * MILLIS_PER_HOUR +
+    Number(minutes ?? 0) * MILLIS_PER_MINUTE +
+    Number(seconds ?? 0) * MILLIS_PER_SECOND
+  );
+}
+
+/**
+ * Render an ISO 8601 duration string for display, falling back to the raw string when it isn't in a
+ * form we can parse (better to show CCloud's value verbatim than to hide it).
+ */
+export function formatIsoDuration(duration: string): string {
+  const millis: number | undefined = isoDurationToMillis(duration);
+  return millis === undefined ? duration : formatDurationMillis(millis);
+}

--- a/src/utils/durations.ts
+++ b/src/utils/durations.ts
@@ -1,11 +1,22 @@
-/** Matches an ISO 8601 duration limited to the day-and-below components CCloud actually emits. */
-const ISO_DURATION_PATTERN =
-  /^P(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
-
 const MILLIS_PER_SECOND = 1000;
 const MILLIS_PER_MINUTE = 60 * MILLIS_PER_SECOND;
 const MILLIS_PER_HOUR = 60 * MILLIS_PER_MINUTE;
 const MILLIS_PER_DAY = 24 * MILLIS_PER_HOUR;
+
+/** A single leading `<number><unit>` component of an ISO 8601 duration, e.g. `30S` or `1.5S`. */
+const DURATION_COMPONENT = /^(\d+(?:\.\d+)?)([A-Z])/;
+
+/**
+ * The components CCloud actually emits, listed in the order ISO 8601 requires them to appear within
+ * their section. Days and below only: anything longer is ambiguous in milliseconds, and `M` means
+ * months before the `T` but minutes after it, so the two sections are kept deliberately separate.
+ */
+const DATE_UNIT_MILLIS: ReadonlyArray<[string, number]> = [["D", MILLIS_PER_DAY]];
+const TIME_UNIT_MILLIS: ReadonlyArray<[string, number]> = [
+  ["H", MILLIS_PER_HOUR],
+  ["M", MILLIS_PER_MINUTE],
+  ["S", MILLIS_PER_SECOND],
+];
 
 /**
  * Render a span of milliseconds the way someone timing a query would read it: coarse units when the
@@ -46,23 +57,28 @@ export function formatDurationMillis(millis: number): string {
  *   leaving the caller free to fall back to displaying it verbatim.
  */
 export function isoDurationToMillis(duration: string): number | undefined {
-  const match: RegExpMatchArray | null = duration.trim().match(ISO_DURATION_PATTERN);
-  if (!match) {
+  const trimmed: string = duration.trim();
+  if (!trimmed.startsWith("P")) {
     return undefined;
   }
 
-  const [, days, hours, minutes, seconds] = match;
-  if (days === undefined && hours === undefined && minutes === undefined && seconds === undefined) {
+  // everything before the "T" is the date section, everything after it the time section
+  const sections: string[] = trimmed.slice(1).split("T");
+  if (sections.length > 2) {
+    return undefined;
+  }
+
+  const date = parseDurationSection(sections[0], DATE_UNIT_MILLIS);
+  const time = parseDurationSection(sections[1] ?? "", TIME_UNIT_MILLIS);
+  if (date === undefined || time === undefined) {
+    return undefined;
+  }
+  if (date.count + time.count === 0) {
     // bare "P" or "PT" carries no duration at all
     return undefined;
   }
 
-  return (
-    Number(days ?? 0) * MILLIS_PER_DAY +
-    Number(hours ?? 0) * MILLIS_PER_HOUR +
-    Number(minutes ?? 0) * MILLIS_PER_MINUTE +
-    Number(seconds ?? 0) * MILLIS_PER_SECOND
-  );
+  return date.millis + time.millis;
 }
 
 /**
@@ -72,4 +88,44 @@ export function isoDurationToMillis(duration: string): number | undefined {
 export function formatIsoDuration(duration: string): string {
   const millis: number | undefined = isoDurationToMillis(duration);
   return millis === undefined ? duration : formatDurationMillis(millis);
+}
+
+/**
+ * Consume `<number><unit>` components from the front of one section of a duration, accumulating
+ * their millisecond total.
+ *
+ * @param section The section's text, without its `P` or `T` marker. Empty means no components.
+ * @param unitMillis The units allowed here, in the order they must appear.
+ * @returns The section's total and how many components it held, or undefined if it contains anything
+ *   other than a run of allowed components in order — an unknown unit, a repeat, or trailing text.
+ */
+function parseDurationSection(
+  section: string,
+  unitMillis: ReadonlyArray<[string, number]>,
+): { millis: number; count: number } | undefined {
+  let rest: string = section;
+  let millis = 0;
+  let count = 0;
+  let nextUnit = 0;
+
+  while (rest.length > 0) {
+    const match: RegExpExecArray | null = DURATION_COMPONENT.exec(rest);
+    if (match === null) {
+      return undefined;
+    }
+
+    const [component, value, unit] = match;
+    const unitIndex: number = unitMillis.findIndex(([name]) => name === unit);
+    if (unitIndex < 0 || unitIndex < nextUnit) {
+      // not a unit this section takes, or one that's out of order or repeated
+      return undefined;
+    }
+
+    millis += Number(value) * unitMillis[unitIndex][1];
+    nextUnit = unitIndex + 1;
+    count++;
+    rest = rest.slice(component.length);
+  }
+
+  return { millis, count };
 }

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -16,11 +16,16 @@
         <section class="statement-details-section">
           <h4>Statement details</h4>
           <div class="statement-info">
-            <div class="flex-row">
-              <div class="info-item">
-                <label>Start Time:</label>
-                <span data-text="this.statementMeta().startTime"></span>
-              </div>
+            <div class="flex-row statement-info-row">
+              <template data-if="this.startTimeDisplay() != null">
+                <div class="info-item">
+                  <label>Start Time:</label>
+                  <span
+                    data-testid="statement-start-time"
+                    data-text="this.startTimeDisplay()"
+                  ></span>
+                </div>
+              </template>
               <div class="info-item">
                 <label>Status:</label>
                 <span data-testid="statement-status" data-text="this.statementMeta().status"></span>
@@ -31,20 +36,73 @@
                   >
                 </template>
               </div>
-              <vscode-button
-                data-testid="view-statement-source-button"
-                data-on-click="this.viewStatementSource()"
-              >
-                <label>View Statement Source</label>
-              </vscode-button>
-              <vscode-button
-                appearance="primary"
-                data-testid="stop-statement-button"
-                data-on-click="this.stopStatement()"
-                data-attr-disabled="!this.statementMeta().stoppable || this.stopButtonClicked()"
-              >
-                <label>Stop</label>
-              </vscode-button>
+              <div class="info-item">
+                <label>Mode:</label>
+                <span
+                  class="mode-chip"
+                  data-testid="statement-mode"
+                  data-text="this.statementMeta().modeLabel"
+                  data-attr-title="this.statementMeta().modeDescription"
+                ></span>
+              </div>
+              <template data-if="this.elapsedTimer() != null">
+                <div class="info-item">
+                  <label data-text="this.elapsedLabel()"></label>
+                  <flink-timer
+                    data-testid="statement-elapsed"
+                    data-prop-time="this.elapsedTimer()"
+                    data-prop-state="this.elapsedTimerState()"
+                  ></flink-timer>
+                </div>
+              </template>
+              <template data-if="this.endTimeDisplay() != null">
+                <div class="info-item">
+                  <label>End Time:</label>
+                  <span data-testid="statement-end-time" data-text="this.endTimeDisplay()"></span>
+                </div>
+              </template>
+              <template data-if="this.executionDurationDisplay() != null">
+                <div class="info-item">
+                  <label
+                    title="Time Confluent Cloud spent executing the statement, which excludes any time it spent pending."
+                  >
+                    Execution:
+                  </label>
+                  <span
+                    data-testid="statement-execution-duration"
+                    data-text="this.executionDurationDisplay()"
+                  ></span>
+                </div>
+              </template>
+              <template data-if="this.fetchedBytesDisplay() != null">
+                <div class="info-item">
+                  <label
+                    title="Result data this viewer has downloaded so far. Confluent Cloud does not report the size of a statement's full result set."
+                  >
+                    Fetched:
+                  </label>
+                  <span
+                    data-testid="statement-fetched-bytes"
+                    data-text="this.fetchedBytesDisplay()"
+                  ></span>
+                </div>
+              </template>
+              <div class="header-actions">
+                <vscode-button
+                  data-testid="view-statement-source-button"
+                  data-on-click="this.viewStatementSource()"
+                >
+                  <label>View Statement Source</label>
+                </vscode-button>
+                <vscode-button
+                  appearance="primary"
+                  data-testid="stop-statement-button"
+                  data-on-click="this.stopStatement()"
+                  data-attr-disabled="!this.statementMeta().stoppable || this.stopButtonClicked()"
+                >
+                  <label>Stop</label>
+                </vscode-button>
+              </div>
             </div>
           </div>
           <div class="flex-row">
@@ -207,7 +265,22 @@
           >
             <div class="grid-banner" data-testid="waiting-for-results">
               <vscode-progress-ring></vscode-progress-ring>
-              <label>Waiting for results…</label>
+              <div class="banner-status">
+                <label data-testid="waiting-message" data-text="this.waitingMessage()"></label>
+                <template data-if="this.elapsedTimer() != null">
+                  <flink-timer
+                    data-prop-time="this.elapsedTimer()"
+                    data-prop-state="this.elapsedTimerState()"
+                  ></flink-timer>
+                </template>
+              </div>
+              <template data-if="this.snapshotModeHint() != null">
+                <label
+                  class="banner-hint"
+                  data-testid="snapshot-mode-hint"
+                  data-text="this.snapshotModeHint()"
+                ></label>
+              </template>
             </div>
           </template>
         </div>
@@ -572,6 +645,50 @@
       .info-item label {
         font-weight: 500;
         color: var(--vscode-descriptionForeground);
+      }
+
+      /* the header carries a variable number of facts, so let them wrap rather than squeeze */
+      .statement-info-row {
+        flex-wrap: wrap;
+        align-items: center;
+        row-gap: 0.5rem;
+      }
+
+      .header-actions {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .mode-chip {
+        padding: 1px 8px;
+        border-radius: 10px;
+        border: 1px solid var(--vscode-badge-background);
+        background: var(--vscode-badge-background);
+        color: var(--vscode-badge-foreground);
+        font-size: 90%;
+        white-space: nowrap;
+      }
+
+      /* tabular figures so the ticking clock doesn't shift the layout every second */
+      flink-timer {
+        font-variant-numeric: tabular-nums;
+        color: var(--vscode-editor-foreground);
+      }
+
+      .banner-status {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .banner-hint {
+        color: var(--vscode-descriptionForeground);
+        font-size: 95%;
+        max-width: 32rem;
+        text-align: center;
       }
 
       .detail-section {

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -302,7 +302,7 @@
         <template data-if="this.noResultsAvailable()">
           <div class="grid-banner" data-testid="no-results-available">
             <span class="codicon codicon-info"></span>
-            <label>No results available</label>
+            <label>The statement produced no results.</label>
           </div>
         </template>
       </section>

--- a/src/webview/flink-statement-results.html
+++ b/src/webview/flink-statement-results.html
@@ -299,10 +299,8 @@
           </div>
         </template>
 
-        <template
-          data-if="!this.waitingForResults() && !this.hasResults() && !this.emptyFilterResult()"
-        >
-          <div class="grid-banner">
+        <template data-if="this.noResultsAvailable()">
+          <div class="grid-banner" data-testid="no-results-available">
             <span class="codicon codicon-info"></span>
             <label>No results available</label>
           </div>

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -64,6 +64,7 @@ export class FlinkStatementResultsViewModel extends ViewModel {
   readonly waitingForResults: Signal<boolean>;
   readonly emptyFilterResult: Signal<boolean>;
   readonly hasResults: Signal<boolean>;
+  readonly noResultsAvailable: Signal<boolean>;
   readonly streamState: Signal<StreamState>;
   readonly streamError: Signal<{ message: string } | null>;
   readonly pageStatLabel: Signal<string | null>;
@@ -443,6 +444,20 @@ export class FlinkStatementResultsViewModel extends ViewModel {
     this.streamError = this.resolve(() => {
       return this.post("GetStreamError", { timestamp: this.timestamp() });
     }, null);
+
+    /**
+     * Nothing to show, and nothing more coming: the host reports "completed" once the result stream
+     * is exhausted, so this is the point at which zero rows means zero rows rather than "not yet".
+     * Keyed off the stream rather than the statement's own terminal state, since a COMPLETED
+     * snapshot statement's rows are still being paged in for a moment afterwards.
+     */
+    this.noResultsAvailable = this.derive(
+      () =>
+        this.streamState() === "completed" &&
+        this.streamError() == null &&
+        !this.hasResults() &&
+        !this.emptyFilterResult(),
+    );
   }
 
   search = this.resolve(async () => {

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -5,10 +5,12 @@ import { createColumnDefinitions, getColumnOrder } from "../flinkSql/flinkStatem
 import type {
   PostFunction,
   ResultCount,
+  StatementMeta,
   StreamState,
 } from "../flinkSql/flinkStatementResultsManager";
-import type { SqlV1StatementWarning } from "../clients/flinkSql";
 import { stripWarningsFromDetail } from "../flinkSql/warningParser";
+import { formatBytes } from "../utils/bytes";
+import { formatIsoDuration } from "../utils/durations";
 import { ViewModel } from "./bindings/view-model";
 import type { WebviewStorage } from "./comms/comms";
 import { createWebviewStorage, sendWebviewMessage } from "./comms/comms";
@@ -49,16 +51,16 @@ export class FlinkStatementResultsViewModel extends ViewModel {
   readonly emptySnapshot: { results: any[] };
   readonly snapshot: Signal<{ results: any[] }>;
   readonly resultCount: Signal<ResultCount>;
-  readonly statementMeta: Signal<{
-    name: string;
-    status: string;
-    startTime: string | null;
-    detail: string | null;
-    failed: boolean;
-    areResultsViewable: boolean;
-    isForeground: boolean;
-    warnings: SqlV1StatementWarning[];
-  }>;
+  readonly statementMeta: Signal<StatementMeta>;
+  readonly startTimeDisplay: Signal<string | null>;
+  readonly endTimeDisplay: Signal<string | null>;
+  readonly executionDurationDisplay: Signal<string | null>;
+  readonly fetchedBytesDisplay: Signal<string | null>;
+  readonly elapsedLabel: Signal<string>;
+  readonly elapsedTimer: Signal<{ start: number; offset: number } | null>;
+  readonly elapsedTimerState: Signal<"running" | "paused" | null>;
+  readonly waitingMessage: Signal<string>;
+  readonly snapshotModeHint: Signal<string | null>;
   readonly waitingForResults: Signal<boolean>;
   readonly emptyFilterResult: Signal<boolean>;
   readonly hasResults: Signal<boolean>;
@@ -155,18 +157,104 @@ export class FlinkStatementResultsViewModel extends ViewModel {
       {
         name: "",
         status: "",
-        startTime: null,
+        startTimeMillis: null,
+        endTimeMillis: null,
+        totalDurationMillis: null,
+        executionDuration: null,
+        fetchedBytes: 0,
+        modeLabel: "",
+        modeDescription: "",
+        isSnapshotMode: false,
+        isTerminal: false,
         detail: null,
         failed: false,
+        stoppable: false,
         areResultsViewable: true,
+        possiblyViewable: true,
         isForeground: false,
         warnings: [],
       },
     );
 
+    this.startTimeDisplay = this.derive(() =>
+      formatTimestamp(this.statementMeta().startTimeMillis),
+    );
+    this.endTimeDisplay = this.derive(() => formatTimestamp(this.statementMeta().endTimeMillis));
+
+    /**
+     * CCloud's execution time, which excludes any time the statement spent PENDING. Shown alongside
+     * the wall-clock total so the difference between the two reads as queue time.
+     */
+    this.executionDurationDisplay = this.derive(() => {
+      const duration = this.statementMeta().executionDuration;
+      return duration ? formatIsoDuration(duration) : null;
+    });
+
+    /** Bytes of results this viewer has pulled down; nothing to say before the first row arrives. */
+    this.fetchedBytesDisplay = this.derive(() => {
+      const bytes = this.statementMeta().fetchedBytes;
+      return bytes > 0 ? formatBytes(bytes) : null;
+    });
+
+    /**
+     * Elapsed wall-clock time, as the `<flink-timer>` element wants it: it ticks up from `start`
+     * while "running", and displays a frozen `offset` while "paused". A terminal statement therefore
+     * hands over the total it actually took, and a live one keeps counting from submission.
+     */
+    this.elapsedTimer = this.derive(() => {
+      const { startTimeMillis, isTerminal, totalDurationMillis } = this.statementMeta();
+      if (startTimeMillis == null) {
+        return null;
+      }
+      if (isTerminal) {
+        // fall back to the last elapsed time we can compute when CCloud hasn't reported an end
+        return {
+          start: startTimeMillis,
+          offset: totalDurationMillis ?? Date.now() - startTimeMillis,
+        };
+      }
+      return { start: startTimeMillis, offset: 0 };
+    });
+
+    this.elapsedTimerState = this.derive(() => {
+      if (this.elapsedTimer() == null) {
+        return null;
+      }
+      return this.statementMeta().isTerminal ? "paused" : "running";
+    });
+
+    this.elapsedLabel = this.derive<string>(() =>
+      this.statementMeta().isTerminal ? "Total:" : "Elapsed:",
+    );
+
     /** For now, the only way to expose a loading spinner. */
     this.waitingForResults = this.derive(() => {
       return this.resultCount().total === 0 && this.statementMeta().areResultsViewable;
+    });
+
+    /**
+     * What the statement is doing while we have nothing to show yet. Snapshot queries can sit in
+     * PENDING for a while and then run for minutes, so naming the phase beats a bare spinner.
+     */
+    this.waitingMessage = this.derive<string>(() => {
+      switch (this.statementMeta().status) {
+        case "PENDING":
+          return "Statement is pending…";
+        case "RUNNING":
+        case "DEGRADED":
+          return "Running — waiting for the first results…";
+        default:
+          return "Waiting for results…";
+      }
+    });
+
+    /** Snapshot queries emit nothing at all until they finish, which otherwise looks like a stall. */
+    this.snapshotModeHint = this.derive<string | null>(() => {
+      const { isSnapshotMode, isTerminal } = this.statementMeta();
+      if (!isSnapshotMode || isTerminal) {
+        return null;
+      }
+      return "Snapshot queries return no rows until the whole query has finished.";
     });
 
     this.emptyFilterResult = this.derive(
@@ -584,4 +672,9 @@ export class FlinkStatementResultsViewModel extends ViewModel {
     fragment.append(input.substring(cursor));
     return fragment;
   }
+}
+
+/** Render epoch millis in the viewer's local time zone, or null when we have no timestamp. */
+function formatTimestamp(millis: number | null): string | null {
+  return millis == null ? null : new Date(millis).toLocaleString();
 }

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -446,14 +446,18 @@ export class FlinkStatementResultsViewModel extends ViewModel {
     }, null);
 
     /**
-     * Nothing to show, and nothing more coming: the host reports "completed" once the result stream
-     * is exhausted, so this is the point at which zero rows means zero rows rather than "not yet".
-     * Keyed off the stream rather than the statement's own terminal state, since a COMPLETED
-     * snapshot statement's rows are still being paged in for a moment afterwards.
+     * Nothing to show, and nothing more coming: the point at which zero rows means zero rows rather
+     * than "not yet". Two ways to get there, and both are needed — the host reports "completed" once
+     * the result stream is exhausted, but a statement that stops being fetchable (it failed, or it
+     * aged out of the 24-hour window) leaves the stream sitting in "running" forever, since polling
+     * self-destructs without completing it.
+     *
+     * Deliberately not keyed off the statement's own terminal state: a COMPLETED snapshot
+     * statement's rows are still being paged in for a moment afterwards.
      */
     this.noResultsAvailable = this.derive(
       () =>
-        this.streamState() === "completed" &&
+        (this.streamState() === "completed" || !this.statementMeta().areResultsViewable) &&
         this.streamError() == null &&
         !this.hasResults() &&
         !this.emptyFilterResult(),

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -185,10 +185,17 @@ export class FlinkStatementResultsViewModel extends ViewModel {
     /**
      * CCloud's execution time, which excludes any time the statement spent PENDING. Shown alongside
      * the wall-clock total so the difference between the two reads as queue time.
+     *
+     * Withheld in snapshot mode: those statements barely queue, so CCloud's coarse duration and our
+     * millisecond-precision total are two measurements of the same span, and can disagree — even
+     * invert — by a second without either being wrong.
      */
     this.executionDurationDisplay = this.derive(() => {
-      const duration = this.statementMeta().executionDuration;
-      return duration ? formatIsoDuration(duration) : null;
+      const { executionDuration, isSnapshotMode } = this.statementMeta();
+      if (!executionDuration || isSnapshotMode) {
+        return null;
+      }
+      return formatIsoDuration(executionDuration);
     });
 
     /** Bytes of results this viewer has pulled down; nothing to say before the first row arrives. */

--- a/src/webview/flink-statement-results.ts
+++ b/src/webview/flink-statement-results.ts
@@ -255,7 +255,7 @@ export class FlinkStatementResultsViewModel extends ViewModel {
       if (!isSnapshotMode || isTerminal) {
         return null;
       }
-      return "Snapshot queries return no rows until the whole query has finished.";
+      return "Snapshot queries will only return results when statement execution completes.";
     });
 
     this.emptyFilterResult = this.derive(

--- a/tests/unit/testResources/flinkStatement.ts
+++ b/tests/unit/testResources/flinkStatement.ts
@@ -23,6 +23,10 @@ export interface CreateFlinkStatementArgs {
 
   createdAt?: Date;
   updatedAt?: Date;
+  /** When the statement reached a terminal phase. Only set by CCloud for terminal statements. */
+  endTime?: Date;
+  /** CCloud's execution time as an ISO 8601 duration, e.g. `PT1M30S`. */
+  duration?: string;
 
   appendOnly?: boolean;
   upsertColumns?: number[];
@@ -50,6 +54,8 @@ export function createFlinkStatement(overrides: CreateFlinkStatementArgs = {}): 
     status: {
       phase: (overrides.phase as string) || Phase.RUNNING,
       detail: overrides.detail || "Running",
+      end_time: overrides.endTime,
+      duration: overrides.duration,
       traits: {
         sql_kind: overrides.sqlKind || "SELECT",
         is_bounded: true,


### PR DESCRIPTION
## Summary of Changes

Second of three PRs for epic #1848, Flink Snapshot-mode statement submission. PR #3425 shipped the ability to _submit_ a statement in snapshot mode; this one makes the resulting statement's mode and timing legible in the UI.

- **Mode is now visible wherever a statement is** — a chip in the Flink statement results viewer
  header, and a `Mode` field in the statement tooltip. The CodeLens toggle, the tooltip, and the
  viewer all share one pair of helpers (`flinkSnapshotModeLabel()` /
  `flinkSnapshotModeDescription()`) so they can't drift apart in wording. (#1851, #1852)
- **Timing** — the viewer runs an elapsed clock while the statement is live and freezes it as a
  total once terminal, alongside End Time and Confluent Cloud's own Execution time. The tooltip
  gains `Ended At`, `Total Duration`, and `Execution Time`, all of which render only for terminal
  statements. Total Duration is wall clock from submission, so it includes queue time; Execution
  Time is CCloud's `status.duration`, which does not. Showing both is what makes queue time visible.
  (#2673, #2674)
- **Waiting state names the phase** instead of showing a bare spinner ("Statement is pending…" /
  "Running — waiting for the first results…"), with an inline elapsed timer, plus a
  snapshot-specific hint that a bounded query returns no rows at all until it completes — which
  otherwise reads as a stall. (#2674)

The elapsed clock reuses the existing `<flink-timer>` custom element, which was already registered
in `flink-statement-results-init.ts` but had no callers.

### On #2673, please read this bit

#2673 asks for result set size. **The Flink SQL API does not expose one.** There is no
result-size-or-bytes metric on `status`, on `traits`, or on `ResultListMeta` anywhere in
`flink-sql.openapi.yaml` — this is the question noeldevelops raised with flippingbits in that
issue's comment thread and it is still unanswered.

So the `Fetched` figure here is deliberately **client-side accounting of what this viewer has
downloaded**, not the size of the statement's full result set, and its hover text says exactly that.
It's also an estimate: the generated clients hand back parsed JSON, so the original response body is
gone by the time we can measure it, and we re-serialize to approximate the UTF-8 byte count.

If that isn't what #2673 wanted, this is the place to say so — it would need a server-side metric we
don't have today.

### Click-testing instructions

1. Open a Flink SQL document, and use the CodeLens `Mode:` toggle to submit one statement in
   **Streaming** mode. In the results viewer header, confirm the `Streaming` chip (hover it for the
   explanation) and an `Elapsed:` clock that ticks.
2. Submit a bounded query in **Snapshot** mode. While it's still pending/running with no rows yet,
   confirm the banner names the phase and shows the snapshot hint about no rows until completion.
3. When the snapshot statement completes, confirm the clock relabels to `Total:` and freezes, and
   that `End Time` and `Execution` appear. `Execution` should read shorter than `Total` by roughly
   the time the statement sat in PENDING.
4. Confirm `Fetched` appears once rows arrive and grows as you scroll/fetch more.
5. Hover a statement in the Flink Statements view: the tooltip should show `Mode`, and for a
   finished statement also `Ended At`, `Total Duration`, and `Execution Time`.
6. Confirm the header wraps rather than squeezing at a narrow viewer width, and that
   `View Statement Source` / `Stop` stay pinned right.

### Optional: Any additional details or context that should be provided?

- `StatementMeta` is now a single exported type in `flinkStatementResultsManager.ts`. It replaced
  three drifting copies of the viewer's header payload — and the old `PostFunction` overload was
  missing `stoppable` and `possiblyViewable` even though the HTML already read `stoppable`, a gap
  the string-evaluated bindings hid.
- `startTime` (a `Date` that JSON-serialized into a raw ISO string the header rendered verbatim) is
  now `startTimeMillis`, so the webview formats it in local time and can do timer arithmetic.
- The mode _enum_ is deliberately not in the payload; label/description/boolean are computed
  extension-side so the webview doesn't have to import the vscode-coupled statement model.
- Removed a dead `FlinkStatement.startTime` getter — an unused duplicate of `createdAt`, with no
  references anywhere in `src/` or `tests/`.
- `_fetchedBytes` skips empty pages, so idle polling doesn't accrue phantom bytes.
- New `src/utils/durations.ts` and `src/utils/bytes.ts`, both table-driven-tested. The ISO duration
  parser falls back to displaying CCloud's raw string when it can't parse it, rather than hiding the
  value.
- **Reviewers:** #2673 and #2674 both carry `needs UI/UX Review`, and #2674 also carries
  `needs discussion`. Per #2674 this shows phase + elapsed + row count only — there is no
  percent-complete signal from CCloud, so no progress bar and no fabricated percentages.


## Relationships
Closes #1851
Closes #1852 
Closes #2674

#2673 is only partly addressed — end time and duration ship here; server-side result size is not
possible as specified. 

## Pull request checklist

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

- [x] Does anything in this PR need to be mentioned in the user-facing CHANGELOG? — yes, two bullets
      added under `## Unreleased` → `### Added`.
      
 ## Screenshots

Submitted snapshot mode statement while still running ...

<img width="1103" height="476" alt="Screenshot 2026-08-11 at 10 14 40 AM" src="https://github.com/user-attachments/assets/12e9e530-1a40-4ae5-a121-95ff30e74560" />

Snapshot mode completed, found 0 rows:

<img width="1095" height="356" alt="Screenshot 2026-08-11 at 10 15 03 AM" src="https://github.com/user-attachments/assets/a2f27080-7f04-421b-8c83-f133814e041a" />


Streaming statement in PENDING state (no results yet ...)
<img width="1093" height="379" alt="Screenshot 2026-08-11 at 10 15 28 AM" src="https://github.com/user-attachments/assets/02b35568-394a-44c9-a6cb-f4257c427841" />

Streaming statement running, having found some rows already:
<img width="1096" height="572" alt="Screenshot 2026-08-11 at 10 15 44 AM" src="https://github.com/user-attachments/assets/09db4e41-9709-4007-aee1-316b5407d9f0" />




