### PR TITLE
test(Docker): cover `getDockerCredentials()` paths

### DIFF
--- a/src/docker/credentials.test.ts
+++ b/src/docker/credentials.test.ts
@@ -1,8 +1,14 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
+import {
+  getStubbedSecretStorage,
+  type StubbedSecretStorage,
+} from "../../tests/stubs/extensionStorage";
 import type { AuthConfig } from "../clients/docker";
+import { SecretStorageKeys } from "../storage/constants";
 import * as fsWrappers from "../utils/fsWrappers";
 import {
+  getDockerCredentials,
   getDockerCredsStore,
   isValidCredsStoreName,
   validateDockerCredentials,
@@ -176,4 +182,126 @@ describe("docker/credentials.ts validateDockerCredentials()", function () {
       });
     });
   }
+});
+
+describe("docker/credentials.ts getDockerCredentials()", function () {
+  let sandbox: sinon.SinonSandbox;
+  let secretStorage: StubbedSecretStorage;
+  let readFileSyncStub: sinon.SinonStub;
+  let execSyncStub: sinon.SinonStub;
+
+  // a `~/.docker/config.json` pointing at a valid credential store
+  const DOCKER_CONFIG_JSON = JSON.stringify({ credsStore: "desktop" });
+  // valid output from the `docker-credential-<store> get` command
+  const VALID_CREDS_OUTPUT = JSON.stringify({ Username: "testuser", Secret: "testpass" });
+  const EXPECTED_AUTH_CONFIG: AuthConfig = {
+    username: "testuser",
+    password: "testpass",
+    serveraddress: "https://index.docker.io/v1/",
+  };
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    secretStorage = getStubbedSecretStorage(sandbox);
+    readFileSyncStub = sandbox.stub(fsWrappers, "readFileSync");
+    execSyncStub = sandbox.stub(fsWrappers, "execSync");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should return cached credentials without invoking the credential store", async function () {
+    secretStorage.get.resolves("cached-creds");
+
+    const result: string | undefined = await getDockerCredentials();
+
+    assert.strictEqual(result, "cached-creds");
+    sinon.assert.notCalled(execSyncStub);
+    sinon.assert.notCalled(secretStorage.store);
+  });
+
+  it("should return undefined when no credsStore is configured", async function () {
+    // no cache, and the Docker config has no credsStore
+    readFileSyncStub.returns(JSON.stringify({}));
+
+    const result: string | undefined = await getDockerCredentials();
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.notCalled(execSyncStub);
+  });
+
+  it("should return undefined when the Docker config cannot be read", async function () {
+    // e.g. a user with no `~/.docker/config.json` at all, the most common real-world state
+    readFileSyncStub.throws(new Error("ENOENT"));
+
+    const result: string | undefined = await getDockerCredentials();
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.notCalled(execSyncStub);
+  });
+
+  it("should query the credential store, then cache and return the encoded credentials", async function () {
+    readFileSyncStub.returns(DOCKER_CONFIG_JSON);
+    execSyncStub.returns(VALID_CREDS_OUTPUT);
+
+    const result: string | undefined = await getDockerCredentials();
+
+    // the returned value should be a base64-encoding of the validated auth config
+    assert.ok(result);
+    const decoded = JSON.parse(Buffer.from(result, "base64").toString("utf-8"));
+    assert.deepStrictEqual(decoded, EXPECTED_AUTH_CONFIG);
+    // the "desktop" store should be queried via its `docker-credential-` command, with the Docker
+    // Hub registry URL piped in on stdin (how the credential helper protocol receives the lookup)
+    sinon.assert.calledOnce(execSyncStub);
+    assert.strictEqual(execSyncStub.firstCall.args[0], "docker-credential-desktop get");
+    assert.strictEqual(execSyncStub.firstCall.args[1].input, "https://index.docker.io/v1/");
+    // and the encoded credentials should be cached for future lookups
+    sinon.assert.calledOnceWithExactly(
+      secretStorage.store,
+      SecretStorageKeys.DOCKER_CREDS_SECRET_KEY,
+      result,
+    );
+  });
+
+  it("should not double-prefix a credsStore that already starts with `docker-credential-`", async function () {
+    readFileSyncStub.returns(JSON.stringify({ credsStore: "docker-credential-desktop" }));
+    execSyncStub.returns(VALID_CREDS_OUTPUT);
+
+    await getDockerCredentials();
+
+    assert.strictEqual(execSyncStub.firstCall.args[0], "docker-credential-desktop get");
+  });
+
+  it("should return undefined when the credential store command fails", async function () {
+    readFileSyncStub.returns(DOCKER_CONFIG_JSON);
+    execSyncStub.throws(new Error("command not found"));
+
+    const result: string | undefined = await getDockerCredentials();
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.notCalled(secretStorage.store);
+  });
+
+  it("should return undefined and not cache when the credential store returns invalid credentials", async function () {
+    readFileSyncStub.returns(DOCKER_CONFIG_JSON);
+    // missing the required `Secret` field, so validation fails
+    execSyncStub.returns(JSON.stringify({ Username: "testuser" }));
+
+    const result: string | undefined = await getDockerCredentials();
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.notCalled(secretStorage.store);
+  });
+
+  it("should return undefined when the credential store emits non-JSON output", async function () {
+    readFileSyncStub.returns(DOCKER_CONFIG_JSON);
+    // some credential helpers print a plain-text error to stdout instead of JSON
+    execSyncStub.returns("credentials not found in native keychain");
+
+    const result: string | undefined = await getDockerCredentials();
+
+    assert.strictEqual(result, undefined);
+    sinon.assert.notCalled(secretStorage.store);
+  });
 });

