### PR TITLE
New user setting for default Flink snapshot vs streaming statement submission.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ All notable changes to this extension will be documented in this file.
 - Flink statement tooltips now include the submission mode, and, for statements that have finished,
   when they ended and how long they took.
   ([#2673](https://github.com/confluentinc/vscode/issues/2673))
+- New
+  [`confluent.flink.defaultSubmissionMode`](vscode://settings/confluent.flink.defaultSubmissionMode)
+  setting controls which mode Flink statements are submitted in by default. It ships set to
+  `streaming`, matching the existing behavior; the per-document 'Mode:' codelens still overrides it.
+  ([#3429](https://github.com/confluentinc/vscode/issues/3429))
 
 ## 2.3.1
 

--- a/package.json
+++ b/package.json
@@ -1113,6 +1113,19 @@
               "Open Flink statement results in the **bottom panel area** (show results for one executing statement at a time)."
             ],
             "description": "Default location for displaying Flink statement results."
+          },
+          "confluent.flink.defaultSubmissionMode": {
+            "type": "string",
+            "default": "streaming",
+            "enum": [
+              "streaming",
+              "snapshot"
+            ],
+            "markdownEnumDescriptions": [
+              "Statements run **continuously** against new data as it arrives.",
+              "Statements run **once** against a snapshot of the data as of submission time, then complete. See [snapshot queries](https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html)."
+            ],
+            "markdownDescription": "Default submission mode for Flink SQL statements. Can be overridden per document with the 'Mode:' codelens."
           }
         }
       },

--- a/src/codelens/flinkSqlProvider.test.ts
+++ b/src/codelens/flinkSqlProvider.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
-import type { CodeLens, TextDocument } from "vscode";
+import type { CodeLens, ConfigurationChangeEvent, TextDocument } from "vscode";
 import { Position, Range, Uri } from "vscode";
 import type { StubbedEventEmitters } from "../../tests/stubs/emitters";
 import { eventEmitterStubs } from "../../tests/stubs/emitters";
@@ -10,7 +10,11 @@ import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfig
 import { TEST_CCLOUD_ENVIRONMENT, TEST_CCLOUD_KAFKA_CLUSTER } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import { TEST_CCLOUD_ORGANIZATION } from "../../tests/unit/testResources/organization";
-import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../extensionSettings/constants";
+import {
+  FLINK_CONFIG_COMPUTE_POOL,
+  FLINK_CONFIG_DATABASE,
+  FLINK_DEFAULT_SUBMISSION_MODE,
+} from "../extensionSettings/constants";
 import type { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import { CCloudFlinkComputePool } from "../models/flinkComputePool";
@@ -65,6 +69,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
   describe("FlinkSqlCodelensProvider", () => {
     let provider: FlinkSqlCodelensProvider;
     let resourceManagerStub: sinon.SinonStubbedInstance<ResourceManager>;
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
 
     // NOTE: setting up fake TextDocuments is tricky since we can't create them directly, so we're
     // only populating the fields needed for the test and associated codebase logic, then using the
@@ -75,6 +80,9 @@ describe("codelens/flinkSqlProvider.ts", () => {
       // reset any stored metadata
       await getResourceManager().deleteAllUriMetadata();
       resourceManagerStub = getStubbedResourceManager(sandbox);
+      // don't let the developer's own settings affect the codelens titles under test
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
+      stubbedConfigs.stubGet(FLINK_DEFAULT_SUBMISSION_MODE, FlinkSnapshotMode.STREAMING);
 
       provider = FlinkSqlCodelensProvider.getInstance();
     });
@@ -105,7 +113,8 @@ describe("codelens/flinkSqlProvider.ts", () => {
 
       it("setEventListeners() should return the expected number of listeners", () => {
         const listeners = provider["setEventListeners"]();
-        assert.strictEqual(listeners.length, handlerEmitterPairs.length);
+        // the emitter-driven handlers, plus the workspace configuration listener
+        assert.strictEqual(listeners.length, handlerEmitterPairs.length + 1);
       });
 
       handlerEmitterPairs.forEach(([emitterName, handlerMethodName]) => {
@@ -154,6 +163,33 @@ describe("codelens/flinkSqlProvider.ts", () => {
       it("uriMetadataSetHandler() should call onDidChangeCodeLenses.fire()", () => {
         provider.uriMetadataSetHandler(); // disregards the Uri of the document, so no need to pass it.
         sinon.assert.calledOnce(onDidChangeCodeLensesFireStub);
+      });
+
+      const flinkDefaultSettings = [
+        FLINK_CONFIG_COMPUTE_POOL,
+        FLINK_CONFIG_DATABASE,
+        FLINK_DEFAULT_SUBMISSION_MODE,
+      ];
+      for (const setting of flinkDefaultSettings) {
+        it(`configurationChangedHandler() should call onDidChangeCodeLenses.fire() when "${setting.id}" changes`, () => {
+          const event = {
+            affectsConfiguration: sandbox.stub().callsFake((id: string) => id === setting.id),
+          } as unknown as ConfigurationChangeEvent;
+
+          provider.configurationChangedHandler(event);
+
+          sinon.assert.calledOnce(onDidChangeCodeLensesFireStub);
+        });
+      }
+
+      it("configurationChangedHandler() should not call onDidChangeCodeLenses.fire() for unrelated settings", () => {
+        const event = {
+          affectsConfiguration: sandbox.stub().returns(false),
+        } as unknown as ConfigurationChangeEvent;
+
+        provider.configurationChangedHandler(event);
+
+        sinon.assert.notCalled(onDidChangeCodeLensesFireStub);
       });
     });
 
@@ -355,7 +391,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
       assert.deepStrictEqual(resetLens.command?.arguments, [fakeDocument.uri]);
     });
 
-    it("should provide 'Mode: Snapshot' codelens when snapshot mode metadata is set to BATCH", async () => {
+    it("should provide 'Mode: Snapshot' codelens when snapshot mode metadata is set to SNAPSHOT", async () => {
       const pool: CCloudFlinkComputePool = TEST_CCLOUD_FLINK_COMPUTE_POOL;
       const database: CCloudKafkaCluster = TEST_CCLOUD_KAFKA_CLUSTER;
       resourceManagerStub.getUriMetadata.resolves({
@@ -364,7 +400,7 @@ describe("codelens/flinkSqlProvider.ts", () => {
         [UriMetadataKeys.FLINK_CATALOG_NAME]: TEST_CCLOUD_ENVIRONMENT.name,
         [UriMetadataKeys.FLINK_DATABASE_ID]: database.id,
         [UriMetadataKeys.FLINK_DATABASE_NAME]: database.name,
-        [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: FlinkSnapshotMode.BATCH,
+        [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: FlinkSnapshotMode.SNAPSHOT,
       });
       ccloudLoaderStub.getEnvironments.resolves([testEnvWithPoolAndCluster]);
 
@@ -378,32 +414,71 @@ describe("codelens/flinkSqlProvider.ts", () => {
       assert.strictEqual(snapshotModeLens.command?.title, "Mode: Snapshot");
       assert.deepStrictEqual(snapshotModeLens.command?.arguments, [
         fakeDocument.uri,
-        FlinkSnapshotMode.BATCH,
+        FlinkSnapshotMode.SNAPSHOT,
+      ]);
+    });
+
+    it(`should provide 'Mode: Snapshot' codelens when the "${FLINK_DEFAULT_SUBMISSION_MODE.id}" setting is SNAPSHOT and no snapshot mode metadata is set`, async () => {
+      stubbedConfigs.stubGet(FLINK_DEFAULT_SUBMISSION_MODE, FlinkSnapshotMode.SNAPSHOT);
+      resourceManagerStub.getUriMetadata.resolves({});
+
+      const codeLenses: CodeLens[] = await provider.provideCodeLenses(fakeDocument);
+
+      const snapshotModeLens = codeLenses[0];
+      assert.strictEqual(
+        snapshotModeLens.command?.command,
+        "confluent.document.flinksql.toggleSnapshotMode",
+      );
+      assert.strictEqual(snapshotModeLens.command?.title, "Mode: Snapshot");
+      assert.deepStrictEqual(snapshotModeLens.command?.arguments, [
+        fakeDocument.uri,
+        FlinkSnapshotMode.SNAPSHOT,
       ]);
     });
   });
 
   describe("getSnapshotModeFromMetadata()", () => {
-    it("should return STREAMING when metadata is undefined", () => {
-      assert.strictEqual(getSnapshotModeFromMetadata(undefined), FlinkSnapshotMode.STREAMING);
+    let stubbedConfigs: StubbedWorkspaceConfiguration;
+
+    beforeEach(() => {
+      stubbedConfigs = new StubbedWorkspaceConfiguration(sandbox);
     });
 
-    it("should return STREAMING when snapshot mode metadata is unset", () => {
-      const metadata: UriMetadata = { [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: "pool-123" };
-      assert.strictEqual(getSnapshotModeFromMetadata(metadata), FlinkSnapshotMode.STREAMING);
-    });
+    for (const defaultMode of [FlinkSnapshotMode.STREAMING, FlinkSnapshotMode.SNAPSHOT]) {
+      it(`should return the default "${FLINK_DEFAULT_SUBMISSION_MODE.id}" value (${defaultMode}) when metadata is undefined`, () => {
+        stubbedConfigs.stubGet(FLINK_DEFAULT_SUBMISSION_MODE, defaultMode);
 
-    it("should return STREAMING when snapshot mode metadata is explicitly cleared (null)", () => {
-      const metadata: UriMetadata = { [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: null };
-      assert.strictEqual(getSnapshotModeFromMetadata(metadata), FlinkSnapshotMode.STREAMING);
-    });
+        assert.strictEqual(getSnapshotModeFromMetadata(undefined), defaultMode);
+      });
 
-    it("should return BATCH when snapshot mode metadata is set to BATCH", () => {
-      const metadata: UriMetadata = {
-        [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: FlinkSnapshotMode.BATCH,
-      };
-      assert.strictEqual(getSnapshotModeFromMetadata(metadata), FlinkSnapshotMode.BATCH);
-    });
+      it(`should return the default "${FLINK_DEFAULT_SUBMISSION_MODE.id}" value (${defaultMode}) when snapshot mode metadata is unset`, () => {
+        stubbedConfigs.stubGet(FLINK_DEFAULT_SUBMISSION_MODE, defaultMode);
+        const metadata: UriMetadata = { [UriMetadataKeys.FLINK_COMPUTE_POOL_ID]: "pool-123" };
+
+        assert.strictEqual(getSnapshotModeFromMetadata(metadata), defaultMode);
+      });
+
+      it(`should return the default "${FLINK_DEFAULT_SUBMISSION_MODE.id}" value (${defaultMode}) when snapshot mode metadata is explicitly cleared (null)`, () => {
+        stubbedConfigs.stubGet(FLINK_DEFAULT_SUBMISSION_MODE, defaultMode);
+        const metadata: UriMetadata = { [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: null };
+
+        assert.strictEqual(getSnapshotModeFromMetadata(metadata), defaultMode);
+      });
+    }
+
+    for (const storedMode of [FlinkSnapshotMode.STREAMING, FlinkSnapshotMode.SNAPSHOT]) {
+      it(`should favor stored "${UriMetadataKeys.FLINK_SNAPSHOT_MODE}" metadata (${storedMode}) over the default "${FLINK_DEFAULT_SUBMISSION_MODE.id}" value`, () => {
+        // stub the opposite mode as the default to prove the metadata wins
+        const oppositeMode =
+          storedMode === FlinkSnapshotMode.SNAPSHOT
+            ? FlinkSnapshotMode.STREAMING
+            : FlinkSnapshotMode.SNAPSHOT;
+        stubbedConfigs.stubGet(FLINK_DEFAULT_SUBMISSION_MODE, oppositeMode);
+        const metadata: UriMetadata = { [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: storedMode };
+
+        assert.strictEqual(getSnapshotModeFromMetadata(metadata), storedMode);
+      });
+    }
   });
 
   describe("getComputePoolFromMetadata()", () => {

--- a/src/codelens/flinkSqlProvider.ts
+++ b/src/codelens/flinkSqlProvider.ts
@@ -1,7 +1,18 @@
-import type { CodeLensProvider, Command, Disposable, Event, TextDocument } from "vscode";
-import { CodeLens, EventEmitter, Position, Range } from "vscode";
+import type {
+  CodeLensProvider,
+  Command,
+  ConfigurationChangeEvent,
+  Disposable,
+  Event,
+  TextDocument,
+} from "vscode";
+import { CodeLens, EventEmitter, Position, Range, workspace } from "vscode";
 import { ccloudConnected, uriMetadataSet } from "../emitters";
-import { FLINK_CONFIG_COMPUTE_POOL, FLINK_CONFIG_DATABASE } from "../extensionSettings/constants";
+import {
+  FLINK_CONFIG_COMPUTE_POOL,
+  FLINK_CONFIG_DATABASE,
+  FLINK_DEFAULT_SUBMISSION_MODE,
+} from "../extensionSettings/constants";
 import { CCloudResourceLoader } from "../loaders";
 import { Logger } from "../logging";
 import type { CCloudEnvironment } from "../models/environment";
@@ -15,6 +26,13 @@ import type { UriMetadata } from "../storage/types";
 import { DisposableCollection } from "../utils/disposables";
 
 const logger = new Logger("codelens.flinkSqlProvider");
+
+/** Settings whose values can appear in a Flink SQL document's codelens titles. */
+const FLINK_DEFAULT_SETTINGS = [
+  FLINK_CONFIG_COMPUTE_POOL,
+  FLINK_CONFIG_DATABASE,
+  FLINK_DEFAULT_SUBMISSION_MODE,
+];
 
 export class FlinkSqlCodelensProvider extends DisposableCollection implements CodeLensProvider {
   // controls refreshing the available codelenses
@@ -39,6 +57,7 @@ export class FlinkSqlCodelensProvider extends DisposableCollection implements Co
     return [
       ccloudConnected.event(this.ccloudConnectedHandler.bind(this)),
       uriMetadataSet.event(this.uriMetadataSetHandler.bind(this)),
+      workspace.onDidChangeConfiguration(this.configurationChangedHandler.bind(this)),
     ];
   }
 
@@ -57,6 +76,23 @@ export class FlinkSqlCodelensProvider extends DisposableCollection implements Co
    */
   uriMetadataSetHandler(): void {
     logger.debug("uriMetadataSetHandler called, updating codelenses");
+    this._onDidChangeCodeLenses.fire();
+  }
+
+  /**
+   * Refresh/update all codelenses when one of the Flink default settings changes, since documents
+   * without their own metadata show these defaults in their codelens titles.
+   */
+  configurationChangedHandler(event: ConfigurationChangeEvent): void {
+    const changedSetting = FLINK_DEFAULT_SETTINGS.find((setting) =>
+      event.affectsConfiguration(setting.id),
+    );
+    if (!changedSetting) {
+      return;
+    }
+    logger.debug("configurationChangedHandler called, updating codelenses", {
+      settingId: changedSetting.id,
+    });
     this._onDidChangeCodeLenses.fire();
   }
 
@@ -92,7 +128,7 @@ export class FlinkSqlCodelensProvider extends DisposableCollection implements Co
 
     // codelens for toggling between streaming (default, continuous) and snapshot (one-shot,
     // bounded) statement execution mode
-    const isSnapshotMode = snapshotMode === FlinkSnapshotMode.BATCH;
+    const isSnapshotMode = snapshotMode === FlinkSnapshotMode.SNAPSHOT;
     const toggleSnapshotModeCommand: Command = {
       title: `Mode: ${flinkSnapshotModeLabel(snapshotMode)}`,
       command: "confluent.document.flinksql.toggleSnapshotMode",
@@ -178,14 +214,21 @@ export async function getComputePoolFromMetadata(
 }
 
 /**
- * Get the snapshot ("batch") vs streaming execution mode from the metadata stored in the document.
- * Defaults to {@link FlinkSnapshotMode.STREAMING} when unset or explicitly cleared.
+ * Get the snapshot vs streaming execution mode from the metadata stored in the document.
+ *
+ * Falls back to the {@link FLINK_DEFAULT_SUBMISSION_MODE} setting when the document has no mode of
+ * its own. Unlike the compute pool and database, a cleared (`null`) mode also falls back: there is
+ * no "no mode" state for a statement, so clearing a document's settings should return it to the
+ * user's default rather than pin it to streaming.
+ *
  * @param metadata The metadata stored in the document.
  */
 export function getSnapshotModeFromMetadata(metadata: UriMetadata | undefined): FlinkSnapshotMode {
-  return metadata?.[UriMetadataKeys.FLINK_SNAPSHOT_MODE] === FlinkSnapshotMode.BATCH
-    ? FlinkSnapshotMode.BATCH
-    : FlinkSnapshotMode.STREAMING;
+  const storedMode = metadata?.[UriMetadataKeys.FLINK_SNAPSHOT_MODE];
+  if (storedMode === FlinkSnapshotMode.SNAPSHOT || storedMode === FlinkSnapshotMode.STREAMING) {
+    return storedMode;
+  }
+  return FLINK_DEFAULT_SUBMISSION_MODE.value;
 }
 
 export interface CatalogDatabase {

--- a/src/commands/documents.test.ts
+++ b/src/commands/documents.test.ts
@@ -472,24 +472,24 @@ describe("commands/documents.ts toggleSnapshotModeForUriCommand()", () => {
     sinon.assert.notCalled(setFlinkDocumentMetadataStub);
   });
 
-  it("should set mode to BATCH when current mode is undefined", async () => {
+  it("should set mode to SNAPSHOT when current mode is undefined", async () => {
     await toggleSnapshotModeForUriCommand(testUri, undefined);
 
     sinon.assert.calledOnceWithExactly(setFlinkDocumentMetadataStub, testUri, {
-      snapshotMode: FlinkSnapshotMode.BATCH,
+      snapshotMode: FlinkSnapshotMode.SNAPSHOT,
     });
   });
 
-  it("should set mode to BATCH when current mode is STREAMING", async () => {
+  it("should set mode to SNAPSHOT when current mode is STREAMING", async () => {
     await toggleSnapshotModeForUriCommand(testUri, FlinkSnapshotMode.STREAMING);
 
     sinon.assert.calledOnceWithExactly(setFlinkDocumentMetadataStub, testUri, {
-      snapshotMode: FlinkSnapshotMode.BATCH,
+      snapshotMode: FlinkSnapshotMode.SNAPSHOT,
     });
   });
 
-  it("should set mode to STREAMING when current mode is BATCH", async () => {
-    await toggleSnapshotModeForUriCommand(testUri, FlinkSnapshotMode.BATCH);
+  it("should set mode to STREAMING when current mode is SNAPSHOT", async () => {
+    await toggleSnapshotModeForUriCommand(testUri, FlinkSnapshotMode.SNAPSHOT);
 
     sinon.assert.calledOnceWithExactly(setFlinkDocumentMetadataStub, testUri, {
       snapshotMode: FlinkSnapshotMode.STREAMING,

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -158,7 +158,9 @@ export async function toggleSnapshotModeForUriCommand(
   }
 
   const newMode: FlinkSnapshotMode =
-    currentMode === FlinkSnapshotMode.BATCH ? FlinkSnapshotMode.STREAMING : FlinkSnapshotMode.BATCH;
+    currentMode === FlinkSnapshotMode.SNAPSHOT
+      ? FlinkSnapshotMode.STREAMING
+      : FlinkSnapshotMode.SNAPSHOT;
 
   await setFlinkDocumentMetadata(uri, { snapshotMode: newMode });
 }

--- a/src/extensionSettings/constants.test.ts
+++ b/src/extensionSettings/constants.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import { extensions } from "vscode";
 import { EXTENSION_ID } from "../constants";
+import { FlinkSnapshotMode } from "../models/flinkStatement";
 import type { ExtensionConfiguration } from "./base";
 import {
   ALLOW_OLDER_SCHEMA_VERSIONS,
@@ -12,6 +13,7 @@ import {
   FLINK_CONFIG_COMPUTE_POOL,
   FLINK_CONFIG_DATABASE,
   FLINK_CONFIG_STATEMENT_PREFIX,
+  FLINK_DEFAULT_SUBMISSION_MODE,
   KRB5_CONFIG_PATH,
   LOCAL_DOCKER_SOCKET_PATH,
   LOCAL_KAFKA_IMAGE,
@@ -283,6 +285,30 @@ describe("extensionSettings/constants.ts", function () {
       assert.ok(FLINK_CONFIG_STATEMENT_PREFIX.defaultValue !== undefined);
       assert.strictEqual(FLINK_CONFIG_STATEMENT_PREFIX.defaultValue, expectedDefault);
       assert.ok(FLINK_CONFIG_STATEMENT_PREFIX.value !== undefined);
+    });
+
+    it("should set the correct section and default value for FLINK_DEFAULT_SUBMISSION_MODE", () => {
+      const section: ExtensionConfiguration | undefined = getSectionForSetting(
+        FLINK_DEFAULT_SUBMISSION_MODE.id,
+      );
+      assert.ok(section);
+      assert.strictEqual(FLINK_DEFAULT_SUBMISSION_MODE.sectionTitle, section.title);
+
+      const expectedDefault = section.properties[FLINK_DEFAULT_SUBMISSION_MODE.id].default;
+      assert.strictEqual(expectedDefault, FlinkSnapshotMode.STREAMING);
+      assert.ok(FLINK_DEFAULT_SUBMISSION_MODE.defaultValue !== undefined);
+      assert.strictEqual(FLINK_DEFAULT_SUBMISSION_MODE.defaultValue, expectedDefault);
+      assert.ok(FLINK_DEFAULT_SUBMISSION_MODE.value !== undefined);
+    });
+
+    it("should only allow FlinkSnapshotMode values for FLINK_DEFAULT_SUBMISSION_MODE", () => {
+      const section: ExtensionConfiguration | undefined = getSectionForSetting(
+        FLINK_DEFAULT_SUBMISSION_MODE.id,
+      );
+      assert.ok(section);
+
+      const enumValues: string[] = section.properties[FLINK_DEFAULT_SUBMISSION_MODE.id].enum;
+      assert.deepStrictEqual(enumValues.slice().sort(), Object.values(FlinkSnapshotMode).sort());
     });
 
     it("should set the correct section and default value for UPDATE_DEFAULT_POOL_ID_FROM_LENS", () => {

--- a/src/extensionSettings/constants.ts
+++ b/src/extensionSettings/constants.ts
@@ -1,3 +1,4 @@
+import type { FlinkSnapshotMode } from "../models/flinkStatement";
 import { ExtensionSetting, Setting, SettingsSection } from "./base";
 
 export type NeverAskAlways = "never" | "ask" | "always";
@@ -183,6 +184,14 @@ export const STATEMENT_POLLING_CONCURRENCY = new ExtensionSetting<number>(
 /** Default location for displaying Flink statement results (editor area or bottom panel). */
 export const STATEMENT_RESULTS_LOCATION = new ExtensionSetting<"editor" | "panel">(
   "confluent.flink.statementResults.defaultLocation",
+  SettingsSection.FLINK,
+);
+/**
+ * Default {@link FlinkSnapshotMode} to submit Flink statements with, used when a document doesn't
+ * have its own mode set via the "Mode:" codelens.
+ */
+export const FLINK_DEFAULT_SUBMISSION_MODE = new ExtensionSetting<FlinkSnapshotMode>(
+  "confluent.flink.defaultSubmissionMode",
   SettingsSection.FLINK,
 );
 

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -315,7 +315,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
       assert.strictEqual(meta.isSnapshotMode, true);
       assert.strictEqual(
         meta.modeDescription,
-        flinkSnapshotModeDescription(FlinkSnapshotMode.BATCH),
+        flinkSnapshotModeDescription(FlinkSnapshotMode.SNAPSHOT),
       );
     });
   });
@@ -998,7 +998,7 @@ describe("FlinkStatementResultsViewModel execution duration display", () => {
       spec: {
         ...base.spec,
         properties:
-          mode === FlinkSnapshotMode.BATCH
+          mode === FlinkSnapshotMode.SNAPSHOT
             ? { ...base.spec.properties, "sql.snapshot.mode": "now" }
             : base.spec.properties,
       },
@@ -1016,7 +1016,7 @@ describe("FlinkStatementResultsViewModel execution duration display", () => {
 
   it("should withhold execution time for a snapshot statement", async () => {
     const snapshotVm: FlinkStatementResultsViewModel = await createViewModel(
-      FlinkSnapshotMode.BATCH,
+      FlinkSnapshotMode.SNAPSHOT,
     );
 
     await eventually(() => {

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -85,7 +85,7 @@ export type StatementMeta = {
   modeLabel: string;
   /** One-line explanation of the execution mode, for the mode chip's hover text. */
   modeDescription: string;
-  /** Whether this is a bounded snapshot ("batch") query, which yields no rows until it finishes. */
+  /** Whether this is a bounded snapshot query, which yields no rows until it finishes. */
   isSnapshotMode: boolean;
   isTerminal: boolean;
   detail: string | null;
@@ -678,7 +678,7 @@ export class FlinkStatementResultsManager {
       fetchedBytes: this._fetchedBytes(),
       modeLabel: flinkSnapshotModeLabel(statement.mode),
       modeDescription: flinkSnapshotModeDescription(statement.mode),
-      isSnapshotMode: statement.mode === FlinkSnapshotMode.BATCH,
+      isSnapshotMode: statement.mode === FlinkSnapshotMode.SNAPSHOT,
       isTerminal: statement.isTerminal,
       detail: statement.status?.detail ?? null,
       failed: statement.failed,

--- a/src/flinkSql/statementUtils.test.ts
+++ b/src/flinkSql/statementUtils.test.ts
@@ -261,7 +261,7 @@ describe("flinkSql/statementUtils.ts", function () {
     }> = [
       { snapshotMode: undefined, expectedProperty: undefined },
       { snapshotMode: FlinkSnapshotMode.STREAMING, expectedProperty: undefined },
-      { snapshotMode: FlinkSnapshotMode.BATCH, expectedProperty: "now" },
+      { snapshotMode: FlinkSnapshotMode.SNAPSHOT, expectedProperty: "now" },
     ];
 
     for (const { snapshotMode, expectedProperty } of snapshotModeCases) {
@@ -535,11 +535,11 @@ describe("flinkSql/statementUtils.ts", function () {
 
     it("should set the snapshot mode metadata when provided", async () => {
       await setFlinkDocumentMetadata(uri, {
-        snapshotMode: FlinkSnapshotMode.BATCH,
+        snapshotMode: FlinkSnapshotMode.SNAPSHOT,
       });
 
       sinon.assert.calledWith(rmSetUriMetadataStub, uri, {
-        [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: FlinkSnapshotMode.BATCH,
+        [UriMetadataKeys.FLINK_SNAPSHOT_MODE]: FlinkSnapshotMode.SNAPSHOT,
       });
 
       sinon.assert.calledWith(uriMetadataSetFireStub, uri);

--- a/src/flinkSql/statementUtils.ts
+++ b/src/flinkSql/statementUtils.ts
@@ -51,7 +51,7 @@ export interface IFlinkStatementSubmitParameters {
   properties: FlinkSpecProperties;
 
   /**
-   * Batch ("snapshot") vs streaming execution mode to submit the statement with.
+   * Snapshot vs streaming execution mode to submit the statement with.
    * Defaults to {@link FlinkSnapshotMode.STREAMING} when omitted.
    */
   snapshotMode?: FlinkSnapshotMode;
@@ -72,7 +72,7 @@ export async function submitFlinkStatement(
   const handle = await getSidecar();
 
   const properties: Record<string, string> = params.properties.toProperties();
-  if (params.snapshotMode === FlinkSnapshotMode.BATCH) {
+  if (params.snapshotMode === FlinkSnapshotMode.SNAPSHOT) {
     properties["sql.snapshot.mode"] = "now";
   }
 

--- a/src/models/flinkStatement.test.ts
+++ b/src/models/flinkStatement.test.ts
@@ -303,9 +303,9 @@ describe("FlinkStatement", () => {
       assert.strictEqual(statement.mode, FlinkSnapshotMode.STREAMING);
     });
 
-    it("returns BATCH when sql.snapshot.mode property is 'now'", () => {
-      const statement = createFlinkStatement({ mode: FlinkSnapshotMode.BATCH });
-      assert.strictEqual(statement.mode, FlinkSnapshotMode.BATCH);
+    it("returns SNAPSHOT when sql.snapshot.mode property is 'now'", () => {
+      const statement = createFlinkStatement({ mode: FlinkSnapshotMode.SNAPSHOT });
+      assert.strictEqual(statement.mode, FlinkSnapshotMode.SNAPSHOT);
     });
 
     it("returns STREAMING when sql.snapshot.mode property is some other unrecognized value", () => {
@@ -553,7 +553,7 @@ describe("FlinkStatementTreeItem", () => {
     const statement = createFlinkStatement({
       name: "statement0",
       phase: Phase.COMPLETED,
-      mode: FlinkSnapshotMode.BATCH,
+      mode: FlinkSnapshotMode.SNAPSHOT,
       createdAt,
       endTime: new Date(createdAt.getTime() + 95_000),
       duration: "PT1M15S",

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -256,13 +256,13 @@ export class FlinkStatement implements IResourceBase, IdItem, ISearchable, IEnvP
   }
 
   /**
-   * Whether the statement was (or will be) evaluated in bounded "batch" (snapshot) mode or
-   * continuous "streaming" mode.
+   * Whether the statement was (or will be) evaluated in bounded "snapshot" mode or continuous
+   * "streaming" mode.
    * @see https://docs.confluent.io/cloud/current/flink/concepts/snapshot-queries.html#snapshot-mode
    */
   get mode(): FlinkSnapshotMode {
     return this.spec.properties?.["sql.snapshot.mode"] === "now"
-      ? FlinkSnapshotMode.BATCH
+      ? FlinkSnapshotMode.SNAPSHOT
       : FlinkSnapshotMode.STREAMING;
   }
 
@@ -495,7 +495,7 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
       // withheld for snapshot statements, which barely queue: CCloud's duration and our own
       // "Total Duration" then measure the same span two ways and can disagree by a second in
       // either direction, which reads as nonsense rather than as queue time
-      resource.executionDuration && resource.mode !== FlinkSnapshotMode.BATCH
+      resource.executionDuration && resource.mode !== FlinkSnapshotMode.SNAPSHOT
         ? formatIsoDuration(resource.executionDuration)
         : undefined,
     )
@@ -513,7 +513,7 @@ export function createFlinkStatementTooltip(resource: FlinkStatement) {
  */
 export enum FlinkSnapshotMode {
   /** Bounded, one-shot evaluation against a snapshot of the data as of submission time. */
-  BATCH = "batch",
+  SNAPSHOT = "snapshot",
   /** Continuous, unbounded evaluation against data as it arrives. This is the CCloud default. */
   STREAMING = "streaming",
 }
@@ -523,7 +523,7 @@ export enum FlinkSnapshotMode {
  * tooltip, and the results viewer so all three name the mode the same way.
  */
 export function flinkSnapshotModeLabel(mode: FlinkSnapshotMode): string {
-  return mode === FlinkSnapshotMode.BATCH ? "Snapshot" : "Streaming";
+  return mode === FlinkSnapshotMode.SNAPSHOT ? "Snapshot" : "Streaming";
 }
 
 /**
@@ -532,7 +532,7 @@ export function flinkSnapshotModeLabel(mode: FlinkSnapshotMode): string {
  * there the mode is still a choice the user can click to change.)
  */
 export function flinkSnapshotModeDescription(mode: FlinkSnapshotMode): string {
-  return mode === FlinkSnapshotMode.BATCH
+  return mode === FlinkSnapshotMode.SNAPSHOT
     ? "Bounded query: ran once against a snapshot of the data as of submission time, then completed."
     : "Streaming query: runs continuously against new data as it arrives.";
 }

--- a/src/storage/constants.ts
+++ b/src/storage/constants.ts
@@ -45,7 +45,7 @@ export enum UriMetadataKeys {
   FLINK_DATABASE_NAME = "flinkDatabaseName",
   /** True when the document was opened from a Flink workspace deep link. */
   FLINK_FROM_WORKSPACE = "flinkFromWorkspace",
-  /** Batch ("snapshot") vs streaming execution mode to submit the statement with. */
+  /** Snapshot vs streaming execution mode to submit the statement with. */
   FLINK_SNAPSHOT_MODE = "flinkSnapshotMode",
 }
 

--- a/tests/unit/testResources/flinkStatement.ts
+++ b/tests/unit/testResources/flinkStatement.ts
@@ -73,7 +73,7 @@ export function createFlinkStatement(overrides: CreateFlinkStatementArgs = {}): 
         "sql.current-catalog": TEST_CCLOUD_ENVIRONMENT.name,
         "sql.current-database": TEST_CCLOUD_KAFKA_CLUSTER.name,
         "sql.local-time-zone": "GMT-04:00",
-        ...(overrides.mode === FlinkSnapshotMode.BATCH ? { "sql.snapshot.mode": "now" } : {}),
+        ...(overrides.mode === FlinkSnapshotMode.SNAPSHOT ? { "sql.snapshot.mode": "now" } : {}),
       },
       stopped: false,
     },


### PR DESCRIPTION
* New user setting for default Flink snapshot vs streaming statement submission, defaulting to streaming. Controls the default codelens / urimetadata value for new FlinkSQL documents.
* Event listener for open FlinkSQL documents to update the statement mode if the user changes the setting while such a document is open.
* Rename the constant indicating to use snapshot mode to be SNAPSHOT, not BATCH.

Closes #3429 
Closes #1848 , being the final child.

<img width="741" height="366" alt="Screenshot 2026-08-12 at 4 22 25 PM" src="https://github.com/user-attachments/assets/7045613c-70ae-4d79-b3c9-e17574f3c287" />
