### PR TITLE
chore: bump @vscode/test-electron to v3 to fix macOS test launch

### DIFF
--- a/.claude/rules/testing/unit-tests.md
+++ b/.claude/rules/testing/unit-tests.md
@@ -52,34 +52,18 @@ assignment instead: `obj["methodName"] = sandbox.stub()`.
 - Unit test fixtures in `tests/fixtures/`
 - Shared stubs in `tests/stubs/`
 
-## macOS: Local Electron Test Host Won't Launch (e.g. VS Code 1.131.0)
+## macOS: Local Test Host Issues
 
 `npx gulp test` downloads a real VS Code build into `.vscode-test/vscode-darwin-arm64-<version>/`
-(gitignored cache) and spawns it via `@vscode/test-electron@2.3.9` as the Extension Development
-Host. Two independent problems show up together on newer VS Code releases (first seen with 1.131.0):
+(gitignored cache) and spawns it via `@vscode/test-electron` as the Extension Development Host.
 
-**1. `spawn .../Electron ENOENT`** — `@vscode/test-electron@2.3.9` hardcodes the launcher binary
-name as `Electron`, but this VS Code build ships it renamed to `Code`. Fix locally (never commit —
-this only touches the gitignored cache):
+The `spawn .../Contents/MacOS/Electron ENOENT` failure that older `@vscode/test-electron` (2.x) hit
+on VS Code 1.110+ — VS Code renamed its macOS launcher binary from `Electron` to `Code`, which 2.x
+hardcoded and could no longer find — is resolved by `@vscode/test-electron@^3.1.0`, which locates
+the launcher dynamically. No `Electron` symlink or ad-hoc re-signing of the `.app` bundle is needed.
+A couple of macOS-specific problems can still stop the test host from launching:
 
-```bash
-cd ".vscode-test/vscode-darwin-arm64-<version>/Visual Studio Code.app/Contents/MacOS/"
-ln -s Code Electron
-```
-
-**2. `"Visual Studio Code" is damaged and can't be opened`** — adding that symlink modifies the
-signed `.app` bundle's contents, which invalidates its code signature. macOS then refuses to launch
-it and reports it as "damaged" (this is a broken-signature error, not a Gatekeeper quarantine issue
-— no `com.apple.quarantine` xattr needs to be present for it to happen). Fix by re-signing ad hoc
-after adding the symlink:
-
-```bash
-codesign --force --deep --sign - "Visual Studio Code.app"
-```
-
-Re-run `npx gulp test` after both steps.
-
-**3. `bad option: --no-sandbox` (and every other flag), exit code 9** — the test host is being run
+**1. `bad option: --no-sandbox` (and every other flag), exit code 9** — the test host is being run
 as plain Node instead of as Electron, so it rejects all of the Chromium/VS Code flags the runner
 passes. The cause is an inherited `ELECTRON_RUN_AS_NODE=1`, which any terminal hosted inside VS Code
 (or another Electron app) exports to its child processes — including agent sessions running in the
@@ -97,7 +81,7 @@ A quick tell that this is the problem rather than a broken bundle:
 `.../Contents/MacOS/Code --version` prints a Node version (e.g. `v24.18.0`) instead of a VS Code
 version.
 
-**4. Global suite setup times out or fails with `PORT_IN_USE` on 26636** — activation starts the
+**2. Global suite setup times out or fails with `PORT_IN_USE` on 26636** — activation starts the
 sidecar, and the sidecar port is shared machine-wide. Another VS Code window running the
 marketplace-installed Confluent extension (or a second dev host) already owns it, and it re-spawns
 its own sidecar within seconds of being killed, so the test run loses the race repeatedly. Close the

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@types/yauzl": "^2.10.3",
         "@types/yazl": "^3.3.0",
         "@vscode/test-cli": "^0.0.10",
-        "@vscode/test-electron": "^2.3.9",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.1.0",
         "dotenv": "^16.4.5",
         "electron-playwright-helpers": "^1.7.1",
@@ -7671,10 +7671,11 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
@@ -7683,7 +7684,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/package.json
+++ b/package.json
@@ -2699,7 +2699,7 @@
     "@types/yauzl": "^2.10.3",
     "@types/yazl": "^3.3.0",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.3.9",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.1.0",
     "dotenv": "^16.4.5",
     "electron-playwright-helpers": "^1.7.1",


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Running `npx gulp test` on macOS fails immediately with `spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT`, so the unit suite never starts locally (another teammate hit the same thing).

VS Code renamed the macOS app's launcher binary from `Electron` to `Code` starting in version 1.110, and we pin VS Code 1.134.0, so `@vscode/test-electron` 2.x's hardcoded `Contents/MacOS/Electron` path no longer resolves. `@vscode/test-electron` 3.x locates the launcher dynamically, so it works with both the old and new binary names.

> [!NOTE]
> This didn't appear in CI because we don't test with macOS/darwin agents there. This was mainly discovered through local dev/testing. 

- Bump `@vscode/test-electron` `^2.3.9` → `^3.1.0` (lockfile regenerated).

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

On macOS:

1. Clear any stale download so a fresh VS Code is fetched: `rm -rf .vscode-test`
2. Run `npx gulp test`
3. Confirm VS Code 1.134.0 launches and the full unit suite runs (3520 passing / 5 pending, 0 failing), instead of dying at launch with `spawn ... /Contents/MacOS/Electron ENOENT`.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- **Node version**: `@vscode/test-electron` 3.x raises its `engines.node` floor to `>=22`. Our `.nvmrc` already pins `v22.17.0`, so there's nothing to change.
- **Left `@vscode/test-cli` at `^0.0.10` on purpose**: it has no dependency on `@vscode/test-electron` and isn't in the `gulp test` path, so bumping it would only pull unrelated `mocha`/`c8` major upgrades into its subtree for no benefit here.
- The lockfile change is intentionally just the `test-electron` entry (regenerated with `npm install --package-lock-only` to avoid incidental transitive churn).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [ ] Updated existing
- [ ] Deleted existing

<!-- Tooling-only change: it restores the existing unit suite on macOS rather than adding test code. -->

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)? (No - developer tooling only.)