--- a/src/docker/credentials.ts
+++ b/src/docker/credentials.ts
@@ -1,4 +1,3 @@
-import { execSync } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
 import type { SecretStorage } from "vscode";
@@ -6,7 +5,7 @@ import type { AuthConfig } from "../clients/docker";
 import { Logger } from "../logging";
 import { SecretStorageKeys } from "../storage/constants";
 import { getSecretStorage } from "../storage/utils";
-import { readFileSync } from "../utils/fsWrappers";
+import { execSync, readFileSync } from "../utils/fsWrappers";
 
 const logger = new Logger("docker.credentials");
 
@@ -70,26 +69,25 @@ export async function getDockerCredentials(): Promise<string | undefined> {
     return;
   }
 
-  let credsString: string | undefined;
+  // parsing happens inside the try since a credential helper can emit non-JSON on stdout, and a
+  // JSON.parse() throw should be handled the same as a failed command: log and bail, not propagate
+  let credentialHeaders: AuthConfig | undefined;
   try {
     // unfortunately, there isn't a way to get the credentials directly from the store, so we have
     // to try calling the `docker-credential-<store> get` command and parse the output
     const command: string = credsStore.startsWith("docker-credential-")
       ? credsStore
       : `docker-credential-${credsStore}`;
-    credsString = execSync(`${command} get`, {
+    const credsString: string = execSync(`${command} get`, {
       input: "https://index.docker.io/v1/",
-      encoding: "utf-8",
       timeout: 10000,
     });
+    credentialHeaders = validateDockerCredentials(JSON.parse(credsString));
   } catch (error) {
     logger.debug("failed to load Docker credentials:", error);
     return;
   }
 
-  const credentialHeaders: AuthConfig | undefined = validateDockerCredentials(
-    JSON.parse(credsString),
-  );
   if (!credentialHeaders) {
     logger.debug("invalid Docker credentials, not storing");
     return;

--- a/src/utils/fsWrappers.ts
+++ b/src/utils/fsWrappers.ts
@@ -1,10 +1,12 @@
+import * as childProcess from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as vscode from "vscode";
 
 /**
- * Very thin wrappers around {@link vscode.workspace.fs} and {@link fs} related methods and functions which cannot
- * be stubbed directly in tests due to implementation directly in C, not JS.
+ * Very thin wrappers around {@link vscode.workspace.fs}, {@link fs}, and other native (C-backed)
+ * methods and functions which cannot be stubbed directly in tests due to implementation directly in
+ * C, not JS.
  */
 
 /**
@@ -107,4 +109,15 @@ export function statSync(path: fs.PathLike): fs.Stats {
 /** Wrapper for {@link fs.unlinkSync} */
 export function unlinkSync(path: fs.PathLike): void {
   fs.unlinkSync(path);
+}
+
+/**
+ * Wrapper for {@link childProcess.execSync}. Always decodes as UTF-8 so the result is a string
+ * rather than a {@link Buffer}; `encoding` is therefore not a caller-overridable option.
+ */
+export function execSync(
+  command: string,
+  options?: Omit<childProcess.ExecSyncOptions, "encoding">,
+): string {
+  return childProcess.execSync(command, { ...options, encoding: "utf-8" });
 }


### PR DESCRIPTION
## Summary of Changes

`getDockerCredentials()` (which reads the local Docker credential helper so the extension can authenticate to a private registry) shipped in #1940 without unit tests, because it called `execSync` imported straight from `child_process` and Sinon can only stub module exports. This PR closes that gap.

- Add a thin, stubbable `execSync` wrapper to `src/utils/fsWrappers.ts` (the same module `getDockerCredentials()` already imports `readFileSync` from) and route the credential lookup through it.
- Add a `getDockerCredentials()` test suite covering all eight branches: cache hit, missing/unreadable Docker config, no `credsStore` configured, the happy path (query + validate + cache), the `docker-credential-` prefix dedup, command failure, invalid credentials, and non-JSON output.
- Harden one path found while writing the tests: `JSON.parse()` of the helper's stdout now runs **inside** the command `try`/`catch`, so a helper that prints a plain-text error instead of JSON is handled like any other failure (log and return `undefined`) rather than throwing to the caller.

### Click-testing instructions

Not applicable - this PR only adds tests and hardens one error path (see above), so there's nothing to click-test. Verified via the unit tests noted in the section below.

### Optional: Any additional details or context that should be provided?

- **Wrapper placement.** The wrapper lives in `fsWrappers.ts` per the issue title. That module is already the home for stubbable native (C-backed) wrappers, not strictly filesystem ones - it also wraps `os.tmpdir()` - so its doc comment was broadened to say so. A separate, sidecar-specific `child_process.spawn()` wrapper exists in `src/sidecar/utils.ts`; consolidating the two `child_process` wrappers into one home is a reasonable follow-up but out of scope here.
- **Wrapper contract.** `execSync` always decodes as UTF-8 and returns a `string`, so `encoding` is intentionally not a caller-overridable option (`Omit<ExecSyncOptions, "encoding">`), keeping the `: string` return type honest.
- **Testing.** `npx gulp check`, `npx gulp lint` (0 errors), and `npx gulp test -t "credentials"` all pass - 30 tests, including the 8 new `getDockerCredentials()` cases.

Closes #1941

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
