### PR TITLE
improve(produce): opt out of `partition_id`/`timestamp` before producing

### DIFF
--- a/src/commands/topics.test.ts
+++ b/src/commands/topics.test.ts
@@ -24,6 +24,7 @@ import * as queryResourceValidation from "../flinkSql/queryResourceValidation";
 import * as statementUtils from "../flinkSql/statementUtils";
 import { CCloudEnvironment } from "../models/environment";
 import { KafkaTopic } from "../models/topic";
+import * as produceQuickPicks from "../quickpicks/produceMessage";
 import * as schemaQuickPicks from "../quickpicks/schemas";
 import * as uriQuickpicks from "../quickpicks/uris";
 import * as schemaSubjectUtils from "../quickpicks/utils/schemaSubjects";
@@ -57,6 +58,7 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
 
   let uriQuickpickStub: sinon.SinonStub;
   let getEditorOrFileContents: sinon.SinonStub;
+  let produceControlFieldMultiSelectStub: sinon.SinonStub;
 
   let clientStub: sinon.SinonStubbedInstance<RecordsV3Api>;
 
@@ -66,6 +68,12 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
     showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
     showInfoMessageStub = sandbox.stub(vscode.window, "showInformationMessage").resolves();
     executeCommandStub = sandbox.stub(vscode.commands, "executeCommand").resolves();
+
+    // default to keeping any control fields the record(s) specify; overridden per-test to
+    // exercise deselection/cancellation
+    produceControlFieldMultiSelectStub = sandbox
+      .stub(produceQuickPicks, "produceControlFieldMultiSelect")
+      .resolves({ partitionId: true, timestamp: true });
 
     // stub the quickpick for file/editor URI and the resulting content
     uriQuickpickStub = sandbox
@@ -184,6 +192,34 @@ describe("commands/topics.ts produceMessageFromDocument() without schemas", func
     const requestArg: ProduceRecordRequest = clientStub.produceRecord.firstCall.args[0];
     assert.strictEqual(requestArg.ProduceRequest!.partition_id, partition_id);
     assert.strictEqual(requestArg.ProduceRequest!.timestamp, undefined);
+  });
+
+  it("should strip control fields the user deselected in the control-field quickpick", async function () {
+    const partition_id = 123;
+    const timestamp = 1234567890;
+    getEditorOrFileContents.resolves({
+      content: JSON.stringify({ ...fakeMessage, partition_id, timestamp }),
+    });
+    // user kept `partition_id` but deselected `timestamp`
+    produceControlFieldMultiSelectStub.resolves({ partitionId: true, timestamp: false });
+
+    await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    sinon.assert.calledOnce(clientStub.produceRecord);
+    const requestArg: ProduceRecordRequest = clientStub.produceRecord.firstCall.args[0];
+    assert.strictEqual(requestArg.ProduceRequest!.partition_id, partition_id);
+    assert.strictEqual(requestArg.ProduceRequest!.timestamp, undefined);
+  });
+
+  it("should exit early if the control-field quickpick is cancelled", async function () {
+    getEditorOrFileContents.resolves({
+      content: JSON.stringify({ ...fakeMessage, partition_id: 123 }),
+    });
+    produceControlFieldMultiSelectStub.resolves(undefined);
+
+    await produceMessagesFromDocument(TEST_LOCAL_KAFKA_TOPIC);
+
+    sinon.assert.notCalled(clientStub.produceRecord);
   });
 
   // `key` is an object that won't serialize to a string cleanly

--- a/src/commands/topics.ts
+++ b/src/commands/topics.ts
@@ -31,6 +31,11 @@ import {
   DEFAULT_ERROR_NOTIFICATION_BUTTONS,
   showErrorNotificationWithButtons,
 } from "../notifications";
+import {
+  produceControlFieldMultiSelect,
+  stripDeselectedControlFields,
+} from "../quickpicks/produceMessage";
+import type { ControlFieldSelection } from "../quickpicks/produceMessage";
 import type { SchemaKindSelection } from "../quickpicks/schemas";
 import { schemaKindMultiSelect } from "../quickpicks/schemas";
 import { uriQuickpick } from "../quickpicks/uris";
