### PR TITLE
MINOR fix(CI): increase execution time limit for release E2E smoketests to 30 minutes

### DIFF
--- a/.semaphore/release-e2e-smoketests.yml
+++ b/.semaphore/release-e2e-smoketests.yml
@@ -5,7 +5,7 @@ agent:
     type: s1-prod-ubuntu24-04-amd64-1
 
 execution_time_limit:
-  minutes: 10
+  minutes: 30
 
 global_job_config:
   prologue:


### PR DESCRIPTION
Many of the scheduled tasks are timing out due to the npm cache restore step, so this just increases the pipeline timeout from 10min to 30min.
<img width="862" height="561" alt="image" src="https://github.com/user-attachments/assets/3a524a4d-57e0-4d0b-b08a-eccabe2e9d04" />
