### PR TITLE
MINOR: update claude settings.json permissions to use 'Edit' instead of 'Write' for .env files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,8 +3,8 @@
     "deny": [
       "Read(**/.env)",
       "Read(**/.env.*)",
-      "Write(**/.env)",
-      "Write(**/.env.*)"
+      "Edit(**/.env)",
+      "Edit(**/.env.*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Cleans up the warnings from a recent(ish) tool change:
```
Permission deny rule (.claude/settings.json): Write(**/.env) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/.env) instead (Edit rules cover all file-editing tools).
Permission deny rule (.claude/settings.json): Write(**/.env.*) is not matched by file permission checks — only Edit(path) rules are. Use Edit(**/.env.*) instead (Edit rules cover all file-editing tools).
```