@@ -278,6 +283,25 @@ export async function produceMessagesFromDocument(topic: KafkaTopic) {
     uriScheme: messageUri.scheme,
   });
 
+  // always treat producing as a "bulk" action, even if there's only one message
+  const contents: ProduceMessage[] = [];
+  const msgContent = JSON.parse(content);
+  if (Array.isArray(msgContent)) {
+    contents.push(...msgContent);
+  } else {
+    contents.push(msgContent);
+  }
+
+  // if any record specifies the optional `partition_id`/`timestamp` control fields, let the user
+  // opt out of sending them before choosing schema(s), then strip any they deselected
+  const controlFieldSelection: ControlFieldSelection | undefined =
+    await produceControlFieldMultiSelect(contents);
+  if (!controlFieldSelection) {
+    // user exited the control-field quickpick
+    return;
+  }
+  stripDeselectedControlFields(contents, controlFieldSelection);
+
   // ask the user if they want to use a schema for the key and/or value
   const selectResult: SchemaKindSelection | undefined = await schemaKindMultiSelect(topic);
   if (!selectResult) {
@@ -317,15 +341,6 @@ export async function produceMessagesFromDocument(topic: KafkaTopic) {
     keySubjectNameStrategy,
     valueSubjectNameStrategy: valueSubjectNameStrategy,
   };
-
-  // always treat producing as a "bulk" action, even if there's only one message
-  const contents: any[] = [];
-  const msgContent: any = JSON.parse(content);
-  if (Array.isArray(msgContent)) {
-    contents.push(...msgContent);
-  } else {
-    contents.push(msgContent);
-  }
 
   // TODO: bump this number up?
   if (contents.length === 1) {

--- a/src/quickpicks/produceMessage.test.ts
+++ b/src/quickpicks/produceMessage.test.ts
@@ -1,0 +1,120 @@
+import * as assert from "assert";
+import sinon from "sinon";
+import { window } from "vscode";
+import type { ProduceMessage } from "../diagnostics/produceMessage";
+import {
+  detectControlFields,
+  produceControlFieldMultiSelect,
+  stripDeselectedControlFields,
+} from "./produceMessage";
+
+const messageWithBoth: ProduceMessage = { key: "k", value: "v", partition_id: 3, timestamp: 100 };
+
+describe("quickpicks/produceMessage.ts detectControlFields()", function () {
+  it("should report a field present when any record specifies it", function () {
+    const contents: ProduceMessage[] = [{ value: "a" }, { value: "b", partition_id: 0 }];
+
+    const present = detectControlFields(contents);
+
+    assert.strictEqual(present.partitionId, true);
+    assert.strictEqual(present.timestamp, false);
+  });
+
+  it("should treat a `partition_id` of 0 as present", function () {
+    // guards against a truthiness check that would miss partition 0
+    const present = detectControlFields([{ value: "a", partition_id: 0 }]);
+
+    assert.strictEqual(present.partitionId, true);
+  });
+
+  it("should report neither field present for records without control fields", function () {
+    const present = detectControlFields([{ value: "a" }, { value: "b" }]);
+
+    assert.deepStrictEqual(present, { partitionId: false, timestamp: false });
+  });
+});
+
+describe("quickpicks/produceMessage.ts produceControlFieldMultiSelect()", function () {
+  let sandbox: sinon.SinonSandbox;
+  let showQuickPickStub: sinon.SinonStub;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    showQuickPickStub = sandbox.stub(window, "showQuickPick");
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("should not show a quickpick and return both false when no control fields are present", async function () {
+    const selection = await produceControlFieldMultiSelect([{ value: "a" }]);
+
+    sinon.assert.notCalled(showQuickPickStub);
+    assert.deepStrictEqual(selection, { partitionId: false, timestamp: false });
+  });
+
+  it("should only offer control fields that are present in the record(s)", async function () {
+    // only `partition_id` present, so `timestamp` should not be offered
+    showQuickPickStub.resolves([{ label: "Partition ID" }]);
+
+    const selection = await produceControlFieldMultiSelect([{ value: "a", partition_id: 1 }]);
+
+    const offeredItems = showQuickPickStub.firstCall.args[0];
+    assert.strictEqual(offeredItems.length, 1);
+    assert.strictEqual(offeredItems[0].label, "Partition ID");
+    assert.deepStrictEqual(selection, { partitionId: true, timestamp: false });
+  });
+
+  it("should pre-select every offered control field", async function () {
+    showQuickPickStub.resolves([]);
+
+    await produceControlFieldMultiSelect([messageWithBoth]);
+
+    const offeredItems = showQuickPickStub.firstCall.args[0];
+    assert.strictEqual(offeredItems.length, 2);
+    assert.ok(offeredItems.every((item: { picked?: boolean }) => item.picked === true));
+  });
+
+  it("should mark a field excluded when the user deselects it", async function () {
+    // user kept only "Timestamp"
+    showQuickPickStub.resolves([{ label: "Timestamp" }]);
+
+    const selection = await produceControlFieldMultiSelect([messageWithBoth]);
+
+    assert.deepStrictEqual(selection, { partitionId: false, timestamp: true });
+  });
+
+  it("should return undefined when the user cancels the quickpick", async function () {
+    showQuickPickStub.resolves(undefined);
+
+    const selection = await produceControlFieldMultiSelect([messageWithBoth]);
+
+    assert.strictEqual(selection, undefined);
+  });
+});
+
+describe("quickpicks/produceMessage.ts stripDeselectedControlFields()", function () {
+  it("should delete only the deselected control field(s) from every record", function () {
+    const contents: ProduceMessage[] = [
+      { value: "a", partition_id: 1, timestamp: 100 },
+      { value: "b", partition_id: 2, timestamp: 200 },
+    ];
+
+    stripDeselectedControlFields(contents, { partitionId: true, timestamp: false });
+
+    assert.strictEqual(contents[0].partition_id, 1);
+    assert.strictEqual(contents[0].timestamp, undefined);
+    assert.strictEqual(contents[1].partition_id, 2);
+    assert.strictEqual(contents[1].timestamp, undefined);
+  });
+
+  it("should leave records untouched when both fields are kept", function () {
+    const contents: ProduceMessage[] = [{ value: "a", partition_id: 1, timestamp: 100 }];
+
+    stripDeselectedControlFields(contents, { partitionId: true, timestamp: true });
+
+    assert.strictEqual(contents[0].partition_id, 1);
+    assert.strictEqual(contents[0].timestamp, 100);
+  });
+});

--- a/src/quickpicks/produceMessage.ts
+++ b/src/quickpicks/produceMessage.ts
@@ -1,0 +1,107 @@
+import * as vscode from "vscode";
+import type { ProduceMessage } from "../diagnostics/produceMessage";
+import { logUsage, UserEvent } from "../telemetry/events";
+
+/**
+ * Which optional Kafka control fields to include in a produce request.
+ *
+ * `true` means the field should be sent for any record that specifies it; `false` means it should
+ * be stripped from the record(s) before producing.
+ */
+export interface ControlFieldSelection {
+  partitionId: boolean;
+  timestamp: boolean;
+}
+
+const PARTITION_ID_LABEL = "Partition ID";
+const TIMESTAMP_LABEL = "Timestamp";
+
+/** Whether the given records specify `partition_id` and/or `timestamp` in at least one record. */
+export function detectControlFields(contents: ProduceMessage[]): ControlFieldSelection {
+  return {
+    partitionId: contents.some((record) => record.partition_id !== undefined),
+    timestamp: contents.some((record) => record.timestamp !== undefined),
+  };
+}
+
+/**
+ * If any record specifies the `partition_id` and/or `timestamp` control field(s), prompt the user
+ * to confirm which of those to include in the produce request. Both present fields are pre-selected,
+ * so confirming without changes preserves the record(s) as written.
+ *
+ * @returns the control fields to include, or `undefined` if the user cancelled the quickpick.
+ *   When no control fields are present, resolves immediately (no quickpick) with both `false`, since
+ *   there is nothing to include or strip.
+ */
+export async function produceControlFieldMultiSelect(
+  contents: ProduceMessage[],
+): Promise<ControlFieldSelection | undefined> {
+  const present: ControlFieldSelection = detectControlFields(contents);
+  if (!present.partitionId && !present.timestamp) {
+    return { partitionId: false, timestamp: false };
+  }
+
+  // pre-select present fields so this is an opt-out: producing already sends any control field a
+  // record specifies, so checked-by-default preserves that behavior
+  const items: vscode.QuickPickItem[] = [];
+  if (present.partitionId) {
+    items.push({
+      label: PARTITION_ID_LABEL,
+      description: "Route each record to its specified partition",
+      picked: true,
+      iconPath: new vscode.ThemeIcon("symbol-number"),
+    });
+  }
+  if (present.timestamp) {
+    items.push({
+      label: TIMESTAMP_LABEL,
+      description: "Produce each record with its specified timestamp",
+      picked: true,
+      iconPath: new vscode.ThemeIcon("watch"),
+    });
+  }
+
+  const selectedItems: vscode.QuickPickItem[] | undefined = await vscode.window.showQuickPick(
+    items,
+    {
+      canPickMany: true,
+      title: "Include control fields in produce request?",
+      placeHolder: "Deselect any control field(s) to omit from the record(s)",
+      ignoreFocusOut: true,
+    },
+  );
+  if (selectedItems === undefined) {
+    // user cancelled
+    return;
+  }
+
+  // a label is only ever offered when that field is present, so a match here implies presence
+  const selection: ControlFieldSelection = {
+    partitionId: selectedItems.some((item) => item.label === PARTITION_ID_LABEL),
+    timestamp: selectedItems.some((item) => item.label === TIMESTAMP_LABEL),
+  };
+  logUsage(UserEvent.MessageProduceAction, {
+    status: "selected produce control fields",
+    partitionIdSelected: selection.partitionId,
+    timestampSelected: selection.timestamp,
+  });
+  return selection;
+}
+
+/**
+ * Delete any control-field key the user opted out of from each record, mutating the record(s) in
+ * place so the stripped field is not sent in the produce request.
+ */
+export function stripDeselectedControlFields(
+  contents: ProduceMessage[],
+  selection: ControlFieldSelection,
+): void {
+  for (const record of contents) {
+    if (!selection.partitionId) {
+      delete record.partition_id;
+    }
+    if (!selection.timestamp) {
+      delete record.timestamp;
+    }
+  }
+}


### PR DESCRIPTION
## Summary of Changes

Producing a message used to send any `partition_id` or `timestamp` fields present in the selected document straight through to the produce request. A record could land on an unintended partition, or carry a backdated timestamp, without the user realizing those fields were being honored.

This adds an opt-out step. When a record specifies either field, a multi-select quickpick appears before the schema picker, listing only the present field(s), each pre-checked so accepting the prompt preserves today's send-everything behavior. Unchecking a field strips it from the record(s) before the produce request. Records with neither field see no extra prompt.

Closes #1222.

### Click-testing instructions

1. Open a document whose record includes `partition_id` and/or `timestamp`.
2. Run the produce-message command. Confirm the new multi-select appears before the schema picker, listing only the present control field(s), each checked.
3. Uncheck one field and produce. Confirm that field is absent from the produced record and the other is retained.
4. Produce a record with neither field. Confirm no extra quickpick appears.

### Optional: Any additional details or context that should be provided?

- New helpers in `src/quickpicks/produceMessage.ts`: `detectControlFields()` scans the parsed record(s), `produceControlFieldMultiSelect()` raises the opt-out picker only when a control field is present, and `stripDeselectedControlFields()` deletes unchecked keys from every record. Wired into `produceMessagesFromDocument()` in `src/commands/topics.ts`, which now parses the bulk records before the picker and exits early if the picker is cancelled.

## Pull request checklist

#### Tests

- [x] Added new
- [ ] Updated existing
- [ ] Deleted existing

#### Release notes

<!-- prettier-ignore -->
- [ ] Does anything in this PR need to be mentioned in the user-facing [CHANGELOG](https://github.com/confluentinc/vscode/blob/main/CHANGELOG.md)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
