### PR TITLE
fix(authz): make schema access 403 test hit real denial path

### DIFF
--- a/src/authz/schemaRegistry.test.ts
+++ b/src/authz/schemaRegistry.test.ts
@@ -100,9 +100,12 @@ describe("authz.schemaRegistry", function () {
   });
 
   it("canAccessSchemaTypeForTopic() should return false on a 403 ResponseError", async function () {
-    const error = new ResponseError(new Response(null, { status: 403 }));
+    // determineAccessFromResponseError() can't be stubbed (bare in-module reference), so drive it
+    // with a realistic 40301 "denied Read on Subject" body that exercises its genuine denial branch.
+    const error = new ResponseError(
+      new Response(JSON.stringify({ error_code: 40301 }), { status: 403 }),
+    );
     mockClient.lookUpSchemaUnderSubject.rejects(error);
-    sandbox.stub(schemaRegistry, "determineAccessFromResponseError").resolves(false);
     const result = await schemaRegistry.canAccessSchemaTypeForTopic(TEST_CCLOUD_KAFKA_TOPIC, "key");
     assert.strictEqual(result, false);
   });


### PR DESCRIPTION
## Summary of Changes

A unit test meant to prove "no schema access on a 403 returns `false`" was passing for the wrong reason. Sinon couldn't stub the helper it targeted (a same-module function call, not a real dependency), so the test's mock never ran. It only went green because an empty response body made the real code throw and fall into an unrelated `catch` branch that also returns `false`.

This change replaces that empty body with a realistic denied-access response (`error_code: 40301`, HTTP 403), matching the sibling tests in the file, so the assertion now exercises the actual access-decision logic for a genuine denial.

### Click-testing instructions

No user-facing behavior changed (test-only fix). To confirm the fix locally:

1. Run `npx gulp test -t "authz.schemaRegistry"`.
2. Confirm the suite passes (11 tests), including "canAccessSchemaTypeForTopic() should return false on a 403 ResponseError".

### Optional: Any additional details or context that should be provided?

- Sinon can only intercept calls made through the module object, not same-file references, so the stub on `determineAccessFromResponseError()` was a no-op (see the repo's "Design for Stubbing" testing rule). The fix drives the real function down its genuine denial branch instead.
- No production code changed; the fix is confined to `src/authz/schemaRegistry.test.ts`.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
