### PR TITLE
refactor(models): fold `IdItem`/`ISearchable` into `IResourceBase`

### DIFF
--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -104,16 +104,19 @@ describe("commands/index.ts", () => {
       assert.deepStrictEqual(result, {});
     });
 
-    it("should include 'resourceConnectionType' when the first arg implements IResourceBase", () => {
+    it("should include 'resourceConnectionType' and 'resourceId' when the first arg implements IResourceBase", () => {
       const fakeResource: IResourceBase = {
+        id: "abc123",
         connectionId: "abc123" as ConnectionId,
         connectionType: ConnectionType.Direct,
+        searchableText: () => "",
       };
 
       const result = getCommandArgsContext([fakeResource]);
 
       assert.deepStrictEqual(result, {
         resourceConnectionType: fakeResource.connectionType,
+        resourceId: fakeResource.id,
       });
     });
 

--- a/src/loaders/resourceLoader.ts
+++ b/src/loaders/resourceLoader.ts
@@ -31,7 +31,11 @@ const logger = new Logger("resourceLoader");
  *
  * Generic class over the concrete {@link EnvironmentType}
  */
-export abstract class ResourceLoader extends DisposableCollection implements IResourceBase {
+// a loader only carries the connection-identity pair, not the id/searchableText of a full resource
+export abstract class ResourceLoader
+  extends DisposableCollection
+  implements Pick<IResourceBase, "connectionId" | "connectionType">
+{
   /** The connectionId for this resource loader. */
   public abstract connectionId: ConnectionId;
   /** The parent connectionType for this resource loader. */

--- a/src/models/consumerGroup.ts
+++ b/src/models/consumerGroup.ts
@@ -2,9 +2,8 @@ import * as vscode from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_BASE_PATH } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
 /**
  * Consumer group states as returned by the Kafka REST API.
@@ -26,7 +25,7 @@ const INACTIVE_STATES: readonly ConsumerGroupState[] = [
 ];
 
 /** Main class representing a Kafka consumer group. */
-export class ConsumerGroup implements IResourceBase, ISearchable, IdItem {
+export class ConsumerGroup implements IResourceBase {
   connectionId: ConnectionId;
   connectionType: ConnectionType;
   environmentId: EnvironmentId;
@@ -105,7 +104,7 @@ export class ConsumerGroup implements IResourceBase, ISearchable, IdItem {
 }
 
 /** A member (consumer instance) of a {@link ConsumerGroup}. */
-export class Consumer implements IResourceBase, ISearchable, IdItem {
+export class Consumer implements IResourceBase {
   connectionId: ConnectionId;
   connectionType: ConnectionType;
   environmentId: EnvironmentId;

--- a/src/models/containers/resourceContainer.ts
+++ b/src/models/containers/resourceContainer.ts
@@ -15,7 +15,7 @@ export abstract class ResourceContainer<T extends ISearchable>
   extends TreeItem
   implements ISearchable
 {
-  // narrow TreeItem.id from `string | undefined` to satisfy IdItem (required by BaseViewProviderData)
+  // narrow TreeItem.id from `string | undefined` to satisfy IResourceBase.id (required by BaseViewProviderData)
   declare id: string;
 
   // IResourceBase fields required by BaseViewProviderData

--- a/src/models/environment.ts
+++ b/src/models/environment.ts
@@ -32,7 +32,7 @@ import { CCloudSchemaRegistry, DirectSchemaRegistry, LocalSchemaRegistry } from 
  * - {@link SchemaRegistry}
  * ...more, in the future.
  */
-export abstract class Environment implements IResourceBase, ISearchable, IUpdatableResource {
+export abstract class Environment implements IResourceBase, IUpdatableResource {
   abstract connectionId: ConnectionId;
   abstract connectionType: ConnectionType;
   abstract iconName: IconNames;

--- a/src/models/flinkAiAgent.ts
+++ b/src/models/flinkAiAgent.ts
@@ -2,11 +2,10 @@ import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
-export class FlinkAIAgent implements IResourceBase, IdItem, ISearchable {
+export class FlinkAIAgent implements IResourceBase {
   connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   connectionType: ConnectionType = ConnectionType.Ccloud;
 

--- a/src/models/flinkAiConnection.ts
+++ b/src/models/flinkAiConnection.ts
@@ -2,11 +2,10 @@ import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
-export class FlinkAIConnection implements IResourceBase, IdItem, ISearchable {
+export class FlinkAIConnection implements IResourceBase {
   connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   connectionType: ConnectionType = ConnectionType.Ccloud;
 

--- a/src/models/flinkAiModel.ts
+++ b/src/models/flinkAiModel.ts
@@ -2,11 +2,10 @@ import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
-export class FlinkAIModel implements IResourceBase, IdItem, ISearchable {
+export class FlinkAIModel implements IResourceBase {
   connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   connectionType: ConnectionType = ConnectionType.Ccloud;
 

--- a/src/models/flinkAiTool.ts
+++ b/src/models/flinkAiTool.ts
@@ -2,11 +2,10 @@ import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
-export class FlinkAITool implements IResourceBase, IdItem, ISearchable {
+export class FlinkAITool implements IResourceBase {
   connectionId: ConnectionId = CCLOUD_CONNECTION_ID;
   connectionType: ConnectionType = ConnectionType.Ccloud;
 

--- a/src/models/flinkArtifact.ts
+++ b/src/models/flinkArtifact.ts
@@ -3,11 +3,10 @@ import type { ArtifactV1FlinkArtifactMetadata } from "../clients/flinkArtifacts"
 import type { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_BASE_PATH, UTM_SOURCE_VSCODE } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
-export class FlinkArtifact implements IResourceBase, IdItem, ISearchable {
+export class FlinkArtifact implements IResourceBase {
   connectionId!: ConnectionId;
   connectionType!: ConnectionType;
   iconName: IconNames = IconNames.FLINK_ARTIFACT;

--- a/src/models/flinkComputePool.ts
+++ b/src/models/flinkComputePool.ts
@@ -3,16 +3,10 @@ import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_BASE_PATH, CCLOUD_CONNECTION_ID, UTM_SOURCE_VSCODE } from "../constants";
 import { IconNames } from "../icons";
 import { CustomMarkdownString } from "./main";
-import type {
-  ConnectionId,
-  EnvironmentId,
-  IEnvProviderRegion,
-  IResourceBase,
-  ISearchable,
-} from "./resource";
+import type { ConnectionId, EnvironmentId, IEnvProviderRegion, IResourceBase } from "./resource";
 import { isCCloud } from "./resource";
 
-export abstract class FlinkComputePool implements IResourceBase, ISearchable {
+export abstract class FlinkComputePool implements IResourceBase {
   abstract connectionId: ConnectionId;
   abstract connectionType: ConnectionType;
   iconName: IconNames = IconNames.FLINK_COMPUTE_POOL;

--- a/src/models/flinkRelation.ts
+++ b/src/models/flinkRelation.ts
@@ -9,9 +9,8 @@ import { formatFlinkTypeForDisplay, formatSqlType } from "../utils/flinkTypes";
 import { FlinkTypeNode } from "./flinkTypeNode";
 import type { FlinkType } from "./flinkTypes";
 import { FlinkTypeKind, isFlinkTypeExpandable } from "./flinkTypes";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
 /**
  * Represents a column of a Flink relation (table or view).
@@ -269,7 +268,7 @@ export enum FlinkRelationType {
  * Represents a Flink relation (base table or view) within the system catalog.
  * Immutable data holder with light convenience getters, mirroring the style of FlinkUdf and Column.
  */
-export class FlinkRelation implements IResourceBase, IdItem, ISearchable {
+export class FlinkRelation implements IResourceBase {
   /** What CCloud environment this relation came from (from the Kafka Cluster) */
   environmentId: EnvironmentId;
   /** What cloud provider hosts the parent Kafka Cluster? */

--- a/src/models/flinkStatement.ts
+++ b/src/models/flinkStatement.ts
@@ -12,7 +12,6 @@ import { CCLOUD_BASE_PATH, CCLOUD_CONNECTION_ID, UTM_SOURCE_VSCODE } from "../co
 import type { SqlV1StatementWarning } from "../clients/flinkSql";
 import { extractWarnings } from "../flinkSql/warningParser";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
 import { formatDurationMillis, formatIsoDuration } from "../utils/durations";
 import type {
@@ -21,7 +20,6 @@ import type {
   IEnvProviderRegion,
   IProviderRegion,
   IResourceBase,
-  ISearchable,
   OrganizationId,
 } from "./resource";
 
@@ -61,7 +59,7 @@ export const UNSTOPPABLE_PHASES = [
 /**
  * Model for a Flink statement.
  */
-export class FlinkStatement implements IResourceBase, IdItem, ISearchable, IEnvProviderRegion {
+export class FlinkStatement implements IResourceBase, IEnvProviderRegion {
   // Immutable foreign reference properties
   readonly connectionId!: ConnectionId;
   readonly connectionType!: ConnectionType;

--- a/src/models/flinkUDF.ts
+++ b/src/models/flinkUDF.ts
@@ -3,9 +3,8 @@ import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID } from "../constants";
 import { IconNames } from "../icons";
 import { formatSqlType } from "../utils/flinkTypes";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 
 /** Class representing a parameter for a Flink UDF. */
 export class FlinkUdfParameter {
@@ -25,7 +24,7 @@ export class FlinkUdfParameter {
 /**
  * Represents a Flink UDF.
  */
-export class FlinkUdf implements IResourceBase, IdItem, ISearchable {
+export class FlinkUdf implements IResourceBase {
   /** What CCloud environment this UDF came from (from the Kafka Cluster) */
   environmentId: EnvironmentId;
   /** What cloud provider hosts the parent Kafka Cluster? */

--- a/src/models/kafkaCluster.ts
+++ b/src/models/kafkaCluster.ts
@@ -13,18 +13,12 @@ import { localTimezoneOffset } from "../utils/timezone";
 import type { CCloudFlinkComputePool } from "./flinkComputePool";
 import { FlinkSpecProperties } from "./flinkStatement";
 import { CustomMarkdownString } from "./main";
-import type {
-  ConnectionId,
-  EnvironmentId,
-  IEnvProviderRegion,
-  IResourceBase,
-  ISearchable,
-} from "./resource";
+import type { ConnectionId, EnvironmentId, IEnvProviderRegion, IResourceBase } from "./resource";
 import { connectionIdToType, isCCloud } from "./resource";
 import type { KafkaTopic } from "./topic";
 
 /** Base class for all KafkaClusters */
-export abstract class KafkaCluster extends Data implements IResourceBase, ISearchable {
+export abstract class KafkaCluster extends Data implements IResourceBase {
   abstract connectionId: ConnectionId;
   abstract connectionType: ConnectionType;
 

--- a/src/models/main.ts
+++ b/src/models/main.ts
@@ -1,11 +1,6 @@
 import * as vscode from "vscode";
 import { IconNames } from "../icons";
 
-/** Anything with an `id` string property */
-export interface IdItem {
-  readonly id: string;
-}
-
 export type KeyValuePair = [string, string | undefined];
 export type KeyValuePairArray = KeyValuePair[];
 

--- a/src/models/medusa.ts
+++ b/src/models/medusa.ts
@@ -5,9 +5,9 @@ import { ConnectionType } from "../clients/sidecar";
 import { LOCAL_CONNECTION_ID } from "../constants";
 import { IconNames } from "../icons";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, IResourceBase } from "./resource";
 
-export class LocalMedusa extends Data implements IResourceBase, ISearchable {
+export class LocalMedusa extends Data implements IResourceBase {
   connectionId: ConnectionId = LOCAL_CONNECTION_ID;
   connectionType: ConnectionType = ConnectionType.Local;
   iconName: IconNames = IconNames.CONFLUENT_LOGO; //todo update this to Medusa icon

--- a/src/models/resource.test.ts
+++ b/src/models/resource.test.ts
@@ -98,16 +98,20 @@ describe("isResource", () => {
     const value = {
       connectionId: "abc123" as ConnectionId,
       connectionType: ConnectionType.Direct,
+      id: "abc123",
+      searchableText: () => "",
     };
 
     assert.strictEqual(isResource(value), true);
   });
 
-  for (const missingField of ["connectionId", "connectionType"]) {
+  for (const missingField of ["connectionId", "connectionType", "id", "searchableText"]) {
     it(`should return false for values missing "${missingField}"`, () => {
       const value: any = {
         connectionId: "abc123" as ConnectionId,
         connectionType: ConnectionType.Direct,
+        id: "abc123",
+        searchableText: () => "",
       };
       delete value[missingField];
 

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -44,10 +44,21 @@ export interface ICCloudUrlable {
   ccloudUrl: string;
 }
 
-// the connection-identity pair is the discriminator for one of our resources; we don't also probe
-// the id/searchableText IResourceBase requires, since any resource with the connection pair has them.
-export function isResource(value: any): value is IResourceBase {
-  return value.connectionId !== undefined && value.connectionType !== undefined;
+// the connection-identity pair identifies one of our resources; the id/searchableText checks keep a
+// connection-only carrier (e.g. a ResourceLoader, which no longer implements IResourceBase) from matching.
+export function isResource(value: unknown): value is IResourceBase {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    "connectionId" in value &&
+    value.connectionId !== undefined &&
+    "connectionType" in value &&
+    value.connectionType !== undefined &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    "searchableText" in value &&
+    typeof value.searchableText === "function"
+  );
 }
 
 /** Does this resource come from a "local" connection? */

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -1,7 +1,6 @@
 import { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_CONNECTION_ID, LOCAL_CONNECTION_ID } from "../constants";
 import type { IconNames } from "../icons";
-import type { IdItem } from "./main";
 
 /** A uniquely-branded string-type for a connection ID. */
 export type ConnectionId = string & { readonly brand: unique symbol };
@@ -31,7 +30,9 @@ export function connectionIdToType(id: ConnectionId): ConnectionType {
   }
 }
 
-export interface IResourceBase {
+export interface IResourceBase extends ISearchable {
+  /** Unique identifier for this resource. */
+  readonly id: string;
   connectionId: ConnectionId;
   connectionType: ConnectionType;
   /** How this resource should be represented as a {@link TreeItem} or {@link QuickPickItem}. */
@@ -43,6 +44,8 @@ export interface ICCloudUrlable {
   ccloudUrl: string;
 }
 
+// the connection-identity pair is the discriminator for one of our resources; we don't also probe
+// the id/searchableText IResourceBase requires, since any resource with the connection pair has them.
 export function isResource(value: any): value is IResourceBase {
   return value.connectionId !== undefined && value.connectionType !== undefined;
 }
@@ -137,7 +140,7 @@ export interface ISchemaRegistryResource extends IResourceBase {
 }
 
 /** Resources with IDs which are in-place updateable given a reference to same class */
-export interface IUpdatableResource extends IResourceBase, IdItem {
+export interface IUpdatableResource extends IResourceBase {
   /** Update this resource in-place. */
   update(resource: this): void;
 }

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -9,7 +9,6 @@ import type {
   EnvironmentId,
   IResourceBase,
   ISchemaRegistryResource,
-  ISearchable,
 } from "./resource";
 import { connectionIdToType, isCCloud } from "./resource";
 
@@ -41,7 +40,7 @@ export function getLanguageTypes(schemaType: SchemaType): string[] {
  *
  * Depending on the constructor path, may also carry an array of Schema instances.
  */
-export class Subject implements IResourceBase, ISearchable, ISchemaRegistryResource {
+export class Subject implements IResourceBase, ISchemaRegistryResource {
   name!: string;
 
   connectionId!: ConnectionId;

--- a/src/models/schemaRegistry.ts
+++ b/src/models/schemaRegistry.ts
@@ -14,13 +14,12 @@ import type {
   EnvironmentId,
   IResourceBase,
   ISchemaRegistryResource,
-  ISearchable,
 } from "./resource";
 import { connectionIdToType, isCCloud } from "./resource";
 
 export abstract class SchemaRegistry
   extends Data
-  implements IResourceBase, ISearchable, ISchemaRegistryResource
+  implements IResourceBase, ISchemaRegistryResource
 {
   abstract connectionId: ConnectionId;
   abstract connectionType: ConnectionType;

--- a/src/models/topic.ts
+++ b/src/models/topic.ts
@@ -4,14 +4,13 @@ import type { KafkaTopicOperation } from "../authz/types";
 import type { ConnectionType } from "../clients/sidecar";
 import { CCLOUD_BASE_PATH, UTM_SOURCE_VSCODE } from "../constants";
 import { IconNames } from "../icons";
-import type { IdItem } from "./main";
 import { CustomMarkdownString } from "./main";
-import type { ConnectionId, EnvironmentId, IResourceBase, ISearchable } from "./resource";
+import type { ConnectionId, EnvironmentId, IResourceBase } from "./resource";
 import { isCCloud } from "./resource";
 import type { Subject } from "./schema";
 
 /** Main class representing Kafka topic */
-export class KafkaTopic implements IResourceBase, ISearchable, IdItem {
+export class KafkaTopic implements IResourceBase {
   connectionId: ConnectionId;
   connectionType: ConnectionType;
 

--- a/src/viewProviders/baseModels/base.ts
+++ b/src/viewProviders/baseModels/base.ts
@@ -12,8 +12,7 @@ import type { ContextValues } from "../../context/values";
 import { setContextValue } from "../../context/values";
 import { ExtensionContextNotSetError } from "../../errors";
 import { Logger } from "../../logging";
-import type { IdItem } from "../../models/main";
-import type { IResourceBase, ISearchable } from "../../models/resource";
+import type { IResourceBase } from "../../models/resource";
 import { logUsage, UserEvent } from "../../telemetry/events";
 import { titleCase } from "../../utils";
 import { DisposableCollection } from "../../utils/disposables";
@@ -27,7 +26,7 @@ export interface RefreshableTreeViewProvider {
 }
 
 /** Requirement interfaces for BaseViewProvider data elements */
-export type BaseViewProviderData = IResourceBase & IdItem & ISearchable;
+export type BaseViewProviderData = IResourceBase;
 
 /**
  * Base class for all tree view providers handling a primary resource type.

--- a/src/viewProviders/resources.ts
+++ b/src/viewProviders/resources.ts
@@ -42,15 +42,9 @@ import type {
   LocalKafkaCluster,
 } from "../models/kafkaCluster";
 import { KafkaCluster, KafkaClusterTreeItem } from "../models/kafkaCluster";
-import type { IdItem } from "../models/main";
 import { LocalMedusa, MedusaTreeItem } from "../models/medusa";
 import type { CCloudOrganization } from "../models/organization";
-import type {
-  ConnectionId,
-  IResourceBase,
-  ISearchable,
-  IUpdatableResource,
-} from "../models/resource";
+import type { ConnectionId, IResourceBase, IUpdatableResource } from "../models/resource";
 import { connectionIdToType } from "../models/resource";
 import type {
   CCloudSchemaRegistry,
@@ -78,7 +72,7 @@ type ConnectionRowChildren =
   | CCloudFlinkComputePool;
 
 export abstract class ConnectionRow<ET extends ConcreteEnvironment, LT extends ResourceLoader>
-  implements IResourceBase, IdItem, ISearchable
+  implements IResourceBase
 {
   logger: Logger;
   readonly environments: ET[];


### PR DESCRIPTION
## Summary of Changes

Consolidates two small model interfaces into `IResourceBase`, so our resource models implement one interface instead of three.

Every "main resource" model (Kafka topics, schemas, Flink statements, compute pools, and so on) already carried the same trio: `implements IResourceBase, IdItem, ISearchable`. `IdItem` was just `{ readonly id: string }`, and `ISearchable` adds a `searchableText()` method plus optional `children`. This folds both into `IResourceBase`:

- `IResourceBase` now declares `readonly id: string` directly (the former `IdItem`, now deleted) and `extends ISearchable`.
- The ~15 resource classes drop the redundant `, IdItem, ISearchable` and simply `implements IResourceBase`.
- `BaseViewProviderData` collapses from `IResourceBase & IdItem & ISearchable` to just `IResourceBase`.

This is a type-only change with no runtime behavior difference. Closes #3041.

### Optional: Any additional details or context that should be provided?

Two deliberate asymmetries worth a reviewer's eye:

- **`ISearchable` is kept, `IdItem` is deleted.** `ISearchable` has non-resource consumers, `ResourceContainer` and `KafkaClusterResourceContainer` plus the search utilities in `src/viewProviders/utils/`, that implement or consume it without being resources, so it stays a standalone interface that `IResourceBase` extends. `IdItem` had no such standalone consumers, so it is removed entirely.
- **`ResourceLoader` narrows to a subset.** It was `implements IResourceBase` purely to declare its `connectionId`/`connectionType`, but a loader is not a searchable, id-bearing resource. It now `implements Pick<IResourceBase, "connectionId" | "connectionType">` rather than gaining a meaningless `id`/`searchableText()`.

Verified that every current `IResourceBase` implementer already supplies `id` and `searchableText()`, so making them required breaks nothing (`npx gulp check` passes clean).

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [ ] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
