### PR TITLE
fix(consume): guard message viewer against empty-body response crash

### DIFF
--- a/src/consume.ts
+++ b/src/consume.ts
@@ -18,7 +18,7 @@ import { registerCommandWithLogging } from "./commands";
 import { LOCAL_CONNECTION_ID } from "./constants";
 import { getExtensionContext } from "./context/extension";
 import { showJsonPreview } from "./documentProviders/message";
-import { logError } from "./errors";
+import { extractResponseBody, logError } from "./errors";
 import type { ResourceLoader } from "./loaders";
 import { CCloudResourceLoader, DirectResourceLoader, LocalResourceLoader } from "./loaders";
 import { Logger } from "./logging";
@@ -504,7 +504,9 @@ function messageViewerStartPollingCommand(
       /* In case of network issue, the current assumption is that the user is
       going to see auth related error alerts. Logging and error displays is WIP. */
       if (error instanceof ResponseError) {
-        const payload = await error.response.json();
+        // parse defensively: on an empty body a raw `.json()` throws `Unexpected end of JSON
+        // input`, which would abort this catch block before the stream pauses or the user is told.
+        const payload = await extractResponseBody(error);
         // FIXME: this response error coming from the middleware that has to be present to avoid openapi error about missing middlewares
         if (!payload?.aborted) {
           const status = error.response.status;

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -206,6 +206,16 @@ describe("errors.ts extractResponseBody()", () => {
     assert.strictEqual(body, textResponse);
   });
 
+  it("should return an empty string for an empty response body", async () => {
+    // an empty body makes `JSON.parse("")` throw `Unexpected end of JSON input`; the helper must
+    // swallow that and fall back to the (empty) text body rather than propagating the SyntaxError.
+    const error = createResponseError(500, "Internal Server Error", "");
+
+    const body = await extractResponseBody(error);
+
+    assert.strictEqual(body, "");
+  });
+
   it("should throw if the error is not a ResponseError", async () => {
     const error = new Error("test");
     await assert.rejects(


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Closes #776.

The topic message viewer sometimes stops reacting to server errors while polling: the stream keeps running and no "Authentication required" / "Insufficient permissions" / "Topic not found" notification appears, while the underlying `SyntaxError: Unexpected end of JSON input` shows up in Sentry ([VSCODE-EXTENSION-AJ](https://confluent.sentry.io/issues/5943076343)).

The cause: the error handler called `error.response.json()` directly to read the response body. An empty response body makes that throw, and the throw escapes the `catch` block before it can pause the stream or notify the user.

This routes the parse through the existing `extractResponseBody()` helper (`src/errors.ts`), which already falls back to `.text()` when `.json()` fails. An empty body now resolves to `""` instead of throwing, so the existing status-based handling (pause and notify) runs as intended. Five other call sites already use this helper for the same reason.

### Click-testing instructions

<!-- Include any special instructions to help reviewers test your changes, if applicable. Delete this section if clicktesting is not applicable, for example, changes to docs or CI -->

Not directly click-testable (the trigger is an intermittent empty-body error response from the server). Verified via unit test instead: `npx gulp test -t "extractResponseBody"`.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- **Before:** empty-body error response → `SyntaxError` escapes the catch block → stream keeps running, no user notification, `Unexpected end of JSON input` in Sentry.
- **After:** empty-body error response → payload falls back to `""` → status-based handling runs, stream pauses on 4xx, user is notified.
- **Follow-up (out of scope):** six other call sites still call `error.response.json()` directly and carry the same latent empty-body crash (`topics.ts`, `kafkaClusters.ts`, `scaffoldUtils.ts`, `schemaManagement/upload.ts`, `loaderUtils.ts`, `sidecar/middlewares.ts`); worth a separate cleanup pass.
- **Test coverage:** `src/consume.ts` has no co-located test file, so this is covered at the `extractResponseBody()` helper level rather than through the message-viewer catch block.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
