### PR TITLE
improve(Docker): route API errors through `logError()`

### DIFF
--- a/src/commands/docker.test.ts
+++ b/src/commands/docker.test.ts
@@ -3,12 +3,14 @@ import * as sinon from "sinon";
 import type { Uri } from "vscode";
 import { window } from "vscode";
 import { StubbedWorkspaceConfiguration } from "../../tests/stubs/workspaceConfiguration";
+import { ResponseError } from "../clients/docker";
 import * as dockerConfigs from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { LocalResourceWorkflow } from "../docker/workflows/base";
 import { ConfluentLocalWorkflow } from "../docker/workflows/confluent-local";
 import { ConfluentPlatformSchemaRegistryWorkflow } from "../docker/workflows/cp-schema-registry";
 import { MedusaWorkflow } from "../docker/workflows/medusa";
+import * as errors from "../errors";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../extensionSettings/constants";
 import * as notifications from "../notifications";
 import * as quickpicks from "../quickpicks/localResources";
@@ -18,6 +20,7 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
   let sandbox: sinon.SinonSandbox;
 
   let showErrorNotificationStub: sinon.SinonStub;
+  let logErrorStub: sinon.SinonStub;
 
   // Docker+workflow stubs
   let isDockerAvailableStub: sinon.SinonStub;
@@ -37,6 +40,8 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
     showErrorNotificationStub = sandbox
       .stub(notifications, "showErrorNotificationWithButtons")
       .resolves();
+
+    logErrorStub = sandbox.stub(errors, "logError");
 
     // default to Docker being available for majority of tests
     isDockerAvailableStub = sandbox.stub(dockerConfigs, "isDockerAvailable").resolves(true);
@@ -117,6 +122,30 @@ describe("commands/docker.ts runWorkflowWithProgress()", () => {
 
     sinon.assert.calledOnce(stubKafkaWorkflow.start);
     sinon.assert.notCalled(stubKafkaWorkflow.stop);
+    sinon.assert.calledOnce(showErrorNotificationStub);
+  });
+
+  it("should route a failed workflow through logError() so a ResponseError's body reaches Sentry", async () => {
+    const fakeError = new ResponseError(
+      new Response("no such image", { status: 404, statusText: "Not Found" }),
+    );
+    stubKafkaWorkflow.start.rejects(fakeError);
+
+    await runWorkflowWithProgress();
+
+    // logError extracts the ResponseError status/body into the Sentry event; the tags carry the
+    // workflow context for that event
+    sinon.assert.calledOnceWithMatch(
+      logErrorStub,
+      fakeError,
+      sinon.match(/running .* workflow/),
+      sinon.match({
+        tags: sinon.match
+          .has("dockerImage")
+          .and(sinon.match.has("localResourceKind"))
+          .and(sinon.match({ extensionUserFlow: "Local Resource Management" })),
+      }),
+    );
     sinon.assert.calledOnce(showErrorNotificationStub);
   });
 

--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -5,13 +5,13 @@ import { ResponseError } from "../clients/docker";
 import { isDockerAvailable } from "../docker/configs";
 import { LocalResourceKind } from "../docker/constants";
 import { LocalResourceWorkflow } from "../docker/workflows/base";
+import { logError } from "../errors";
 import { LOCAL_DOCKER_SOCKET_PATH } from "../extensionSettings/constants";
 import { Logger } from "../logging";
 import { ConnectionLabel } from "../models/resource";
 import { showErrorNotificationWithButtons } from "../notifications";
 import { localResourcesQuickPick } from "../quickpicks/localResources";
 import { UserEvent } from "../telemetry/events";
-import { sentryCaptureException } from "../telemetry/sentryClient";
 
 const logger = new Logger("commands.docker");
 
