### PR TITLE
fix(sidecar): harden `WebsocketManager` reconnect and disposal

### DIFF
--- a/src/sidecar/sidecarHandle.test.ts
+++ b/src/sidecar/sidecarHandle.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import { graphql } from "gql.tada";
 import "mocha";
 import sinon from "sinon";
+import { eventually } from "../../tests/eventually";
 import { TEST_CCLOUD_FLINK_COMPUTE_POOL } from "../../tests/unit/testResources/flinkComputePool";
 import { BASE_PATH as SCAFFOLDING_SERVICE_BASE_PATH } from "../clients/scaffoldingService";
 import { MicroProfileHealthApi, ResponseError } from "../clients/sidecar";
@@ -153,9 +154,14 @@ describe("sidecarHandle websocket tests", () => {
     const websocketManager = WebsocketManager.getInstance();
 
     after(async () => {
-      // restore the websocket as side-effect of getting sidecar handle
+      // This test disposed the shared singleton's websocket; restore it via getSidecar() so later
+      // suites aren't left disconnected. Poll for reconnection to absorb the reconnect race.
       await sidecar.getSidecar();
-      assert.equal(true, websocketManager.isConnected());
+      await eventually(
+        () => assert.strictEqual(websocketManager.isConnected(), true),
+        15_000,
+        "Websocket should be connected after reconnection",
+      );
     });
 
     it("wsSend() should raise exception when disconnected", async () => {

--- a/src/sidecar/sidecarManager.test.ts
+++ b/src/sidecar/sidecarManager.test.ts
@@ -6,10 +6,12 @@ import * as errors from "../errors";
 import * as fsWrappers from "../utils/fsWrappers";
 import { SidecarFatalError } from "./errors";
 import * as sidecarLogging from "./logging";
-import { SidecarManager } from "./sidecarManager";
+import { SidecarHandle } from "./sidecarHandle";
+import { MAX_WEBSOCKET_CONNECT_ATTEMPTS, SidecarManager } from "./sidecarManager";
 import type { SidecarLogFormat, SidecarOutputs } from "./types";
 import { SidecarStartupFailureReason } from "./types";
 import * as utils from "./utils";
+import { WebsocketConnectionError } from "./websocketManager";
 
 describe("sidecarManager.ts", () => {
   describe("class SidecarManager", () => {
@@ -284,6 +286,67 @@ describe("sidecarManager.ts", () => {
         sinon.assert.calledOnce(disposeStub);
         // and should be dereferenced.
         assert.strictEqual(manager["logTailer"], undefined);
+      });
+    });
+
+    describe("getHandlePromise()", () => {
+      let setupWebsocketManagerStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        // sidecar is healthy and already contacted; isolate the websocket-setup step under test.
+        manager["logTailer"] = {} as unknown as Tail;
+        manager["sidecarContacted"] = true;
+        sandbox.stub(manager, "getAuthTokenFromSecretStore").resolves("token");
+        // healthcheck and setupWebsocketManager are private, so stub via bracket-notation.
+        manager["healthcheck"] = sandbox.stub().resolves(true);
+        setupWebsocketManagerStub = sandbox.stub();
+        manager["setupWebsocketManager"] = setupWebsocketManagerStub;
+      });
+
+      it("retries and returns a handle when the websocket handshake fails once", async () => {
+        // the sidecar is healthy; only the websocket handshake fails the first time.
+        setupWebsocketManagerStub
+          .onFirstCall()
+          .rejects(new WebsocketConnectionError("handshake timed out"))
+          .onSecondCall()
+          .resolves();
+
+        const handlePromise = manager["getHandlePromise"](0);
+        await clock.runAllAsync(); // let the pause() between retries elapse
+        const handle = await handlePromise;
+
+        assert.ok(handle instanceof SidecarHandle);
+        sinon.assert.calledTwice(setupWebsocketManagerStub);
+      });
+
+      it("retries across multiple consecutive websocket handshake failures", async () => {
+        setupWebsocketManagerStub
+          .onFirstCall()
+          .rejects(new WebsocketConnectionError("stall 1"))
+          .onSecondCall()
+          .rejects(new WebsocketConnectionError("stall 2"))
+          .onThirdCall()
+          .resolves();
+
+        const handlePromise = manager["getHandlePromise"](0);
+        await clock.runAllAsync();
+        const handle = await handlePromise;
+
+        assert.ok(handle instanceof SidecarHandle);
+        sinon.assert.calledThrice(setupWebsocketManagerStub);
+      });
+
+      it("gives up after MAX_WEBSOCKET_CONNECT_ATTEMPTS consecutive handshake failures", async () => {
+        const triageStub = sandbox.stub(utils, "triageSidecarStartupError").resolves();
+        setupWebsocketManagerStub.rejects(new WebsocketConnectionError("persistent stall"));
+
+        const handlePromise = manager["getHandlePromise"](0);
+        const assertion = assert.rejects(handlePromise, WebsocketConnectionError);
+        await clock.runAllAsync();
+
+        await assertion;
+        sinon.assert.callCount(setupWebsocketManagerStub, MAX_WEBSOCKET_CONNECT_ATTEMPTS);
+        sinon.assert.called(triageStub);
       });
     });
   });

--- a/src/sidecar/sidecarManager.test.ts
+++ b/src/sidecar/sidecarManager.test.ts
@@ -11,7 +11,7 @@ import { MAX_WEBSOCKET_CONNECT_ATTEMPTS, SidecarManager } from "./sidecarManager
 import type { SidecarLogFormat, SidecarOutputs } from "./types";
 import { SidecarStartupFailureReason } from "./types";
 import * as utils from "./utils";
-import { WebsocketConnectionError } from "./websocketManager";
+import { WebsocketConnectionError, WebsocketStateEvent } from "./websocketManager";
 
 describe("sidecarManager.ts", () => {
   describe("class SidecarManager", () => {
@@ -347,6 +347,54 @@ describe("sidecarManager.ts", () => {
         await assertion;
         sinon.assert.callCount(setupWebsocketManagerStub, MAX_WEBSOCKET_CONNECT_ATTEMPTS);
         sinon.assert.called(triageStub);
+      });
+    });
+
+    describe("onWebsocketStateChange()", () => {
+      it("reconnects via getHandle() on DISCONNECTED", async () => {
+        const getHandleStub = sandbox.stub(manager, "getHandle").resolves();
+
+        await manager["onWebsocketStateChange"](WebsocketStateEvent.DISCONNECTED);
+
+        sinon.assert.calledOnce(getHandleStub);
+      });
+
+      it("logs and does not rethrow when the reconnect handshake keeps failing", async () => {
+        // getHandle() now rejects (a stalled handshake rejects instead of hanging); this
+        // fire-and-forget listener must swallow it rather than raise an unhandled rejection.
+        const reconnectError = new WebsocketConnectionError("reconnect exhausted");
+        sandbox.stub(manager, "getHandle").rejects(reconnectError);
+
+        await manager["onWebsocketStateChange"](WebsocketStateEvent.DISCONNECTED);
+
+        sinon.assert.calledOnceWithExactly(
+          logErrorStub,
+          reconnectError,
+          "Failed to reconnect sidecar handle after websocket disconnect",
+        );
+      });
+
+      it("reuses an in-flight reconnect instead of starting a second one", async () => {
+        // a reconnect is already in flight, so getHandle() must hand back the pending promise rather
+        // than kick off a second getHandlePromise - the single-flight dedup the DISCONNECTED path
+        // relies on to avoid overlapping reconnects.
+        const getHandlePromiseStub = sandbox.stub();
+        manager["getHandlePromise"] = getHandlePromiseStub;
+        manager["pendingHandlePromise"] = Promise.resolve(
+          sandbox.createStubInstance(SidecarHandle),
+        );
+
+        await manager["onWebsocketStateChange"](WebsocketStateEvent.DISCONNECTED);
+
+        sinon.assert.notCalled(getHandlePromiseStub);
+      });
+
+      it("does nothing on CONNECTED", async () => {
+        const getHandleStub = sandbox.stub(manager, "getHandle");
+
+        await manager["onWebsocketStateChange"](WebsocketStateEvent.CONNECTED);
+
+        sinon.assert.notCalled(getHandleStub);
       });
     });
   });

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -286,8 +286,14 @@ export class SidecarManager {
   private async onWebsocketStateChange(event: WebsocketStateEvent) {
     if (event === WebsocketStateEvent.DISCONNECTED) {
       // Try to get a new sidecar handle, which will start a new sidecar process
-      // and reconnect websocket.
-      await this.getHandle();
+      // and reconnect websocket. getHandle() can now reject (a stalled websocket handshake
+      // rejects instead of hanging), and this runs as a fire-and-forget event listener, so
+      // catch here to avoid an unhandled promise rejection.
+      try {
+        await this.getHandle();
+      } catch (e) {
+        logError(e, "Failed to reconnect sidecar handle after websocket disconnect");
+      }
     }
   }
 

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -15,7 +15,11 @@ import {
 } from "./constants";
 import { ErrorResponseMiddleware } from "./middlewares";
 import { SidecarHandle } from "./sidecarHandle";
-import { WebsocketManager, WebsocketStateEvent } from "./websocketManager";
+import {
+  WebsocketConnectionError,
+  WebsocketManager,
+  WebsocketStateEvent,
+} from "./websocketManager";
 
 import type { Tail } from "tail";
 import { observabilityContext } from "../context/observability";
@@ -51,6 +55,13 @@ const WORKSPACE_PROCESS_ID_HEADER: string = "x-workspace-process-id";
 
 /** How many loop attempts to try in startSidecar() and doHand */
 export const MAX_ATTEMPTS = 20;
+
+/**
+ * How many consecutive websocket-handshake failures to retry before giving up. Kept small (and
+ * separate from {@link MAX_ATTEMPTS}) because each attempt can burn up to the connect timeout
+ * (~15s), so a large budget would let a persistently-stalling handshake block for minutes.
+ */
+export const MAX_WEBSOCKET_CONNECT_ATTEMPTS = 3;
 
 const logger = new Logger("sidecarManager");
 
@@ -124,6 +135,7 @@ export class SidecarManager {
     }
 
     try {
+      let websocketConnectFailures = 0;
       for (let i = 0; i < MAX_ATTEMPTS; i++) {
         const logPrefix = `getHandlePromise(${callnum} attempt ${i})`;
 
@@ -179,6 +191,22 @@ export class SidecarManager {
             logger.info(`${logPrefix}: Started new sidecar, got new access token.`);
 
             // Now jump back to the top, try healthcheck / authentication again.
+            continue;
+          } else if (e instanceof WebsocketConnectionError) {
+            // The sidecar itself is healthy (healthcheck passed); only the websocket handshake
+            // stalled or failed. Retry a bounded number of times rather than treating it as an
+            // unrecoverable startup error (which would surface a fatal notification and abort).
+            websocketConnectFailures++;
+            if (websocketConnectFailures >= MAX_WEBSOCKET_CONNECT_ATTEMPTS) {
+              logger.error(
+                `${logPrefix}: websocket connect failed ${websocketConnectFailures} times, giving up`,
+              );
+              throw e;
+            }
+            logger.info(
+              `${logPrefix}: websocket connect failed, retrying (${websocketConnectFailures}/${MAX_WEBSOCKET_CONNECT_ATTEMPTS}): ${e}`,
+            );
+            await pause(MOMENTARY_PAUSE_MS);
             continue;
           } else {
             logger.error(`${logPrefix}: unhandled error`, e);

--- a/src/sidecar/sidecarManager.ts
+++ b/src/sidecar/sidecarManager.ts
@@ -57,9 +57,10 @@ const WORKSPACE_PROCESS_ID_HEADER: string = "x-workspace-process-id";
 export const MAX_ATTEMPTS = 20;
 
 /**
- * How many consecutive websocket-handshake failures to retry before giving up. Kept small (and
- * separate from {@link MAX_ATTEMPTS}) because each attempt can burn up to the connect timeout
- * (~15s), so a large budget would let a persistently-stalling handshake block for minutes.
+ * How many websocket-handshake failures to tolerate within a single getHandle() cycle before giving
+ * up. Kept small (and separate from {@link MAX_ATTEMPTS}) because each attempt can burn up to the
+ * connect timeout (~15s), so a large budget would let a persistently-stalling handshake block for
+ * minutes.
  */
 export const MAX_WEBSOCKET_CONNECT_ATTEMPTS = 3;
 

--- a/src/sidecar/utils.test.ts
+++ b/src/sidecar/utils.test.ts
@@ -9,6 +9,7 @@ import { MOMENTARY_PAUSE_MS } from "./constants";
 import { SidecarFatalError } from "./errors";
 import { getSidecarLogfilePath } from "./logging";
 import { SidecarStartupFailureReason } from "./types";
+import { WebsocketConnectionError } from "./websocketManager";
 import {
   constructSidecarEnv,
   isProcessRunning,
@@ -304,6 +305,7 @@ describe("sidecar/utils.ts", () => {
     let sandbox: sinon.SinonSandbox;
 
     let showErrorNotificationWithButtonsStub: sinon.SinonStub;
+    let showWarningNotificationWithButtonsStub: sinon.SinonStub;
     let logErrorStub: sinon.SinonStub;
     let logUsageStub: sinon.SinonStub;
 
@@ -312,6 +314,10 @@ describe("sidecar/utils.ts", () => {
       showErrorNotificationWithButtonsStub = sandbox.stub(
         notifications,
         "showErrorNotificationWithButtons",
+      );
+      showWarningNotificationWithButtonsStub = sandbox.stub(
+        notifications,
+        "showWarningNotificationWithButtons",
       );
       logErrorStub = sandbox.stub(errorsModule, "logError");
       logUsageStub = sandbox.stub(eventsModule, "logUsage");
@@ -485,6 +491,29 @@ describe("sidecar/utils.ts", () => {
       assert.deepStrictEqual(logErrorArgs[2], { extra: { reason: "Unknown" } });
       // will not have sent to Segment.
       sinon.assert.notCalled(logUsageStub);
+    });
+
+    it("shows a non-fatal warning (not a startup error) when the websocket connect fails after retries", async () => {
+      // the sidecar is healthy; only its websocket event stream could not be (re)established, so
+      // this is a recoverable degradation, not a startup failure.
+      const error = new WebsocketConnectionError("handshake timed out");
+
+      await triageSidecarStartupError(error);
+
+      // a warning with a retry action, not the fatal "Sidecar failed to start" error notification.
+      sinon.assert.notCalled(showErrorNotificationWithButtonsStub);
+      sinon.assert.calledOnce(showWarningNotificationWithButtonsStub);
+      const message = showWarningNotificationWithButtonsStub.getCall(0).args[0];
+      assert.strictEqual(/event stream/.test(message), true, `Message: ${message}`);
+      const buttons: NotificationButtons =
+        showWarningNotificationWithButtonsStub.getCall(0).args[1];
+      assert.strictEqual(buttons["Reload Window"] !== undefined, true);
+
+      // bucketed under its own Sentry reason, not the catch-all "Unknown".
+      sinon.assert.calledOnce(logErrorStub);
+      assert.deepStrictEqual(logErrorStub.getCall(0).args[2], {
+        extra: { reason: "WebsocketConnectFailed" },
+      });
     });
   });
 });

--- a/src/sidecar/utils.ts
+++ b/src/sidecar/utils.ts
@@ -8,13 +8,17 @@ import { CCLOUD_BASE_PATH, EXTENSION_VERSION } from "../constants";
 import { logError } from "../errors";
 import { Logger } from "../logging";
 import type { NotificationButtons } from "../notifications";
-import { showErrorNotificationWithButtons } from "../notifications";
+import {
+  showErrorNotificationWithButtons,
+  showWarningNotificationWithButtons,
+} from "../notifications";
 import { logUsage, UserEvent } from "../telemetry/events";
 import { checkSidecarOsAndArch } from "./checkArchitecture";
 import { MOMENTARY_PAUSE_MS, SIDECAR_PORT } from "./constants";
 import { SidecarFatalError } from "./errors";
 import { getSidecarLogfilePath } from "./logging";
 import { SidecarStartupFailureReason } from "./types";
+import { WebsocketConnectionError } from "./websocketManager";
 
 const logger = new Logger("sidecar/utils.ts");
 
@@ -222,6 +226,24 @@ export function checkSidecarFile(executablePath: string) {
  * carrying a SidecarStartupFailureReason.
  */
 export async function triageSidecarStartupError(e: any): Promise<void> {
+  if (e instanceof WebsocketConnectionError) {
+    // The sidecar is healthy (its healthcheck passed); only its websocket event stream could not be
+    // (re)established after retries. REST/GraphQL still work, so this is a recoverable degradation,
+    // not a startup failure - surface it as a warning with a retry action, and bucket it under its
+    // own Sentry reason rather than the catch-all "Unknown".
+    logError(e, "Websocket connect failed after retries", {
+      extra: { reason: "WebsocketConnectFailed" },
+    });
+    void showWarningNotificationWithButtons(
+      "Connected to the sidecar, but its live event stream could not be established, so some " +
+        "updates may be delayed or missing. Reload the window to retry.",
+      {
+        "Reload Window": () => vscode.commands.executeCommand("workbench.action.reloadWindow"),
+      },
+    );
+    return;
+  }
+
   // Most of these are errors from the user's environment / OS, and we cannot fix.
   // So only send the rather oddball ones to Sentry so we could learn more.
 

--- a/src/sidecar/websocketManager.test.ts
+++ b/src/sidecar/websocketManager.test.ts
@@ -7,7 +7,11 @@ import { eventually } from "../../tests/eventually";
 import { GOOD_CCLOUD_CONNECTION_EVENT_MESSAGE } from "../../tests/unit/testResources/websocketMessages";
 import type { Message, WorkspacesChangedBody } from "../ws/messageTypes";
 import { MessageType, newMessageHeaders } from "../ws/messageTypes";
-import { constructMessageRouter, WebsocketManager } from "./websocketManager";
+import {
+  constructMessageRouter,
+  WebsocketConnectionError,
+  WebsocketManager,
+} from "./websocketManager";
 
 // tests over WebsocketManager
 
@@ -136,12 +140,16 @@ describe("WebsocketManager.connect() failure handling", () => {
     WebsocketManager.instance = savedInstance;
   });
 
-  it("rejects (rather than hanging) when the socket errors before the handshake completes", async () => {
-    // port 1 is not listening, so the socket errors immediately
-    await assert.rejects(isolated.connect("localhost:1", "test-token", 5000));
+  it("rejects with a WebsocketConnectionError when the socket errors before the handshake completes", async () => {
+    // port 1 is not listening, so the socket errors immediately. The error type is load-bearing:
+    // sidecarManager's reconnect loop retries on WebsocketConnectionError specifically.
+    await assert.rejects(
+      isolated.connect("localhost:1", "test-token", 5000),
+      WebsocketConnectionError,
+    );
   });
 
-  it("rejects with a timeout when the handshake stalls past the timeout", async () => {
+  it("rejects with a WebsocketConnectionError timeout when the handshake stalls past the timeout", async () => {
     // a server that accepts the socket but never replies to WORKSPACE_HELLO, so the handshake
     // stalls and connect() must reject on its own timeout instead of hanging forever
     const server = new WebSocketServer({ port: 0 });
@@ -149,7 +157,54 @@ describe("WebsocketManager.connect() failure handling", () => {
     const port = (server.address() as AddressInfo).port;
 
     try {
-      await assert.rejects(isolated.connect(`localhost:${port}`, "test-token", 300), /timed out/);
+      await assert.rejects(
+        isolated.connect(`localhost:${port}`, "test-token", 300),
+        (err: unknown) => err instanceof WebsocketConnectionError && /timed out/.test(err.message),
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it("does not accumulate connection cleanup in disposables across reconnect attempts", async () => {
+    // each connect()'s socket/timer teardown is tracked off disposables (replaced per attempt),
+    // so repeated reconnects (without an intervening dispose) must not grow this.disposables.
+    const disposables = isolated["disposables"];
+    const before = disposables.length;
+
+    await assert.rejects(isolated.connect("localhost:1", "test-token", 2000));
+    await assert.rejects(isolated.connect("localhost:1", "test-token", 2000));
+    await assert.rejects(isolated.connect("localhost:1", "test-token", 2000));
+
+    assert.strictEqual(disposables.length, before);
+  });
+
+  it("a timed-out attempt's stale WORKSPACE_COUNT_CHANGED handler does not clobber this.websocket", async () => {
+    // a server that accepts the socket (so the once() handler is installed) but never replies, so
+    // the attempt times out and settles while its handler stays registered on the messageRouter.
+    const server = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      await assert.rejects(
+        isolated.connect(`localhost:${port}`, "test-token", 300),
+        WebsocketConnectionError,
+      );
+
+      // deliver the message the stale handler waits for; the guard must make it a no-op so
+      // this.websocket is not set to the dead socket.
+      const message: Message<MessageType.WORKSPACE_COUNT_CHANGED> = {
+        headers: {
+          message_type: MessageType.WORKSPACE_COUNT_CHANGED,
+          originator: "sidecar",
+          message_id: "1",
+        },
+        body: { current_workspace_count: 2 },
+      };
+      await isolated.deliverToCallbacks(message);
+
+      assert.strictEqual(isolated["websocket"], null);
     } finally {
       server.close();
     }

--- a/src/sidecar/websocketManager.test.ts
+++ b/src/sidecar/websocketManager.test.ts
@@ -1,6 +1,9 @@
 import assert from "assert";
 import * as sinon from "sinon";
+import type { AddressInfo } from "ws";
+import { WebSocketServer } from "ws";
 import { getSidecar } from ".";
+import { eventually } from "../../tests/eventually";
 import { GOOD_CCLOUD_CONNECTION_EVENT_MESSAGE } from "../../tests/unit/testResources/websocketMessages";
 import type { Message, WorkspacesChangedBody } from "../ws/messageTypes";
 import { MessageType, newMessageHeaders } from "../ws/messageTypes";
@@ -103,15 +106,53 @@ describe("WebsocketManager dispose tests", () => {
   });
 
   after(async () => {
-    // getting sidecar handle should kick off websocket reconnection
+    // dispose() above closed the shared singleton's websocket; getSidecar() kicks off reconnection.
+    // Poll until it completes so a racing reconnect doesn't leave later suites disconnected.
     await getSidecar();
 
     const websocketManager = WebsocketManager.getInstance();
-    assert.equal(
-      true,
-      websocketManager.isConnected(),
+    await eventually(
+      () => assert.strictEqual(websocketManager.isConnected(), true),
+      15_000,
       "Websocket should be connected after reconnection",
     );
+  });
+});
+
+describe("WebsocketManager.connect() failure handling", () => {
+  // Swap in a fresh, unregistered singleton so a failed connect here can't disturb the real shared
+  // connection: no sidecarManager reconnect handler is wired to this throwaway instance.
+  let savedInstance: WebsocketManager | null;
+  let isolated: WebsocketManager;
+
+  beforeEach(() => {
+    savedInstance = WebsocketManager.instance;
+    WebsocketManager.instance = null;
+    isolated = WebsocketManager.getInstance();
+  });
+
+  afterEach(() => {
+    isolated.dispose();
+    WebsocketManager.instance = savedInstance;
+  });
+
+  it("rejects (rather than hanging) when the socket errors before the handshake completes", async () => {
+    // port 1 is not listening, so the socket errors immediately
+    await assert.rejects(isolated.connect("localhost:1", "test-token", 5000));
+  });
+
+  it("rejects with a timeout when the handshake stalls past the timeout", async () => {
+    // a server that accepts the socket but never replies to WORKSPACE_HELLO, so the handshake
+    // stalls and connect() must reject on its own timeout instead of hanging forever
+    const server = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      await assert.rejects(isolated.connect(`localhost:${port}`, "test-token", 300), /timed out/);
+    } finally {
+      server.close();
+    }
   });
 });
 

--- a/src/sidecar/websocketManager.test.ts
+++ b/src/sidecar/websocketManager.test.ts
@@ -4,7 +4,10 @@ import type { AddressInfo } from "ws";
 import { WebSocketServer } from "ws";
 import { getSidecar } from ".";
 import { eventually } from "../../tests/eventually";
-import { GOOD_CCLOUD_CONNECTION_EVENT_MESSAGE } from "../../tests/unit/testResources/websocketMessages";
+import {
+  createWorkspaceCountMessage,
+  GOOD_CCLOUD_CONNECTION_EVENT_MESSAGE,
+} from "../../tests/unit/testResources/websocketMessages";
 import type { Message, WorkspacesChangedBody } from "../ws/messageTypes";
 import { MessageType, newMessageHeaders } from "../ws/messageTypes";
 import {
@@ -123,7 +126,18 @@ describe("WebsocketManager dispose tests", () => {
   });
 });
 
-describe("WebsocketManager.connect() failure handling", () => {
+/**
+ * Start a websocket server that accepts the socket but never replies to WORKSPACE_HELLO, so a
+ * connect() handshake against it stalls until its own timeout fires.
+ */
+async function startStallingServer(): Promise<{ port: number; close: () => void }> {
+  const server = new WebSocketServer({ port: 0 });
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+  return { port, close: () => server.close() };
+}
+
+describe("WebsocketManager.connect() failure tests", () => {
   // Swap in a fresh, unregistered singleton so a failed connect here can't disturb the real shared
   // connection: no sidecarManager reconnect handler is wired to this throwaway instance.
   let savedInstance: WebsocketManager | null;
@@ -150,11 +164,7 @@ describe("WebsocketManager.connect() failure handling", () => {
   });
 
   it("rejects with a WebsocketConnectionError timeout when the handshake stalls past the timeout", async () => {
-    // a server that accepts the socket but never replies to WORKSPACE_HELLO, so the handshake
-    // stalls and connect() must reject on its own timeout instead of hanging forever
-    const server = new WebSocketServer({ port: 0 });
-    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
-    const port = (server.address() as AddressInfo).port;
+    const { port, close } = await startStallingServer();
 
     try {
       await assert.rejects(
@@ -162,7 +172,7 @@ describe("WebsocketManager.connect() failure handling", () => {
         (err: unknown) => err instanceof WebsocketConnectionError && /timed out/.test(err.message),
       );
     } finally {
-      server.close();
+      close();
     }
   });
 
@@ -179,12 +189,10 @@ describe("WebsocketManager.connect() failure handling", () => {
     assert.strictEqual(disposables.length, before);
   });
 
-  it("a timed-out attempt's stale WORKSPACE_COUNT_CHANGED handler does not clobber this.websocket", async () => {
+  it("deregisters a timed-out attempt's stale WORKSPACE_COUNT_CHANGED handler", async () => {
     // a server that accepts the socket (so the once() handler is installed) but never replies, so
-    // the attempt times out and settles while its handler stays registered on the messageRouter.
-    const server = new WebSocketServer({ port: 0 });
-    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
-    const port = (server.address() as AddressInfo).port;
+    // the attempt times out with its one-shot handler registered until settleReject removes it.
+    const { port, close } = await startStallingServer();
 
     try {
       await assert.rejects(
@@ -192,22 +200,27 @@ describe("WebsocketManager.connect() failure handling", () => {
         WebsocketConnectionError,
       );
 
-      // deliver the message the stale handler waits for; the guard must make it a no-op so
-      // this.websocket is not set to the dead socket.
-      const message: Message<MessageType.WORKSPACE_COUNT_CHANGED> = {
-        headers: {
-          message_type: MessageType.WORKSPACE_COUNT_CHANGED,
-          originator: "sidecar",
-          message_id: "1",
-        },
-        body: { current_workspace_count: 2 },
-      };
-      await isolated.deliverToCallbacks(message);
+      // only the durable subscriber remains; the timed-out attempt's one-shot handler was removed.
+      const router = isolated["messageRouter"];
+      assert.strictEqual(router.listenerCount(MessageType.WORKSPACE_COUNT_CHANGED), 1);
+
+      // and delivering the message it waited for must not clobber this.websocket with the dead socket.
+      await isolated.deliverToCallbacks(createWorkspaceCountMessage(2));
 
       assert.strictEqual(isolated["websocket"], null);
     } finally {
-      server.close();
+      close();
     }
+  });
+
+  it("keeps durable message routing alive across dispose()", async () => {
+    // routing has instance lifetime: dispose() must not tear down the WORKSPACE_COUNT_CHANGED
+    // handler, so a reused singleton still tracks peerWorkspaceCount (the flake this fixes).
+    isolated.dispose();
+
+    await isolated.deliverToCallbacks(createWorkspaceCountMessage(4));
+
+    assert.strictEqual(isolated.getPeerWorkspaceCount(), 3);
   });
 });
 

--- a/src/sidecar/websocketManager.test.ts
+++ b/src/sidecar/websocketManager.test.ts
@@ -14,6 +14,7 @@ import {
   constructMessageRouter,
   WebsocketConnectionError,
   WebsocketManager,
+  WebsocketStateEvent,
 } from "./websocketManager";
 
 // tests over WebsocketManager
@@ -221,6 +222,18 @@ describe("WebsocketManager.connect() failure tests", () => {
     await isolated.deliverToCallbacks(createWorkspaceCountMessage(4));
 
     assert.strictEqual(isolated.getPeerWorkspaceCount(), 3);
+  });
+
+  it("keeps the state-change emitter alive across dispose() so reconnect still notifies", () => {
+    // sidecarManager registers its reconnect listener only once, so disposing the emitter on a
+    // reused singleton would strip it and silently stop auto-reconnection.
+    const events: WebsocketStateEvent[] = [];
+    isolated.registerStateChangeHandler((event) => events.push(event));
+
+    isolated.dispose();
+    isolated["websocketStateEmitter"].fire(WebsocketStateEvent.DISCONNECTED);
+
+    assert.deepStrictEqual(events, [WebsocketStateEvent.DISCONNECTED]);
   });
 });
 

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -11,6 +11,14 @@ import { MessageBodyDecoders, MessageType, validateMessageBody } from "../ws/mes
 
 const logger = new Logger("websocketManager");
 
+/**
+ * How long to wait for the full websocket connect handshake (socket open + WORKSPACE_HELLO +
+ * the initial WORKSPACE_COUNT_CHANGED reply) before giving up. Without a bound, a connection that
+ * errors or stalls before completing the handshake leaves {@link WebsocketManager.connect} pending
+ * forever, and anything awaiting it (e.g. reconnection) hangs until an unrelated timeout fires.
+ */
+export const CONNECT_TIMEOUT_MS = 15_000;
+
 /** Type describing message handler callbacks to whom received messages are routed. */
 export type MessageCallback<T extends MessageType> = (message: Message<T>) => Promise<void>;
 
@@ -35,6 +43,9 @@ export class WebsocketManager extends DisposableCollection {
    */
   private messageRouter: NodeEventEmitter;
   private peerWorkspaceCount = 0;
+
+  /** Monotonic counter used only to correlate a connect attempt's log lines. */
+  private connectAttempts = 0;
 
   private constructor() {
     super();
@@ -78,23 +89,64 @@ export class WebsocketManager extends DisposableCollection {
    *
    * @param hostPortFragment The host and port fragment to connect to, e.g. "localhost:8080".
    * @param accessToken The access token to use for authorization.
+   * @param timeoutMs How long to wait for the full handshake before giving up; defaults to
+   *   {@link CONNECT_TIMEOUT_MS}.
+   * @throws if the handshake times out, the socket errors, or the socket closes before the
+   *   handshake completes.
    */
-  async connect(hostPortFragment: string, accessToken: string): Promise<void> {
-    return new Promise<void>((resolve) => {
+  async connect(
+    hostPortFragment: string,
+    accessToken: string,
+    timeoutMs: number = CONNECT_TIMEOUT_MS,
+  ): Promise<void> {
+    const attempt = ++this.connectAttempts;
+    return new Promise<void>((resolve, reject) => {
       if (this.websocket && this.websocket.readyState === WebSocket.OPEN) {
-        logger.info("Websocket already connected");
+        logger.debug(`[connect #${attempt}] websocket already connected`);
         resolve();
         return;
       }
 
-      logger.info("Setting up websocket to sidecar");
+      logger.debug(`[connect #${attempt}] setting up websocket to sidecar`);
 
       const websocket = new WebSocket(`ws://${hostPortFragment}/ws`, {
         headers: { authorization: `Bearer ${accessToken}` },
       });
 
+      // Guard against settling more than once: the handshake resolves this promise, but a late
+      // error/close/timeout must not resolve-or-reject it a second time. The first outcome wins.
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        logger.error(
+          `[connect #${attempt}] handshake to sidecar timed out after ${timeoutMs}ms (readyState=${websocket.readyState}); terminating socket`,
+        );
+        // Forcibly tear down the half-open socket so it can't leak or fire a late CONNECTED.
+        try {
+          websocket.terminate();
+        } catch {
+          // best-effort teardown; ignore
+        }
+        settleReject(
+          new Error(`Websocket connect handshake to sidecar timed out after ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+
+      const settleResolve = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const settleReject = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      };
+
       websocket.on("open", () => {
-        logger.info("Websocket connected to sidecar, saying hello ...");
+        logger.debug(`[connect #${attempt}] websocket opened, saying hello ...`);
 
         // send the hello message
         const helloMessage: Message<MessageType.WORKSPACE_HELLO> = {
@@ -115,14 +167,14 @@ export class WebsocketManager extends DisposableCollection {
           MessageType.WORKSPACE_COUNT_CHANGED,
           async (m: Message<MessageType.WORKSPACE_COUNT_CHANGED>) => {
             logger.info(
-              "Received initial WORKSPACE_COUNT_CHANGED message, websocket now fully connected.",
+              `[connect #${attempt}] received initial WORKSPACE_COUNT_CHANGED, websocket now fully connected`,
             );
             this.websocket = websocket;
             this.peerWorkspaceCount = m.body.current_workspace_count - 1;
             // Emit an event to let the extension know the websocket has closed.
             // This will get picked up by sidecarManager, which will then attempt to reconnect.
             this.websocketStateEmitter.fire(WebsocketStateEvent.CONNECTED);
-            resolve();
+            settleResolve();
           },
         );
 
@@ -135,7 +187,7 @@ export class WebsocketManager extends DisposableCollection {
       });
 
       websocket.on("close", () => {
-        logger.info("Websocket closed");
+        logger.info(`[connect #${attempt}] websocket closed`);
 
         // do additional cleanup here
         this.websocket = null;
@@ -143,11 +195,16 @@ export class WebsocketManager extends DisposableCollection {
         // Emit an event to let the extension know the websocket has closed.
         // This will get picked up by sidecarManager, which will then attempt to reconnect.
         this.websocketStateEmitter.fire(WebsocketStateEvent.DISCONNECTED);
+
+        // If we closed before the handshake finished, reject connect() rather than leaving it
+        // pending forever. Once already settled (normal later disconnect), this is a no-op.
+        settleReject(new Error("Websocket closed before connect handshake completed"));
       });
 
       websocket.on("error", (error) => {
-        logger.error(`Websocket error: ${error}`);
-        // Go ahead and close the websocket, which will trigger the close event above.
+        logger.error(`[connect #${attempt}] websocket error: ${error}`);
+        // Go ahead and close the websocket, which will trigger the close event above (which
+        // rejects connect() if the handshake had not yet completed).
         websocket.close();
       });
 
@@ -171,9 +228,14 @@ export class WebsocketManager extends DisposableCollection {
 
       this.disposables.push({
         dispose: () => {
-          // Close the websocket when we're disposed of.
-          if (this.websocket && this.websocket.readyState !== WebSocket.CLOSED) {
-            this.websocket.close();
+          // Tear down THIS attempt on disposal. Capture the local websocket/timer rather than
+          // this.websocket, which isn't assigned until the handshake completes - otherwise
+          // disposing mid-handshake would leave the pending timer and half-open socket alive.
+          clearTimeout(timer);
+          if (websocket.readyState !== WebSocket.CLOSED) {
+            websocket.close();
+          }
+          if (this.websocket === websocket) {
             this.websocket = null;
           }
         },

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -47,6 +47,12 @@ export class WebsocketManager extends DisposableCollection {
   /** Monotonic counter used only to correlate a connect attempt's log lines. */
   private connectAttempts = 0;
 
+  /**
+   * Teardown for the current connect attempt's socket + timer, tracked so each new attempt can
+   * replace (rather than accumulate) it in {@link disposables} across reconnects.
+   */
+  private activeConnectionCleanup: Disposable | null = null;
+
   private constructor() {
     super();
     // Set up a NodeJS EventEmitter to route received websocket messages to the appropriate async handlers
@@ -66,6 +72,14 @@ export class WebsocketManager extends DisposableCollection {
         this.messageRouter.removeAllListeners();
       },
     });
+  }
+
+  override dispose(): void {
+    // The current connect attempt's socket/timer cleanup is tracked off {@link disposables} (it is
+    // replaced per attempt to avoid accumulation), so tear it down explicitly here.
+    this.activeConnectionCleanup?.dispose();
+    this.activeConnectionCleanup = null;
+    super.dispose();
   }
 
   /** Are we currently connected to sidecar via websocket? */
@@ -128,7 +142,9 @@ export class WebsocketManager extends DisposableCollection {
           // best-effort teardown; ignore
         }
         settleReject(
-          new Error(`Websocket connect handshake to sidecar timed out after ${timeoutMs}ms`),
+          new WebsocketConnectionError(
+            `Websocket connect handshake to sidecar timed out after ${timeoutMs}ms`,
+          ),
         );
       }, timeoutMs);
 
@@ -166,6 +182,11 @@ export class WebsocketManager extends DisposableCollection {
         this.once(
           MessageType.WORKSPACE_COUNT_CHANGED,
           async (m: Message<MessageType.WORKSPACE_COUNT_CHANGED>) => {
+            // Ignore a stale attempt's late reply (e.g. this attempt already timed out and was
+            // torn down): it must not clobber this.websocket with a dead socket. The shared
+            // messageRouter is per-instance, so a lingering once() handler from a failed attempt
+            // would otherwise fire on a later, unrelated WORKSPACE_COUNT_CHANGED broadcast.
+            if (settled) return;
             logger.info(
               `[connect #${attempt}] received initial WORKSPACE_COUNT_CHANGED, websocket now fully connected`,
             );
@@ -198,7 +219,9 @@ export class WebsocketManager extends DisposableCollection {
 
         // If we closed before the handshake finished, reject connect() rather than leaving it
         // pending forever. Once already settled (normal later disconnect), this is a no-op.
-        settleReject(new Error("Websocket closed before connect handshake completed"));
+        settleReject(
+          new WebsocketConnectionError("Websocket closed before connect handshake completed"),
+        );
       });
 
       websocket.on("error", (error) => {
@@ -226,11 +249,14 @@ export class WebsocketManager extends DisposableCollection {
         });
       });
 
-      this.disposables.push({
+      // Tear down THIS attempt's socket + timer. Capture the local websocket/timer rather than
+      // this.websocket, which isn't assigned until the handshake completes - otherwise disposing
+      // mid-handshake would leave the pending timer and half-open socket alive. Dispose (and
+      // replace) the prior attempt's cleanup so repeated reconnects don't accumulate; the manager's
+      // dispose() override runs the current one.
+      this.activeConnectionCleanup?.dispose();
+      this.activeConnectionCleanup = {
         dispose: () => {
-          // Tear down THIS attempt on disposal. Capture the local websocket/timer rather than
-          // this.websocket, which isn't assigned until the handshake completes - otherwise
-          // disposing mid-handshake would leave the pending timer and half-open socket alive.
           clearTimeout(timer);
           if (websocket.readyState !== WebSocket.CLOSED) {
             websocket.close();
@@ -239,7 +265,7 @@ export class WebsocketManager extends DisposableCollection {
             this.websocket = null;
           }
         },
-      });
+      };
     });
   }
 
@@ -388,6 +414,19 @@ class WebsocketClosedError extends Error {
   constructor() {
     super("Websocket closed");
     this.name = "WebsocketClosedError";
+  }
+}
+
+/**
+ * Thrown by {@link WebsocketManager.connect} when the handshake fails to complete: a timeout, a
+ * socket error, or the socket closing before the handshake finishes. Distinguishes a recoverable
+ * websocket failure (the sidecar itself may be healthy) from an unrecoverable sidecar startup
+ * error, so callers can retry rather than surfacing a fatal error.
+ */
+export class WebsocketConnectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebsocketConnectionError";
   }
 }
 

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -16,6 +16,8 @@ const logger = new Logger("websocketManager");
  * the initial WORKSPACE_COUNT_CHANGED reply) before giving up. Without a bound, a connection that
  * errors or stalls before completing the handshake leaves {@link WebsocketManager.connect} pending
  * forever, and anything awaiting it (e.g. reconnection) hangs until an unrelated timeout fires.
+ * A conservative default: a localhost handshake to an already-health-checked sidecar completes in
+ * well under a second, so this is headroom, not an expected duration.
  */
 export const CONNECT_TIMEOUT_MS = 15_000;
 
@@ -55,23 +57,21 @@ export class WebsocketManager extends DisposableCollection {
 
   private constructor() {
     super();
-    // Set up a NodeJS EventEmitter to route received websocket messages to the appropriate async handlers
-    // based on the message type.
+    // The message router and its durable subscriptions have instance lifetime, not connection
+    // lifetime: they are set up once here and deliberately survive websocket disconnect/reconnect
+    // (and dispose()). Tearing them down on disconnect would drop this instance's own
+    // WORKSPACE_COUNT_CHANGED handler and any external subscriber (e.g. ConnectionStateWatcher's
+    // CONNECTION_EVENT), leaving a reconnected singleton silently missing handlers.
     this.messageRouter = constructMessageRouter();
 
-    // Install handler for WORKSPACE_COUNT_CHANGED messages. Will recieve one when connected, and whenever
-    // any other workspaces connect or disconnect.
+    // Install handler for WORKSPACE_COUNT_CHANGED messages. Will receive one when connected, and
+    // whenever any other workspaces connect or disconnect.
     this.subscribe(MessageType.WORKSPACE_COUNT_CHANGED, async (message) => {
       // The reply is inclusive of the current workspace, but we want to retain the peer count.
       this.peerWorkspaceCount = message.body.current_workspace_count - 1;
     });
 
-    // Deregister all message handlers when we're disposed of.
-    this.disposables.push({
-      dispose: () => {
-        this.messageRouter.removeAllListeners();
-      },
-    });
+    this.disposables.push(this.websocketStateEmitter);
   }
 
   override dispose(): void {
@@ -105,8 +105,8 @@ export class WebsocketManager extends DisposableCollection {
    * @param accessToken The access token to use for authorization.
    * @param timeoutMs How long to wait for the full handshake before giving up; defaults to
    *   {@link CONNECT_TIMEOUT_MS}.
-   * @throws if the handshake times out, the socket errors, or the socket closes before the
-   *   handshake completes.
+   * @throws {WebsocketConnectionError} if the handshake times out, the socket errors, or the socket
+   *   closes before the handshake completes.
    */
   async connect(
     hostPortFragment: string,
@@ -130,6 +130,10 @@ export class WebsocketManager extends DisposableCollection {
       // Guard against settling more than once: the handshake resolves this promise, but a late
       // error/close/timeout must not resolve-or-reject it a second time. The first outcome wins.
       let settled = false;
+      // This attempt's one-shot WORKSPACE_COUNT_CHANGED handler, captured so a failed attempt can
+      // deregister it (see settleReject) instead of leaving it on the shared messageRouter until an
+      // unrelated broadcast reaps it.
+      let onInitialCountChanged: MessageCallback<MessageType.WORKSPACE_COUNT_CHANGED> | null = null;
       const timer = setTimeout(() => {
         if (settled) return;
         logger.error(
@@ -158,6 +162,11 @@ export class WebsocketManager extends DisposableCollection {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        // Deregister this attempt's one-shot handler so it can't linger on the shared router.
+        if (onInitialCountChanged) {
+          this.messageRouter.off(MessageType.WORKSPACE_COUNT_CHANGED, onInitialCountChanged);
+          onInitialCountChanged = null;
+        }
         reject(error);
       };
 
@@ -177,27 +186,22 @@ export class WebsocketManager extends DisposableCollection {
         };
 
         // Resolve when we have gotten the first WORKSPACE_COUNT_CHANGED message. Will be sent
-        // when any connect/disconnect happens, even ours.
-        // Install a one-time handler for this message type.
-        this.once(
-          MessageType.WORKSPACE_COUNT_CHANGED,
-          async (m: Message<MessageType.WORKSPACE_COUNT_CHANGED>) => {
-            // Ignore a stale attempt's late reply (e.g. this attempt already timed out and was
-            // torn down): it must not clobber this.websocket with a dead socket. The shared
-            // messageRouter is per-instance, so a lingering once() handler from a failed attempt
-            // would otherwise fire on a later, unrelated WORKSPACE_COUNT_CHANGED broadcast.
-            if (settled) return;
-            logger.info(
-              `[connect #${attempt}] received initial WORKSPACE_COUNT_CHANGED, websocket now fully connected`,
-            );
-            this.websocket = websocket;
-            this.peerWorkspaceCount = m.body.current_workspace_count - 1;
-            // Emit an event to let the extension know the websocket has closed.
-            // This will get picked up by sidecarManager, which will then attempt to reconnect.
-            this.websocketStateEmitter.fire(WebsocketStateEvent.CONNECTED);
-            settleResolve();
-          },
-        );
+        // when any connect/disconnect happens, even ours. A failed attempt deregisters this handler
+        // in settleReject; the settled guard is a backstop for a broadcast already in flight when
+        // this attempt settles.
+        onInitialCountChanged = async (m: Message<MessageType.WORKSPACE_COUNT_CHANGED>) => {
+          if (settled) return;
+          logger.info(
+            `[connect #${attempt}] received initial WORKSPACE_COUNT_CHANGED, websocket now fully connected`,
+          );
+          this.websocket = websocket;
+          this.peerWorkspaceCount = m.body.current_workspace_count - 1;
+          // Emit an event to let the extension know the websocket is up, which sidecarManager uses
+          // to track connection state.
+          this.websocketStateEmitter.fire(WebsocketStateEvent.CONNECTED);
+          settleResolve();
+        };
+        this.messageRouter.once(MessageType.WORKSPACE_COUNT_CHANGED, onInitialCountChanged);
 
         // Now send the hello message (after the handler is installed)
         // (this.websocket isn't assigned yet, so explicitly pass it to send())
@@ -210,12 +214,14 @@ export class WebsocketManager extends DisposableCollection {
       websocket.on("close", () => {
         logger.info(`[connect #${attempt}] websocket closed`);
 
-        // do additional cleanup here
-        this.websocket = null;
-
-        // Emit an event to let the extension know the websocket has closed.
-        // This will get picked up by sidecarManager, which will then attempt to reconnect.
-        this.websocketStateEmitter.fire(WebsocketStateEvent.DISCONNECTED);
+        // Only react if this socket is (or was) the live connection. A superseded attempt's late
+        // close must not null out a newer connection or fire a spurious DISCONNECTED - a
+        // never-established attempt is driven back to reconnect by the rejection below instead.
+        if (this.websocket === websocket) {
+          this.websocket = null;
+          // sidecarManager picks up DISCONNECTED and attempts to reconnect.
+          this.websocketStateEmitter.fire(WebsocketStateEvent.DISCONNECTED);
+        }
 
         // If we closed before the handshake finished, reject connect() rather than leaving it
         // pending forever. Once already settled (normal later disconnect), this is a no-op.

--- a/src/sidecar/websocketManager.ts
+++ b/src/sidecar/websocketManager.ts
@@ -70,8 +70,10 @@ export class WebsocketManager extends DisposableCollection {
       // The reply is inclusive of the current workspace, but we want to retain the peer count.
       this.peerWorkspaceCount = message.body.current_workspace_count - 1;
     });
-
-    this.disposables.push(this.websocketStateEmitter);
+    // websocketStateEmitter is deliberately NOT registered for disposal: like the message router it
+    // has instance lifetime. sidecarManager registers its reconnect listener exactly once (guarded
+    // by `if (!this.websocketManager)`), so disposing the emitter on a reused singleton would strip
+    // that listener for good and silently stop automatic reconnection.
   }
 
   override dispose(): void {
@@ -171,6 +173,9 @@ export class WebsocketManager extends DisposableCollection {
       };
 
       websocket.on("open", () => {
+        // A late open after this attempt already settled (e.g. it timed out and was terminated) must
+        // not install a one-shot handler or send() on the now-dead socket.
+        if (settled) return;
         logger.debug(`[connect #${attempt}] websocket opened, saying hello ...`);
 
         // send the hello message

--- a/tests/unit/testResources/websocketMessages.ts
+++ b/tests/unit/testResources/websocketMessages.ts
@@ -5,6 +5,20 @@ import { CCLOUD_AUTH_CALLBACK_URI } from "../../../src/constants";
 import type { Message } from "../../../src/ws/messageTypes";
 import { ConnectionEventAction, MessageType } from "../../../src/ws/messageTypes";
 
+/** Build a WORKSPACE_COUNT_CHANGED message reporting the given total workspace count. */
+export function createWorkspaceCountMessage(
+  count: number,
+): Message<MessageType.WORKSPACE_COUNT_CHANGED> {
+  return {
+    headers: {
+      message_type: MessageType.WORKSPACE_COUNT_CHANGED,
+      originator: "sidecar",
+      message_id: "1",
+    },
+    body: { current_workspace_count: count },
+  };
+}
+
 export const GOOD_CCLOUD_CONNECTION_EVENT_MESSAGE: Message<MessageType.CONNECTION_EVENT> = {
   headers: {
     message_type: MessageType.CONNECTION_EVENT,


### PR DESCRIPTION
## Summary of Changes

Fixes an intermittent unit-test flake where exactly 12 tests failed in a single CI job, then passed on re-run. The root cause was in `WebsocketManager`'s reconnect and disposal handling: a reused instance silently dropped its message-routing subscriptions on reconnect, and a stalled handshake had no timeout, so it could hang or settle late against a socket that had already been torn down.

- **Bound the connect handshake.** `connect()` now [times out](https://github.com/confluentinc/vscode/blob/332b4969b3ff06cc35961669d687c47e344a2a5b/src/sidecar/websocketManager.ts#L22) and rejects with a typed `WebsocketConnectionError` instead of hanging, with a settle-once guard so success/timeout/error/close can't race each other.
- **Retry a failed handshake instead of aborting.** `getHandlePromise()` retries up to `MAX_WEBSOCKET_CONNECT_ATTEMPTS` - a small budget separate from the sidecar-start retries - since the sidecar's healthcheck already passed and only its websocket is failing.
- **Give message routing instance lifetime (the core fix).** The `messageRouter` and its subscriptions are now [built once and never torn down](https://github.com/confluentinc/vscode/blob/332b4969b3ff06cc35961669d687c47e344a2a5b/src/sidecar/websocketManager.ts#L60-L64) on disconnect or `dispose()`, so a reused instance and its subscribers keep receiving messages across a reconnect. Per-attempt sockets/timers are still cleaned up individually.
- **Report a failed reconnect accurately.** A failed reconnect now surfaces as a [recoverable warning](https://github.com/confluentinc/vscode/blob/332b4969b3ff06cc35961669d687c47e344a2a5b/src/sidecar/utils.ts#L229-L245) with a **Reload Window** button and its own Sentry reason, instead of the misleading "Sidecar failed to start" error - the sidecar itself is healthy; only its event stream is down.

### Click-testing instructions

Not readily click-testable - this is reconnect/disposal internals plus a CI-only test flake, all covered by the unit tests below.

1. `npx gulp test -t "WebsocketManager"`
2. `npx gulp test -t "sidecarManager"`
3. `npx gulp test -t "triageSidecarStartupError"`

### Optional: Any additional details or context that should be provided?

- Both the initial startup handshake and the mid-session reconnect funnel through the same `triageSidecarStartupError` path, so the new warning is consistent either way. `onWebsocketStateChange` also now catches `getHandle()` rejections, so a failed reconnect can't raise an unhandled promise rejection.
- The only user-facing change is the improved reconnect-failure notification; everything else is internal reconnect/disposal behavior plus tests.

## Pull request checklist

#### Tests

- [x] Added new
- [x] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?
