### PR TITLE
improve(E2E): add `Quickpick` title filter and visibility gate

### DIFF
--- a/tests/e2e/objects/quickInputs/Quickpick.ts
+++ b/tests/e2e/objects/quickInputs/Quickpick.ts
@@ -5,11 +5,22 @@ import { expect } from "@playwright/test";
  * Object representing a VS Code {@link https://code.visualstudio.com/api/ux-guidelines/quick-picks quickpick}.
  */
 export class Quickpick {
-  constructor(public readonly page: Page) {}
+  constructor(
+    public readonly page: Page,
+    /** Optional pattern to filter quickpicks by their `title` text. */
+    public readonly titlePattern?: string | RegExp,
+  ) {}
 
   /** The main quickpick widget locator. */
   get locator(): Locator {
-    return this.page.locator(".quick-input-widget");
+    const baseLocator = this.page.locator(".quick-input-widget");
+    if (!this.titlePattern) {
+      return baseLocator;
+    }
+
+    return baseLocator.filter({
+      has: this.page.locator(".quick-input-title", { hasText: this.titlePattern }),
+    });
   }
 
   /** The quickpick header container. */
@@ -17,16 +28,23 @@ export class Quickpick {
     return this.locator.locator(".quick-input-header");
   }
 
+  /** Wait for the quickpick widget to be visible before interacting with it. */
+  async waitForVisible(): Promise<void> {
+    await expect(this.locator).toBeVisible();
+  }
+
   /**
    * Press Enter to confirm the current selection(s). This is mainly done with multi-select
    * quickpicks since clicking a single item in a regular quickpick will automatically confirm it.
    */
   async confirm(): Promise<void> {
+    await this.waitForVisible();
     await this.locator.press("Enter");
   }
 
   /** Press Escape to cancel the input. */
   async cancel(): Promise<void> {
+    await this.waitForVisible();
     await this.locator.press("Escape");
   }
 
@@ -48,6 +66,7 @@ export class Quickpick {
    * one matches before clicking, so a stale/prefix name can't silently select the wrong item.
    */
   async selectItemByText(text: string, options: { exact?: boolean } = {}): Promise<void> {
+    await this.waitForVisible();
     await this.textInput.fill(text);
     // `hasText` is a substring match; `exact` instead requires a label that equals `text` so a
     // prefix/stale name (e.g. "env" against "env-2") resolves to 0 items and the guard below fires


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

The `Quickpick` E2E page object always grabs the first `.quick-input-widget` on the page and leaves each caller to assert it's visible before typing or clicking into it. Only one quickpick renders at a time, so this mostly works, but it's fragile: a test can act on a quickpick that hasn't rendered yet (a source of intermittent E2E flakes), and there's no way to say which quickpick a step expects. ~35 call sites repeat their own `toBeVisible()` gate to work around this.

This PR makes two changes to `tests/e2e/objects/quickInputs/Quickpick.ts`:

- Adds an optional `titlePattern?: string | RegExp` constructor argument that filters the widget by its `.quick-input-title`, mirroring the sibling `InputBox` page object.
- Adds a `waitForVisible()` helper that `confirm()`, `cancel()`, and `selectItemByText()` call before interacting, moving the visibility gate into the page object instead of every call site.

`titlePattern` is optional, so all existing `new Quickpick(page)` call sites keep working unchanged.

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

Not applicable (E2E test infrastructure with no user-facing behavior).

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- `npx gulp check`, ESLint, and Prettier all pass on the changed file. The full Playwright E2E suite (which is what actually exercises this page object) needs Docker, the sidecar, and Electron, so it was **not** run on this branch; please run E2E before merging.
- Deliberately out of scope, as follow-ups: giving the sibling `InputBox` the same `waitForVisible()` gate for parity, and dropping the now-redundant manual `toBeVisible()` assertions from the call sites that no longer need them.

Closes #2740

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
