### PR TITLE
fix(authn): dispose auth provider before nulling in tests

### DIFF
--- a/src/authn/ccloudProvider.test.ts
+++ b/src/authn/ccloudProvider.test.ts
@@ -15,6 +15,7 @@ import {
 import type { Connection } from "../clients/sidecar";
 import { ConnectedState, ConnectionFromJSON } from "../clients/sidecar";
 import { CCLOUD_AUTH_CALLBACK_URI, CCLOUD_BASE_PATH, CCLOUD_CONNECTION_ID } from "../constants";
+import * as contextValues from "../context/values";
 import { ccloudAuthCallback, ccloudAuthSessionInvalidated, ccloudConnected } from "../emitters";
 import * as errors from "../errors";
 import * as notifications from "../notifications";
@@ -702,6 +703,31 @@ describe("authn/ccloudProvider.ts", () => {
         const session: vscode.AuthenticationSession = authProvider.convertToAuthSession(connection);
 
         assert.deepStrictEqual(session, TEST_CCLOUD_AUTH_SESSION);
+      });
+    });
+
+    describe("dispose()", () => {
+      it("should stop handling ccloudAuthSessionInvalidated so a replaced instance handles the event only once", async () => {
+        // a discarded-but-undisposed instance keeps its process-global emitter subscription,
+        // so a single fire invokes clearCurrentCCloudResources() once per surviving instance
+        getStubbedSecretStorage(sandbox);
+        // keep handleSessionRemoved()'s awaits synchronous so the assertion is deterministic
+        sandbox.stub(contextValues, "setContextValue").resolves();
+
+        authProvider.dispose();
+        ConfluentCloudAuthProvider["instance"] = null;
+        const replacement: ConfluentCloudAuthProvider = ConfluentCloudAuthProvider.getInstance();
+
+        try {
+          ccloudAuthSessionInvalidated.fire();
+          // setImmediate (a macrotask) flushes the listener's multi-await chain
+          await new Promise((resolve) => setImmediate(resolve));
+
+          // only the live replacement should handle the event, not the disposed instance
+          sinon.assert.calledOnce(clearCurrentCCloudResourcesStub);
+        } finally {
+          replacement.dispose();
+        }
       });
     });
   });

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -28,6 +28,11 @@ describe("ExtensionContext", () => {
   });
 
   after(() => {
+    // dispose the auth provider re-created during (re)activation below; it subscribes to
+    // process-global emitters (e.g. ccloudAuthSessionInvalidated), so leaving it live would
+    // leak listeners into other test files and double-fire handleSessionRemoved
+    ConfluentCloudAuthProvider["instance"]?.dispose();
+    ConfluentCloudAuthProvider["instance"] = null;
     if (origExtensionContext) {
       setExtensionContext(origExtensionContext);
     }
@@ -38,7 +43,12 @@ describe("ExtensionContext", () => {
       {
         callable: () => ConfluentCloudAuthProvider.getInstance(),
         source: "ConfluentCloudAuthProvider",
-        clear: () => (ConfluentCloudAuthProvider["instance"] = null),
+        // dispose before dropping the singleton so its process-global emitter subscriptions
+        // don't outlive it and contaminate other tests
+        clear: () => {
+          ConfluentCloudAuthProvider["instance"]?.dispose();
+          ConfluentCloudAuthProvider["instance"] = null;
+        },
       },
       {
         callable: () => ResourceManager.getInstance(),


### PR DESCRIPTION
## Summary of Changes

<!-- Include a high-level overview of your implementation, including any alternatives you considered and items you'll address in follow-up PRs -->

Fixes an intermittent CI failure in the `ConfluentCloudAuthProvider` unit tests, where `clearCurrentCCloudResources` was asserted to be called once but was sometimes called twice or thrice.

Closes #2970

The provider subscribes to process-global event emitters (e.g. `ccloudAuthSessionInvalidated`) in its constructor. `extension.test.ts` reset the singleton with `ConfluentCloudAuthProvider["instance"] = null` **without** first calling `dispose()`, so the discarded instance's listeners stayed alive. A later real fire of `ccloudAuthSessionInvalidated` then ran `handleSessionRemoved()` → `clearCurrentCCloudResources()` once per orphaned instance, contaminating an unrelated test's call-count assertion (the "twice/thrice" count tracked how many instances had leaked).

- Dispose the auth-provider singleton before dropping it, in the `clear` closure and the `ExtensionContext` describe's `after` hook, matching how `ccloudProvider.test.ts` already disposes-then-nulls.
- Add a regression test that fires `ccloudAuthSessionInvalidated` and asserts a disposed instance no longer handles it, so a single fire yields exactly one `clearCurrentCCloudResources` call.

### Click-testing instructions

Not applicable - test-only change. To verify locally: `npx gulp test -t "ConfluentCloudAuthProvider"`. Reverting either `dispose()` call reproduces `expected clearCurrentCCloudResources to be called once but was called twice`.

### Optional: Any additional details or context that should be provided?

<!-- Behavior before/after, more technical details/screenshots, follow-on work that should be expected, links to discussions or issues, etc -->

- The regression test stubs `setContextValue` (so `handleSessionRemoved()`'s awaits stay synchronous) and secret storage (to prevent a real `secrets.onDidChange` cascade), then flushes the fire-and-forget async listener with a single `setImmediate` turn.
- Follow-up idea (not pursued here): a `ConfluentCloudAuthProvider.disposeInstance()` static could centralize dispose-before-null, since the repo's other singletons bare-null in tests and this is the only one with process-global constructor side effects.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
