### PR TITLE
improve(loaders): add `getClusterForTopic()` helper

### DIFF
--- a/src/commands/kafkaClusters.test.ts
+++ b/src/commands/kafkaClusters.test.ts
@@ -452,7 +452,7 @@ describe("commands/kafkaClusters.ts", () => {
 
     it("should fire the topicChanged event with change='deleted' after successful deletion", async () => {
       showInputBoxStub.resolves(TEST_CCLOUD_KAFKA_TOPIC.name);
-      stubbedLoader.getKafkaClustersForEnvironmentId.resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
+      stubbedLoader.getClusterForTopic.resolves(TEST_CCLOUD_KAFKA_CLUSTER);
 
       await deleteTopicCommand(TEST_CCLOUD_KAFKA_TOPIC);
 

--- a/src/commands/kafkaClusters.ts
+++ b/src/commands/kafkaClusters.ts
@@ -152,8 +152,7 @@ export async function deleteTopicCommand(topic: KafkaTopic) {
 
         // look up the parent Kafka cluster in order to fire the topicChanged event
         const loader = ResourceLoader.getInstance(topic.connectionId);
-        const clusters = await loader.getKafkaClustersForEnvironmentId(topic.environmentId);
-        const cluster = clusters.find((c) => c.id === topic.clusterId);
+        const cluster = await loader.getClusterForTopic(topic);
         if (cluster) {
           topicChanged.fire({ change: "deleted", cluster });
         }

--- a/src/commands/scaffold.test.ts
+++ b/src/commands/scaffold.test.ts
@@ -7,6 +7,7 @@ import {
   TEST_CCLOUD_SCHEMA_REGISTRY,
 } from "../../tests/unit/testResources";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
+import * as errors from "../errors";
 import type { CCloudResourceLoader } from "../loaders";
 import { CCloudEnvironment } from "../models/environment";
 import { KafkaTopic } from "../models/topic";
@@ -102,19 +103,23 @@ describe("commands/scaffold.ts", () => {
       );
     });
 
-    it("should show an error notification if environment for topic is not found", async () => {
+    it("should show an error notification and log to Sentry if no cluster is found for the topic", async () => {
       const showErrorNotificationWithButtonsStub = sandbox.stub(
         notifications,
         "showErrorNotificationWithButtons",
       );
+      const logErrorStub = sandbox.stub(errors, "logError");
 
-      // make a new topic with an environment ID that won't be found
-      const topicWithMissingEnv = new KafkaTopic({
+      // topic whose cluster can't be resolved within its environment
+      const topicWithMissingCluster = new KafkaTopic({
         ...TEST_CCLOUD_KAFKA_TOPIC,
         clusterId: "missing-cluster-id",
       });
+      stubbedResourceLoader.getClusterForTopic
+        .withArgs(topicWithMissingCluster)
+        .resolves(undefined);
 
-      await resourceScaffoldProjectCommand(topicWithMissingEnv);
+      await resourceScaffoldProjectCommand(topicWithMissingCluster);
 
       sinon.assert.notCalled(scaffoldProjectRequestStub);
       sinon.assert.calledOnce(showErrorNotificationWithButtonsStub);
@@ -122,12 +127,13 @@ describe("commands/scaffold.ts", () => {
         showErrorNotificationWithButtonsStub,
         `Unable to find Kafka cluster for topic "${TEST_CCLOUD_KAFKA_TOPIC.name}".`,
       );
+      sinon.assert.calledOnce(logErrorStub);
     });
 
     it("should call scaffoldProjectRequest with correct parameters for KafkaTopic", async () => {
-      stubbedResourceLoader.getKafkaClustersForEnvironmentId
-        .withArgs(TEST_CCLOUD_KAFKA_TOPIC.environmentId)
-        .resolves([TEST_CCLOUD_KAFKA_CLUSTER]);
+      stubbedResourceLoader.getClusterForTopic
+        .withArgs(TEST_CCLOUD_KAFKA_TOPIC)
+        .resolves(TEST_CCLOUD_KAFKA_CLUSTER);
 
       await resourceScaffoldProjectCommand(TEST_CCLOUD_KAFKA_TOPIC);
 

--- a/src/commands/scaffold.ts
+++ b/src/commands/scaffold.ts
@@ -2,6 +2,7 @@
 
 import type * as vscode from "vscode";
 import { registerCommandWithLogging } from ".";
+import { logError } from "../errors";
 import { CCloudResourceLoader, ResourceLoader } from "../loaders";
 import type { CCloudFlinkComputePool } from "../models/flinkComputePool";
 import { KafkaCluster } from "../models/kafkaCluster";
@@ -52,9 +53,15 @@ export async function resourceScaffoldProjectCommand(
       telemetrySource = "cluster";
     } else {
       // KafkaTopic
-      const clusters = environment.kafkaClusters;
-      const cluster = clusters.find((c) => c.id === item.clusterId);
+      const cluster = await loader.getClusterForTopic(item);
       if (!cluster) {
+        // a topic should always resolve to a cluster in its environment; log to Sentry so we
+        // learn if this unexpected condition happens in the wild.
+        logError(
+          new Error("Unable to find Kafka cluster for topic during project scaffolding"),
+          "Kafka cluster not found for topic during project scaffolding",
+          { extra: { clusterId: item.clusterId, environmentId: item.environmentId } },
+        );
         void showErrorNotificationWithButtons(
           `Unable to find Kafka cluster for topic "${item.name}".`,
         );

--- a/src/loaders/resourceLoader.test.ts
+++ b/src/loaders/resourceLoader.test.ts
@@ -471,6 +471,53 @@ describe("ResourceLoader::getTopicsForCluster()", () => {
   });
 });
 
+describe("ResourceLoader::getClusterForTopic()", () => {
+  let loaderInstance: ResourceLoader;
+  let sandbox: sinon.SinonSandbox;
+  let getKafkaClustersForEnvironmentIdStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    loaderInstance = LocalResourceLoader.getInstance();
+    getKafkaClustersForEnvironmentIdStub = sandbox.stub(
+      loaderInstance,
+      "getKafkaClustersForEnvironmentId",
+    );
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Raises error for a topic from a mismatched connection", async () => {
+    await assert.rejects(loaderInstance.getClusterForTopic(TEST_CCLOUD_KAFKA_TOPIC), (err) => {
+      return (err as Error).message.startsWith(`Mismatched connectionId ${LOCAL_CONNECTION_ID}`);
+    });
+
+    sinon.assert.notCalled(getKafkaClustersForEnvironmentIdStub);
+  });
+
+  it("Returns the cluster matching the topic's clusterId", async () => {
+    getKafkaClustersForEnvironmentIdStub
+      .withArgs(TEST_LOCAL_KAFKA_TOPIC.environmentId)
+      .resolves([TEST_LOCAL_KAFKA_CLUSTER]);
+
+    const cluster = await loaderInstance.getClusterForTopic(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.strictEqual(cluster, TEST_LOCAL_KAFKA_CLUSTER);
+  });
+
+  it("Returns undefined when no cluster in the environment matches the topic's clusterId", async () => {
+    getKafkaClustersForEnvironmentIdStub
+      .withArgs(TEST_LOCAL_KAFKA_TOPIC.environmentId)
+      .resolves([]);
+
+    const cluster = await loaderInstance.getClusterForTopic(TEST_LOCAL_KAFKA_TOPIC);
+
+    assert.strictEqual(cluster, undefined);
+  });
+});
+
 describe("ResourceLoader::getConsumerGroupsForCluster()", () => {
   let loaderInstance: LocalResourceLoader;
   let sandbox: sinon.SinonSandbox;

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -145,6 +145,28 @@ export abstract class ResourceLoader extends DisposableCollection implements IRe
     forceRefresh?: boolean,
   ): Promise<ConsumerGroup[]>;
 
+  /**
+   * Get the {@link KafkaCluster} that a given {@link KafkaTopic} belongs to.
+   *
+   * Connection-aware (implemented atop {@link getKafkaClustersForEnvironmentId}), so unlike a
+   * raw cluster-id lookup it resolves correctly for direct-connection topics.
+   *
+   * @param topic The topic to resolve. Must belong to the same connection as this loader.
+   * @returns The topic's {@link KafkaCluster}, or `undefined` if no cluster in the topic's
+   *   environment matches its {@linkcode KafkaTopic.clusterId}.
+   * @throws Error if the topic is not from the same connection as this loader.
+   */
+  public async getClusterForTopic(topic: KafkaTopic): Promise<KafkaCluster | undefined> {
+    if (topic.connectionId !== this.connectionId) {
+      throw new Error(
+        `Mismatched connectionId ${this.connectionId} for topic ${topic.name} (${topic.connectionId})`,
+      );
+    }
+
+    const clusters = await this.getKafkaClustersForEnvironmentId(topic.environmentId);
+    return clusters.find((cluster) => cluster.id === topic.clusterId);
+  }
+
   // Schema registry methods.
 
   /**


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Consolidates how the extension looks up the Kafka cluster a topic belongs to. Two commands previously hand-rolled the same `getKafkaClustersForEnvironmentId(...).find(...)` lookup; both now call a new `ResourceLoader.getClusterForTopic(topic)` helper instead, which returns the cluster (or `undefined` if none matches) and works for Confluent Cloud, local, and direct-connection topics alike.

- New `getClusterForTopic()` on the abstract `ResourceLoader` base, mirroring the existing sibling `getTopicSubjectGroups()` (same connection-id guard, same lookup by `topic.environmentId`).
- `resourceScaffoldProjectCommand` (project scaffolding) and `deleteTopic` now route through the helper instead of inlining the lookup.
- Scaffolding logs to Sentry via `logError()` when a topic can't be resolved to a cluster, so we learn if that unexpected condition ever happens in the wild.

Closes #1694.

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

This is internal plumbing with no user-visible change on the happy path. To confirm nothing regressed:

1. Right-click a Kafka topic (try both a Confluent Cloud topic and a direct-connection topic) and run **Create Project** / scaffold. The generated template should pre-fill the cluster's bootstrap server (and schema registry URL, if the environment has one) exactly as before.
2. Delete a topic and confirm the Topics view refreshes afterward (the `topicChanged` event still fires for the parent cluster).

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- The original connection-unaware `ResourceManager.getClusterForTopic()` referenced in #1694 was already removed in a prior change; this adds the connection-aware replacement on the loader and wires the remaining callers to it.
- Deferred: several loader methods repeat the same `connectionId` mismatch guard verbatim; extracting a shared `assertSameConnection()` helper is out of scope here and left as a follow-up.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)? No user-facing behavior change.