@@ -132,19 +132,18 @@ export async function runWorkflowWithProgress(
             start,
           });
         } catch (error) {
-          logger.error(`error running ${workflow.resourceKind} workflow`, error);
           if (error instanceof Error) {
             workflow.sendTelemetryEvent(UserEvent.LocalDockerAction, {
               status: "workflow failed",
               start,
             });
-            sentryCaptureException(error, {
-              captureContext: {
-                tags: {
-                  dockerImage: workflow.imageRepoTag,
-                  extensionUserFlow: "Local Resource Management",
-                  localResourceKind: workflow.resourceKind,
-                },
+            // logError extracts a Docker engine API ResponseError's status/body into the Sentry
+            // event; the tags supply the workflow context
+            logError(error, `running ${workflow.resourceKind} workflow`, {
+              tags: {
+                dockerImage: workflow.imageRepoTag,
+                extensionUserFlow: "Local Resource Management",
+                localResourceKind: workflow.resourceKind,
               },
             });
             let errorMsg: string = "";
@@ -161,6 +160,10 @@ export async function runWorkflowWithProgress(
             void showErrorNotificationWithButtons(
               `Error ${start ? "starting" : "stopping"} ${workflow.resourceKind}: ${errorMsg}`,
             );
+          } else {
+            // logError() discards its message for non-Error throwables, so log directly to keep
+            // the workflow context
+            logger.error(`running ${workflow.resourceKind} workflow`, error);
           }
         }
       }

--- a/src/docker/containers.test.ts
+++ b/src/docker/containers.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as dockerClients from "../clients/docker";
+import * as errors from "../errors";
 import { MANAGED_CONTAINER_LABEL } from "./constants";
 import {
   createContainer,
@@ -28,8 +29,12 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
   let containerStopStub: sinon.SinonStub;
   let containerInspectStub: sinon.SinonStub;
 
+  let logErrorStub: sinon.SinonStub;
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
+    logErrorStub = sandbox.stub(errors, "logError");
 
     imageExistsStub = sandbox.stub(dockerImages, "imageExists");
     pullImageStub = sandbox.stub(dockerImages, "pullImage");
@@ -59,12 +64,13 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     sinon.assert.calledOnce(containerListStub);
   });
 
-  it("getContainersForImage() should re-throw any error from .containerList", async () => {
+  it("getContainersForImage() should log via logError() and re-throw any error from .containerList", async () => {
     const fakeError = new Error("Error listing containers");
     containerListStub.rejects(fakeError);
 
     await assert.rejects(getContainersForImage({}), fakeError);
     sinon.assert.calledOnce(containerListStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "listing containers");
   });
 
   it("createContainer() should return a ContainerCreateResponse after successfully creating a container", async () => {
@@ -110,13 +116,14 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     });
   });
 
-  it("createContainer() should re-throw any error from .containerCreate", async () => {
+  it("createContainer() should log via logError() and re-throw any error from .containerCreate", async () => {
     imageExistsStub.resolves(true);
     const fakeError = new Error("Error creating container");
     containerCreateStub.rejects(fakeError);
 
     await assert.rejects(createContainer("repo", "tag", { body: {} }), fakeError);
     sinon.assert.calledOnce(containerCreateStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "creating container");
   });
 
   it("startContainer() should return nothing after successfully starting a container", async () => {
@@ -128,12 +135,13 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     sinon.assert.calledOnce(containerStartStub);
   });
 
-  it("startContainer() should re-throw any error from .containerStart", async () => {
+  it("startContainer() should log via logError() and re-throw any error from .containerStart", async () => {
     const fakeError = new Error("Error starting container");
     containerStartStub.rejects(fakeError);
 
     await assert.rejects(startContainer("1"), fakeError);
     sinon.assert.calledOnce(containerStartStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "starting container");
   });
 
   it("getContainer() should return a ContainerInspectResponse from a successful request", async () => {
@@ -155,20 +163,22 @@ describe("docker/containers.ts ContainerApi wrappers", () => {
     sinon.assert.calledOnce(containerStopStub);
   });
 
-  it("stopContainer() should re-throw any error from .containerStop", async () => {
+  it("stopContainer() should log via logError() and re-throw any error from .containerStop", async () => {
     const fakeError = new Error("Error stopping container");
     containerStopStub.rejects(fakeError);
 
     await assert.rejects(stopContainer("1"), fakeError);
     sinon.assert.calledOnce(containerStopStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "stopping container");
   });
 
-  it("getContainer() should re-throw any error from .containerInspect", async () => {
+  it("getContainer() should log via logError() and re-throw any error from .containerInspect", async () => {
     const fakeError = new Error("Error inspecting container");
     containerInspectStub.rejects(fakeError);
 
     await assert.rejects(getContainer("1"), fakeError);
     sinon.assert.calledOnce(containerInspectStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "inspecting container");
   });
 });
 

--- a/src/docker/containers.ts
+++ b/src/docker/containers.ts
@@ -5,7 +5,8 @@ import type {
   ContainerListRequest,
   ContainerSummary,
 } from "../clients/docker";
-import { ContainerApi, ResponseError } from "../clients/docker";
+import { ContainerApi } from "../clients/docker";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import { defaultRequestInit } from "./configs";
 import { MANAGED_CONTAINER_LABEL } from "./constants";
@@ -28,15 +29,7 @@ export async function getContainersForImage(
     logger.debug("Containers listed successfully:", JSON.stringify(containerIdsAndNames));
     return response;
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response listing containers:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().json(),
-      });
-    } else {
-      logger.error("Error listing containers:", error);
-    }
+    logError(error, "listing containers");
     throw error;
   }
 }
@@ -62,15 +55,7 @@ export async function createContainer(
     logger.info("Container created successfully:", response);
     return response;
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Container creation returned error response:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().json(),
-      });
-    } else {
-      logger.error("Error creating container:", error);
-    }
+    logError(error, "creating container");
     throw error;
   }
 }
@@ -82,15 +67,7 @@ export async function startContainer(containerId: string): Promise<void> {
   try {
     await client.containerStart({ id: containerId }, init);
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response starting container:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().text(),
-      });
-    } else {
-      logger.error("Error starting container:", error);
-    }
+    logError(error, "starting container");
     throw error;
   }
 }
