### PR TITLE
Implement canAccessSchemaForTopic() unit tests

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -43,34 +43,48 @@ describe("authz.schemaRegistry", function () {
     sandbox.restore();
   });
 
-  // FIXME: canAccessSchemaForTopic() tests
-  // it("canAccessSchemaForTopic() should return true if both key and value access are true", async function () {
-  //   const stub = sandbox.stub(schemaRegistry, "canAccessSchemaTypeForTopic").resolves(true);
-  //   const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
-  //   sinon.assert.calledTwice(stub);
-  //   assert.strictEqual(result, true);
-  // });
+  // canAccessSchemaForTopic() tests. These go through the stubbed SubjectsV1Api client because
+  // canAccessSchemaTypeForTopic() is an in-module call Sinon can't stub.
 
-  // it("canAccessSchemaForTopic() should return true if either key or value access is true", async function () {
-  //   // stub the canAccessSchemaTypeForTopic "key" request to return true, "value" to return false
-  //   const topic = TEST_CCLOUD_KAFKA_TOPIC;
-  //   const stub = sandbox
-  //     .stub(schemaRegistry, "canAccessSchemaTypeForTopic")
-  //     .withArgs(topic, "key")
-  //     .resolves(true)
-  //     .withArgs(topic, "value")
-  //     .resolves(false);
-  //   const result = await schemaRegistry.canAccessSchemaForTopic(topic);
-  //   sinon.assert.calledTwice(stub);
-  //   assert.strictEqual(result, true);
-  // });
+  // a denial-shaped ResponseError (403 with a non-access error_code) so the real
+  // determineAccessFromResponseError() path runs; fresh instance per call since the body reads once.
+  function schemaAccessDeniedError(): ResponseError {
+    return new ResponseError(new Response(JSON.stringify({ error_code: 40301 }), { status: 403 }));
+  }
 
-  // it("canAccessSchemaForTopic() should return false if both key and value access are false", async function () {
-  //   const stub = sandbox.stub(schemaRegistry, "canAccessSchemaTypeForTopic").resolves(false);
-  //   const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
-  //   sinon.assert.calledTwice(stub);
-  //   assert.strictEqual(result, false);
-  // });
+  it("canAccessSchemaForTopic() should return true if both key and value access are true", async function () {
+    mockClient.lookUpSchemaUnderSubject.resolves({});
+
+    const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
+
+    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    assert.strictEqual(result, true);
+  });
+
+  it("canAccessSchemaForTopic() should return true if either key or value access is true", async function () {
+    const topic = TEST_CCLOUD_KAFKA_TOPIC;
+    // "key" subject lookup succeeds (access), "value" is denied
+    mockClient.lookUpSchemaUnderSubject
+      .withArgs(sinon.match({ subject: `${topic.name}-key` }))
+      .resolves({});
+    mockClient.lookUpSchemaUnderSubject
+      .withArgs(sinon.match({ subject: `${topic.name}-value` }))
+      .rejects(schemaAccessDeniedError());
+
+    const result = await schemaRegistry.canAccessSchemaForTopic(topic);
+
+    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    assert.strictEqual(result, true);
+  });
+
+  it("canAccessSchemaForTopic() should return false if both key and value access are false", async function () {
+    mockClient.lookUpSchemaUnderSubject.callsFake(() => Promise.reject(schemaAccessDeniedError()));
+
+    const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
+
+    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    assert.strictEqual(result, false);
+  });
 
   // canAccessSchemaTypeForTopic() tests
   it("canAccessSchemaTypeForTopic() should return true if asked about a local topic.", async function () {

--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -14,6 +14,7 @@ import { ResponseError, SubjectsV1Api } from "../clients/schemaRegistryRest";
 import { CCLOUD_BASE_PATH, UTM_SOURCE_VSCODE } from "../constants";
 import { SCHEMA_RBAC_WARNINGS_ENABLED } from "../extensionSettings/constants";
 import type { CCloudResourceLoader } from "../loaders";
+import type { KafkaTopic } from "../models/topic";
 import type { SidecarHandle } from "../sidecar";
 import * as schemaRegistry from "./schemaRegistry";
 
@@ -52,12 +53,26 @@ describe("authz.schemaRegistry", function () {
     return new ResponseError(new Response(JSON.stringify({ error_code: 40301 }), { status: 403 }));
   }
 
+  // assert both the key and value subjects were looked up exactly once, not just that two lookups
+  // happened (a regression querying the key subject twice would satisfy a bare count check).
+  function assertKeyAndValueSubjectsLookedUp(topic: KafkaTopic): void {
+    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    sinon.assert.calledWith(
+      mockClient.lookUpSchemaUnderSubject,
+      sinon.match({ subject: `${topic.name}-key` }),
+    );
+    sinon.assert.calledWith(
+      mockClient.lookUpSchemaUnderSubject,
+      sinon.match({ subject: `${topic.name}-value` }),
+    );
+  }
+
   it("canAccessSchemaForTopic() should return true if both key and value access are true", async function () {
     mockClient.lookUpSchemaUnderSubject.resolves({});
 
     const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
 
-    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    assertKeyAndValueSubjectsLookedUp(TEST_CCLOUD_KAFKA_TOPIC);
     assert.strictEqual(result, true);
   });
 
@@ -73,7 +88,7 @@ describe("authz.schemaRegistry", function () {
 
     const result = await schemaRegistry.canAccessSchemaForTopic(topic);
 
-    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    assertKeyAndValueSubjectsLookedUp(topic);
     assert.strictEqual(result, true);
   });
 
@@ -82,7 +97,7 @@ describe("authz.schemaRegistry", function () {
 
     const result = await schemaRegistry.canAccessSchemaForTopic(TEST_CCLOUD_KAFKA_TOPIC);
 
-    sinon.assert.calledTwice(mockClient.lookUpSchemaUnderSubject);
+    assertKeyAndValueSubjectsLookedUp(TEST_CCLOUD_KAFKA_TOPIC);
     assert.strictEqual(result, false);
   });
 


### PR DESCRIPTION
## Summary of Changes

Closes https://github.com/confluentinc/vscode/issues/2017

Implements the three `canAccessSchemaForTopic()` unit tests that were left commented out with a `FIXME`, covering the both-accessible, either-accessible, and neither-accessible cases. `canAccessSchemaForTopic()` decides whether the current user can read a topic's schemas before the message viewer tries to deserialize it, returning `true` if the user can access *either* the key or value subject.

The original stubs never worked: they replaced the in-module helper `canAccessSchemaTypeForTopic()` directly, and Sinon can only stub module exports, not a function a module calls from within itself (see the project's ["Design for Stubbing"](https://github.com/confluentinc/vscode/blob/main/.claude/rules/testing/unit-tests.md) rule). The new tests instead drive the real code path through the stubbed `SubjectsV1Api` client (the schema registry API), so the "no access" cases exercise the genuine `403 -> determineAccessFromResponseError()` denial path rather than mocking it away.

Test-only change; no runtime behavior changes.

### Optional: Any additional details or context that should be provided?

Follow-up (not fixed here): the pre-existing `canAccessSchemaTypeForTopic() should return false on a 403 ResponseError` test has the same in-module stubbing bug, so it currently passes for an unrelated reason. Worth a separate cleanup.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)? No - internal test coverage only.
