### PR TITLE
improve(E2E): wire quickpick titles into `Quickpick` call sites

### DIFF
--- a/tests/e2e/baseTest.ts
+++ b/tests/e2e/baseTest.ts
@@ -472,7 +472,7 @@ async function saveSidecarLogs(
   await executeVSCodeCommand(page, "confluent.support.saveSidecarLogs");
 
   // select the formatted log option in the quick pick
-  const formatQuickPick = new Quickpick(page);
+  const formatQuickPick = new Quickpick(page, "Choose sidecar log format");
   await expect(formatQuickPick.locator).toBeVisible({ timeout: 5000 });
   await formatQuickPick.selectItemByText("Human-readable format");
 

--- a/tests/e2e/objects/views/FlinkDatabaseView.ts
+++ b/tests/e2e/objects/views/FlinkDatabaseView.ts
@@ -130,7 +130,7 @@ export class FlinkDatabaseView extends SearchableView {
   private async clickClusterItemFromSelectedDB(clusterLabel?: string): Promise<void> {
     await this.clickSelectKafkaClusterAsFlinkDatabase();
 
-    const kafkaClusterQuickpick = new Quickpick(this.page);
+    const kafkaClusterQuickpick = new Quickpick(this.page, "Select a Kafka cluster");
     await expect(kafkaClusterQuickpick.locator).toBeVisible();
 
     const label = clusterLabel ?? CCLOUD_KAFKA_CLUSTER_NAME;
@@ -178,7 +178,7 @@ export class FlinkDatabaseView extends SearchableView {
   async selectKafkaClusterByProviderRegion(provider: string, region: string): Promise<void> {
     await this.clickSelectKafkaClusterAsFlinkDatabase();
 
-    const kafkaClusterQuickpick = new Quickpick(this.page);
+    const kafkaClusterQuickpick = new Quickpick(this.page, "Select a Kafka cluster");
     await expect(kafkaClusterQuickpick.locator).toBeVisible();
 
     // select by the configured cluster's unique name: the quickpick lists clusters from every
@@ -278,7 +278,7 @@ export class FlinkDatabaseView extends SearchableView {
     const containerItem = new ViewItem(this.page, container);
     await containerItem.clickInlineAction("Upload Flink Artifact to Confluent Cloud");
 
-    const quickpick = new Quickpick(this.page);
+    const quickpick = new Quickpick(this.page, "Upload Flink Artifact");
     await expect(quickpick.locator).toBeVisible();
     await expect(quickpick.items).not.toHaveCount(0);
   }
@@ -289,7 +289,7 @@ export class FlinkDatabaseView extends SearchableView {
    * @param filePath - The path to the JAR file
    */
   private async selectJarFile(electronApp: ElectronApplication, filePath: string): Promise<void> {
-    const quickpick = new Quickpick(this.page);
+    const quickpick = new Quickpick(this.page, "Upload Flink Artifact");
     const selectedJarFileItem = quickpick.items.filter({ hasText: "3. Select JAR File" }).first();
     await expect(selectedJarFileItem).toBeVisible();
 
@@ -306,7 +306,7 @@ export class FlinkDatabaseView extends SearchableView {
    * @returns The full artifact name with random suffix
    */
   private async enterArtifactName(filePath: string): Promise<string> {
-    const quickpick = new Quickpick(this.page);
+    const quickpick = new Quickpick(this.page, "Upload Flink Artifact");
     const artifactItem = quickpick.items.filter({ hasText: "4. Artifact Name" }).first();
     await expect(artifactItem).toBeVisible();
     await artifactItem.click();
@@ -326,7 +326,7 @@ export class FlinkDatabaseView extends SearchableView {
    * Confirm the artifact upload by clicking the upload action.
    */
   private async confirmUpload(): Promise<void> {
-    const quickpick = new Quickpick(this.page);
+    const quickpick = new Quickpick(this.page, "Upload Flink Artifact");
     const uploadAction = quickpick.items.filter({ hasText: "Upload Artifact" }).first();
     await expect(uploadAction).toBeVisible();
     await uploadAction.click();
@@ -375,7 +375,7 @@ export class FlinkDatabaseView extends SearchableView {
    */
   async uploadFlinkArtifactFromJAR(artifactName: string, providerRegion?: string): Promise<string> {
     // Wait for the quickpick to appear
-    const quickpick = new Quickpick(this.page);
+    const quickpick = new Quickpick(this.page, "Upload Flink Artifact");
     await expect(quickpick.locator).toBeVisible();
 
     // Step 1: Select Environment - pin to the configured env instead of `.first()`, which could

--- a/tests/e2e/objects/views/SchemasView.ts
+++ b/tests/e2e/objects/views/SchemasView.ts
@@ -115,7 +115,7 @@ export class SchemasView extends SearchableView {
       }
       case SelectSchemaRegistry.FromSchemasViewButton: {
         await this.clickSelectSchemaRegistry();
-        const schemaRegistryQuickpick = new Quickpick(this.page);
+        const schemaRegistryQuickpick = new Quickpick(this.page, "Select Schema Registry");
         await expect(schemaRegistryQuickpick.locator).toBeVisible();
         await expect(schemaRegistryQuickpick.items).not.toHaveCount(0);
         const registryItem = registryLabel
@@ -148,7 +148,7 @@ export class SchemasView extends SearchableView {
     await this.clickCreateNewSchema();
 
     // select initial schema type before the document opens
-    const createSchemaTypeQuickpick = new Quickpick(page);
+    const createSchemaTypeQuickpick = new Quickpick(page, "Choose a schema type");
     await expect(createSchemaTypeQuickpick.locator).toBeVisible();
     await createSchemaTypeQuickpick.selectItemByText(schemaType);
 
@@ -161,12 +161,12 @@ export class SchemasView extends SearchableView {
     await this.clickUploadSchema();
 
     // select editor/file name in the first quickpick
-    const documentQuickpick = new Quickpick(page);
+    const documentQuickpick = new Quickpick(page, "Select a file");
     await expect(documentQuickpick.locator).toBeVisible();
     await documentQuickpick.selectItemByText("Untitled");
 
     // select schema type in the next quickpick
-    const uploadSchemaTypeQuickpick = new Quickpick(page);
+    const uploadSchemaTypeQuickpick = new Quickpick(page, "Choose a schema type");
     await expect(uploadSchemaTypeQuickpick.locator).toBeVisible();
     await uploadSchemaTypeQuickpick.selectItemByText(schemaType);
 
@@ -219,7 +219,7 @@ export class SchemasView extends SearchableView {
     await subjectItem.rightClickContextMenuAction("Delete All Schemas in Subject");
 
     // select the Hard Delete option
-    const deletionQuickpick = new Quickpick(page);
+    const deletionQuickpick = new Quickpick(page, "Delete Schema Subject");
     const hardDelete = deletionQuickpick.items.filter({ hasText: "Hard Delete" });
     await expect(hardDelete).not.toHaveCount(0);
     await hardDelete.click();

--- a/tests/e2e/objects/views/TopicsView.ts
+++ b/tests/e2e/objects/views/TopicsView.ts
@@ -127,7 +127,7 @@ export class TopicsView extends SearchableView {
       }
       case SelectKafkaCluster.FromTopicsViewButton: {
         await this.clickSelectKafkaCluster();
-        const kafkaClusterQuickpick = new Quickpick(this.page);
+        const kafkaClusterQuickpick = new Quickpick(this.page, "Select a Kafka cluster");
         await expect(kafkaClusterQuickpick.locator).toBeVisible();
         if (effectiveLabel) {
           // CCloud: pin to the configured cluster name with an exact single-match guard

--- a/tests/e2e/specs/produceMessage.spec.ts
+++ b/tests/e2e/specs/produceMessage.spec.ts
@@ -124,7 +124,7 @@ test.describe("Produce Message(s) to Topic", { tag: [Tag.ProduceMessageToTopic] 
 
               await topicItem.clickSendMessages();
               // click the currently open document item in the document/URI quickpick
-              const documentQuickpick = new Quickpick(page);
+              const documentQuickpick = new Quickpick(page, "Select a file");
               await expect(documentQuickpick.locator).toBeVisible();
               const currentDocumentItem = documentQuickpick.items.filter({
                 hasText: "Untitled",
@@ -132,7 +132,10 @@ test.describe("Produce Message(s) to Topic", { tag: [Tag.ProduceMessageToTopic] 
               await expect(currentDocumentItem).not.toHaveCount(0);
               await currentDocumentItem.click();
               // confirm the default selection in the schema multi-select quickpick
-              const schemaQuickpick = new Quickpick(page);
+              const schemaQuickpick = new Quickpick(
+                page,
+                /^Producing to .*Select Schema Kind\(s\)/,
+              );
               await expect(schemaQuickpick.locator).toBeVisible();
               // we could check the default selection(s) here based on which schemas are used (key,
               // value, key+value, etc) but that isn't necessary for now
@@ -158,7 +161,7 @@ test.describe("Produce Message(s) to Topic", { tag: [Tag.ProduceMessageToTopic] 
 
               await topicItem.clickSendMessages();
               // click the currently open document item in the document/URI quickpick
-              const documentQuickpick = new Quickpick(page);
+              const documentQuickpick = new Quickpick(page, "Select a file");
               await expect(documentQuickpick.locator).toBeVisible();
               const currentDocumentItem = documentQuickpick.items.filter({
                 hasText: "Untitled",
@@ -190,7 +193,7 @@ test.describe("Produce Message(s) to Topic", { tag: [Tag.ProduceMessageToTopic] 
 
                 await topicItem.clickSendMessages();
                 // click the currently open document item in the document/URI quickpick
-                const documentQuickpick = new Quickpick(page);
+                const documentQuickpick = new Quickpick(page, "Select a file");
                 await expect(documentQuickpick.locator).toBeVisible();
                 const currentDocumentItem = documentQuickpick.items.filter({
                   hasText: "Untitled",
@@ -198,7 +201,10 @@ test.describe("Produce Message(s) to Topic", { tag: [Tag.ProduceMessageToTopic] 
                 await expect(currentDocumentItem).not.toHaveCount(0);
                 await currentDocumentItem.click();
                 // confirm the default selection in the schema multi-select quickpick
-                const schemaQuickpick = new Quickpick(page);
+                const schemaQuickpick = new Quickpick(
+                  page,
+                  /^Producing to .*Select Schema Kind\(s\)/,
+                );
                 await expect(schemaQuickpick.locator).toBeVisible();
                 // we could check the default selection(s) here based on which schemas are used (key,
                 // value, key+value, etc) but that isn't necessary for now

--- a/tests/e2e/specs/schemas.spec.ts
+++ b/tests/e2e/specs/schemas.spec.ts
@@ -128,11 +128,11 @@ test.describe("Schema Management", { tag: [Tag.EvolveSchema] }, () => {
             // attempt to upload from the subject item (instead of the Schemas view nav action)
             await subjectItem.clickUploadSchemaForSubject();
             // select editor/file name in the first quickpick
-            const documentQuickpick = new Quickpick(page);
+            const documentQuickpick = new Quickpick(page, "Select a file");
             await expect(documentQuickpick.locator).toBeVisible();
             await documentQuickpick.selectItemByText(expectedTabName);
             // select schema type in the next quickpick
-            const uploadSchemaTypeQuickpick = new Quickpick(page);
+            const uploadSchemaTypeQuickpick = new Quickpick(page, "Choose a schema type");
             await expect(uploadSchemaTypeQuickpick.locator).toBeVisible();
             await uploadSchemaTypeQuickpick.selectItemByText(schemaType);
 
@@ -177,11 +177,11 @@ test.describe("Schema Management", { tag: [Tag.EvolveSchema] }, () => {
             // attempt to upload from the subject item (instead of the Schemas view nav action)
             await subjectItem.clickUploadSchemaForSubject();
             // select editor/file name in the first quickpick
-            const documentQuickpick = new Quickpick(page);
+            const documentQuickpick = new Quickpick(page, "Select a file");
             await expect(documentQuickpick.locator).toBeVisible();
             await documentQuickpick.selectItemByText(expectedTabName);
             // select schema type in the next quickpick
-            const uploadSchemaTypeQuickpick = new Quickpick(page);
+            const uploadSchemaTypeQuickpick = new Quickpick(page, "Choose a schema type");
             await expect(uploadSchemaTypeQuickpick.locator).toBeVisible();
             await uploadSchemaTypeQuickpick.selectItemByText(schemaType);
 

--- a/tests/e2e/utils/connections.ts
+++ b/tests/e2e/utils/connections.ts
@@ -279,7 +279,7 @@ export async function setupLocalKafka(page: Page) {
   await localItem.clickStartResources();
 
   // multi-select quickpick to select which resources to start
-  const containerQuickpick = new Quickpick(page);
+  const containerQuickpick = new Quickpick(page, "Local Resources to Start");
   await expect(containerQuickpick.locator).toBeVisible();
   // local Kafka should be checked by default - if not, we'll fail the expect below
   await containerQuickpick.confirm();
@@ -312,7 +312,7 @@ export async function setupLocalSchemaRegistry(page: Page) {
   await localItem.clickStartResources();
 
   // multi-select quickpick to select which resources to start
-  const containerQuickpick = new Quickpick(page);
+  const containerQuickpick = new Quickpick(page, "Local Resources to Start");
   await expect(containerQuickpick.locator).toBeVisible();
   await containerQuickpick.selectItemByText("Schema Registry");
   await containerQuickpick.confirm();

--- a/tests/e2e/utils/flinkStatement.ts
+++ b/tests/e2e/utils/flinkStatement.ts
@@ -51,14 +51,14 @@ export async function submitFlinkStatement(
 
   // Select the Flink compute pool
   await codeLens.getByText("Set Compute Pool").click();
-  const computePoolQuickpick = new Quickpick(page);
+  const computePoolQuickpick = new Quickpick(page, "Select a Flink compute pool");
   await computePoolQuickpick.selectItemByText(computePoolName, { exact: true });
   await expect(codeLens.getByText(computePoolName)).toBeVisible();
 
   // Select a Kafka cluster (the quickpick auto-filters to clouds/regions matching the pool, but
   // there can still be multiple matches; pin via the configured name so we never pick the wrong one)
   await codeLens.getByText("Set Catalog & Database").click();
-  const kafkaClusterQuickpick = new Quickpick(page);
+  const kafkaClusterQuickpick = new Quickpick(page, "Select a Kafka cluster");
   await kafkaClusterQuickpick.selectItemByText(CCLOUD_KAFKA_CLUSTER_NAME, { exact: true });
 
   // Submit the Flink statement


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

> [!NOTE]
> Stacked on top of #3442, which adds the `titlePattern` capability to the `Quickpick` page object. Review and merge that one first; this PR's diff is only the call-site wiring.

Previously, an E2E step could interact with the wrong quickpick (for example, a transient "Loading Kafka clusters..." placeholder) before the real one appeared, because nothing verified which quickpick was on screen. This PR closes that gap by wiring the `titlePattern` argument added in #3442 into the ~26 existing `new Quickpick(...)` call sites, so each step now asserts on the exact title the quickpick renders before interacting with it.

Titles were traced to their source literals in `src/quickpicks/` and `src/commands/` (e.g. `Select a Kafka cluster`, `Choose a schema type`, `Upload Flink Artifact`). The two schema-kind pickers use a dynamic title (`Producing to ${topic.name}: Select Schema Kind(s)...`), so those pass a `RegExp` instead of a string. Call sites with no title (project-template picker, connection-type picker) or backed by a VS Code built-in (command palette, language-mode picker) were left untitled on purpose.

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

Not applicable (E2E test infrastructure with no user-facing behavior). This should be validated by a full E2E run on CI.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- `npx gulp check`, ESLint, and Prettier pass on the changed files. As with the parent PR, the full Playwright E2E suite needs Docker, the sidecar, and Electron, so it was **not** run locally; a CI E2E run is the real verification that each wired title resolves.
- Scoped intentionally to `Quickpick`. Deliberately out of scope: wiring `titlePattern` into the adjacent `InputBox` call sites. This PR applies it broadly to `Quickpick`s (unlike `InputBox`, which uses it in only 1 call site) because multiple quickpicks can be visible or transitioning at once.

Relates to #2740

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
