### PR TITLE
refactor(storage): use `mapToString()` in `addDirectConnection()`

### DIFF
--- a/src/storage/resourceManager.test.ts
+++ b/src/storage/resourceManager.test.ts
@@ -914,6 +914,37 @@ describe("storage/resourceManager", () => {
       assert.deepStrictEqual(storedSpec, spec);
     });
 
+    it("addDirectConnection() should preserve nested Kafka and Schema Registry configs (with credentials) across the storage round-trip", async () => {
+      // the default fixture has neither config, so build one that exercises both nested shapes
+      // (and their secret credentials) to guard the mapToString() write path
+      const spec: CustomConnectionSpec = {
+        ...CustomConnectionSpecFromJSON({
+          id: TEST_DIRECT_CONNECTION_ID,
+          name: "Connection with configs",
+          type: ConnectionType.Direct,
+          kafka_cluster: {
+            bootstrap_servers: "localhost:9092",
+            credentials: { username: "kafka-user", password: "kafka-pass" },
+          },
+          schema_registry: {
+            id: "sr-1",
+            uri: "http://localhost:8081",
+            credentials: { username: "sr-user", password: "sr-pass" },
+          },
+        }),
+        id: TEST_DIRECT_CONNECTION_ID,
+        formConnectionType: "Apache Kafka",
+        specifiedConnectionType: undefined,
+      };
+
+      await rm.addDirectConnection(spec);
+
+      const storedSpec: CustomConnectionSpec | null =
+        await rm.getDirectConnection(TEST_DIRECT_CONNECTION_ID);
+      assert.ok(storedSpec);
+      assert.deepStrictEqual(storedSpec, spec);
+    });
+
     it("getDirectConnections() should return an empty map if no direct connections are found", async () => {
       // no preloading
 

--- a/src/storage/resourceManager.ts
+++ b/src/storage/resourceManager.ts
@@ -878,15 +878,11 @@ export class ResourceManager {
   async addDirectConnection(spec: CustomConnectionSpec): Promise<void> {
     const key = SecretStorageKeys.DIRECT_CONNECTIONS;
     return await this.runWithMutex(key, async () => {
-      const connectionIds: DirectConnectionsById = await this.getDirectConnections();
-      connectionIds.set(spec.id, spec);
-      const serializedConnections = Object.fromEntries(
-        Array.from(connectionIds.entries()).map(([id, spec]) => [
-          id,
-          CustomConnectionSpecToJSON(spec),
-        ]),
-      );
-      await this.secrets.store(key, JSON.stringify(serializedConnections));
+      const connections: DirectConnectionsById = await this.getDirectConnections();
+      connections.set(spec.id, spec);
+      // getDirectConnections() re-runs CustomConnectionSpecFromJSON() on read, so it re-normalizes
+      // every field regardless of how it was written; a plain mapToString() write is enough here.
+      await this.secrets.store(key, mapToString(connections));
     });
   }
 


### PR DESCRIPTION
## Summary of Changes

`ResourceManager.addDirectConnection()` serialized each direct-connection spec by hand (`Object.fromEntries` + a per-entry `CustomConnectionSpecToJSON()` map + `JSON.stringify`), while every other setter in `resourceManager.ts` - including its sibling `deleteDirectConnection()` - writes through the shared `mapToString()` helper. This switches `addDirectConnection()` to `mapToString()` too, matching the rest of the file.

The explicit write-side conversion was redundant, not load-bearing: [`getDirectConnections()` re-runs `CustomConnectionSpecFromJSON()` on every read](https://github.com/confluentinc/vscode/blob/9c7563e959509c00d1afb550cff73005810304e6/src/storage/resourceManager.ts#L852-L866), so it re-normalizes every field regardless of how the value was written. No behavior change.

### Click-testing instructions

Not applicable - internal storage refactor, covered by unit tests.

### Optional: Any additional details or context that should be provided?

- The default `TEST_DIRECT_CONNECTION_FORM_SPEC` fixture has no `kafka_cluster` or `schema_registry` config, so the existing round-trip test didn't exercise nested shapes. A new test fills that gap: `addDirectConnection() should preserve nested Kafka and Schema Registry configs (with credentials) across the storage round-trip` builds a spec with both nested configs and their credentials and asserts it survives the SecretStorage round-trip unchanged - guarding the `mapToString()` write path.
- `CustomConnectionSpecToJSON()` is untouched and still exported/tested; it's just no longer called internally by `addDirectConnection()`.

Closes #1495

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