@@ -103,15 +80,7 @@ export async function stopContainer(id: string): Promise<void> {
     logger.debug("Stopping container", { id });
     await client.containerStop({ id }, init);
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response stopping container:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().json(),
-      });
-    } else {
-      logger.error("Error stopping container:", error);
-    }
+    logError(error, "stopping container");
     throw error;
   }
 }
@@ -128,15 +97,7 @@ export async function getContainer(id: string): Promise<ContainerInspectResponse
   try {
     return await client.containerInspect({ id }, init);
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response inspecting container:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().text(),
-      });
-    } else {
-      logger.error("Error inspecting container:", error);
-    }
+    logError(error, "inspecting container");
     throw error;
   }
 }

--- a/src/docker/images.test.ts
+++ b/src/docker/images.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as sinon from "sinon";
 import type { ApiResponse, ImageSummary } from "../clients/docker";
 import { ImageApi } from "../clients/docker";
+import * as errors from "../errors";
 import { imageExists, pullImage } from "./images";
 
 const fakeImageRepo = "repo";
@@ -25,9 +26,12 @@ describe("docker/images.ts ImageApi wrappers", () => {
 
   let imageListStub: sinon.SinonStub;
   let imageCreateRawStub: sinon.SinonStub;
+  let logErrorStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
+    logErrorStub = sandbox.stub(errors, "logError");
 
     // need to stub the ImageApi class methods directly instead of using a stubbed instance,
     // because the functions below are constructing new instances of the ImageApi class each time
@@ -63,7 +67,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
     sinon.assert.calledOnce(imageListStub);
   });
 
-  it("imageExists() should return false if there is a non-ResponseError error", async () => {
+  it("imageExists() should log via logError() and return false on error", async () => {
     const fakeError = new Error("Some other error");
     imageListStub.rejects(fakeError);
 
@@ -71,6 +75,7 @@ describe("docker/images.ts ImageApi wrappers", () => {
 
     assert.strictEqual(result, false);
     sinon.assert.calledOnce(imageListStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "listing images");
   });
 
   it("pullImage() should return nothing after successfully pulling an image", async () => {
@@ -89,11 +94,12 @@ describe("docker/images.ts ImageApi wrappers", () => {
     sinon.assert.calledOnceWithMatch(imageCreateRawStub, { fromImage: fakeImageRepoTag });
   });
 
-  it("pullImage() should re-throw any error from .imageCreate", async () => {
+  it("pullImage() should log via logError() and re-throw any error from .imageCreate", async () => {
     const fakeError = new Error("Error pulling image");
     imageCreateRawStub.rejects(fakeError);
 
     await assert.rejects(pullImage(fakeImageRepo, fakeImageTag), fakeError);
     sinon.assert.calledOnce(imageCreateRawStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "pulling image");
   });
 });

--- a/src/docker/images.ts
+++ b/src/docker/images.ts
@@ -1,5 +1,6 @@
 import type { ImageSummary } from "../clients/docker";
-import { ImageApi, ResponseError } from "../clients/docker";
+import { ImageApi } from "../clients/docker";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import { UserEvent, logUsage } from "../telemetry/events";
 import { defaultRequestInit } from "./configs";
@@ -19,15 +20,7 @@ export async function imageExists(repo: string, tag: string): Promise<boolean> {
     logger.debug(`"${repoTag}" image exists:`, !!matchingImage);
     return !!matchingImage;
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response listing images:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().text(),
-      });
-    } else {
-      logger.error("Error inspecting image:", error);
-    }
+    logError(error, "listing images");
   }
   return false;
 }
@@ -53,15 +46,7 @@ export async function pullImage(repo: string, tag: string): Promise<void> {
       dockerImage: repoTag,
     });
   } catch (error) {
-    if (error instanceof ResponseError) {
-      logger.error("Error response pulling image:", {
-        status: error.response.status,
-        statusText: error.response.statusText,
-        body: await error.response.clone().text(),
-      });
-    } else {
-      logger.error("Error pulling image:", error);
-    }
+    logError(error, "pulling image");
     throw error;
   }
 }

