### PR TITLE
refactor(flinkSql): extract `FlinkStatementResultsManager.start()`

### DIFF
--- a/src/commands/utils/statements.test.ts
+++ b/src/commands/utils/statements.test.ts
@@ -79,6 +79,8 @@ describe("src/commands/utils/statements.ts", () => {
       // openFlinkStatementResultsInEditor is called, so the panel cache is accessed
       sinon.assert.calledOnce(getPanelForStatementStub);
       sinon.assert.calledOnceWithExactly(getPanelForStatementStub, TEST_CCLOUD_FLINK_STATEMENT);
+      // the newly-created results manager must be started, since construction no longer polls
+      sinon.assert.calledOnce(stubbedFlinkStatementResultsManager.start);
       // openFlinkStatementResultsInPanel isn't called, so the panel provider isn't accessed
       sinon.assert.notCalled(stubbedPanelProvider.showStatementResults);
     });

--- a/src/commands/utils/statements.ts
+++ b/src/commands/utils/statements.ts
@@ -75,6 +75,7 @@ async function openFlinkStatementResultsInEditor(statement: FlinkStatement) {
     notifyUI,
     DEFAULT_RESULT_LIMIT,
   );
+  resultsManager.start();
 
   // Handle messages from the webview and delegate to the results manager
   const handler = handleWebviewMessage(panel.webview, (...args) => {

--- a/src/flinkSql/flinkStatementResultsManager.test.ts
+++ b/src/flinkSql/flinkStatementResultsManager.test.ts
@@ -298,6 +298,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
   });
 
   it("should report snapshot mode in GetStatementMeta for a snapshot-mode statement", async () => {
+    ctx.manager.start();
     const snapshotStatement = new FlinkStatement({
       ...ctx.statement,
       spec: {
@@ -321,6 +322,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
   });
 
   it("should report end time and durations in GetStatementMeta once the statement is terminal", async () => {
+    ctx.manager.start();
     const createdAt: Date = ctx.statement.createdAt!;
     const endTime = new Date(createdAt.getTime() + 90_000);
     const completedStatement = new FlinkStatement({
@@ -345,6 +347,7 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
   });
 
   it("should stop polling when statement is not results viewable", async () => {
+    ctx.manager.start();
     assert.ok(ctx.manager["_pollingInterval"] as NodeJS.Timeout);
 
     const nonViewableStatement = new FlinkStatement({
@@ -373,17 +376,52 @@ describe("FlinkStatementResultsViewModel and FlinkStatementResultsManager", () =
     assert.equal(ctx.flinkSqlStatementsApi.updateSqlv1Statement.callCount, 1);
   });
 
+  describe("start()", () => {
+    it("should not begin polling until start() is called", () => {
+      assert.strictEqual(ctx.manager["_pollingInterval"], undefined);
+      assert.strictEqual(ctx.manager["_statementRefreshInterval"], undefined);
+    });
+
+    it("should begin polling once start() is called", () => {
+      ctx.manager.start();
+
+      assert.ok(ctx.manager["_pollingInterval"]);
+      assert.ok(ctx.manager["_statementRefreshInterval"]);
+    });
+
+    it("should be a no-op when start() is called more than once", () => {
+      ctx.manager.start();
+      const pollingInterval = ctx.manager["_pollingInterval"];
+      const refreshInterval = ctx.manager["_statementRefreshInterval"];
+
+      ctx.manager.start();
+
+      assert.strictEqual(ctx.manager["_pollingInterval"], pollingInterval);
+      assert.strictEqual(ctx.manager["_statementRefreshInterval"], refreshInterval);
+    });
+
+    it("should not restart polling after fetchResults() has self-destructed the interval", () => {
+      ctx.manager.start();
+      // Simulate fetchResults() self-destructing the poll interval once results are exhausted.
+      clearInterval(ctx.manager["_pollingInterval"]);
+      ctx.manager["_pollingInterval"] = undefined;
+
+      ctx.manager.start();
+
+      assert.strictEqual(ctx.manager["_pollingInterval"], undefined);
+    });
+  });
+
   describe("with fetchResults not running in a setInterval", () => {
     let clock: sinon.SinonFakeTimers;
 
     beforeEach(() => {
-      clearInterval(ctx.manager["_pollingInterval"]);
-      ctx.manager["_pollingInterval"] = undefined;
+      // The manager is left un-started by the shared factory, so no polling interval is running to
+      // clear here; these tests drive fetchResults() directly.
       ctx.flinkSqlStatementResultsApi.getSqlv1StatementResult.resetHistory();
 
-      // Eventually, the idea would be to move this fake timer up to
-      // the top-level describe's beforeEach.
-      // See https://github.com/confluentinc/vscode/issues/1807
+      // Fake timers stay scoped to this block rather than the top-level describe because those tests
+      // rely on eventually(), which polls its assertion on real timers.
       clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
     });
 

--- a/src/flinkSql/flinkStatementResultsManager.ts
+++ b/src/flinkSql/flinkStatementResultsManager.ts
@@ -206,6 +206,7 @@ export class FlinkStatementResultsManager {
   private readonly _flinkStatementsSqlApi: StatementsSqlV1Api;
 
   private _fetchResultsLocked = false;
+  private _started = false;
 
   constructor(
     private os: Scope,
@@ -235,10 +236,29 @@ export class FlinkStatementResultsManager {
 
     this._viewMode = this.os.signal<ViewMode>("table");
 
-    this.setupPolling();
+    // Watch for results full state. This reactive subscription is independent of the polling
+    // timers, so it is wired up at construction rather than in start().
+    this.os.watch(() => {
+      if (this._isResultsFull()) {
+        this._state("completed");
+      }
+    });
   }
 
-  private setupPolling() {
+  /**
+   * Begins polling for results and periodically refreshing the statement.
+   *
+   * Construction no longer starts the timers, so callers must invoke this once the manager is
+   * ready to poll. Calling this more than once is a no-op: the existing intervals are left in place.
+   */
+  start(): void {
+    // Guard on a dedicated flag rather than the interval handle: fetchResults() clears
+    // _pollingInterval when it self-destructs, so the handle is not a reliable "started" signal.
+    if (this._started) {
+      return;
+    }
+    this._started = true;
+
     this._pollingInterval = setInterval(
       this.fetchResults.bind(this),
       this.resultsPollingIntervalMs,
@@ -248,13 +268,6 @@ export class FlinkStatementResultsManager {
       this.refreshStatement.bind(this),
       this.statementRefreshIntervalMs,
     );
-
-    // Watch for results full state
-    this.os.watch(() => {
-      if (this._isResultsFull()) {
-        this._state("completed");
-      }
-    });
   }
 
   private async refreshStatement() {

--- a/src/panelProviders/flinkStatementResults.ts
+++ b/src/panelProviders/flinkStatementResults.ts
@@ -145,6 +145,7 @@ export class FlinkStatementResultsPanelProvider
       notifyUI,
       DEFAULT_RESULT_LIMIT,
     );
+    this.resultsManager.start();
     // Handle messages from the webview and delegate to the results manager
     const handler = handleWebviewMessage(this.view.webview, (...args) => {
       let result;

--- a/tests/createResultsManager.ts
+++ b/tests/createResultsManager.ts
@@ -10,7 +10,6 @@ import type * as sidecar from "../src/sidecar";
 import type { WebviewStorage } from "../src/webview/comms/comms";
 import type { ResultsViewerStorageState } from "../src/webview/flink-statement-results";
 import { FlinkStatementResultsViewModel } from "../src/webview/flink-statement-results";
-import { eventually } from "./eventually";
 import { loadFixtureFromFile } from "./fixtures/utils";
 import { getSidecarStub } from "./stubs/sidecar";
 
@@ -45,13 +44,12 @@ export interface FlinkStatementResultsManagerTestContext {
  * to process them.
  *
  * The manager is set up with:
- * - A polling interval of 0 for immediate testing
- * - A refresh interval of 100ms
  * - Mock APIs that return the fixture data
  * - Stubs for refreshing statement status
  *
- * After initialization, the manager will have processed 10 total result rows that can be retrieved
- * via GetResults/GetResultsCount messages.
+ * The manager is deliberately left un-started (its polling/refresh timers never run); the fixture
+ * pages are applied by calling {@linkcode FlinkStatementResultsManager.fetchResults} directly, once
+ * per page, leaving 10 total result rows retrievable via GetResults/GetResultsCount messages.
  *
  * @returns Initialized FlinkStatementResultsViewModel and FlinkStatementResultsManager with processed results
  */
@@ -115,22 +113,27 @@ export async function createTestResultsManagerContext(
     resourceLoader,
   );
 
-  // Wait for results to be processed, it should eventually become 10
-  await eventually(() => {
-    assert.equal(manager.handleMessage("GetResultsCount", {}).total, 10);
+  // Drive result processing deterministically by fetching every fixture page rather than relying on
+  // the polling interval (the manager is left un-started so its setInterval never runs here). Each
+  // fetchResults() consumes one page; the last pages carry changelog updates that shape the final
+  // 10-row state, so all pages must be applied, not just enough to first reach 10 rows.
+  for (let i = 0; i < stmtResults.length; i++) {
+    await manager.fetchResults();
+  }
 
-    const results = manager.handleMessage("GetResults", {
-      page: 0,
-      pageSize: DEFAULT_RESULTS_LIMIT,
-    });
+  assert.equal(manager.handleMessage("GetResultsCount", {}).total, 10);
 
-    // Verify the results match expected format
-    const expected: string = loadFixtureFromFile(
-      "flink-statement-results-processing/expected-parsed-results.json",
-    );
-    const expectedParsedResults = JSON.parse(expected);
-    assert.deepStrictEqual(results, { results: expectedParsedResults });
-  }, 10_000);
+  const results = manager.handleMessage("GetResults", {
+    page: 0,
+    pageSize: DEFAULT_RESULTS_LIMIT,
+  });
+
+  // Verify the results match expected format
+  const expected: string = loadFixtureFromFile(
+    "flink-statement-results-processing/expected-parsed-results.json",
+  );
+  const expectedParsedResults = JSON.parse(expected);
+  assert.deepStrictEqual(results, { results: expectedParsedResults });
 
   const storage = new FakeWebviewStorage<ResultsViewerStorageState>();
   const timestamp = os.produce(Date.now(), (ts) => {


### PR DESCRIPTION
## Summary of Changes

`FlinkStatementResultsManager` started its two `setInterval` timers (results polling and statement refresh) inside its constructor, so simply constructing one kicked off background polling. That forced its unit tests to either tolerate real timers (via `eventually()`) or clear the interval in a `beforeEach` before driving `fetchResults()` themselves.

This extracts a public `start()` method that owns the timers. Construction no longer polls, so tests can call `fetchResults()` intentionally. Behavior in production is unchanged: the two call sites that build a manager now call `start()` immediately after construction.

- The reactive `os.watch` results-full subscription stays in the constructor since it isn't a timer; only the two `setInterval` timers moved into `start()`.
- Added `resultsManager.start()` at both construction sites (`openFlinkStatementResultsInEditor` and the panel provider).
- Reworked the shared test factory to drive `fetchResults()` once per fixture page instead of racing the poll interval, and removed the `beforeEach` that used to clear the factory-started interval.

### Optional: Any additional details or context that should be provided?

- A `_started` flag guards `start()` against a repeat call, since the interval handle alone isn't a reliable "started" signal once `fetchResults()` self-destructs the poll interval.
- The test factory applies **all** fixture pages, not just enough to first reach 10 rows: the later pages carry changelog updates that shape the final row state, so stopping early lands on the wrong state.
- Fake timers stay scoped to the `"with fetchResults not running in a setInterval"` block rather than being hoisted to the top-level `describe` (the ask in #1807), because the other tests use `eventually()`, which polls its assertion on real timers.
- Added a caller-side test asserting `start()` is invoked after construction, so a future edit that drops the call fails a test rather than silently shipping a results view that never polls.

Closes #1807

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