--- a/src/docker/networks.test.ts
+++ b/src/docker/networks.test.ts
@@ -1,15 +1,19 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import { NetworkApi, ResponseError } from "../clients/docker";
+import * as errors from "../errors";
 import { createNetwork } from "./networks";
 
 describe("docker/networks.ts NetworkApi wrappers", () => {
   let sandbox: sinon.SinonSandbox;
 
   let networkCreateStub: sinon.SinonStub;
+  let logErrorStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
+    logErrorStub = sandbox.stub(errors, "logError");
 
     // need to stub the NetworkApi class methods directly instead of using a stubbed instance,
     // because the functions below are constructing new instances of the NetworkApi class each time
@@ -46,9 +50,10 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
 
     assert.strictEqual(result, undefined);
     sinon.assert.calledOnce(networkCreateStub);
+    sinon.assert.notCalled(logErrorStub);
   });
 
-  it("createNetwork() should re-throw any ResponseError that doesn't contain 'already exists' in the message", async () => {
+  it("createNetwork() should log via logError() and re-throw any ResponseError that doesn't contain 'already exists' in the message", async () => {
     const fakeError = new ResponseError(
       new Response("uh oh", {
         status: 500,
@@ -59,13 +64,15 @@ describe("docker/networks.ts NetworkApi wrappers", () => {
 
     await assert.rejects(createNetwork("test-network", "bridge"), fakeError);
     sinon.assert.calledOnce(networkCreateStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "creating network");
   });
 
-  it("createNetwork() should re-throw any non-ResponseError error", async () => {
+  it("createNetwork() should log via logError() and re-throw any non-ResponseError error", async () => {
     const fakeError = new Error("Some other error");
     networkCreateStub.rejects(fakeError);
 
     await assert.rejects(createNetwork("test-network", "bridge"), fakeError);
     sinon.assert.calledOnce(networkCreateStub);
+    sinon.assert.calledOnceWithExactly(logErrorStub, fakeError, "creating network");
   });
 });

--- a/src/docker/networks.ts
+++ b/src/docker/networks.ts
@@ -1,4 +1,5 @@
 import { NetworkApi, ResponseError } from "../clients/docker";
+import { logError } from "../errors";
 import { Logger } from "../logging";
 import { defaultRequestInit } from "./configs";
 
@@ -17,16 +18,9 @@ export async function createNetwork(name: string, driver: string = "bridge"): Pr
         // this is fine, no need to re-throw the error
         logger.debug(`Network "${name}" with ${driver} driver already exists`);
         return;
-      } else {
-        logger.error("Error response creating network:", {
-          status: error.response.status,
-          statusText: error.response.statusText,
-          body: body,
-        });
       }
-    } else {
-      logger.error("Error creating network:", error);
     }
+    logError(error, "creating network");
     throw error;
   }
 }


### PR DESCRIPTION
## Summary of Changes

When a local Docker engine API call fails (pulling the `confluent-local` image, creating the network, starting a container), the error we send to Sentry today just says `"Response returned an error code"` - no HTTP status, no response body, no way to tell why it failed. This routes Docker engine API errors through the shared `logError()` helper (`src/errors.ts`), which extracts the status, statusText, response body (up to 5000 chars), and any cause chain from a `ResponseError`, matching the pattern `isDockerAvailable()` already uses via [`logError(error, "docker ping")`](https://github.com/confluentinc/vscode/blob/515a995ad57500d7f22df0cad7bdbf0164d8c6a1/src/docker/configs.ts#L73).

- Converted the `ResponseError` catch blocks in `src/docker/images.ts`, `src/docker/containers.ts`, and `src/docker/networks.ts` (8 call sites) from hand-rolled `logger.error(...)` with manual `{status, statusText, body}` extraction to a single `logError(error, "<action>")` call.
- `src/commands/docker.ts`'s workflow orchestrator: replaced `sentryCaptureException(error, {tags})` with `logError(error, "running <kind> workflow", {tags})`, so the Sentry event carries the extracted response body instead of the bare message.

### Click-testing instructions

No UI change; covered by unit tests. To see the richer logging by hand:

1. With Docker running, point Confluent Local at an unreachable/misconfigured socket and trigger a Docker engine error.
2. Check the **Confluent** output channel - the error line now includes the response status and body instead of the bare `"Response returned an error code"`.

### Optional: Any additional details or context that should be provided?

- **Not converted:** the streaming poller in `src/docker/eventListener.ts` (different subsystem, never used the response-extraction idiom).
- **Not converted:** container start/create failures caught and notified on by the workflow layer before reaching the orchestrator - logs are enriched locally, but these still don't reach Sentry.
- Only the orchestrator forwards to Sentry: `logError()` forwards only when a non-empty context is passed, so the re-throwing wrappers (which pass none) don't double-report.
- **Non-`Error` throwables** in the orchestrator still log via `logger.error` directly, because `logError()` drops its message argument for non-`Error` values.

## Pull request checklist

Please check if your PR fulfills the following (if applicable):

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?

No user-facing behavior change; this only affects logging and error telemetry.

Closes #1924
